### PR TITLE
Add approval guidelines + Git workflow notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @periphalist

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,23 +1,30 @@
 ---
 name: Bug report
 about: I can't use the app because something is broken or too confusing
-title: "[BUG] "
+title: '[BUG] '
 labels: bug
 assignees: ''
-
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Summary
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
+ <!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+
+<!-- 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
 
-**Setup (please complete the following information):**
- - Device/OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Hardware wallet [e.g. Ledger w/ Metamask]
+## What is the _current_ bug behavior?
+
+## What is the expected _correct_ behavior?
+
+## Relevant logs and/or screenshots
+
+## Environment
+
+- Device/OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Hardware wallet [e.g. Ledger w/ Metamask]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,14 +8,14 @@ assignees: ''
 
 ## Summary
 
- <!-- A clear and concise description of what the bug is. -->
+_A clear and concise description of what the bug is._
 
 ## Steps to reproduce
 
-<!-- 1. Go to '...'
+1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error -->
+4. See error
 
 ## What is the _current_ bug behavior?
 
@@ -25,6 +25,6 @@ assignees: ''
 
 ## Environment
 
-- Device/OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Hardware wallet [e.g. Ledger w/ Metamask]
+- **Device/OS**: [e.g. iOS]
+- **Browser:** [e.g. chrome, safari]
+- **Hardware wallet**: [e.g. Ledger w/ Metamask]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,15 +8,14 @@ assignees: ''
 
 ## Problem to solve
 
-<!-- Is your feature request related to a problem?
-Provide a clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
- -->
+_Is your feature request related to a problem? Provide a clear and concise
+description of what the problem is. Ex. I'm always frustrated when [...]_
 
 ## Proposal
 
-<!-- Describe the feature/solution you'd like.
-A clear and concise description of what you want to happen. -->
+_Describe the feature/solution you'd like. A clear and concise description of
+what you want to happen._
 
 ## More details
 
-<!-- Add any other notes or screenshots about the feature request here. -->
+_Add any other notes or screenshots about the feature request here._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,22 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[IDEA] "
+title: '[IDEA] '
 labels: idea
 assignees: ''
-
 ---
 
-**Is your feature request related to a problem?**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Problem to solve
 
-**Describe the feature/solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- Is your feature request related to a problem?
+Provide a clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+ -->
 
-**More details**
-Add any other notes or screenshots about the feature request here.
+## Proposal
+
+<!-- Describe the feature/solution you'd like.
+A clear and concise description of what you want to happen. -->
+
+## More details
+
+<!-- Add any other notes or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,17 +1,19 @@
 ---
 name: Improvement
 about: Not quite a bug, but something could be better
-title: "[BUGish]"
+title: '[BUGish]'
 labels: bugish
 assignees: ''
-
 ---
 
-**Describe the issue**
-A clear and concise description of what could be better.
+## Description
 
-**Proposed solution**
-A description of the change you'd like to see.
+<!-- A clear and concise description of what could be better. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Proposal
+
+<!-- A description of the change you'd like to see. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -8,12 +8,12 @@ assignees: ''
 
 ## Description
 
-<!-- A clear and concise description of what could be better. -->
+_A clear and concise description of what could be better._
 
 ## Proposal
 
-<!-- A description of the change you'd like to see. -->
+_A description of the change you'd like to see._
 
 ## Screenshots
 
