### PR TITLE
Use BrowserRouter for requests served through cloudflare [link-unfurling 2/3]

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="cloudflare" content="no" />
     <meta property="og:site_name" content="juicebox" />
     <meta property="og:url" content="https://juicebox.money" />
     <meta property="og:title" content="Juicebox" />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,7 +8,7 @@ import { useContext, useLayoutEffect, useState } from 'react'
 import { readNetwork } from 'constants/networks'
 
 import Navbar from './Navbar'
-import Router from './Router'
+import Routes, { Router } from './Router'
 
 function App() {
   const [switchNetworkModalVisible, setSwitchNetworkModalVisible] =
@@ -30,7 +30,7 @@ function App() {
   }, [networkName, signerNetwork])
 
   return (
-    <>
+    <Router>
       <Layout
         style={{
           display: 'flex',
@@ -41,7 +41,7 @@ function App() {
       >
         <Navbar />
         <Content>
-          <Router />
+          <Routes />
         </Content>
       </Layout>
 
@@ -76,7 +76,7 @@ function App() {
           </Space>
         </div>
       </Modal>
-    </>
+    </Router>
   )
 }
 

--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -39,6 +39,8 @@ import {
 } from 'utils/ipfs'
 import { feeForAmount } from 'utils/math'
 
+import { useHistory } from 'react-router'
+
 import BudgetForm from './BudgetForm'
 import ConfirmDeployProject from './ConfirmDeployProject'
 import IncentivesForm from './IncentivesForm'
@@ -77,6 +79,7 @@ export default function Create() {
     payoutMods: editingPayoutMods,
   } = useAppSelector(state => state.editingProject)
   const dispatch = useAppDispatch()
+  const history = useHistory()
 
   useEffect(() => {
     if (adminFeePercent) {
@@ -254,7 +257,7 @@ export default function Create() {
             name: logoNameForHandle(editingProjectInfo.handle),
           })
 
-          window.location.hash = '/p/' + editingProjectInfo.handle
+          history.push('/p/' + editingProjectInfo.handle)
         },
       },
     )
@@ -265,6 +268,7 @@ export default function Create() {
     editingProjectInfo.handle,
     editingProjectInfo.metadata,
     editingTicketMods,
+    history,
     transactor,
     userAddress,
   ])

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -8,6 +8,7 @@ import { useProjectsQuery } from 'hooks/Projects'
 
 import { CSSProperties, useContext } from 'react'
 import { t, Trans } from '@lingui/macro'
+import { Link } from 'react-router-dom'
 
 import { ThemeOption } from 'constants/theme/theme-option'
 
@@ -219,9 +220,9 @@ export default function Landing() {
                 )}
               </div>
               <div style={{ textAlign: 'center', marginTop: 20 }}>
-                <a href="/#/projects">
+                <Link to="/projects">
                   <Button>All projects</Button>
-                </a>
+                </Link>
               </div>
             </Col>
             <Col xs={24} md={12} style={{ marginBottom: 100 }}>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -24,29 +24,34 @@ export default function Navbar() {
     forThemeOption,
   } = useContext(ThemeContext)
 
