### PR TITLE
Change project id to hex string format

### DIFF
--- a/packages/app/src/components/Dashboard/ProjectHeader.tsx
+++ b/packages/app/src/components/Dashboard/ProjectHeader.tsx
@@ -8,9 +8,8 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useContext, useState } from 'react'
 
 export default function ProjectHeader() {
-  const [editProjectModalVisible, setEditProjectModalVisible] = useState<
-    boolean
-  >(false)
+  const [editProjectModalVisible, setEditProjectModalVisible] =
+    useState<boolean>(false)
   const [toolDrawerVisible, setToolDrawerVisible] = useState<boolean>(false)
 
   const { projectId, handle, metadata, isOwner } = useContext(ProjectContext)
@@ -97,7 +96,7 @@ export default function ProjectHeader() {
               paddingRight: 10,
             }}
           >
-            ID: {projectId.toNumber()}
+            ID: {projectId.toHexString()}
           </div>
 
           <div>


### PR DESCRIPTION
I think that this probably makes more sense if people are trying to grab their project id to deploy a contract/run a certain function.

e.g., 12 ->0x0c which is a bit misleading

![Screen Shot 2021-08-09 at 6 28 03 PM](https://user-images.githubusercontent.com/88144767/128782327-60fedb20-352b-4d2a-a4b4-45918e8e1bb1.png)
