### PR TITLE
Add clarity to modals `ok` button text

### DIFF
--- a/src/components/Create/ConfirmDeployProject.tsx
+++ b/src/components/Create/ConfirmDeployProject.tsx
@@ -3,7 +3,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import PayoutModsList from 'components/shared/PayoutModsList'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import TicketModsList from 'components/shared/TicketModsList'
-import { getBallotStrategyByAddress } from 'constants/ballot-strategies'
+
 import { UserContext } from 'contexts/userContext'
 import {
   useAppSelector,
@@ -20,6 +20,8 @@ import {
 import { hasFundingTarget, isRecurring } from 'utils/fundingCycle'
 import { amountSubFee } from 'utils/math'
 import { orEmpty } from 'utils/orEmpty'
+
+import { getBallotStrategyByAddress } from 'constants/ballot-strategies'
 
 export default function ConfirmDeployProject() {
   const editingFC = useEditingFundingCycleSelector()

--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -52,27 +52,20 @@ export default function Create() {
   const { colors, radii } = useContext(ThemeContext).theme
   const [currentStep, setCurrentStep] = useState<number>()
   const [viewedSteps, setViewedSteps] = useState<number[]>([])
-  const [payModsModalVisible, setPayModsFormModalVisible] = useState<boolean>(
-    false,
-  )
-  const [budgetFormModalVisible, setBudgetFormModalVisible] = useState<boolean>(
-    false,
-  )
-  const [projectFormModalVisible, setProjectFormModalVisible] = useState<
-    boolean
-  >(false)
-  const [incentivesFormModalVisible, setIncentivesFormModalVisible] = useState<
-    boolean
-  >(false)
-  const [ticketingFormModalVisible, setTicketingFormModalVisible] = useState<
-    boolean
-  >(false)
-  const [rulesFormModalVisible, setRulesFormModalVisible] = useState<boolean>(
-    false,
-  )
-  const [deployProjectModalVisible, setDeployProjectModalVisible] = useState<
-    boolean
-  >(false)
+  const [payModsModalVisible, setPayModsFormModalVisible] =
+    useState<boolean>(false)
+  const [budgetFormModalVisible, setBudgetFormModalVisible] =
+    useState<boolean>(false)
+  const [projectFormModalVisible, setProjectFormModalVisible] =
+    useState<boolean>(false)
+  const [incentivesFormModalVisible, setIncentivesFormModalVisible] =
+    useState<boolean>(false)
+  const [ticketingFormModalVisible, setTicketingFormModalVisible] =
+    useState<boolean>(false)
+  const [rulesFormModalVisible, setRulesFormModalVisible] =
+    useState<boolean>(false)
+  const [deployProjectModalVisible, setDeployProjectModalVisible] =
+    useState<boolean>(false)
   const [loadingCreate, setLoadingCreate] = useState<boolean>()
   const [projectForm] = useForm<ProjectFormFields>()
   const [ticketingForm] = useForm<TicketingFormFields>()
@@ -652,7 +645,11 @@ export default function Create() {
 
         <Modal
           visible={deployProjectModalVisible}
-          okText={signerNetwork ? 'Deploy on ' + signerNetwork : 'Deploy'}
+          okText={
+            signerNetwork
+              ? 'Deploy project on ' + signerNetwork
+              : 'Deploy project'
+          }
           onOk={deployProject}
           confirmLoading={loadingCreate}
           width={600}

--- a/src/components/modals/BalancesModal.tsx
+++ b/src/components/modals/BalancesModal.tsx
@@ -123,7 +123,7 @@ export default function BalancesModal({
           width={600}
           confirmLoading={loading}
           onOk={updateTokenRefs}
-          okText="Save"
+          okText="Save tracked assets"
         >
           <p style={{ marginBottom: 40 }}>
             Display ERC20 tokens and other Juicebox project tokens that are in

--- a/src/components/modals/ConfirmUnstakeTokensModal.tsx
+++ b/src/components/modals/ConfirmUnstakeTokensModal.tsx
@@ -75,10 +75,10 @@ export default function ConfirmUnstakeTokensModal({
 
   return (
     <Modal
-      title={'Claim ' + (tokenSymbol ?? 'tokens')}
+      title={`Claim ${tokenSymbol ?? 'tokens'} as ERC20 tokens`}
       visible={visible}
       onOk={unstake}
-      okText="Claim"
+      okText={`Claim ${unstakeAmount} ERC20 tokens`}
       confirmLoading={loading}
       okButtonProps={{ disabled: parseWad(unstakeAmount).eq(0) }}
       onCancel={onCancel}
@@ -96,8 +96,8 @@ export default function ConfirmUnstakeTokensModal({
 
         <div>
           <p>
-            Claiming {tokenSymbol} tokens will convert your balance to ERC20
-            tokens and mint them to your wallet.
+            Claiming {tokenSymbol} tokens will convert your {tokenSymbol}{' '}
+            balance to ERC20 tokens and mint them to your wallet.
           </p>
           <p style={{ fontWeight: 600 }}>
             If you're unsure if you need to claim, you probably don't.

--- a/src/components/modals/DistributeTokensModal.tsx
+++ b/src/components/modals/DistributeTokensModal.tsx
@@ -58,10 +58,10 @@ export default function DistributeTokensModal({
 
   return (
     <Modal
-      title={'Distribute reserved ' + tokenSymbol ?? 'tokens'}
+      title={`Distribute reserved ${tokenSymbol ?? 'tokens'}`}
       visible={visible}
       onOk={distribute}
-      okText="Distribute"
+      okText={`Distribute ${tokenSymbol ?? 'tokens'}`}
       confirmLoading={loading}
       onCancel={onCancel}
       okButtonProps={{ disabled: !reservedTokens?.gt(0) }}

--- a/src/components/shared/PayoutModsList.tsx
+++ b/src/components/shared/PayoutModsList.tsx
@@ -170,6 +170,7 @@ export default function PayoutModsList({
         <Modal
           visible={modalVisible}
           title="Edit payouts"
+          okText="Save payouts"
           onOk={() => setMods()}
           onCancel={() => {
             setEditingMods(mods)

--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -133,6 +133,7 @@ export default function TicketModsList({
         <Modal
           visible={modalVisible}
           title="Edit reserved token receivers"
+          okText="Save token receivers"
           onOk={() => setMods()}
           onCancel={() => {
             setEditingMods(mods)

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -376,9 +376,10 @@ export default function ProjectPayoutMods({
       </Space>
 
       <Modal
-        title="Add a payout"
+        title={editingModProjectId ? 'Edit existing payout' : 'Add a payout'}
         visible={editingModIndex !== undefined}
         onOk={setReceiver}
+        okText={editingModProjectId ? 'Save payout' : 'Add payout'}
         onCancel={() => {
           form.resetFields()
           setEditingModIndex(undefined)

--- a/src/components/shared/formItems/ProjectTicketMods.tsx
+++ b/src/components/shared/formItems/ProjectTicketMods.tsx
@@ -270,6 +270,7 @@ export default function ProjectTicketMods({
         title="Add token receiver"
         visible={editingModIndex !== undefined}
         onOk={setReceiver}
+        okText="Add token receiver"
         onCancel={() => {
           form.resetFields()
           setEditingModIndex(undefined)


### PR DESCRIPTION
This PR changes the "okText" prop of most modals. This is an attempt to be as clear and explicit as possible about the action the user is taking.

I also ran `yarn lint:fix` to fix some left-over linting issues.