### PR TITLE
Fix mobile layout of Token Information section

### DIFF
--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -123,6 +123,10 @@ export default function Rewards({
     [],
   )
 
+  const labelStyle: CSSProperties = {
+    width: 128,
+  }
+
   return (
     <div>
       <Space direction="vertical" size="large">
@@ -140,8 +144,9 @@ export default function Rewards({
               {ticketsIssued && (
                 <Descriptions.Item
                   label="Address"
+                  labelStyle={labelStyle}
                   children={
-                    <div style={{ width: '100%', textAlign: 'right' }}>
+                    <div style={{ width: '100%' }}>
                       <FormattedAddress address={tokenAddress} />
                     </div>
                   }
@@ -149,6 +154,7 @@ export default function Rewards({
               )}
               <Descriptions.Item
                 label="Total supply"
+                labelStyle={labelStyle}
                 children={
                   <div
                     style={{
@@ -171,6 +177,7 @@ export default function Rewards({
               />
               <Descriptions.Item
                 label="Your balance"
+                labelStyle={labelStyle}
                 children={
                   <div
                     style={{

--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -12,7 +12,13 @@ import useContractReader, { ContractUpdateOn } from 'hooks/ContractReader'
 import { useErc20Contract } from 'hooks/Erc20Contract'
 import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { ContractName } from 'models/contract-name'
-import { useCallback, useContext, useMemo, useState } from 'react'
+import {
+  CSSProperties,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { decodeFCMetadata } from 'utils/fundingCycle'

--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -25,22 +25,15 @@ export default function Rewards({
 }: {
   totalOverflow: BigNumber | undefined
 }) {
-  const [manageTokensModalVisible, setManageTokensModalVisible] = useState<
-    boolean
-  >()
+  const [manageTokensModalVisible, setManageTokensModalVisible] =
+    useState<boolean>()
   const [unstakeModalVisible, setUnstakeModalVisible] = useState<boolean>()
-  const [participantsModalVisible, setParticipantsModalVisible] = useState<
-    boolean
-  >(false)
+  const [participantsModalVisible, setParticipantsModalVisible] =
+    useState<boolean>(false)
   const { userAddress } = useContext(NetworkContext)
 
-  const {
-    projectId,
-    tokenAddress,
-    tokenSymbol,
-    isPreviewMode,
-    currentFC,
-  } = useContext(ProjectContext)
+  const { projectId, tokenAddress, tokenSymbol, isPreviewMode, currentFC } =
+    useContext(ProjectContext)
 
   const {
     theme: { colors },
@@ -143,14 +136,7 @@ export default function Rewards({
             />
           }
           valueRender={() => (
-            <Descriptions
-              layout={
-                document.documentElement.clientWidth > 600
-                  ? 'horizontal'
-                  : 'vertical'
-              }
-              column={1}
-            >
+            <Descriptions layout="horizontal" column={1}>
               {ticketsIssued && (
                 <Descriptions.Item
                   label="Address"
@@ -175,7 +161,6 @@ export default function Rewards({
                     {formatWad(totalSupply, { decimals: 0 })}
                     <Button
                       size="small"
-                      type="text"
                       onClick={() => setParticipantsModalVisible(true)}
                       disabled={isPreviewMode}
                     >

--- a/src/hooks/Mobile.ts
+++ b/src/hooks/Mobile.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+// Copied from react-use, so if we ever decide to include that library,
+// replace this implementation with the react-use version.
+function useMedia(query: string, defaultState: boolean = false) {
+  const [state, setState] = useState(() =>
+    typeof window === 'undefined'
+      ? defaultState
+      : window.matchMedia(query).matches,
+  )
+
+  useEffect(() => {
+    let mounted = true
+    const queryList = window.matchMedia(query)
+    const onChange = () => {
+      if (!mounted) {
+        return
+      }
+      setState(queryList.matches)
+    }
+
+    queryList.addEventListener('change', onChange)
+    setState(queryList.matches)
+
+    return () => {
+      mounted = false
+      queryList.removeEventListener('change', onChange)
+    }
+  }, [query])
+
+  return state
+}
+
+export default function useMobile() {
+  return useMedia('(max-width: 767px)')
+}


### PR DESCRIPTION
To fix the mobile layout of this section, I changed the layout of the antd component to always "horizontal" fixing much of the alignment issues.

I also made the "Holders" button outlined to match the "Manage" button directly below it.

Addresses: #240 