### PR TITLE
Add infinite scroll loading to projects grid

### DIFF
--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -23,7 +23,7 @@ import { archivedProjectIds } from 'constants/archived-projects'
 
 import Loading from '../shared/Loading'
 import Project from './Project'
-import { useProjects } from '../../hooks/Projects'
+import { useProjectsQuery } from '../../hooks/Projects'
 
 export default function Dashboard() {
   const [projectExists, setProjectExists] = useState<boolean>()
@@ -42,7 +42,7 @@ export default function Dashboard() {
     ),
   })
 
-  const { data: projects } = useProjects({
+  const { data: projects } = useProjectsQuery({
     projectId,
     keys: ['createdAt', 'totalPaid'],
   })

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -4,7 +4,7 @@ import Loading from 'components/shared/Loading'
 
 import { ThemeContext } from 'contexts/themeContext'
 
-import { useProjects } from 'hooks/Projects'
+import { useProjectsQuery } from 'hooks/Projects'
 
 import { CSSProperties, useContext } from 'react'
 
@@ -36,7 +36,7 @@ export default function Landing() {
     </h1>
   )
 
-  const { data: previewProjects } = useProjects({
+  const { data: previewProjects } = useProjectsQuery({
     pageSize: 4,
     filter: 'active',
   })

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -4,7 +4,7 @@ import Loading from 'components/shared/Loading'
 import ProjectsGrid from 'components/shared/ProjectsGrid'
 
 import { ThemeContext } from 'contexts/themeContext'
-import { useProjects } from 'hooks/Projects'
+import { useProjectsQuery } from 'hooks/Projects'
 import { ProjectState } from 'models/project-visibility'
 import { useContext, useState } from 'react'
 
@@ -20,7 +20,7 @@ export default function Projects() {
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const { data: projects } = useProjects({
+  const { data: projects } = useProjectsQuery({
     orderBy,
     orderDirection: 'desc',
     filter: selectedTab,

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -37,17 +37,17 @@ export default function Projects() {
     filter: selectedTab,
   })
 
-  // When we scroll within 128px of our loadMoreContainerRef, fetch the next page.
+  // When we scroll within 200px of our loadMoreContainerRef, fetch the next page.
   useEffect(() => {
     if (loadMoreContainerRef.current) {
       const observer = new IntersectionObserver(
-        () => {
-          if (hasNextPage) {
+        entries => {
+          if (entries.find(e => e.isIntersecting) && hasNextPage) {
             fetchNextPage()
           }
         },
         {
-          rootMargin: '128px',
+          rootMargin: '200px',
         },
       )
       observer.observe(loadMoreContainerRef.current)

--- a/src/hooks/Projects.ts
+++ b/src/hooks/Projects.ts
@@ -20,7 +20,7 @@ interface ProjectsOptions {
 
 let defaultPageSize = 20
 
-export function useProjects({
+export function useProjectsQuery({
   pageNumber,
   projectId,
   keys,


### PR DESCRIPTION
To solve for the ever-growing list of projects without compromising loading times due to querying all projects at once, implement a scrolling-based infinite loader.

I set the page size to 20 (which previously was erroneous) and load 20 more when scrolling within 200px of the bottom of the grid. I also added a backup "Load More" button in case either the browser doesn't support `IntersectionObserver` or something else went wrong.