### PR TITLE
Fix mobile tooltips, including ETH addresses

### DIFF
--- a/src/components/Dashboard/FundingCycles.tsx
+++ b/src/components/Dashboard/FundingCycles.tsx
@@ -19,9 +19,8 @@ export default function FundingCycles({
   showCurrentDetail?: boolean
 }) {
   const [selectedTab, setSelectedTab] = useState<TabOption>('current')
-  const [reconfigureModalVisible, setReconfigureModalVisible] = useState<
-    boolean
-  >(false)
+  const [reconfigureModalVisible, setReconfigureModalVisible] =
+    useState<boolean>(false)
   const [hoverTab, setHoverTab] = useState<TabOption>()
 
   const {

--- a/src/components/shared/FormattedAddress.tsx
+++ b/src/components/shared/FormattedAddress.tsx
@@ -92,6 +92,7 @@ export default function FormattedAddress({
 
   return (
     <Tooltip
+      trigger={['hover', 'click']}
       title={
         <span>
           <span style={{ userSelect: 'all' }}>{address}</span>{' '}

--- a/src/components/shared/TooltipIcon.tsx
+++ b/src/components/shared/TooltipIcon.tsx
@@ -9,7 +9,7 @@ export default function TooltipIcon({
   placement?: TooltipProps['placement']
 }) {
   return (
-    <Tooltip title={tip} placement={placement}>
+    <Tooltip title={tip} placement={placement} trigger={['hover', 'click']}>
       <InfoCircleOutlined />
     </Tooltip>
   )


### PR DESCRIPTION
Setting "trigger" on the common use-cases for Ant's Tooltips to "click" and "hover" make mobile work very well. The addresses are still a little tricky to tap on mobile, but at least the full address and etherscan link _do_ appear now to mobile users.