### PR TITLE
Fix Withdraw & Reserves not showing event data

### DIFF
--- a/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
@@ -23,7 +23,7 @@ export default function ReservesEventElem({
   const { data: distributeEvents } = useSubgraphQuery(
     {
       entity: 'distributeToTicketModEvent',
-      keys: ['timestamp', 'txHash', 'modBeneficiary', 'modPercent', 'modCut'],
+      keys: ['id', 'timestamp', 'txHash', 'modBeneficiary', 'modCut'],
       orderDirection: 'desc',
       orderBy: 'modCut',
       where: printReservesEvent?.id
@@ -75,7 +75,7 @@ export default function ReservesEventElem({
       <div style={{ marginTop: 5 }}>
         {distributeEvents?.map(e => (
           <div
-            key={e.modBeneficiary + (e.modPercent?.toString() ?? '')}
+            key={e.id}
             style={{
               display: 'flex',
               justifyContent: 'space-between',

--- a/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
@@ -23,11 +23,11 @@ export default function TapEventElem({
   const { data: payoutEvents } = useSubgraphQuery({
     entity: 'distributeToPayoutModEvent',
     keys: [
+      'id',
       'timestamp',
       'txHash',
       'modProjectId',
       'modBeneficiary',
-      'modPercent',
       'modCut',
     ],
     orderDirection: 'desc',
@@ -78,11 +78,7 @@ export default function TapEventElem({
       <div style={{ marginTop: 5 }}>
         {payoutEvents?.map(e => (
           <div
-            key={
-              e.modBeneficiary +
-              (e.modProjectId?.toString() ?? '') +
-              (e.modPercent?.toString() ?? '')
-            }
+            key={e.id}
             style={{
               display: 'flex',
               justifyContent: 'space-between',

--- a/src/models/subgraph-entities/distribute-to-payout-mod-event copy.ts
+++ b/src/models/subgraph-entities/distribute-to-payout-mod-event copy.ts
@@ -6,7 +6,6 @@ export interface DistributeToPayoutModEvent {
   fundingCycleId?: BigNumber
   projectId?: BigNumber
   modBeneficiary: string
-  modPercent?: BigNumber
   modPreferUnstaked: boolean
   modProjectId?: BigNumber
   modAllocator: string
@@ -31,7 +30,6 @@ export const parseDistributeToPayoutModEvent = (
     : undefined,
   project: json.project ? BigNumber.from(json.project) : undefined,
   projectId: json.projectId ? BigNumber.from(json.projectId) : undefined,
-  modPercent: json.modPercent ? BigNumber.from(json.modPercent) : undefined,
   modProjectId: json.modProjectId
     ? BigNumber.from(json.modProjectId)
     : undefined,

--- a/src/models/subgraph-entities/distribute-to-ticket-mod-event.ts
+++ b/src/models/subgraph-entities/distribute-to-ticket-mod-event.ts
@@ -6,7 +6,6 @@ export interface DistributeToTicketModEvent {
   fundingCycleId?: BigNumber
   projectId?: BigNumber
   modBeneficiary: string
-  modPercent?: BigNumber
   modPreferUnstaked: boolean
   modCut?: BigNumber
   caller: string
@@ -29,7 +28,6 @@ export const parseDistributeToTicketModEvent = (
     : undefined,
   project: json.project ? BigNumber.from(json.project) : undefined,
   projectId: json.projectId ? BigNumber.from(json.projectId) : undefined,
-  modPercent: json.modPercent ? BigNumber.from(json.modPercent) : undefined,
   modCut: json.modCut ? BigNumber.from(json.modCut) : undefined,
   modPreferUnstaked: !!json.modPreferUnstaked,
   timestamp: json.timestamp ? parseInt(json.timestamp) : undefined,

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -70,6 +70,11 @@ export interface SubgraphQueryReturnTypes {
 
 export type EntityKey = keyof SubgraphEntities
 
+export interface SubgraphError {
+  locations: { column: number; line: number }[]
+  message: string
+}
+
 export type OrderDirection = 'asc' | 'desc'
 
 export type WhereConfig = {


### PR DESCRIPTION
Remove 'modPercent' field from subgraph queries on Tap and Reserve events.

This was causing an error within the Graph, resulting in no data being presented.