### PR TITLE
Mark many strings for translation

### DIFF
--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -3,6 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { Button, Col, Drawer, DrawerProps, Row, Space } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import Modal from 'antd/lib/modal/Modal'
+import { Trans } from '@lingui/macro'
 import Project from 'components/Dashboard/Project'
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext, ProjectContextType } from 'contexts/projectContext'
@@ -359,8 +360,10 @@ export default function Create() {
         })}
 
         <p style={{ fontWeight: 500 }}>
-          The JBX protocol is unaudited, and projects built on it may be
-          vulnerable to bugs or exploits. Be smart!
+          <Trans>
+            The JBX protocol is unaudited, and projects built on it may be
+            vulnerable to bugs or exploits. Be smart!
+          </Trans>
         </p>
 
         <Button

--- a/src/components/Landing/Faq.tsx
+++ b/src/components/Landing/Faq.tsx
@@ -1,5 +1,6 @@
 import { Collapse } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+import { t } from '@lingui/macro'
 
 const QAs: {
   q: string
@@ -10,121 +11,121 @@ const QAs: {
   }
 }[] = [
   {
-    q: 'Who funds Juicebox projects?',
+    q: t`Who funds Juicebox projects?`,
     a: [
-      `Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).`,
-      `For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive Tokens in return.`,
+      t`Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).`,
+      t`For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive Tokens in return.`,
     ],
   },
   {
-    q: `What does Juicebox cost?`,
+    q: t`What does Juicebox cost?`,
     a: [
-      `Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs at https://juicebox.money/#/p/juicebox.`,
-      `5% of all money made by projects is sent to help pay for the maintenance and development of Juicebox itself. In exchange, projects get Juicebox tokens ($JBX), which will be worth more as the ecosystem grows over time.`,
+      t`Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs at https://juicebox.money/#/p/juicebox.`,
+      t`5% of all money made by projects is sent to help pay for the maintenance and development of Juicebox itself. In exchange, projects get Juicebox tokens ($JBX), which will be worth more as the ecosystem grows over time.`,
     ],
   },
   {
-    q: `What is overflow?`,
+    q: t`What is overflow?`,
     a: [
-      `If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for burning their tokens.`,
+      t`If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for burning their tokens.`,
     ],
   },
   {
-    q: 'What are community tokens?',
+    q: t`What are community tokens?`,
     a: [
       `Each project has its own tokens which can either be staked or withdrawn as ERC-20s. Everyone who funds a project gets a newly minted supply of tokens in return. `,
     ],
   },
   {
-    q: `Why should I want to own a project's tokens?`,
+    q: t`Why should I want to own a project's tokens?`,
     a: [
       `Tokens can be redeemed for a portion of a project's overflow, letting you benefit from its success. After all, you helped it get there.`,
     ],
   },
   {
-    q: `What's a discount rate?`,
+    q: t`What's a discount rate?`,
     a: [
-      `Projects can be created with an optional discount rate to incentivize funding it earlier than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later.`,
+      t`Projects can be created with an optional discount rate to incentivize funding it earlier than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later.`,
     ],
   },
   {
-    q: `What's a bonding curve?`,
+    q: t`What's a bonding curve?`,
     a: [
-      `A bonding curve rewards people who wait longer to redeem your tokens for overflow.`,
-      `For example: with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.`,
-      `The rest is left to share between token hodlers.`,
+      t`A bonding curve rewards people who wait longer to redeem your tokens for overflow.`,
+      t`For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.`,
+      t`The rest is left to share between token hodlers.`,
     ],
   },
   {
-    q: 'Does a project benefit from its own overflow?',
+    q: t`Does a project benefit from its own overflow?`,
     a: [
-      `A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.`,
-      `Holding these tokens entitles a project to a portion of its own overflow.`,
+      t`A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.`,
+      t`Holding these tokens entitles a project to a portion of its own overflow.`,
     ],
   },
   {
-    q: "Can I change my project's contract after it's been created?",
+    q: t`Can I change my project's contract after it's been created?`,
     a: [
-      `A project owner can propose changes to any part of the contract at any time, with changes taking effect after the current budgeting time frame has ended.`,
-      `For now, a minimum of 14 days must pass from the time of a proposed reconfiguration for it to take effect. This gives token holders time to react to the decision.`,
-      `Anyone can deploy and use another governance smart contract to override this scheme.`,
+      t`A project owner can propose changes to any part of the contract at any time, with changes taking effect after the current budgeting time frame has ended.`,
+      t`For now, a minimum of 14 days must pass from the time of a proposed reconfiguration for it to take effect. This gives token holders time to react to the decision.`,
+      t`Anyone can deploy and use another governance smart contract to override this scheme.`,
     ],
   },
   {
-    q: 'Can I delete a project?',
+    q: t`Can I delete a project?`,
     a: [
-      `It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it—just let us know in Discord. Keep in mind people will still be able to use your project by interacting directly with the contract.`,
+      t`It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it—just let us know in Discord. Keep in mind people will still be able to use your project by interacting directly with the contract.`,
     ],
   },
   {
-    q: 'Why Ethereum?',
+    q: t`Why Ethereum?`,
     a: [
-      `A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.`,
-      `Ethereum provides a public environment where internet apps like Juicebox can run permissionlessly, trustlessly, and unstoppably.`,
-      `This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.`,
-      `People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.`,
-      `Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.`,
+      t`A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.`,
+      t`Ethereum provides a public environment where internet apps like Juicebox can run permissionlessly, trustlessly, and unstoppably.`,
+      t`This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.`,
+      t`People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.`,
+      t`Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.`,
     ],
   },
   {
-    q: "What's going on under the hood?",
+    q: t`What's going on under the hood?`,
     a: [
-      `This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol.)`,
-      `Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.`,
-      `The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The distribution schedule is proportional to payments recieved, weighted by the project's discount rate over time.`,
+      t`This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol.)`,
+      t`Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.`,
+      t`The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The distribution schedule is proportional to payments recieved, weighted by the project's discount rate over time.`,
     ],
   },
   {
-    q: 'How decentralized is Juicebox?',
+    q: t`How decentralized is Juicebox?`,
     a: [
-      `Juicebox is a governance-minimal protocol, meaning there are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.`,
-      `At the start, power over the governance smart contract is held by Juicebox's founding contributors. The intent is to soon transfer the power to a community of token holders.`,
+      t`Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.`,
+      t`At the start, power over the governance smart contract is held by Juicebox's founding contributors. The intent is to soon transfer the power to a community of token holders.`,
     ],
   },
   {
-    q: 'What are the risks?',
+    q: t`What are the risks?`,
     a: [
-      `Juicebox is experimental software. Although the founding contributors have done their part to shape the smart contracts for public use and have run the code through tons of tests, there still may be bugs.`,
-      `Due to their public nature, any exploits to the contracts may have irreversable consequences, including loss of funds. Please use Juicebox with caution.`,
+      t`Juicebox is experimental software. Although the founding contributors have done their part to shape the smart contracts for public use and have run the code through tons of tests, there still may be bugs.`,
+      t`Due to their public nature, any exploits to the contracts may have irreversable consequences, including loss of funds. Please use Juicebox with caution.`,
     ],
   },
   {
-    q: 'How have the contracts been tested?',
+    q: t`How have the contracts been tested?`,
     a: [
-      `There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.`,
-      `There was also a script written for iteratively running the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 millions test cases through this stress-testing script.`,
-      `The code could always use more eyes and more critique to further the community's confidence. Join our Discord and peek the code on Github to work with us.`,
+      t`There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.`,
+      t`There was also a script written for iteratively running the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 millions test cases through this stress-testing script.`,
+      t`The code could always use more eyes and more critique to further the community's confidence. Join our Discord and peek the code on Github to work with us.`,
     ],
   },
   {
-    q: 'Will it work on L2s?',
+    q: t`Will it work on L2s?`,
     a: [
-      `That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.`,
-      `The founding contributors will then be working on L2 payment terminals for Juicebox projects.`,
+      t`That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.`,
+      t`The founding contributors will then be working on L2 payment terminals for Juicebox projects.`,
     ],
   },
   {
-    q: `Do I have to make my project open source to use Juicebox as its business model?`,
+    q: t`Do I have to make my project open source to use Juicebox as its business model?`,
     img: {
       src: '/assets/cooler_if_you_did.png',
       alt: "It'd be a lot cooler if you did",

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -29,7 +29,7 @@ export default function Footer() {
     >
       <div style={{ display: 'inline-flex', justifyContent: 'center' }}>
         {link('Discord', 'https://discord.gg/6jXrJSyDFf')}
-        {link('Github', 'https://github.com/jbx-protocol/juicehouse')}
+        {link('GitHub', 'https://github.com/jbx-protocol/juice-interface')}
         {link('Twitter', 'https://twitter.com/juiceboxETH')}
       </div>
     </div>

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -7,8 +7,7 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useProjectsQuery } from 'hooks/Projects'
 
 import { CSSProperties, useContext } from 'react'
-import { Trans } from '@lingui/macro'
-import { t } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 
 import { ThemeOption } from 'constants/theme/theme-option'
 
@@ -211,7 +210,7 @@ export default function Landing() {
         >
           <Row gutter={60}>
             <Col xs={24} md={12} style={{ marginBottom: 100 }}>
-              {smallHeader('Projects using Juicebox')}
+              {smallHeader(t`Projects using Juicebox`)}
               <div style={{ marginTop: 20 }}>
                 {previewProjects ? (
                   <ProjectsGrid projects={previewProjects} list />
@@ -226,7 +225,7 @@ export default function Landing() {
               </div>
             </Col>
             <Col xs={24} md={12} style={{ marginBottom: 100 }}>
-              {smallHeader('Latest payments')}
+              {smallHeader(t`Latest payments`)}
               <div style={{ maxHeight: 600, overflow: 'auto' }}>
                 <Payments />
               </div>
@@ -262,37 +261,39 @@ export default function Landing() {
             </Col>
             <Col xs={24} sm={13}>
               <div style={{ display: 'grid', rowGap: 20, marginBottom: 40 }}>
-                {fourthCol('Programmable spending', [
-                  `Commit portions of your revenue to go to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they.`,
+                {fourthCol(t`Programmable spending`, [
+                  t`Commit portions of your revenue to go to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they.`,
                 ])}
-                {fourthCol('ERC20 community tokens', [
-                  `When someone pays your project either as a patron or a user of your app, they earn a proportional amount of your project's token. When you win, your token holders win, so they'll want you to win even more.`,
+                {fourthCol(t`ERC20 community tokens`, [
+                  t`When someone pays your project either as a patron or a user of your app, they earn a proportional amount of your project's token. When you win, your token holders win, so they'll want you to win even more.`,
                 ])}
-                {fourthCol('Redistributable surplus', [
-                  `Set a funding target to cover predictable expenses. Any extra revenue can be claimed by anyone holding your project's tokens alongside you.`,
+                {fourthCol(t`Redistributable surplus`, [
+                  t`Set a funding target to cover predictable expenses. Any extra revenue can be claimed by anyone holding your project's tokens alongside you.`,
                 ])}
-                {fourthCol('Transparency & accountability', [
-                  `Changes to your project's funding require a community approval period to take effect. Your supporters don't have to trust you—even though they already do.`,
+                {fourthCol(t`Transparency & accountability`, [
+                  t`Changes to your project's funding require a community approval period to take effect. Your supporters don't have to trust you—even though they already do.`,
                 ])}
                 <p>
-                  Note: Juicebox is new, unaudited, and not guaranteed to work
-                  perfectly. Before spending money, do your own research:{' '}
-                  <a
-                    href="https://discord.gg/6jXrJSyDFf"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    ask questions
-                  </a>
-                  ,{' '}
-                  <a
-                    href="https://github.com/jbx-protocol/juicehouse"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    check out the code
-                  </a>
-                  , and understand the risks!
+                  <Trans>
+                    Note: Juicebox is new, unaudited, and not guaranteed to work
+                    perfectly. Before spending money, do your own research:{' '}
+                    <a
+                      href="https://discord.gg/6jXrJSyDFf"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      ask questions
+                    </a>
+                    ,{' '}
+                    <a
+                      href="https://github.com/jbx-protocol/juice-interface"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      check out the code
+                    </a>
+                    , and understand the risks!
+                  </Trans>
                 </p>
               </div>
             </Col>
@@ -327,18 +328,24 @@ export default function Landing() {
           <Row align="middle" gutter={40}>
             <Col xs={24} md={14}>
               <div style={{ display: 'grid', rowGap: 20 }}>
-                {bigHeader('Should you Juicebox?')}
+                {bigHeader(t`Should you Juicebox?`)}
                 <div style={{ color: colors.text.over.brand.secondary }}>
-                  <p className="ol">Almost definitely.</p>
                   <p className="ol">
-                    With Juicebox, projects are built and maintained by
-                    motivated punks getting paid transparently, and funded by a
-                    community of users and patrons who are rewarded as the
-                    projects they support succeed.
+                    <Trans>Almost definitely.</Trans>
                   </p>
                   <p className="ol">
-                    The future will be led by creators, and owned by
-                    communities.
+                    <Trans>
+                      With Juicebox, projects are built and maintained by
+                      motivated punks getting paid transparently, and funded by
+                      a community of users and patrons who are rewarded as the
+                      projects they support succeed.
+                    </Trans>
+                  </p>
+                  <p className="ol">
+                    <Trans>
+                      The future will be led by creators, and owned by
+                      communities.
+                    </Trans>
                   </p>
                 </div>
               </div>
@@ -373,7 +380,7 @@ export default function Landing() {
               paddingRight: 20,
             }}
           >
-            {bigHeader('FAQs')}
+            {bigHeader(t`FAQs`)}
             <Faq />
           </div>
         </div>
@@ -415,8 +422,10 @@ export default function Landing() {
       >
         <div style={{ fontSize: 20, marginBottom: 20 }}>🧃⚡️</div>
         <h3 style={{ color: 'white', margin: 0 }}>
-          Big ups to the Ethereum community for crafting the infrastructure and
-          economy to make Juicebox possible.
+          <Trans>
+            Big ups to the Ethereum community for crafting the infrastructure
+            and economy to make Juicebox possible.
+          </Trans>
         </h3>
       </div>
 

--- a/src/components/Navbar/Account.tsx
+++ b/src/components/Navbar/Account.tsx
@@ -1,17 +1,14 @@
 import { Button, Col, Row } from 'antd'
 import { NetworkContext } from 'contexts/networkContext'
 import { useContext } from 'react'
+import { Trans } from '@lingui/macro'
 
 import Balance from './Balance'
 import Wallet from './Wallet'
 
 export default function Account() {
-  const {
-    signingProvider,
-    userAddress,
-    onSelectWallet,
-    onLogOut
-  } = useContext(NetworkContext)
+  const { signingProvider, userAddress, onSelectWallet, onLogOut } =
+    useContext(NetworkContext)
 
   return (
     <div>
@@ -28,9 +25,13 @@ export default function Account() {
         )}
         <Col>
           {!signingProvider ? (
-            <Button onClick={onSelectWallet}>Connect</Button>
+            <Button onClick={onSelectWallet}>
+              <Trans>Connect</Trans>
+            </Button>
           ) : (
-            <Button onClick={onLogOut}>Logout</Button>
+            <Button onClick={onLogOut}>
+              <Trans>Sign out</Trans>
+            </Button>
           )}
         </Col>
       </Row>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -2,6 +2,7 @@ import { Collapse, Space } from 'antd'
 import { MenuOutlined } from '@ant-design/icons'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
 import { Header } from 'antd/lib/layout/layout'
+import { t } from '@lingui/macro'
 
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext, useState } from 'react'
@@ -60,8 +61,8 @@ export default function Navbar() {
   const menu = () => {
     return (
       <>
-        {menuItem('Projects', '/#/projects')}
-        {menuItem('FAQ', undefined, () => {
+        {menuItem(t`Projects`, '/#/projects')}
+        {menuItem(t`FAQ`, undefined, () => {
           window.location.hash = '/'
           setTimeout(() => {
             document
@@ -69,10 +70,10 @@ export default function Navbar() {
               ?.scrollIntoView({ behavior: 'smooth' })
           }, 0)
         })}
-        {menuItem('Docs', 'https://docs.juicebox.money')}
-        {menuItem('Blog', 'https://blog.juicebox.money')}
+        {menuItem(t`Docs`, 'https://docs.juicebox.money')}
+        {menuItem(t`Blog`, 'https://blog.juicebox.money')}
         {menuItem('Discord', 'https://discord.gg/6jXrJSyDFf')}
-        {menuItem('Workspace', 'https://juicebox.notion.site')}
+        {menuItem(t`Workspace`, 'https://juicebox.notion.site')}
       </>
     )
   }

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -6,7 +6,8 @@ import ProjectsGrid from 'components/shared/ProjectsGrid'
 import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteProjectsQuery } from 'hooks/Projects'
 import { ProjectState } from 'models/project-visibility'
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
+import { Trans, t } from '@lingui/macro'
 
 import { layouts } from 'constants/styles/layouts'
 
@@ -87,13 +88,18 @@ export default function Projects() {
 
   return (
     <div style={{ ...layouts.maxWidth }}>
-      <h1>Projects on Juicebox</h1>
+      <h1>
+        <Trans>Projects on Juicebox</Trans>
+      </h1>
       <p style={{ marginBottom: 40, maxWidth: 800 }}>
-        <InfoCircleOutlined /> The Juicebox protocol is open to anyone, and
-        project configurations can vary widely. There are risks associated with
-        interacting with all projects on the protocol. Projects built on the
-        protocol are not endorsed or vetted by JuiceboxDAO, so you should do
-        your own research and understand the risks before committing your funds.
+        <Trans>
+          <InfoCircleOutlined />
+          The Juicebox protocol is open to anyone, and project configurations
+          can vary widely. There are risks associated with interacting with all
+          projects on the protocol. Projects built on the protocol are not
+          endorsed or vetted by JuiceboxDAO, so you should do your own research
+          and understand the risks before committing your funds.
+        </Trans>
       </p>
       <div
         style={{
@@ -130,10 +136,14 @@ export default function Projects() {
 
       {selectedTab === 'archived' && (
         <p style={{ marginBottom: 40, maxWidth: 800 }}>
-          <InfoCircleOutlined /> Archived projects have not been modified or
-          deleted on the blockchain, and can still be interacted with directly
-          through the Juicebox contracts.{' '}
-          <Tooltip title="If you have a project you'd like to archive, let the Juicebox team know in Discord.">
+          <Trans>
+            <InfoCircleOutlined /> Archived projects have not been modified or
+            deleted on the blockchain, and can still be interacted with directly
+            through the Juicebox contracts.{' '}
+          </Trans>
+          <Tooltip
+            title={t`If you have a project you'd like to archive, let the Juicebox team know in Discord.`}
+          >
             <span
               style={{
                 color: colors.text.action.primary,
@@ -141,7 +151,7 @@ export default function Projects() {
                 cursor: 'default',
               }}
             >
-              How do I archive a project?
+              <Trans>How do I archive a project?</Trans>
             </span>
           </Tooltip>
         </p>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,6 +13,54 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Landing/Faq.tsx
+msgid "5% of all money made by projects is sent to help pay for the maintenance and development of Juicebox itself. In exchange, projects get Juicebox tokens ($JBX), which will be worth more as the ecosystem grows over time."
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "<0/>The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO, so you should do your own research and understand the risks before committing your funds."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A bonding curve rewards people who wait longer to redeem your tokens for overflow."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A project owner can propose changes to any part of the contract at any time, with changes taking effect after the current budgeting time frame has ended."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Almost definitely."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Anyone can deploy and use another governance smart contract to override this scheme."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "At the start, power over the governance smart contract is held by Juicebox's founding contributors. The intent is to soon transfer the power to a community of token holders."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Blog"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Build a community around a project, fund it, and program its spending. Light enough for a group of friends, powerful enough for a global network of anons."
 msgstr "Build a community around a project, fund it, and program its spending. Light enough for a group of friends, powerful enough for a global network of anons."
@@ -21,37 +69,305 @@ msgstr "Build a community around a project, fund it, and program its spending. L
 msgid "Built for:"
 msgstr "Built for:"
 
+#: src/components/Landing/Faq.tsx
+msgid "Can I change my project's contract after it's been created?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Can I delete a project?"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Changes to your project's funding require a community approval period to take effect. Your supporters don't have to trust you—even though they already do."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Commit portions of your revenue to go to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Community funding for people and projects"
 msgstr "Community funding for people and projects"
+
+#: src/components/Navbar/Account.tsx
+msgid "Connect"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Design your project"
 msgstr "Design your project"
 
+#: src/components/Landing/Faq.tsx
+msgid "Do I have to make my project open source to use Juicebox as its business model?"
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Docs"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Does a project benefit from its own overflow?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Due to their public nature, any exploits to the contracts may have irreversable consequences, including loss of funds. Please use Juicebox with caution."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "ERC20 community tokens"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Ethereum protocols and DAOs"
 msgstr "Ethereum protocols and DAOs"
+
+#: src/components/Landing/Faq.tsx
+msgid "Ethereum provides a public environment where internet apps like Juicebox can run permissionlessly, trustlessly, and unstoppably."
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "FAQ"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "FAQs"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "For now, a minimum of 14 days must pass from the time of a proposed reconfiguration for it to take effect. This gives token holders time to react to the decision."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive Tokens in return."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Holding these tokens entitles a project to a portion of its own overflow."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "How decentralized is Juicebox?"
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "How do I archive a project?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "How have the contracts been tested?"
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "If you have a project you'd like to archive, let the Juicebox team know in Discord."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for burning their tokens."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Indie artists, devs, creators"
 msgstr "Indie artists, devs, creators"
 
+#: src/components/Landing/Faq.tsx
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it—just let us know in Discord. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs at https://juicebox.money/#/p/juicebox."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox is experimental software. Although the founding contributors have done their part to shape the smart contracts for public use and have run the code through tons of tests, there still may be bugs."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Latest payments"
+msgstr "test"
+
+#: src/components/Landing/index.tsx
+msgid "Note: Juicebox is new, unaudited, and not guaranteed to work perfectly. Before spending money, do your own research: <0>ask questions</0>, <1>check out the code</1>, and understand the risks!"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Open source businesses"
 msgstr "Open source businesses"
+
+#: src/components/Landing/Faq.tsx
+msgid "People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Powered by public smart contracts on <0>Ethereum</0>."
 msgstr "Powered by public smart contracts on <0>Ethereum</0>."
 
 #: src/components/Landing/index.tsx
+msgid "Programmable spending"
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Projects"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Projects can be created with an optional discount rate to incentivize funding it earlier than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Projects using Juicebox"
+msgstr ""
+
+#: src/components/Landing/index.tsx
 msgid "Public goods and services"
 msgstr "Public goods and services"
+
+#: src/components/Landing/index.tsx
+msgid "Redistributable surplus"
+msgstr ""
 
 #: src/components/modals/ConfirmStakeTokensModal.tsx
 msgid "Remove {0} ERC20 tokens from your wallet and lock them in the Juicebox protocol."
 msgstr "Remove {0} ERC20 tokens from your wallet and lock them in the Juicebox protocol."
+
+#: src/components/Landing/index.tsx
+msgid "Set a funding target to cover predictable expenses. Any extra revenue can be claimed by anyone holding your project's tokens alongside you."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Should you Juicebox?"
+msgstr ""
+
+#: src/components/Navbar/Account.tsx
+msgid "Sign out"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet."
+msgstr ""
+
+#: src/components/Create/index.tsx
+msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our Discord and peek the code on Github to work with us."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The founding contributors will then be working on L2 payment terminals for Juicebox projects."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "The future will be led by creators, and owned by communities."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The distribution schedule is proportional to payments recieved, weighted by the project's discount rate over time."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The rest is left to share between token hodlers."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "There was also a script written for iteratively running the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 millions test cases through this stress-testing script."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol.)"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Transparency & accountability"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app)."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What are community tokens?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What are the risks?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What does Juicebox cost?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What is overflow?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What's a bonding curve?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What's a discount rate?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What's going on under the hood?"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "When someone pays your project either as a patron or a user of your app, they earn a proportional amount of your project's token. When you win, your token holders win, so they'll want you to win even more."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Who funds Juicebox projects?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Why Ethereum?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Why should I want to own a project's tokens?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Will it work on L2s?"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Workspace"
+msgstr ""
 
 #: src/components/modals/DistributeTokensModal.tsx
 msgid "{0, plural, one {# token} other {# tokens}}"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -13,6 +13,54 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Landing/Faq.tsx
+msgid "5% of all money made by projects is sent to help pay for the maintenance and development of Juicebox itself. In exchange, projects get Juicebox tokens ($JBX), which will be worth more as the ecosystem grows over time."
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "<0/>The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO, so you should do your own research and understand the risks before committing your funds."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A bonding curve rewards people who wait longer to redeem your tokens for overflow."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "A project owner can propose changes to any part of the contract at any time, with changes taking effect after the current budgeting time frame has ended."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Almost definitely."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Anyone can deploy and use another governance smart contract to override this scheme."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "At the start, power over the governance smart contract is held by Juicebox's founding contributors. The intent is to soon transfer the power to a community of token holders."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Blog"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Build a community around a project, fund it, and program its spending. Light enough for a group of friends, powerful enough for a global network of anons."
 msgstr "围绕一个项目建立一个社区，为其提供资金，并对其支出进行规划。既能简单易用让一群知己好友轻松创建属于自己的社区项目，也可以强大到能够支持一个全球匿名网络的运作"
@@ -21,37 +69,305 @@ msgstr "围绕一个项目建立一个社区，为其提供资金，并对其支
 msgid "Built for:"
 msgstr "服务的对象:"
 
+#: src/components/Landing/Faq.tsx
+msgid "Can I change my project's contract after it's been created?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Can I delete a project?"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Changes to your project's funding require a community approval period to take effect. Your supporters don't have to trust you—even though they already do."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Commit portions of your revenue to go to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Community funding for people and projects"
 msgstr "为个人和项目提供社区资助"
+
+#: src/components/Navbar/Account.tsx
+msgid "Connect"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Design your project"
 msgstr "设计你的项目"
 
+#: src/components/Landing/Faq.tsx
+msgid "Do I have to make my project open source to use Juicebox as its business model?"
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Docs"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Does a project benefit from its own overflow?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Due to their public nature, any exploits to the contracts may have irreversable consequences, including loss of funds. Please use Juicebox with caution."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "ERC20 community tokens"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Ethereum protocols and DAOs"
 msgstr "以太坊协议和 DAO"
+
+#: src/components/Landing/Faq.tsx
+msgid "Ethereum provides a public environment where internet apps like Juicebox can run permissionlessly, trustlessly, and unstoppably."
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "FAQ"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "FAQs"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "For now, a minimum of 14 days must pass from the time of a proposed reconfiguration for it to take effect. This gives token holders time to react to the decision."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive Tokens in return."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Holding these tokens entitles a project to a portion of its own overflow."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "How decentralized is Juicebox?"
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "How do I archive a project?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "How have the contracts been tested?"
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "If you have a project you'd like to archive, let the Juicebox team know in Discord."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for burning their tokens."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Indie artists, devs, creators"
 msgstr "独立艺术家，开发者，创作者"
 
+#: src/components/Landing/Faq.tsx
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it—just let us know in Discord. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs at https://juicebox.money/#/p/juicebox."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox is experimental software. Although the founding contributors have done their part to shape the smart contracts for public use and have run the code through tons of tests, there still may be bugs."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Latest payments"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Note: Juicebox is new, unaudited, and not guaranteed to work perfectly. Before spending money, do your own research: <0>ask questions</0>, <1>check out the code</1>, and understand the risks!"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Open source businesses"
 msgstr "开源业务"
+
+#: src/components/Landing/Faq.tsx
+msgid "People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Powered by public smart contracts on <0>Ethereum</0>."
 msgstr "由<0>以太坊</0>公共智能合约提供支持。"
 
 #: src/components/Landing/index.tsx
+msgid "Programmable spending"
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Projects"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Projects can be created with an optional discount rate to incentivize funding it earlier than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
+msgstr ""
+
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Projects using Juicebox"
+msgstr ""
+
+#: src/components/Landing/index.tsx
 msgid "Public goods and services"
 msgstr "公共产品和服务"
+
+#: src/components/Landing/index.tsx
+msgid "Redistributable surplus"
+msgstr ""
 
 #: src/components/modals/ConfirmStakeTokensModal.tsx
 msgid "Remove {0} ERC20 tokens from your wallet and lock them in the Juicebox protocol."
 msgstr "从你的钱包中扣除 {0} ERC20 代币，并把这些代币锁在Juicebox协议中"
+
+#: src/components/Landing/index.tsx
+msgid "Set a funding target to cover predictable expenses. Any extra revenue can be claimed by anyone holding your project's tokens alongside you."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Should you Juicebox?"
+msgstr ""
+
+#: src/components/Navbar/Account.tsx
+msgid "Sign out"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet."
+msgstr ""
+
+#: src/components/Create/index.tsx
+msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our Discord and peek the code on Github to work with us."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The founding contributors will then be working on L2 payment terminals for Juicebox projects."
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "The future will be led by creators, and owned by communities."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The distribution schedule is proportional to payments recieved, weighted by the project's discount rate over time."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "The rest is left to share between token hodlers."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "There was also a script written for iteratively running the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 millions test cases through this stress-testing script."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol.)"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "Transparency & accountability"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app)."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What are community tokens?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What are the risks?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What does Juicebox cost?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What is overflow?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What's a bonding curve?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What's a discount rate?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "What's going on under the hood?"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "When someone pays your project either as a patron or a user of your app, they earn a proportional amount of your project's token. When you win, your token holders win, so they'll want you to win even more."
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Who funds Juicebox projects?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Why Ethereum?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Why should I want to own a project's tokens?"
+msgstr ""
+
+#: src/components/Landing/Faq.tsx
+msgid "Will it work on L2s?"
+msgstr ""
+
+#: src/components/Landing/index.tsx
+msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
+msgstr ""
+
+#: src/components/Navbar/index.tsx
+msgid "Workspace"
+msgstr ""
 
 #: src/components/modals/DistributeTokensModal.tsx
 msgid "{0, plural, one {# token} other {# tokens}}"


### PR DESCRIPTION
Mark the main app strings for translation.

This excludes Project Creation strings, as the copy is currently being worked on and subject to change.