### PR TITLE
Bugfix: should not show "handle already in use" warning when input value matches the project's current handle

### DIFF
--- a/src/components/modals/EditProjectModal.tsx
+++ b/src/components/modals/EditProjectModal.tsx
@@ -157,6 +157,7 @@ export default function EditProjectModal({
           value={handleForm.getFieldValue('handle')}
           onValueChange={val => handleForm.setFieldsValue({ handle: val })}
           formItemProps={{ rules: [{ required: true }] }}
+          initialValue={handle}
         />
         <Form.Item>
           <Button type="primary" loading={loadingSetHandle} onClick={setHandle}>

--- a/src/components/shared/formItems/ProjectHandle.tsx
+++ b/src/components/shared/formItems/ProjectHandle.tsx
@@ -83,7 +83,7 @@ export default function ProjectHandle({
       
       return Promise.resolve()
     },
-    [handleExists, requireState],
+    [handleExists, initialValue, requireState],
   )
 
   let suffix: string | JSX.Element = ''

--- a/src/components/shared/formItems/ProjectHandle.tsx
+++ b/src/components/shared/formItems/ProjectHandle.tsx
@@ -20,11 +20,13 @@ export default function ProjectHandle({
   value,
   requireState,
   returnValue,
+  initialValue,
 }: {
   onValueChange: (val: string) => void
   value?: string | BigNumber
   requireState?: 'exists' | 'notExist'
   returnValue?: 'id' | 'handle'
+  initialValue?: string
 } & FormItemExt) {
   const {
     theme: { colors },
@@ -71,11 +73,15 @@ export default function ProjectHandle({
 
   const checkHandle = useCallback(
     (rule: any, value: any) => {
+      // Input field is back at it's initial state
+      if (initialValue && initialValue !== value)
+        return Promise.resolve()
       if (handleExists && requireState === 'notExist')
         return Promise.reject('Handle not available')
       if (!handleExists && requireState === 'exists')
         return Promise.reject("Project doesn't exist")
-      else return Promise.resolve()
+      
+      return Promise.resolve()
     },
     [handleExists, requireState],
   )

--- a/src/components/shared/formItems/ProjectHandle.tsx
+++ b/src/components/shared/formItems/ProjectHandle.tsx
@@ -74,7 +74,7 @@ export default function ProjectHandle({
   const checkHandle = useCallback(
     (rule: any, value: any) => {
       // Input field is back at it's initial state
-      if (initialValue && initialValue !== value)
+      if (initialValue && initialValue === value)
         return Promise.resolve()
       if (handleExists && requireState === 'notExist')
         return Promise.reject('Handle not available')


### PR DESCRIPTION
Add initialValue to ProjectHandle to check if value is the same a project's current handle.

https://github.com/jbx-protocol/juice-interface/issues/189