-<!-- If applicable, add screenshots to help explain your problem. -->
+_If applicable, add screenshots to help explain your problem._

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,15 @@
+## What does this PR do and why?
+
+<!-- Provide a description of what this PR does.
+Link to any relevant GitHub issues, Notion tasks or
+Discord discussions. -->
+
+## Screenshots or screen recordings
+
+<!-- If applicable, provide screenshots or screen recordings to demonstrate the changes. -->
+
+## Acceptance checklist
+
+- [ ] I have evaluted the
+      [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this
+      PR.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,12 +1,12 @@
 ## What does this PR do and why?
 
-<!-- Provide a description of what this PR does.
-Link to any relevant GitHub issues, Notion tasks or
-Discord discussions. -->
+_Provide a description of what this PR does. Link to any relevant GitHub issues,
+Notion tasks or Discord discussions._
 
 ## Screenshots or screen recordings
 
-<!-- If applicable, provide screenshots or screen recordings to demonstrate the changes. -->
+_If applicable, provide screenshots or screen recordings to demonstrate the
+changes._
 
 ## Acceptance checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,39 +8,46 @@ right place!
 Check out the [README](README.md#usage) for instructions on running the app in
 development.
 
-## Contribution process
-
-### Find something to work on
+## Finding something to work on
 
 Start with issues labelled
 [`good first issue`](https://github.com/jbx-protocol/juice-juicehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
-### Create a pull request
+## Getting your pull request reviewed, approved, and merged
 
-To contribute, create a pull request (PR) that targets the `main` branch. A live
-Fleek preview will be automatically deployed for each PR. Before your PR is
-merged, it must meet the following criteria:
+Create a pull request (PR) that targets the `main` branch. A live Fleek preview
+will be automatically deployed for each PR.
 
-- Passes all CI checks.
-- Approved by at least one code owner.
-- Discussed by other design/dev contributors (for contributions that make
-  significant UI/UX changes).
+When your PR has met the [#approval guidelines](approval-guidelines) and is
+ready for review, `@mention` a [codeowner](.github/CODEOWNERS) and ask for a
+review.
+
+### Git workflow
+
+We opt for a **rebase policy** where the repository history is kept flat and
+clean. When a feature branch's development is complete, rebase/squash all the
+work down to the minimum number of meaningful commits.
+
+While the work is still in progress and a feature branch needs to be brought up
+to date with the upstream target branch, use rebase – as opposed to pull or
+merge – to avoid polluting the commit history with spurious merges.
+[Learn more](https://www.atlassian.com/git/articles/git-team-workflows-merge-or-rebase)
+about the differences between merge and rebase Git workflows.
+
+### Approval guidelines
+
+Before your PR is merged, it must meet the following criteria:
+
+1. The PR follows the [Git workflow](#git-workflow) and contains no merge
+   commits.
+1. All CI checks pass.
+1. The PR is approved by at least one [codeowner](.github/CODEOWNERS).
+1. Significant UI/UX changes are discussed by other design/dev contributors.
 
 ### Juicebox app release
 
 All changes to the `main` branch will be automatically deployed via
 [Fleek](https://fleek.co).
-
-## Suggest a feature
-
-Have an idea or suggestion? Create a
-[feature request](https://github.com/jbx-protocol/juice-interface/issues/new?assignees=&labels=idea&template=feature_request.md&title=%5BIDEA%5D+)
-or mention it in the [Discord](https://discord.gg/6jXrJSyDFf).
-
-## Report a bug
-
-Notice something broken? Create a
-[bug report](https://github.com/jbx-protocol/juice-interface/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D+).
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ Juicebox frontend application.
 - Mainnet: https://juicebox.money
 - Rinkeby: https://rinkeby.juicebox.money
 
+## Suggest a feature
+
+Have an idea or suggestion? Create a
+[feature request](https://github.com/jbx-protocol/juice-interface/issues/new?assignees=&labels=idea&template=feature_request.md&title=%5BIDEA%5D+)
+or mention it in the [Discord](https://discord.gg/6jXrJSyDFf).
+
+## Report a bug
+
+Notice something broken? Create a
+[bug report](https://github.com/jbx-protocol/juice-interface/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D+).
+
 ## Development
 
 ### Installation


### PR DESCRIPTION

## What does this PR do and why?

- Add Git workflow notes re: rebase strategy (fixes #259)
- Makes approval guidelines explicit
- Adds a pull request GitHub template, with link to approval guidelines
- Makes some minor updates to the Issue templates
- Adds CODEOWNERS file (currently only has Peri)

## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
