### PR TITLE
add notice for untracked erc20s

### DIFF
--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -7,10 +7,12 @@ import { Modal, Select } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import Loading from 'components/shared/Loading'
+import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import useContractReader from 'hooks/ContractReader'
 import { ContractName } from 'models/contract-name'
+import { NetworkName } from 'models/network-name'
 import {
   parseParticipantJson,
   Participant,
@@ -226,7 +228,9 @@ export default function ParticipantsModal({
   const erc20IsUntracked =
     tokenSymbol &&
     projectId &&
-    !indexedProjectERC20s.includes(projectId?.toNumber())
+    !indexedProjectERC20s[
+      process.env.REACT_APP_INFURA_NETWORK as NetworkName
+    ]?.includes(projectId?.toNumber())
 
   return (
     <Modal
@@ -239,7 +243,7 @@ export default function ParticipantsModal({
       <div>
         <h4>{tokenSymbol || 'Token'} holders</h4>
 
-        {true && (
+        {erc20IsUntracked && (
           <p>
             <b>Notice:</b> {tokenSymbol} ERC20 tokens have not been indexed by
             Juicebox, meaning that the balances reflected below will be

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -20,6 +20,7 @@ import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { OrderDirection, querySubgraph } from 'utils/graph'
+import { indexedProjectERC20s } from '../../constants/indexed-project-erc20s'
 
 const pageSize = 100
 
@@ -222,6 +223,11 @@ export default function ParticipantsModal({
     ],
   )
 
+  const erc20IsUntracked =
+    tokenSymbol &&
+    projectId &&
+    !indexedProjectERC20s.includes(projectId?.toNumber())
+
   return (
     <Modal
       visible={visible}
@@ -232,6 +238,31 @@ export default function ParticipantsModal({
     >
       <div>
         <h4>{tokenSymbol || 'Token'} holders</h4>
+
+        {true && (
+          <p>
+            <b>Notice:</b> {tokenSymbol} ERC20 tokens have not been indexed by
+            Juicebox, meaning that the balances reflected below will be
+            inaccurate for users who have unstaked and transferred their tokens.
+            This will be solved with the release of{' '}
+            <a
+              href="https://app.gitbook.com/@jbx/s/juicebox/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Juicebox V2
+            </a>
+            . If this is a big issue for your project, let us know in the{' '}
+            <a
+              href="https://discord.gg/6jXrJSyDFf"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Discord
+            </a>
+            .
+          </p>
+        )}
 
         {list}
 

--- a/src/constants/indexed-project-erc20s.ts
+++ b/src/constants/indexed-project-erc20s.ts
@@ -1,0 +1,1 @@
+export const indexedProjectERC20s = [1, 2, 7, 8]

--- a/src/constants/indexed-project-erc20s.ts
+++ b/src/constants/indexed-project-erc20s.ts
@@ -1,1 +1,5 @@
-export const indexedProjectERC20s = [1, 2, 7, 8]
+import { NetworkName } from 'models/network-name'
+
+export const indexedProjectERC20s: Partial<Record<NetworkName, number[]>> = {
+  [NetworkName.mainnet]: [1, 2, 7, 8],
+}


### PR DESCRIPTION
This notice will be seen for any projects that launch their ERC20 token that hasn't been indexed by the Juicebox subgraph. The list of newly indexed tokens will need to be manually updated in the UI, until V2 is released and this process becomes unnecessary.

(SHARK tokens ARE indexed, screenshot only for demo purpose)

![image](https://user-images.githubusercontent.com/79433522/135944437-f356948d-73eb-4ec0-800a-c5ad930bed53.png)
