### PR TITLE
Various fixes to reserved token form

### DIFF
--- a/src/components/shared/formItems/EthAddress.tsx
+++ b/src/components/shared/formItems/EthAddress.tsx
@@ -84,7 +84,11 @@ export default function EthAddress({
         onChange={e => onInputChange(e.target.value)}
         value={displayValue}
       />
-      <Form.Item name={name} style={{ height: 0, maxHeight: 0, margin: 0 }}>
+      <Form.Item
+        name={name}
+        style={{ height: 0, maxHeight: 0, margin: 0 }}
+        rules={formItemProps?.rules ?? []} // rules weren't being applied to inner FormItem
+      >
         {/* Hidden input allows for address value to be used in form, while visible input can display ENS name */}
         <Input hidden type="string" autoComplete="off" />
       </Form.Item>

--- a/src/components/shared/formItems/ProjectTicketMods.tsx
+++ b/src/components/shared/formItems/ProjectTicketMods.tsx
@@ -16,9 +16,7 @@ import FormattedAddress from '../FormattedAddress'
 import NumberSlider from '../inputs/NumberSlider'
 import { FormItemExt } from './formItemExt'
 
-const MODAL_MODE_EDIT = 'Edit'
-const MODAL_MODE_ADD = 'Add'
-type MODAL_MODE = 'Add' | 'Edit'
+type ModalMode = 'Add' | 'Edit' | undefined
 
 export default function ProjectTicketMods({
   name,
@@ -37,7 +35,7 @@ export default function ProjectTicketMods({
     lockedUntil: moment.Moment
   }>()
   const [editingModIndex, setEditingModIndex] = useState<number>() // index of the mod currently being edited (edit modal open)
-  const [modalMode, setModalMode] = useState<MODAL_MODE>() //either 'Add', 'Edit' or undefined
+  const [modalMode, setModalMode] = useState<ModalMode>() //either 'Add', 'Edit' or undefined
   const { owner } = useContext(ProjectContext)
 
   const {
@@ -82,7 +80,7 @@ export default function ProjectTicketMods({
                   : undefined,
               })
               setEditingModIndex(index)
-              setModalMode(MODAL_MODE_EDIT)
+              setModalMode('Edit')
             }}
           >
             <Row gutter={gutter} style={{ width: '100%' }} align="middle">
@@ -228,7 +226,7 @@ export default function ProjectTicketMods({
       return Promise.reject('Address is required')
     else if (address === constants.AddressZero)
       return Promise.reject('Cannot use zero address.')
-    else if (mods.filter(mod => mod.beneficiary === address).length > 0)
+    else if (mods.some(mod => mod.beneficiary === address))
       return Promise.reject('Address already in use.')
     else return Promise.resolve()
   }
@@ -287,7 +285,7 @@ export default function ProjectTicketMods({
           type="dashed"
           onClick={() => {
             setEditingModIndex(mods.length)
-            setModalMode(MODAL_MODE_ADD)
+            setModalMode('Add')
             form.resetFields()
           }}
           block
@@ -298,16 +296,12 @@ export default function ProjectTicketMods({
 
       <Modal
         title={
-          modalMode === MODAL_MODE_ADD
-            ? 'Add token receiver'
-            : 'Edit token receiver'
+          modalMode === 'Add' ? 'Add token receiver' : 'Edit token receiver'
         } // Full sentences for translation purposes
         visible={editingModIndex !== undefined}
         onOk={setReceiver}
         okText={
-          modalMode === MODAL_MODE_ADD
-            ? 'Add token receiver'
-            : 'Save token receiver'
+          modalMode === 'Add' ? 'Add token receiver' : 'Save token receiver'
         }
         onCancel={() => {
           form.resetFields()


### PR DESCRIPTION
- Modal displays edit-related text when editing
- Prevent null address being added as beneficiary
- Prevent duplicate beneficiaries being added

## What does this PR do and why?

Went to fix issue #136 and realised none of the current validation (e.g. null address) was being applied. Fixed this and added the new one, but then was unable to edit existing beneficiaries (duplicate address validation breaking) - so added some extra logic in the validation. Then made the modal text edit-related for when a beneficiary is being edited. 

## Screenshots or screen recordings
Video shows attempting to add a null address, edit-related modal text when editing, and then attempting to add the same address. There are preexisting issues with the error message styling which I intend to fix in a follow-up PR.
 
https://user-images.githubusercontent.com/96150256/146656758-774cfab1-41b1-45f2-b56e-c0a6dfe4c1d4.mp4

## Acceptance checklist

- [x] I have evaluated the
      [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this
      PR.
