### PR TITLE
Fix project description "read more" button styling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,4 @@ changes._
 
 ## Acceptance checklist
 
-- [ ] I have evaluted the
-      [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this
-      PR.
+- [ ] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.

--- a/src/components/Dashboard/ProjectActivity/RichNote.tsx
+++ b/src/components/Dashboard/ProjectActivity/RichNote.tsx
@@ -7,7 +7,9 @@ import { useContext, useMemo } from 'react'
 export default function RichNote({
   note,
   style,
+  children,
 }: {
+  children?: any
   note: string | undefined
   style?: React.CSSProperties | undefined
 }) {
@@ -44,9 +46,13 @@ export default function RichNote({
       : note
 
   return (
-    <span style={{ marginTop: 5, ...style }}>
+    <p style={{ marginTop: 5, ...style }}>
       <span
-        style={{ color: colors.text.secondary, overflowWrap: 'break-word' }}
+        style={{
+          color: colors.text.secondary,
+          overflowWrap: 'break-word',
+          paddingRight: '0.5rem',
+        }}
         dangerouslySetInnerHTML={{
           __html: Autolinker.link(_note, {
             sanitizeHtml: true,
@@ -57,14 +63,19 @@ export default function RichNote({
           }),
         }}
       ></span>
-      <div>
-        <RichImgPreview
-          src={mediaLink}
-          style={{ marginTop: 10 }}
-          width="100%"
-          height={140}
-        />
-      </div>
-    </span>
+
+      {children}
+
+      {mediaLink && (
+        <div>
+          <RichImgPreview
+            src={mediaLink}
+            style={{ marginTop: 10 }}
+            width="100%"
+            height={140}
+          />
+        </div>
+      )}
+    </p>
   )
 }

--- a/src/components/Dashboard/ProjectActivity/RichNote.tsx
+++ b/src/components/Dashboard/ProjectActivity/RichNote.tsx
@@ -4,15 +4,16 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useContentType } from 'hooks/ContentType'
 import { useContext, useMemo } from 'react'
 
+type RichNoteProps = {
+  note: string | undefined
+  style?: React.CSSProperties | undefined
+}
+
 export default function RichNote({
   note,
   style,
   children,
-}: {
-  children?: any
-  note: string | undefined
-  style?: React.CSSProperties | undefined
-}) {
+}: React.PropsWithChildren<RichNoteProps>) {
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/Dashboard/ProjectHeader.tsx
+++ b/src/components/Dashboard/ProjectHeader.tsx
@@ -13,7 +13,7 @@ import { ThemeContext } from 'contexts/themeContext'
 import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
 import { useContext, useState } from 'react'
 
-import ProjectDescription from '../shared/Paragraph'
+import Paragraph from '../shared/Paragraph'
 
 export default function ProjectHeader() {
   const [editProjectModalVisible, setEditProjectModalVisible] =
@@ -63,7 +63,13 @@ export default function ProjectHeader() {
           alignItems: 'flex-start',
         }}
       >
-        <div style={{ marginRight: 20, height: '100%' }}>
+        <div
+          style={{
+            marginRight: '1.25rem',
+            marginBottom: '1.25rem',
+            height: '100%',
+          }}
+        >
           <ProjectLogo
             uri={metadata?.logoUri}
             name={metadata?.name}
@@ -71,7 +77,7 @@ export default function ProjectHeader() {
           />
         </div>
 
-        <div style={{ flex: 1 }}>
+        <div style={{ flex: 1, minWidth: '70%' }}>
           <div
             style={{
               display: 'flex',
@@ -208,7 +214,7 @@ export default function ProjectHeader() {
             )}
           </div>
           {metadata?.description && (
-            <ProjectDescription
+            <Paragraph
               description={metadata.description}
               characterLimit={250}
             />

--- a/src/components/shared/Paragraph.tsx
+++ b/src/components/shared/Paragraph.tsx
@@ -28,16 +28,17 @@ export default function Paragraph({
         note={
           !expanded && CHARACTER_LIMIT_EXCEEDED ? shortDescription : description
         }
-      />
-      {CHARACTER_LIMIT_EXCEEDED && (
-        <Button
-          type="link"
-          style={{ paddingTop: 0, paddingBottom: 0, height: 'auto' }}
-          onClick={() => toggleExpanded()}
-        >
-          {expanded ? 'Read less' : 'Read more'}
-        </Button>
-      )}
+      >
+        {CHARACTER_LIMIT_EXCEEDED && (
+          <Button
+            type="link"
+            style={{ padding: 0, paddingBottom: 0, height: 'auto' }}
+            onClick={() => toggleExpanded()}
+          >
+            {expanded ? 'Read less' : 'Read more'}
+          </Button>
+        )}
+      </RichNote>
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

- makes "read more/less" button inline with the project description
- improves responsiveness of project header

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="370" alt="Screen Shot 2021-12-21 at 7 47 22 am" src="https://user-images.githubusercontent.com/94939382/146837055-b1e44ed1-a3c9-4d47-a846-219d80365e2c.png"> | <img width="372" alt="Screen Shot 2021-12-21 at 7 44 25 am" src="https://user-images.githubusercontent.com/94939382/146837084-3c65c4ed-147b-47d0-a596-ae4b06755a53.png"> |
| <img width="1072" alt="Screen Shot 2021-12-21 at 7 46 40 am" src="https://user-images.githubusercontent.com/94939382/146837102-d8a9c823-571a-4e1b-bf26-d4b8ed10531b.png"> | <img width="1089" alt="Screen Shot 2021-12-21 at 7 44 46 am" src="https://user-images.githubusercontent.com/94939382/146837174-81e4ec31-9258-458b-b3a3-6e2d6536fbae.png"> |

## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
