### PR TITLE
Download participants modal with custom block number

### DIFF
--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -1,6 +1,7 @@
 import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+import UntrackedErc20Notice from 'components/shared/UntrackedErc20Notice'
 import { indexedProjectERC20s } from 'constants/indexed-project-erc20s'
 import { readProvider } from 'constants/readProvider'
 import { ProjectContext } from 'contexts/projectContext'
@@ -135,30 +136,7 @@ export default function DownloadParticipantsModal({
       <div>
         <h4>Download CSV of {tokenSymbol || 'token'} holders</h4>
 
-        {erc20IsUntracked && (
-          <p>
-            <b>Notice:</b> {tokenSymbol} ERC20 tokens have not been indexed by
-            Juicebox, meaning that the balances reflected below will be
-            inaccurate for users who have unstaked and transferred their tokens.
-            This will be solved with the release of{' '}
-            <a
-              href="https://app.gitbook.com/@jbx/s/juicebox/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Juicebox V2
-            </a>
-            . If this is a big issue for your project, let us know in the{' '}
-            <a
-              href="https://discord.gg/6jXrJSyDFf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Discord
-            </a>
-            .
-          </p>
-        )}
+        {erc20IsUntracked && <UntrackedErc20Notice tokenSymbol={tokenSymbol} />}
 
         <label style={{ display: 'block', marginTop: 20, marginBottom: 5 }}>
           Block number

--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -1,0 +1,180 @@
+import { Modal } from 'antd'
+import InputAccessoryButton from 'components/shared/InputAccessoryButton'
+import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+import { indexedProjectERC20s } from 'constants/indexed-project-erc20s'
+import { readProvider } from 'constants/readProvider'
+import { ProjectContext } from 'contexts/projectContext'
+import { NetworkName } from 'models/network-name'
+import { parseParticipantJson } from 'models/subgraph-entities/participant'
+import { useCallback, useContext, useEffect, useState } from 'react'
+import { fromWad } from 'utils/formatNumber'
+import { querySubgraph } from 'utils/graph'
+
+export default function DownloadParticipantsModal({
+  visible,
+  onCancel,
+}: {
+  visible: boolean | undefined
+  onCancel: VoidFunction | undefined
+}) {
+  const [latestBlockNumber, setLatestBlockNumber] = useState<number>()
+  const [blockNumber, setBlockNumber] = useState<number>()
+  const [loading, setLoading] = useState<boolean>()
+  const { projectId, tokenSymbol, handle } = useContext(ProjectContext)
+
+  useEffect(() => {
+    readProvider.getBlockNumber().then(val => {
+      setLatestBlockNumber(val)
+      setBlockNumber(val)
+    })
+  }, [])
+
+  const download = useCallback(() => {
+    setLoading(true)
+
+    const pageSize = 1000
+    let pageNumber = 0
+
+    const rows = [
+      [
+        'Wallet address',
+        'Token balance',
+        'Total ETH paid',
+        'Last paid timestamp',
+      ], // CSV header row
+    ]
+
+    function query() {
+      querySubgraph(
+        {
+          entity: 'participant',
+          keys: ['wallet', 'totalPaid', 'lastPaidTimestamp', 'tokenBalance'],
+          first: pageSize,
+          skip: pageSize * pageNumber,
+          orderBy: 'tokenBalance',
+          orderDirection: 'desc',
+          block: blockNumber
+            ? {
+                number: blockNumber,
+              }
+            : undefined,
+          where: projectId
+            ? {
+                key: 'project',
+                value: projectId.toString(),
+              }
+            : undefined,
+        },
+        res => {
+          if (!res) return
+
+          res.participants.forEach(e => {
+            const p = parseParticipantJson(e)
+
+            let date = new Date((p.lastPaidTimestamp ?? 0) * 1000).toUTCString()
+
+            if (date.includes(',')) date = date.split(',')[1]
+
+            rows.push([
+              p.wallet ?? '--',
+              fromWad(p.tokenBalance),
+              fromWad(p.totalPaid),
+              date,
+            ])
+          })
+
+          const expectNextPage =
+            res.participants.length && res.participants.length % pageSize === 0
+
+          if (expectNextPage) {
+            pageNumber++
+            query()
+          } else {
+            setLoading(false)
+
+            // Encode CSV content and download
+            const csvContent =
+              'data:text/csv;charset=utf-8,' +
+              rows.map(e => e.join(',')).join('\n')
+            const encodedUri = encodeURI(csvContent)
+            const link = document.createElement('a')
+            link.setAttribute('href', encodedUri)
+            link.setAttribute(
+              'download',
+              `@${handle}_holders-block${blockNumber}.csv`,
+            )
+            document.body.appendChild(link)
+
+            link.click()
+          }
+        },
+      )
+    }
+
+    query()
+  }, [projectId, setLoading, blockNumber, handle])
+
+  const erc20IsUntracked =
+    tokenSymbol &&
+    projectId &&
+    !indexedProjectERC20s[
+      process.env.REACT_APP_INFURA_NETWORK as NetworkName
+    ]?.includes(projectId?.toNumber())
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onCancel}
+      onOk={download}
+      okText="Download CSV"
+      okButtonProps={{ type: 'primary' }}
+      cancelText="Close"
+      confirmLoading={loading}
+      centered
+    >
+      <div>
+        <h4>Download CSV of {tokenSymbol || 'token'} holders</h4>
+
+        {erc20IsUntracked && (
+          <p>
+            <b>Notice:</b> {tokenSymbol} ERC20 tokens have not been indexed by
+            Juicebox, meaning that the balances reflected below will be
+            inaccurate for users who have unstaked and transferred their tokens.
+            This will be solved with the release of{' '}
+            <a
+              href="https://app.gitbook.com/@jbx/s/juicebox/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Juicebox V2
+            </a>
+            . If this is a big issue for your project, let us know in the{' '}
+            <a
+              href="https://discord.gg/6jXrJSyDFf"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Discord
+            </a>
+            .
+          </p>
+        )}
+
+        <label style={{ display: 'block', marginTop: 20, marginBottom: 5 }}>
+          Block number
+        </label>
+        <FormattedNumberInput
+          value={blockNumber?.toString()}
+          onChange={val => setBlockNumber(val ? parseInt(val) : undefined)}
+          accessory={
+            <InputAccessoryButton
+              content="Latest"
+              onClick={() => setBlockNumber(latestBlockNumber)}
+              disabled={blockNumber === latestBlockNumber}
+            />
+          }
+        />
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -8,6 +8,7 @@ import { Button, Modal, Select } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import Loading from 'components/shared/Loading'
+import UntrackedErc20Notice from 'components/shared/UntrackedErc20Notice'
 import { indexedProjectERC20s } from 'constants/indexed-project-erc20s'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -252,30 +253,7 @@ export default function ParticipantsModal({
       <div>
         <h4>{tokenSymbol || 'Token'} holders</h4>
 
-        {erc20IsUntracked && (
-          <p>
-            <b>Notice:</b> {tokenSymbol} ERC20 tokens have not been indexed by
-            Juicebox, meaning that the balances reflected below will be
-            inaccurate for users who have unstaked and transferred their tokens.
-            This will be solved with the release of{' '}
-            <a
-              href="https://app.gitbook.com/@jbx/s/juicebox/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Juicebox V2
-            </a>
-            . If this is a big issue for your project, let us know in the{' '}
-            <a
-              href="https://discord.gg/6jXrJSyDFf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Discord
-            </a>
-            .
-          </p>
-        )}
+        {erc20IsUntracked && <UntrackedErc20Notice tokenSymbol={tokenSymbol} />}
 
         {list}
 

--- a/src/components/shared/InputAccessoryButton.tsx
+++ b/src/components/shared/InputAccessoryButton.tsx
@@ -7,22 +7,28 @@ export default function InputAccessoryButton({
   onClick,
   withArrow,
   placement,
+  disabled,
 }: {
   content: string | JSX.Element | undefined
   withArrow?: boolean
   onClick?: VoidFunction
   placement?: 'prefix' | 'suffix'
+  disabled?: boolean
 }) {
   const { colors, radii } = useContext(ThemeContext).theme
 
   return content ? (
     <div
       style={{
-        cursor: onClick ? 'pointer' : 'default',
-        color: onClick ? colors.text.action.primary : colors.text.primary,
-        background: onClick
-          ? colors.background.action.secondary
-          : colors.background.l1,
+        cursor: onClick && !disabled ? 'pointer' : 'default',
+        color:
+          onClick && !disabled
+            ? colors.text.action.primary
+            : colors.text.primary,
+        background:
+          onClick && !disabled
+            ? colors.background.action.secondary
+            : colors.background.l1,
         fontWeight: 500,
         whiteSpace: 'nowrap',
         padding: '1px 6px',

--- a/src/components/shared/UntrackedErc20Notice.tsx
+++ b/src/components/shared/UntrackedErc20Notice.tsx
@@ -1,0 +1,30 @@
+export default function UntrackedErc20Notice({
+  tokenSymbol,
+}: {
+  tokenSymbol: string
+}) {
+  return (
+    <p>
+      <b>Notice:</b> {tokenSymbol} ERC20 tokens have not been indexed by
+      Juicebox, meaning that the balances reflected below will be inaccurate for
+      users who have unstaked and transferred their tokens. This will be solved
+      with the release of{' '}
+      <a
+        href="https://app.gitbook.com/@jbx/s/juicebox/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Juicebox V2
+      </a>
+      . If this is a big issue for your project, let us know in the{' '}
+      <a
+        href="https://discord.gg/6jXrJSyDFf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Discord
+      </a>
+      .
+    </p>
+  )
+}

--- a/src/styles/antd-overrides/button.scss
+++ b/src/styles/antd-overrides/button.scss
@@ -20,9 +20,9 @@
 }
 
 .ant-btn-primary {
-  background: var(--background-action-primary);
-  border-color: transparent;
-  color: var(--text-over-action-primary);
+  background: var(--background-action-primary) !important;
+  border-color: transparent !important;
+  color: var(--text-over-action-primary) !important;
 
   &:hover {
     background: var(--background-action-highlight);


### PR DESCRIPTION
## What does this PR do and why?

Currently the Participants modal only allows downloading a CSV from the latest block number. This PR allows the user to use a custom block number if they wish, and includes the block number in the filename.

The download function has been moved to its own modal, with a number input that allows setting a custom block number.

![image](https://user-images.githubusercontent.com/79433522/146874253-bdbb9a2c-52d0-4ef5-9a86-84920b50f895.png)

Other small things included: 
- adds a `disabled` property to InputAccessoryButton
- fixes Button CSS style error