### PR TITLE
feat/project-metadatas

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ethers": "^5.1.0",
     "react": "^17",
     "react-dom": "^17.0.1",
+    "react-helmet": "^6.1.0",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -4,17 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta property="og:url" content="https://juicebox.money" />
-    <meta property="og:title" content="Juicebox" />
-    <meta
-      property="og:description"
-      content="Community funding for people and projects on Ethereum."
-    />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="%PUBLIC_URL%/assets/banana-cover.png" />
-    <meta property="og:image:type" content="image/svg" />
-    <meta property="og:image:width" content="2870" />
-    <meta property="og:image:height" content="1245" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/assets/juice_logo-ol.png" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
@@ -22,18 +12,6 @@
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap"
       rel="stylesheet"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@juiceboxETH" />
-    <meta name="twitter:creator" content="@juiceboxETH" />
-    <meta name="twitter:title" content="Juicebox" />
-    <meta
-      name="twitter:description"
-      content="Community funding for people and projects on Ethereum."
-    />
-    <meta
-      name="twitter:image"
-      content="https://jbx.mypinata.cloud/ipfs/QmQYomY5sFvG96FKy3BKFU7mmcSiJsRjSHURmJSMPHrALJ"
     />
     <title>Juicebox</title>
     <script

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,7 @@ import { readNetwork } from 'constants/networks'
 import { NetworkContext } from 'contexts/networkContext'
 import { NetworkName } from 'models/network-name'
 import { useContext, useLayoutEffect, useState } from 'react'
+import ProjectMetadata from './Dashboard/ProjectMetadata'
 
 import Navbar from './Navbar'
 import Router from './Router'