-  const menuItem = (text: string, route?: string, onClick?: VoidFunction) => {
+  const navLinkStyleProps = {
+    className: 'hover-opacity',
+    style: {
+      fontWeight: 600,
+      color: colors.text.primary,
+    },
+  }
+
+  const menuItem = (text: string, route: string, onClick?: VoidFunction) => {
     const external = route?.startsWith('http')
-    const _onClick = () => {
-      onClick && onClick()
-      if (route) {
-        history.push(route)
-      }
+    if (external) {
+      return (
+        <a href={route} target="_blank" rel="noreferrer" {...navLinkStyleProps}>
+          {text}
+        </a>
+      )
+    } else {
+      return (
+        <Link to={route} {...navLinkStyleProps}>
+          {text}
+        </Link>
+      )
     }
+  }
+
+  const menuItemWithOnClickHandler = (text: string, onClick: VoidFunction) => {
     return (
-      <a
-        className="hover-opacity"
-        style={{
-          fontWeight: 600,
-          color: colors.text.primary,
-        }}
-        onClick={_onClick}
-        {...(external
-          ? {
-              target: '_blank',
-              rel: 'noreferrer',
-            }
-          : {})}
-      >
+      <a onClick={onClick} {...navLinkStyleProps}>
         {text}
       </a>
     )
@@ -70,7 +75,7 @@ export default function Navbar() {
     return (
       <>
         {menuItem(t`Projects`, '/projects')}
-        {menuItem(t`FAQ`, undefined, () => {
+        {menuItemWithOnClickHandler(t`FAQ`, () => {
           history.push('/')
           setTimeout(() => {
             document

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -7,12 +7,16 @@ import { t } from '@lingui/macro'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext, useState } from 'react'
 
+import { useHistory } from 'react-router'
+import { Link } from 'react-router-dom'
+
 import { ThemeOption } from 'constants/theme/theme-option'
 
 import Account from './Account'
 import ThemePicker from './ThemePicker'
 
 export default function Navbar() {
+  const history = useHistory()
   const [activeKey, setActiveKey] = useState<0 | undefined>()
 
   const {
@@ -22,7 +26,12 @@ export default function Navbar() {
 
   const menuItem = (text: string, route?: string, onClick?: VoidFunction) => {
     const external = route?.startsWith('http')
-
+    const _onClick = () => {
+      onClick && onClick()
+      if (route) {
+        history.push(route)
+      }
+    }
     return (
       <a
         className="hover-opacity"
@@ -30,8 +39,7 @@ export default function Navbar() {
           fontWeight: 600,
           color: colors.text.primary,
         }}
-        href={route}
-        onClick={onClick}
+        onClick={_onClick}
         {...(external
           ? {
               target: '_blank',
@@ -61,9 +69,9 @@ export default function Navbar() {
   const menu = () => {
     return (
       <>
-        {menuItem(t`Projects`, '/#/projects')}
+        {menuItem(t`Projects`, '/projects')}
         {menuItem(t`FAQ`, undefined, () => {
-          window.location.hash = '/'
+          history.push('/')
           setTimeout(() => {
             document
               .getElementById('faq')
@@ -88,9 +96,9 @@ export default function Navbar() {
       }}
     >
       <Space size="large" style={{ flex: 1 }}>
-        <a href="/" style={{ display: 'inline-block' }}>
+        <Link to="/" style={{ display: 'inline-block' }}>
           {logo()}
-        </a>
+        </Link>
         {menu()}
       </Space>
       <Space size="middle">

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -8,6 +8,7 @@ import { useInfiniteProjectsQuery } from 'hooks/Projects'
 import { ProjectState } from 'models/project-visibility'
 import { useContext, useEffect, useRef, useState } from 'react'
 import { Trans, t } from '@lingui/macro'
+import { Link } from 'react-router-dom'
 
 import { layouts } from 'constants/styles/layouts'
 
@@ -127,9 +128,9 @@ export default function Projects() {
               <Select.Option value="totalPaid">Volume</Select.Option>
               <Select.Option value="createdAt">Created</Select.Option>
             </Select>
-            <a href="/#/create" style={{ marginLeft: 10 }}>
+            <Link to="/create" style={{ marginLeft: 10 }}>
               <Button>New project</Button>
-            </a>
+            </Link>
           </Space>
         </div>
       </div>

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,34 +1,54 @@
 import Dashboard from 'components/Dashboard'
 import Landing from 'components/Landing'
-import { HashRouter, Route, Switch } from 'react-router-dom'
+import { ChildElems } from 'models/child-elems'
+import { useHistory } from 'react-router'
+import { BrowserRouter, HashRouter, Route, Switch } from 'react-router-dom'
+import { isCloudflare } from 'utils/cloudflare'
 
 import CatchallRedirect from './CatchallRedirect'
 import Create from './Create'
 import Projects from './Projects'
 
-export default function Router() {
+interface RouterProps {
+  children: ChildElems
+}
+
+export const Router = ({ children }: RouterProps) => {
+  const history = useHistory()
+
+  if (isCloudflare()) {
+    // Redirects any hash routes to regular routes
+    if (window && window.location.hash.startsWith('#/')) {
+      history.push(window.location.hash.replace('#', ''))
+    }
+    // Use regular routes
+    return <BrowserRouter>{children}</BrowserRouter>
+  }
+
+  return <HashRouter>{children}</HashRouter>
+}
+
+export default function Routes() {
   return (
-    <HashRouter>
-      <Switch>
-        <Route exact path="/">
-          <Landing />
-        </Route>
-        <Route path="/create">
-          <Create />
-        </Route>
-        <Route path="/projects/:owner">
-          <Projects />
-        </Route>
-        <Route path="/projects">
-          <Projects />
-        </Route>
-        <Route path="/p/:handle">
-          <Dashboard />
-        </Route>
-        <Route path="/:route">
-          <CatchallRedirect />
-        </Route>
-      </Switch>
-    </HashRouter>
+    <Switch>
+      <Route exact path="/">
+        <Landing />
+      </Route>
+      <Route path="/create">
+        <Create />
+      </Route>
+      <Route path="/projects/:owner">
+        <Projects />
+      </Route>
+      <Route path="/projects">
+        <Projects />
+      </Route>
+      <Route path="/p/:handle">
+        <Dashboard />
+      </Route>
+      <Route path="/:route">
+        <CatchallRedirect />
+      </Route>
+    </Switch>
   )
 }

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -5,6 +5,7 @@ import { BigNumber } from 'ethers'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import { Project } from 'models/subgraph-entities/project'
 import { useContext } from 'react'
+import { useHistory } from 'react-router'
 import { formatDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 
@@ -17,6 +18,7 @@ export default function ProjectCard({
 }: {
   project: Pick<Project, 'handle' | 'uri' | 'totalPaid' | 'createdAt'>
 }) {
+  const history = useHistory()
   const {
     theme: { colors, radii },
   } = useContext(ThemeContext)
@@ -38,7 +40,7 @@ export default function ProjectCard({
       }}
       className="clickable-border"
       key={project?.handle}
-      onClick={() => (window.location.hash = '/p/' + project.handle)}
+      onClick={() => history.push('/p/' + project.handle)}
     >
       {metadata ? (
         <div

--- a/src/components/shared/ProjectHandle.tsx
+++ b/src/components/shared/ProjectHandle.tsx
@@ -1,4 +1,5 @@
 import { LinkOutlined } from '@ant-design/icons'
+import { Link } from 'react-router-dom'
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { Tooltip } from 'antd'
 import { utils } from 'ethers'
@@ -25,14 +26,14 @@ export default function ProjectHandle({
   return link ? (
     <Tooltip
       title={
-        <a
+        <Link
           style={{ fontWeight: 400 }}
-          href={`https://juicebox.money/#/${handle}`}
+          to={`/${handle}`}
           target="_blank"
           rel="noopener noreferrer"
         >
           @{handle} <LinkOutlined />
-        </a>
+        </Link>
       }
     >
       <span style={{ cursor: 'default', ...style }}>@{handle}</span>

--- a/src/utils/cloudflare.ts
+++ b/src/utils/cloudflare.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks to see if the app is being served through cloudflare.
+ * The cloudflare worker will rewrite the cloudflare meta tag
+ * to have a content type of yes.
+ * @returns boolean
+ */
+export const isCloudflare = (): boolean => {
+  if (!document) return false
+  const els = document.getElementsByName('cloudflare')
+  return els[0] && els[0].getAttribute('content') === 'yes'
+}


### PR DESCRIPTION
[Design Doc](https://www.notion.so/juicebox/Project-Specific-Link-Unfurling-a1ef79379bdb421abd20250667b0d8e9)

Related to https://github.com/jbx-protocol/juice-interface/issues/145

Use a BrowserRouter for requests served through cloudflare. If not through cloudflare, HashRouter will continue to work. In order to make routing work with both routers, links must use `history.push` or the Link component provided by react-router.

[1/3] https://github.com/jbx-protocol/juice-interface/pull/284
[2/3] This PR
[3/3] https://github.com/jbx-protocol/juice-interface/pull/286