### PR TITLE
PoC: make `App.test.tsx` test relevant

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,9 +1,48 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
 
 import App from './App'
+import ProvideReactQuery from '../ReactQuery'
+import store from '../redux/store'
 
-test('renders learn react link', () => {
-  render(<App />)
-  const linkElement = screen.getByText(/learn react/i)
-  expect(linkElement).toBeInTheDocument()
+jest.mock('i18n')
+jest.mock('@lingui/react', () => {
+  return {
+    Trans({ id }: { id: string }) {
+      return id
+    },
+  }
+})
+jest.mock('@lingui/core', () => {
+  return {
+    plural: jest.fn(),
+    i18n: {
+      _: (str: string) => str,
+    },
+  }
+})
+
+test('renders without crashing', () => {
+  global.matchMedia =
+    global.matchMedia ||
+    function () {
+      return {
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      }
+    }
+
+  act(() => {
+    render(
+      <ProvideReactQuery>
+        <Provider store={store}>
+          <App />
+        </Provider>
+      </ProvideReactQuery>,
+    )
+  })
+
+  expect(
+    screen.getByText('Community funding for people and projects'),
+  ).toBeInTheDocument()
 })


### PR DESCRIPTION
This PR updates the `App.test.tsx` spec to check the App component renders as expected.

Previously, it was doing nothing.

** ❓ Question: should we merge this PR, or remove the file?**

Adding the spec is great but it has the potential to slow us down in some circumstances. I'd like to hear the opinions of the team before pursuing this further.

(note, if you `yarn test` locally the test passes, but there are console logs. These would be resolved if we were to continue with this PR.)

Fixes https://github.com/jbx-protocol/juice-interface/issues/277

cc @torvusbug @jnoh @peripheralist 