### PR TITLE
Improve flow for redeeming/claiming tokens

### DIFF
--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -241,21 +241,17 @@ export default function Rewards({
       </Space>
 
       <Modal
-        title="Manage tokens"
+        title={`Manage ${tokenSymbol ? tokenSymbol + ' ' : ''}tokens`}
         visible={manageTokensModalVisible}
         onCancel={() => setManageTokensModalVisible(false)}
         okButtonProps={{ hidden: true }}
       >
         <Space direction="vertical" style={{ width: '100%' }}>
-          <Button
-            disabled={!ticketsIssued}
-            onClick={() => setUnstakeModalVisible(true)}
-            block
-          >
-            Claim tokens as ERC20
+          <Button onClick={() => setUnstakeModalVisible(true)} block>
+            Claim {tokenSymbol || 'tokens'} as ERC20
           </Button>
           <Button onClick={() => setRedeemModalVisible(true)} block>
-            Burn tokens for ETH
+            Burn {tokenSymbol || 'tokens'} for ETH
           </Button>
         </Space>
       </Modal>

--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -245,13 +245,14 @@ export default function Rewards({
         visible={manageTokensModalVisible}
         onCancel={() => setManageTokensModalVisible(false)}
         okButtonProps={{ hidden: true }}
+        centered
       >
         <Space direction="vertical" style={{ width: '100%' }}>
+          <Button onClick={() => setRedeemModalVisible(true)} block>
+            Return my ETH
+          </Button>
           <Button onClick={() => setUnstakeModalVisible(true)} block>
             Claim {tokenSymbol || 'tokens'} as ERC20
-          </Button>
-          <Button onClick={() => setRedeemModalVisible(true)} block>
-            Burn {tokenSymbol || 'tokens'} for ETH
           </Button>
         </Space>
       </Modal>

--- a/src/components/modals/ConfirmUnstakeTokensModal.tsx
+++ b/src/components/modals/ConfirmUnstakeTokensModal.tsx
@@ -83,7 +83,7 @@ export default function ConfirmUnstakeTokensModal({
       okButtonProps={{ disabled: parseWad(unstakeAmount).eq(0) }}
       onCancel={onCancel}
       width={600}
-      centered={true}
+      centered
     >
       <Space direction="vertical" size="large">
         {!ticketsIssued && (

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -12,7 +12,13 @@ import { ContractName } from 'models/contract-name'
 import { BallotState } from 'models/funding-cycle'
 import { useContext, useMemo, useState } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
-import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
+import {
+  formattedNum,
+  formatWad,
+  fracDiv,
+  fromWad,
+  parseWad,
+} from 'utils/formatNumber'
 import { decodeFCMetadata } from 'utils/fundingCycle'
 
 export default function RedeemModal({
@@ -118,6 +124,9 @@ export default function RedeemModal({
     return number.mul(numerator).div(denominator)
   }, [redeemAmount, base, bondingCurveRate, totalSupply, currentOverflow])
 
+  // 0.5% slippage
+  const minAmount = rewardAmount?.mul(1000).div(1005)
+
   function redeem() {
     if (!transactor || !contracts || !rewardAmount) return
 
@@ -126,9 +135,6 @@ export default function RedeemModal({
     const redeemWad = parseWad(redeemAmount)
 
     if (!redeemWad || !projectId) return
-
-    // Arbitrary discrete value (wei) subtracted
-    const minAmount = rewardAmount?.sub(1e12).toHexString()
 
     transactor(
       contracts.TerminalV1,
@@ -171,6 +177,7 @@ export default function RedeemModal({
           redeemDisabled || !redeemAmount || parseInt(redeemAmount) === 0,
       }}
       width={540}
+      centered
     >
       <Space direction="vertical" style={{ width: '100%' }}>
         <div>
@@ -211,7 +218,7 @@ export default function RedeemModal({
             />
             <div style={{ fontWeight: 500, marginTop: 20 }}>
               You will receive minimum{' '}
-              {formatWad(rewardAmount, { decimals: 8 }) || '--'} ETH
+              {formatWad(minAmount, { decimals: 8 }) || '--'} ETH
             </div>
           </div>
         )}

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -1,0 +1,221 @@
+import { Modal, Space } from 'antd'
+import CurrencySymbol from 'components/shared/CurrencySymbol'
+import InputAccessoryButton from 'components/shared/InputAccessoryButton'
+import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import useContractReader from 'hooks/ContractReader'
+import { ContractName } from 'models/contract-name'
+import { BallotState } from 'models/funding-cycle'
+import { useContext, useMemo, useState } from 'react'
+import { bigNumbersDiff } from 'utils/bigNumbersDiff'
+import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
+import { decodeFCMetadata } from 'utils/fundingCycle'
+
+export default function RedeemModal({
+  visible,
+  redeemDisabled,
+  onOk,
+  onCancel,
+  totalSupply,
+  totalBalance,
+}: {
+  visible?: boolean
+  redeemDisabled?: boolean
+  onOk: VoidFunction | undefined
+  onCancel: VoidFunction | undefined
+  totalSupply: BigNumber | undefined
+  totalBalance: BigNumber | undefined
+}) {
+  const [redeemAmount, setRedeemAmount] = useState<string>()
+  const [loading, setLoading] = useState<boolean>()
+
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { contracts, transactor } = useContext(UserContext)
+  const { projectId, tokenSymbol, currentFC } = useContext(ProjectContext)
+
+  const currentOverflow = useContractReader<BigNumber>({
+    contract: ContractName.TerminalV1,
+    functionName: 'currentOverflowOf',
+    args: projectId ? [projectId.toHexString()] : null,
+    valueDidChange: bigNumbersDiff,
+  })
+
+  const maxClaimable = useContractReader<BigNumber>({
+    contract: ContractName.TerminalV1,
+    functionName: 'claimableOverflowOf',
+    args:
+      userAddress && projectId
+        ? [userAddress, projectId.toHexString(), totalBalance?.toHexString()]
+        : null,
+    valueDidChange: bigNumbersDiff,
+    updateOn: useMemo(
+      () =>
+        projectId && userAddress
+          ? [
+              {
+                contract: ContractName.TerminalV1,
+                eventName: 'Pay',
+                topics: [[], projectId.toHexString(), userAddress],
+              },
+              {
+                contract: ContractName.TerminalV1,
+                eventName: 'Redeem',
+                topics: [projectId.toHexString(), userAddress],
+              },
+            ]
+          : undefined,
+      [projectId],
+    ),
+  })
+
+  const currentBallotState = useContractReader<BallotState>({
+    contract: ContractName.FundingCycles,
+    functionName: 'currentBallotStateOf',
+    args: projectId ? [projectId.toHexString()] : null,
+  })
+
+  const metadata = decodeFCMetadata(currentFC?.metadata)
+
+  const bondingCurveRate =
+    currentBallotState === BallotState.Active
+      ? metadata?.reconfigurationBondingCurveRate
+      : metadata?.bondingCurveRate
+
+  const base =
+    totalSupply && redeemAmount && currentOverflow
+      ? currentOverflow?.mul(parseWad(redeemAmount)).div(totalSupply)
+      : BigNumber.from(0)
+
+  const rewardAmount = useMemo(() => {
+    if (
+      !bondingCurveRate ||
+      !totalSupply ||
+      !base ||
+      !redeemAmount ||
+      !currentOverflow
+    )
+      return undefined
+
+    if (totalSupply.sub(parseWad(redeemAmount)).isNegative()) {
+      return currentOverflow
+    }
+
+    const number = base
+    const numerator = parseWad(bondingCurveRate).add(
+      parseWad(redeemAmount)
+        .mul(parseWad(200).sub(parseWad(bondingCurveRate)))
+        .div(totalSupply),
+    )
+    const denominator = parseWad(200)
+
+    return number.mul(numerator).div(denominator)
+  }, [redeemAmount, base, bondingCurveRate, totalSupply, currentOverflow])
+
+  function redeem() {
+    if (!transactor || !contracts || !rewardAmount) return
+
+    setLoading(true)
+
+    const redeemWad = parseWad(redeemAmount)
+
+    if (!redeemWad || !projectId) return
+
+    // Arbitrary discrete value (wei) subtracted
+    const minAmount = rewardAmount?.sub(1e12).toHexString()
+
+    transactor(
+      contracts.TerminalV1,
+      'redeem',
+      [
+        userAddress,
+        projectId.toHexString(),
+        redeemWad.toHexString(),
+        minAmount,
+        userAddress,
+        false, // TODO preferconverted
+      ],
+      {
+        onConfirmed: () => setRedeemAmount(undefined),
+        onDone: () => setLoading(false),
+      },
+    )
+  }
+
+  return (
+    <Modal
+      title={`Burn ${tokenSymbol ? tokenSymbol + ' tokens' : 'tokens'} for ETH`}
+      visible={visible}
+      confirmLoading={loading}
+      onOk={() => {
+        redeem()
+
+        if (onOk) onOk()
+      }}
+      onCancel={() => {
+        setRedeemAmount(undefined)
+
+        if (onCancel) onCancel()
+      }}
+      okText={`Burn ${formattedNum(redeemAmount, {
+        decimals: 8,
+      })} ${tokenSymbol ?? 'tokens'} for ETH`}
+      okButtonProps={{
+        disabled:
+          redeemDisabled || !redeemAmount || parseInt(redeemAmount) === 0,
+      }}
+      width={540}
+    >
+      <Space direction="vertical" style={{ width: '100%' }}>
+        <div>
+          Balance: {formatWad(totalBalance ?? 0, { decimals: 0 })}{' '}
+          {tokenSymbol ?? 'tokens'}
+        </div>
+        <p>
+          Currently worth: <CurrencySymbol currency={0} />
+          {formatWad(maxClaimable, { decimals: 4 })}
+        </p>
+        <p>
+          Tokens can be redeemed for a portion of this project's ETH overflow,
+          according to the bonding curve rate of the current funding cycle.{' '}
+          <span style={{ fontWeight: 500, color: colors.text.warn }}>
+            Tokens are burned when they are redeemed.
+          </span>
+        </p>
+        {redeemDisabled && (
+          <div style={{ color: colors.text.secondary, fontWeight: 500 }}>
+            You can redeem tokens once this project has overflow.
+          </div>
+        )}
+        {!redeemDisabled && (
+          <div>
+            <FormattedNumberInput
+              min={0}
+              step={0.001}
+              placeholder="0"
+              value={redeemAmount}
+              disabled={redeemDisabled}
+              accessory={
+                <InputAccessoryButton
+                  content="MAX"
+                  onClick={() => setRedeemAmount(fromWad(totalBalance))}
+                />
+              }
+              onChange={val => setRedeemAmount(val)}
+            />
+            <div style={{ fontWeight: 500, marginTop: 20 }}>
+              You will receive minimum{' '}
+              {formatWad(rewardAmount, { decimals: 8 }) || '--'} ETH
+            </div>
+          </div>
+        )}
+      </Space>
+    </Modal>
+  )
+}

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -164,7 +164,7 @@ export default function RedeemModal({
         if (onCancel) onCancel()
       }}
       okText={`Burn ${formattedNum(redeemAmount, {
-        decimals: 8,
+        decimals: 2,
       })} ${tokenSymbol ?? 'tokens'} for ETH`}
       okButtonProps={{
         disabled:


### PR DESCRIPTION
The goal here is to prevent confusion around the Claim + Redeem processes.

This turns the buttons for Claim" and Redeem" into a single "Manage Tokens" button. After clicking this, the user is shown buttons with more descriptive names for claim and redeem.

![image](https://user-images.githubusercontent.com/79433522/143722510-4fc3cb78-5bdd-4a72-8b61-f109ac141f56.png)
![image](https://user-images.githubusercontent.com/79433522/143722555-d9540630-46fa-4024-b3ad-df203187397b.png)
