### PR TITLE
Fix issue with percentage sliders

### DIFF
--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -455,7 +455,7 @@ export default function ProjectPayoutMods({
               }
             />
           ) : null}
-          <Form.Item label="Percent" rules={[{ required: true }]} shouldUpdate>
+          <Form.Item label="Percent" rules={[{ required: true }]}>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <span style={{ flex: 1, marginRight: 10 }}>
                 <NumberSlider

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -455,12 +455,7 @@ export default function ProjectPayoutMods({
               }
             />
           ) : null}
-          <Form.Item
-            name="percent"
-            label="Percent"
-            rules={[{ required: true }]}
-            shouldUpdate
-          >
+          <Form.Item label="Percent" rules={[{ required: true }]} shouldUpdate>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <span style={{ flex: 1, marginRight: 10 }}>
                 <NumberSlider

--- a/src/components/shared/formItems/ProjectTicketMods.tsx
+++ b/src/components/shared/formItems/ProjectTicketMods.tsx
@@ -297,12 +297,7 @@ export default function ProjectTicketMods({
             }
           />
 
-          <Form.Item
-            name="percent"
-            label="Percent"
-            rules={[{ required: true }]}
-            shouldUpdate
-          >
+          <Form.Item label="Percent" rules={[{ required: true }]} shouldUpdate>
             <NumberSlider
               onChange={percent => form.setFieldsValue({ percent })}
               step={0.01}

--- a/src/components/shared/formItems/ProjectTicketMods.tsx
+++ b/src/components/shared/formItems/ProjectTicketMods.tsx
@@ -297,7 +297,7 @@ export default function ProjectTicketMods({
             }
           />
 
-          <Form.Item label="Percent" rules={[{ required: true }]} shouldUpdate>
+          <Form.Item label="Percent" rules={[{ required: true }]}>
             <NumberSlider
               onChange={percent => form.setFieldsValue({ percent })}
               step={0.01}


### PR DESCRIPTION
Fixes https://github.com/jbx-protocol/juice-interface/issues/91.

Using the `InputNumber` input of `NumberSlider` caused a bug where only the first digit of the input would be saved.

It turns out `Form.Item` intercepts `change` events from nested `input` elements. If the input element isn't the direct child of `Form.Item`, bad things happen! Even though we are handling `onChange` in `NumberSlider`, it appears `Form.Item` overrides this at some point.

Removing the `name` prop from `Form.Item` fixes the bug by delegating this responsibility to `NumberSlider`'s `onChange` event.

Accessibility is unaffected by this change; the `name` prop doesn't add `name` attribute to the input field.

### Demo

https://user-images.githubusercontent.com/94939382/143429149-10e4ac43-1098-48a6-b732-eaa9695c6e45.mp4