@@ -40,6 +41,7 @@ function App() {
       >
         <Navbar />
         <Content>
+        <ProjectMetadata />
           <Router />
         </Content>
       </Layout>

--- a/src/components/Dashboard/Project.tsx
+++ b/src/components/Dashboard/Project.tsx
@@ -14,6 +14,7 @@ import Pay from './Pay'
 import PrintPremined from './PrintPremined'
 import ProjectActivity from './ProjectActivity'
 import ProjectHeader from './ProjectHeader'
+import ProjectMetadata from './ProjectMetadata'
 import Rewards from './Rewards'
 
 export default function Project({
@@ -23,7 +24,7 @@ export default function Project({
   style?: CSSProperties
   showCurrentDetail?: boolean
 }) {
-  const { projectId } = useContext(ProjectContext)
+  const { projectId, metadata } = useContext(ProjectContext)
 
   const canPrintPreminedTickets = useContractReader<boolean>({
     contract: ContractName.TerminalV1,
@@ -66,6 +67,7 @@ export default function Project({
 
   return (
     <div style={style}>
+      <ProjectMetadata metadata={metadata} />
       <ProjectHeader />
 
       <Row gutter={gutter} align="bottom">

--- a/src/components/Dashboard/ProjectMetadata.tsx
+++ b/src/components/Dashboard/ProjectMetadata.tsx
@@ -42,7 +42,7 @@ const ProjectMetadata = ({
       <meta property="og:type" content="object" />
       <meta property="og:title" content={metadata.name} />
       <meta property="og:description" content={metadata.description} />
-      <meta name="twitter:image" content={DEFAULT_METADATA.logoUri} />
+      <meta name="twitter:image" content={metadata.logoUri} />
     </Helmet>
   )
 }

--- a/src/components/Dashboard/ProjectMetadata.tsx
+++ b/src/components/Dashboard/ProjectMetadata.tsx
@@ -14,12 +14,14 @@ const ProjectMetadata = ({
 }: {
   metadata?: ProjectMetadataV3
 }) => {
+  const isDefault = metadata.name === DEFAULT_METADATA.name
+
   return (
     <Helmet>
       <title>{metadata.name}</title>
       <meta
         property="og:url"
-        content={metadata ? window.location.href : 'https://juicebox.money'}
+        content={!isDefault ? window.location.href : 'https://juicebox.money'}
       />
       <meta property="og:title" content={metadata.name} />
       <meta name="description" content={metadata.description} />
@@ -29,20 +31,20 @@ const ProjectMetadata = ({
         href="/opensearch.xml"
         title="Juicebox"
       ></link>
-      <meta name="twitter:site" content={`@${metadata.twitter}`} />
-      <meta name="twitter:creator" content={`@${metadata.twitter}`} />
-      <meta name="twitter:card" content="summary_large_image" />
+      {metadata.twitter && <meta name="twitter:site" content={`@${metadata.twitter}`} />}
+      {metadata.twitter && <meta name="twitter:creator" content={`@${metadata.twitter}`} />}
+      {metadata.twitter && <meta name="twitter:card" content="summary_large_image" />}
       <meta name="twitter:title" content={metadata.name} />
-      <meta name="twitter:description" content={metadata.description} />
-      <meta property="og:image" content={metadata.logoUri} />
-      <meta property="og:image:alt" content={metadata.description} />
-      <meta property="og:image:width" content={metadata ? '1020' : '2870'} />
-      <meta property="og:image:height" content={metadata ? '1020' : '1245'} />
+      {metadata.description && <meta name="twitter:description" content={metadata.description} />}
+      {metadata.logoUri && <meta property="og:image" content={metadata.logoUri} />}
+      {metadata.description && <meta property="og:image:alt" content={metadata.description} />}
+      <meta property="og:image:width" content={!isDefault ? '1020' : '2870'} />
+      <meta property="og:image:height" content={!isDefault ? '1020' : '1245'} />
       <meta property="og:site_name" content="Juicebox" />
       <meta property="og:type" content="object" />
       <meta property="og:title" content={metadata.name} />
-      <meta property="og:description" content={metadata.description} />
-      <meta name="twitter:image" content={metadata.logoUri} />
+      {metadata.description && <meta property="og:description" content={metadata.description} />}
+      {<meta name="twitter:image" content={metadata.logoUri} />}
     </Helmet>
   )
 }

--- a/src/components/Dashboard/ProjectMetadata.tsx
+++ b/src/components/Dashboard/ProjectMetadata.tsx
@@ -1,0 +1,50 @@
+import { Helmet } from 'react-helmet'
+import { ProjectMetadataV3 } from 'models/project-metadata'
+
+const DEFAULT_METADATA: ProjectMetadataV3 = {
+  name: 'Juicebox',
+  twitter: 'juiceboxETH',
+  description: 'Community funding for people and projects on Ethereum.',
+  logoUri:
+    'https://jbx.mypinata.cloud/ipfs/QmQYomY5sFvG96FKy3BKFU7mmcSiJsRjSHURmJSMPHrALJ',
+}
+
+const ProjectMetadata = ({
+  metadata = DEFAULT_METADATA,
+}: {
+  metadata?: ProjectMetadataV3
+}) => {
+  return (
+    <Helmet>
+      <title>{metadata.name}</title>
+      <meta
+        property="og:url"
+        content={metadata ? window.location.href : 'https://juicebox.money'}
+      />
+      <meta property="og:title" content={metadata.name} />
+      <meta name="description" content={metadata.description} />
+      <link
+        rel="search"
+        type="application/opensearchdescription+xml"
+        href="/opensearch.xml"
+        title="Juicebox"
+      ></link>
+      <meta name="twitter:site" content={`@${metadata.twitter}`} />
+      <meta name="twitter:creator" content={`@${metadata.twitter}`} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={metadata.name} />
+      <meta name="twitter:description" content={metadata.description} />
+      <meta property="og:image" content={metadata.logoUri} />
+      <meta property="og:image:alt" content={metadata.description} />
+      <meta property="og:image:width" content={metadata ? '1020' : '2870'} />
+      <meta property="og:image:height" content={metadata ? '1020' : '1245'} />
+      <meta property="og:site_name" content="Juicebox" />
+      <meta property="og:type" content="object" />
+      <meta property="og:title" content={metadata.name} />
+      <meta property="og:description" content={metadata.description} />
+      <meta name="twitter:image" content={DEFAULT_METADATA.logoUri} />
+    </Helmet>
+  )
+}
+
+export default ProjectMetadata

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,2 +1,3 @@
 declare var Desmos
 declare module 'ethereum-block-by-date'
+declare module 'react-helmet'

--- a/src/hooks/Projects.ts
+++ b/src/hooks/Projects.ts
@@ -9,7 +9,6 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 
 import { querySubgraph } from '../utils/graph'
-import { readNetwork } from 'constants/networks';
 
 export function useProjects({
   pageNumber,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14689,6 +14689,21 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-is@16.10.2:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
@@ -14849,6 +14864,11 @@ react-scripts@4.0.1:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-smooth@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
So with this PR when people share link of their project's page, metadata for preview on the web (discord, twitter, telegram), should show information specific to the project instead of generic Juicebox one, as well as in the tab title they will see the dao name too.

I've used existing metadata from project such as name, description, logoUrl and twitter. In future we could further improve this by creating auto-generated preview images from provided project info