### PR TITLE
Fix error message styling on EthAddress inputs

### DIFF
--- a/src/components/shared/formItems/EthAddress.tsx
+++ b/src/components/shared/formItems/EthAddress.tsx
@@ -74,9 +74,16 @@ export default function EthAddress({
 
     readENSName()
   }, [defaultValue])
-
+  console.log('formItemProps?.extra: ', formItemProps?.extra)
   return (
-    <Form.Item {...formItemProps}>
+    <Form.Item
+      {...formItemProps}
+      className={
+        formItemProps?.extra
+          ? 'ant-form-item-control-input-extra-and-error'
+          : ''
+      } // if we pass form.item an 'extra', need to set different padding for error message
+    >
       <Input
         placeholder={'juicebox.eth / ' + constants.AddressZero}
         type="string"
@@ -84,6 +91,11 @@ export default function EthAddress({
         onChange={e => onInputChange(e.target.value)}
         value={displayValue}
       />
+      {addressForENS?.length ? (
+        <div style={{ fontSize: '0.7rem', color: colors.text.secondary }}>
+          <CheckCircleFilled /> {addressForENS}
+        </div>
+      ) : null}
       <Form.Item
         name={name}
         style={{ height: 0, maxHeight: 0, margin: 0 }}
@@ -92,11 +104,6 @@ export default function EthAddress({
         {/* Hidden input allows for address value to be used in form, while visible input can display ENS name */}
         <Input hidden type="string" autoComplete="off" />
       </Form.Item>
-      {addressForENS?.length ? (
-        <div style={{ fontSize: '0.7rem', color: colors.text.secondary }}>
-          <CheckCircleFilled /> {addressForENS}
-        </div>
-      ) : null}
     </Form.Item>
   )
 }

--- a/src/components/shared/formItems/EthAddress.tsx
+++ b/src/components/shared/formItems/EthAddress.tsx
@@ -74,15 +74,16 @@ export default function EthAddress({
 
     readENSName()
   }, [defaultValue])
-  console.log('formItemProps?.extra: ', formItemProps?.extra)
+
   return (
     <Form.Item
       {...formItemProps}
       className={
+        // if we pass form.item an 'extra', need to set different padding for error message
         formItemProps?.extra
           ? 'ant-form-item-control-input-extra-and-error'
           : ''
-      } // if we pass form.item an 'extra', need to set different padding for error message
+      }
     >
       <Input
         placeholder={'juicebox.eth / ' + constants.AddressZero}

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -405,7 +405,6 @@ export default function ProjectPayoutMods({
               defaultValue={form.getFieldValue('beneficiary')}
               formItemProps={{
                 label: 'Address',
-                // extra: 'The address that should receive the tokens.',
                 rules: [
                   {
                     validator: (rule: any, value: any) => {

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -405,6 +405,7 @@ export default function ProjectPayoutMods({
               defaultValue={form.getFieldValue('beneficiary')}
               formItemProps={{
                 label: 'Address',
+                // extra: 'The address that should receive the tokens.',
                 rules: [
                   {
                     validator: (rule: any, value: any) => {

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -183,3 +183,12 @@ input:-webkit-autofill-selected {
     color: var(--text-secondary);
   }
 }
+
+.ant-form-item-control-input {
+  min-height: 7px; // get error messages appearing closer to the input fields
+}
+
+// added this rule for when an the 'extra' prop is passed to FormItem (error message needs more space in this case)
+.ant-form-item-control-input-extra-and-error .ant-form-item-control-input {
+  min-height: 23px;
+}

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -185,7 +185,7 @@ input:-webkit-autofill-selected {
 }
 
 .ant-form-item-control-input {
-  min-height: 7px; // get error messages appearing closer to the input fields
+  min-height: 4px; // get error messages appearing closer to the input fields
 }
 
 // added this rule for when an the 'extra' prop is passed to FormItem (error message needs more space in this case)


### PR DESCRIPTION
## What does this PR do and why?

Fix error message styling on EthAddress inputs. Previously, they were all over the place depending on two conditions: A, whether 'extra' prop is passed EthAddress, and B, whether the 'addressForENS' and its check symbol were present. I've accounted for these conditions by: A, giving FormItem.EthAddress a new class when 'extra' is passed to it and then making a separate CSS declaration for this class. And for B, moving the position of the 'addressForENS' in the code so the error message behaves the same whether it is present or not. 

## Screenshots or screen recordings

OLD:
<img width="523" alt="Screen Shot 2021-12-21 at 1 00 06 pm" src="https://user-images.githubusercontent.com/96150256/146863702-1fb39089-d78f-4737-ac99-0d454b230181.png">
<img width="524" alt="Screen Shot 2021-12-21 at 1 00 16 pm" src="https://user-images.githubusercontent.com/96150256/146863711-dc6ab88d-53b5-4c92-aaff-5706b3334cb3.png">
<img width="530" alt="Screen Shot 2021-12-21 at 1 00 52 pm" src="https://user-images.githubusercontent.com/96150256/146863727-9816fe03-1bf8-447e-a2d8-032bfc76b7a5.png">


NEW:
<img width="551" alt="Screen Shot 2021-12-21 at 12 57 20 pm" src="https://user-images.githubusercontent.com/96150256/146863745-0b1b3d27-0a28-4b93-9b53-0c6a48f8f86d.png">
<img width="537" alt="Screen Shot 2021-12-21 at 12 55 51 pm" src="https://user-images.githubusercontent.com/96150256/146863771-f9daaa5a-7f8d-4bdb-9ec3-a56039633ed8.png">
<img width="519" alt="Screen Shot 2021-12-21 at 12 56 09 pm" src="https://user-images.githubusercontent.com/96150256/146863784-41072cfc-fd7c-4180-aa27-ed0fbe9e1f7b.png">


## Acceptance checklist

- [x] I have evaluted the
      [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this
      PR.
