### PR TITLE
Language selector in nav and footer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,18 @@ If you need help at any stage, reach out in the
 
 ### Adding a language
 
+1. Add the locale code, english name, and short and long alias's to
+   `constants/languages/language-options.ts`.
+
+   ```diff
+   export const Languages: Language = {
+      en: { code: 'en', name: 'english', short: 'EN', long: 'English' },
+      zh: { code: 'zh', name: 'chinese', short: '中文', long: '中文' },
+      ru: { code: 'ru', name: 'russian', short: 'RU', long: 'Pусский' },
+   +  es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
+   }
+   ```
+
 1. Add the locale code to `./linguirc.json`.
 
    ```diff

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -34,6 +34,7 @@ export default function Footer() {
   function setLanguage(newLanguage: string) {
     localStorage.setItem('lang', newLanguage)
     window.location.reload()
+    window.scrollTo(0, 0)
   }
 
   return (

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer() {
   function setLanguage(newLanguage: string) {
     localStorage.setItem('lang', newLanguage)
     window.location.reload()
-    window.scrollTo(0, 0)
+    window.scrollTo(0, 0) // scroll to top of page after reload
   }
 
   return (

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -1,10 +1,18 @@
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
+import { CSSProperties } from 'react'
+
+import { Languages } from 'constants/languages/language-options'
 
 export default function Footer() {
   const { colors } = useContext(ThemeContext).theme
 
-  const link = (text: string, link: string) => (
+  const footerLinksStyles: CSSProperties = {
+    display: 'inline-flex',
+    justifyContent: 'center',
+  }
+
+  const link = (text: string, link?: string) => (
     <a
       style={{
         color: colors.text.action.primary,
@@ -17,6 +25,17 @@ export default function Footer() {
     </a>
   )
 
+  // Renders language links
+  const languageLink = (lang: string) => (
+    <div onClick={() => setLanguage(lang)}>{link(Languages[lang].long)}</div>
+  )
+
+  // Sets the new language with localStorage and reloads the page
+  function setLanguage(newLanguage: string) {
+    localStorage.setItem('lang', newLanguage)
+    window.location.reload()
+  }
+
   return (
     <div
       style={{
@@ -27,7 +46,10 @@ export default function Footer() {
         textAlign: 'center',
       }}
     >
-      <div style={{ display: 'inline-flex', justifyContent: 'center' }}>
+      <div style={footerLinksStyles}>
+        {Object.keys(Languages).map(languageLink)}
+      </div>
+      <div style={footerLinksStyles}>
         {link('Discord', 'https://discord.gg/6jXrJSyDFf')}
         {link('GitHub', 'https://github.com/jbx-protocol/juice-interface')}
         {link('Twitter', 'https://twitter.com/juiceboxETH')}

--- a/src/components/Navbar/Account.tsx
+++ b/src/components/Navbar/Account.tsx
@@ -1,40 +1,28 @@
-import { Button, Col, Row } from 'antd'
+import { Row, Button } from 'antd'
 import { NetworkContext } from 'contexts/networkContext'
-import { useContext } from 'react'
+
+import React, { useContext } from 'react'
 import { Trans } from '@lingui/macro'
 
-import Balance from './Balance'
 import Wallet from './Wallet'
 
-export default function Account() {
-  const { signingProvider, userAddress, onSelectWallet, onLogOut } =
+export default function Account({ mobile }: { mobile?: boolean }) {
+  const { userAddress, signingProvider, onSelectWallet } =
     useContext(NetworkContext)
 
   return (
-    <div>
-      <Row gutter={10} align="middle">
-        {userAddress && (
-          <Col>
-            <Balance address={userAddress} showEthPrice />
-          </Col>
-        )}
-        {userAddress && (
-          <Col>
-            <Wallet userAddress={userAddress}></Wallet>
-          </Col>
-        )}
-        <Col>
-          {!signingProvider ? (
-            <Button onClick={onSelectWallet}>
-              <Trans>Connect</Trans>
-            </Button>
-          ) : (
-            <Button onClick={onLogOut}>
-              <Trans>Sign out</Trans>
-            </Button>
-          )}
-        </Col>
-      </Row>
-    </div>
+    <Row className="account-badge" gutter={10} align="middle">
+      {!signingProvider ? (
+        <div style={{ marginLeft: mobile ? 'auto' : 10, marginTop: -10 }}>
+          <Button onClick={onSelectWallet}>
+            <Trans>Connect</Trans>
+          </Button>
+        </div>
+      ) : (
+        <React.Fragment>
+          {userAddress && <Wallet userAddress={userAddress}></Wallet>}
+        </React.Fragment>
+      )}
+    </Row>
   )
 }

--- a/src/components/Navbar/Balance.tsx
+++ b/src/components/Navbar/Balance.tsx
@@ -24,6 +24,7 @@ export default function Balance({
       style={{
         verticalAlign: 'middle',
         lineHeight: 1,
+        color: colors.text.tertiary,
       }}
     >
       <CurrencySymbol currency={0} />

--- a/src/components/Navbar/ItemDropdown.tsx
+++ b/src/components/Navbar/ItemDropdown.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+
+import { Collapse, Space } from 'antd'
+import { DownOutlined, UpOutlined } from '@ant-design/icons'
+import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+
+export default function ItemDropDown({
+  heading,
+  dropdownItems,
+}: {
+  heading: string
+  dropdownItems: JSX.Element[]
+}) {
+  const [activeKey, setActiveKey] = useState<0 | undefined>()
+  const iconSize = 12
+
+  return (
+    <div className="resouces-dropdown">
+      <Collapse style={{ border: 'none' }} activeKey={activeKey}>
+        <CollapsePanel
+          style={{
+            border: 'none',
+          }}
+          key={0}
+          showArrow={false}
+          header={
+            <Space
+              onClick={e => {
+                setActiveKey(activeKey === 0 ? undefined : 0)
+                e.stopPropagation()
+              }}
+            >
+              {heading}
+              {activeKey === 0 ? (
+                <UpOutlined style={{ fontSize: iconSize }} />
+              ) : (
+                <DownOutlined style={{ fontSize: iconSize }} />
+              )}
+            </Space>
+          }
+        >
+          {dropdownItems}
+        </CollapsePanel>
+      </Collapse>
+    </div>
+  )
+}

--- a/src/components/Navbar/Logo.tsx
+++ b/src/components/Navbar/Logo.tsx
@@ -1,0 +1,26 @@
+import { ThemeContext } from 'contexts/themeContext'
+import { useContext } from 'react'
+
+import { ThemeOption } from 'constants/theme/theme-option'
+
+export default function Logo({ height }: { height?: number }) {
+  const { forThemeOption } = useContext(ThemeContext)
+
+  if (!height) {
+    height = 40
+  }
+
+  return (
+    <img
+      style={{ height }}
+      src={
+        forThemeOption &&
+        forThemeOption({
+          [ThemeOption.light]: '/assets/juice_logo-ol.png',
+          [ThemeOption.dark]: '/assets/juice_logo-od.png',
+        })
+      }
+      alt="Juicebox logo"
+    />
+  )
+}

--- a/src/components/Navbar/MobileCollapse.tsx
+++ b/src/components/Navbar/MobileCollapse.tsx
@@ -1,0 +1,74 @@
+import { useState, useContext } from 'react'
+import { Collapse, Space, Button } from 'antd'
+import { Header } from 'antd/lib/layout/layout'
+
+import { Trans } from '@lingui/macro'
+
+import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+
+import { MenuOutlined } from '@ant-design/icons'
+
+import { ThemeContext } from 'contexts/themeContext'
+import { NetworkContext } from 'contexts/networkContext'
+
+import ThemePicker from './ThemePicker'
+import Logo from './Logo'
+import Account from './Account'
+import LanguageSelector from './NavLanguageSelector'
+
+export default function MobileCollapse({ menu }: { menu: JSX.Element }) {
+  const [activeKey, setActiveKey] = useState<0 | undefined>()
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  const { signingProvider, onLogOut } = useContext(NetworkContext)
+  return (
+    <Header
+      className="top-nav top-nav-mobile"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      <Collapse style={{ border: 'none' }} activeKey={activeKey}>
+        <CollapsePanel
+          style={{ border: 'none' }}
+          key={0}
+          showArrow={false}
+          header={
+            <Space
+              onClick={e => {
+                setActiveKey(activeKey === 0 ? undefined : 0)
+                e.stopPropagation()
+              }}
+            >
+              {<Logo height={30} />}
+              <MenuOutlined style={{ color: colors.icon.primary }} />
+            </Space>
+          }
+          extra={
+            <div style={{ display: 'flex' }}>
+              <ThemePicker mobile={true} />
+            </div>
+          }
+        >
+          {menu}
+          <LanguageSelector />
+          <Account mobile={true} />
+          {signingProvider ? (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                marginTop: 10,
+              }}
+            >
+              <Button onClick={onLogOut}>
+                <Trans>Disconnect</Trans>
+              </Button>
+            </div>
+          ) : null}
+        </CollapsePanel>
+      </Collapse>
+    </Header>
+  )
+}

--- a/src/components/Navbar/MobileThemePicker.tsx
+++ b/src/components/Navbar/MobileThemePicker.tsx
@@ -1,0 +1,60 @@
+import Moon from 'components/icons/Moon'
+import Sun from 'components/icons/Sun'
+
+import { ThemeContext } from 'contexts/themeContext'
+import React, { CSSProperties, useContext } from 'react'
+
+import { ThemeOption } from 'constants/theme/theme-option'
+
+export default function MobileThemePicker() {
+  const {
+    themeOption,
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const size = 18
+  const padding = 6
+  const height = size + padding * 2
+  const selectedColor = colors.icon.primary
+  const unselectedColor = colors.icon.tertiary
+
+  const iconStyleMobile: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: padding,
+    paddingBottom: padding,
+  }
+
+  return (
+    <div
+      className="clickable-border"
+      style={{
+        width: size * 2 + padding * 4,
+        height,
+        borderRadius: height / 2,
+        display: 'flex',
+        justifyContent: 'space-around',
+      }}
+    >
+      <div
+        style={{
+          ...iconStyleMobile,
+          color:
+            themeOption === ThemeOption.light ? selectedColor : unselectedColor,
+        }}
+      >
+        <Sun size={size} />
+      </div>
+      <div
+        style={{
+          ...iconStyleMobile,
+          color:
+            themeOption === ThemeOption.dark ? selectedColor : unselectedColor,
+        }}
+      >
+        <Moon size={size} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -1,0 +1,46 @@
+import React, { CSSProperties } from 'react'
+import { Select } from 'antd'
+
+import { Languages } from 'constants/languages/language-options'
+
+// Language select tool seen in top nav
+export default function LanguageSelector() {
+  const selectStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-evenly',
+    cursor: 'pointer',
+    height: 30,
+    fontWeight: 500,
+  }
+
+  // Renders Select Option for each language available on Juicebox
+  const renderLanguageOption = (lang: string) => (
+    <Select.Option value={lang}>{Languages[lang].long}</Select.Option>
+  )
+
+  let currentSelectedLanguage = localStorage.getItem('lang') || 'en'
+
+  // Sets the new language with localStorage and reloads the page
+  function setLanguage(newLanguage: string) {
+    currentSelectedLanguage = newLanguage
+    localStorage.setItem('lang', newLanguage)
+    window.location.reload()
+  }
+
+  return (
+    <Select
+      className="medium language-selector"
+      style={{
+        ...selectStyle,
+        width: 100,
+      }}
+      value={Languages[currentSelectedLanguage].short}
+      onChange={newLanguage => {
+        setLanguage(newLanguage)
+      }}
+    >
+      {Object.keys(Languages).map(renderLanguageOption)}
+    </Select>
+  )
+}

--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from 'react'
 import { Select } from 'antd'
+import { GlobalOutlined } from '@ant-design/icons'
 
 import { Languages } from 'constants/languages/language-options'
 
@@ -31,18 +32,20 @@ export default function LanguageSelector() {
   }
 
   return (
-    <Select
-      className="medium language-selector"
-      style={{
-        ...selectStyle,
-        width: 82,
-      }}
-      value={Languages[currentSelectedLanguage].short}
-      onChange={newLanguage => {
-        setLanguage(newLanguage)
-      }}
-    >
-      {Object.keys(Languages).map(renderLanguageOption)}
-    </Select>
+    <div className="language-selector">
+      <GlobalOutlined />
+      <Select
+        className="medium"
+        style={{
+          ...selectStyle,
+        }}
+        value={Languages[currentSelectedLanguage].long}
+        onChange={newLanguage => {
+          setLanguage(newLanguage)
+        }}
+      >
+        {Object.keys(Languages).map(renderLanguageOption)}
+      </Select>
+    </div>
   )
 }

--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -16,7 +16,9 @@ export default function LanguageSelector() {
 
   // Renders Select Option for each language available on Juicebox
   const renderLanguageOption = (lang: string) => (
-    <Select.Option value={lang}>{Languages[lang].long}</Select.Option>
+    <Select.Option class="language-select-option" value={lang}>
+      <div>{Languages[lang].long}</div>
+    </Select.Option>
   )
 
   let currentSelectedLanguage = localStorage.getItem('lang') || 'en'
@@ -33,7 +35,7 @@ export default function LanguageSelector() {
       className="medium language-selector"
       style={{
         ...selectStyle,
-        width: 100,
+        width: 82,
       }}
       value={Languages[currentSelectedLanguage].short}
       onChange={newLanguage => {

--- a/src/components/Navbar/OptionsCollapse.tsx
+++ b/src/components/Navbar/OptionsCollapse.tsx
@@ -1,0 +1,66 @@
+import { useState, useContext } from 'react'
+import { Collapse, Space } from 'antd'
+import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+
+import { Trans } from '@lingui/macro'
+
+import { MoreOutlined, LogoutOutlined } from '@ant-design/icons'
+
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+
+import ThemePicker from './ThemePicker'
+import LanguageSelector from './NavLanguageSelector'
+
+export default function OptionsCollapse() {
+  const [activeKey, setActiveKey] = useState<0 | undefined>()
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  const { signingProvider, onLogOut } = useContext(NetworkContext)
+  return (
+    <div className="top-nav-options">
+      <Collapse style={{ border: 'none' }} activeKey={activeKey}>
+        <CollapsePanel
+          style={{
+            border: 'none',
+          }}
+          key={0}
+          showArrow={false}
+          header={
+            <Space
+              onClick={e => {
+                setActiveKey(activeKey === 0 ? undefined : 0)
+                e.stopPropagation()
+              }}
+            >
+              <MoreOutlined
+                style={{
+                  fontSize: '1.5em',
+                  color: colors.icon.primary,
+                }}
+              />
+            </Space>
+          }
+        >
+          <div className="nav-dropdown-item">
+            <ThemePicker />
+          </div>
+          <div className="nav-dropdown-item">
+            <LanguageSelector />
+          </div>
+          {signingProvider ? (
+            <div className="nav-dropdown-item">
+              <LogoutOutlined />
+              <div onClick={onLogOut}>
+                <div style={{ margin: '0 0 2px 13px' }}>
+                  <Trans>Disconnect</Trans>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </CollapsePanel>
+      </Collapse>
+    </div>
+  )
+}

--- a/src/components/Navbar/ThemePicker.tsx
+++ b/src/components/Navbar/ThemePicker.tsx
@@ -1,44 +1,27 @@
 import Moon from 'components/icons/Moon'
 import Sun from 'components/icons/Sun'
 
+import { Trans } from '@lingui/macro'
+
 import { ThemeContext } from 'contexts/themeContext'
-import React, { CSSProperties, useContext } from 'react'
+import React, { useContext } from 'react'
 
 import { ThemeOption } from 'constants/theme/theme-option'
 
-export default function ThemePicker() {
-  const {
-    themeOption,
-    setThemeOption,
-    theme: { colors },
-  } = useContext(ThemeContext)
+import MobileThemePicker from './MobileThemePicker'
 
-  const size = 18
-  const padding = 6
-  const height = size + padding * 2
-  const selectedColor = colors.icon.primary
-  const unselectedColor = colors.icon.tertiary
+export default function ThemePicker({ mobile }: { mobile?: boolean }) {
+  const { themeOption, setThemeOption } = useContext(ThemeContext)
 
-  const iconStyle: CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingTop: padding,
-    paddingBottom: padding,
-  }
+  const iconSize = 16
 
   return (
     <div
-      className="clickable-border"
       style={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-evenly',
         cursor: 'pointer',
-        width: size * 2 + padding * 4,
-        height,
-        borderRadius: height / 2,
-        marginRight: -33,
       }}
       onClick={() =>
         setThemeOption(
@@ -48,24 +31,27 @@ export default function ThemePicker() {
         )
       }
     >
-      <div
-        style={{
-          ...iconStyle,
-          color:
-            themeOption === ThemeOption.light ? selectedColor : unselectedColor,
-        }}
-      >
-        <Sun size={size} />
-      </div>
-      <div
-        style={{
-          ...iconStyle,
-          color:
-            themeOption === ThemeOption.dark ? selectedColor : unselectedColor,
-        }}
-      >
-        <Moon size={size} />
-      </div>
+      {mobile ? (
+        <MobileThemePicker />
+      ) : (
+        <React.Fragment>
+          {themeOption === ThemeOption.dark ? (
+            <React.Fragment>
+              <Sun size={iconSize} />
+              <div style={{ margin: '0 0 2px 10px' }}>
+                <Trans>Light theme</Trans>
+              </div>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <Moon size={iconSize} />
+              <div style={{ margin: '0 0 2px 10px' }}>
+                <Trans>Dark theme</Trans>
+              </div>
+            </React.Fragment>
+          )}
+        </React.Fragment>
+      )}
     </div>
   )
 }

--- a/src/components/Navbar/ThemePicker.tsx
+++ b/src/components/Navbar/ThemePicker.tsx
@@ -38,6 +38,7 @@ export default function ThemePicker() {
         width: size * 2 + padding * 4,
         height,
         borderRadius: height / 2,
+        marginRight: -33,
       }}
       onClick={() =>
         setThemeOption(

--- a/src/components/Navbar/Wallet.tsx
+++ b/src/components/Navbar/Wallet.tsx
@@ -1,26 +1,43 @@
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
+import { Tooltip } from 'antd'
+
+import EtherscanLink from 'components/shared/EtherscanLink'
+
+import Balance from './Balance'
 
 export default function Wallet({ userAddress }: { userAddress: string }) {
   const { colors } = useContext(ThemeContext).theme
 
-  const height = 30
+  const height = 45
 
   return (
-    <span
-      style={{
-        height,
-        borderRadius: height / 2,
-        padding: '0px 10px',
-        display: 'flex',
-        alignItems: 'center',
-        background: colors.background.l2,
-        cursor: 'default',
-        userSelect: 'all',
-      }}
+    <Tooltip
+      trigger={['hover', 'click']}
+      title={
+        <span>
+          <span style={{ userSelect: 'all' }}>{userAddress}</span>{' '}
+          <EtherscanLink value={userAddress} type="address" />
+        </span>
+      }
     >
-      <FormattedAddress address={userAddress} />
-    </span>
+      <span
+        style={{
+          height,
+          borderRadius: 2,
+          padding: '4px 19px 7px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          background: colors.background.l2,
+          cursor: 'default',
+          userSelect: 'all',
+        }}
+      >
+        <FormattedAddress address={userAddress} linkDisabled />
+        <Balance address={userAddress} />
+      </span>
+    </Tooltip>
   )
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -11,6 +11,7 @@ import { ThemeOption } from 'constants/theme/theme-option'
 
 import Account from './Account'
 import ThemePicker from './ThemePicker'
+import LanguageSelector from './NavLanguageSelector'
 
 export default function Navbar() {
   const [activeKey, setActiveKey] = useState<0 | undefined>()
@@ -94,6 +95,7 @@ export default function Navbar() {
         {menu()}
       </Space>
       <Space size="middle">
+        <LanguageSelector />
         <ThemePicker />
         <div className="hide-mobile">
           <Account />

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,36 +1,20 @@
-import { Collapse, Space } from 'antd'
-import { MenuOutlined } from '@ant-design/icons'
-import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+import { Space } from 'antd'
 import { Header } from 'antd/lib/layout/layout'
 import { t } from '@lingui/macro'
 
-import { ThemeContext } from 'contexts/themeContext'
-import { useContext, useState } from 'react'
-
-import { ThemeOption } from 'constants/theme/theme-option'
-
 import Account from './Account'
-import ThemePicker from './ThemePicker'
-import LanguageSelector from './NavLanguageSelector'
+import MobileCollapse from './MobileCollapse'
+import Logo from './Logo'
+import OptionsCollapse from './OptionsCollapse'
+import ItemDropdown from './ItemDropdown'
 
 export default function Navbar() {
-  const [activeKey, setActiveKey] = useState<0 | undefined>()
-
-  const {
-    theme: { colors },
-    forThemeOption,
-  } = useContext(ThemeContext)
-
   const menuItem = (text: string, route?: string, onClick?: VoidFunction) => {
     const external = route?.startsWith('http')
 
     return (
       <a
-        className="hover-opacity"
-        style={{
-          fontWeight: 600,
-          color: colors.text.primary,
-        }}
+        className="nav-menu-item hover-opacity"
         href={route}
         onClick={onClick}
         {...(external
@@ -45,19 +29,13 @@ export default function Navbar() {
     )
   }
 
-  const logo = (height = 40) => (
-    <img
-      style={{ height }}
-      src={
-        forThemeOption &&
-        forThemeOption({
-          [ThemeOption.light]: '/assets/juice_logo-ol.png',
-          [ThemeOption.dark]: '/assets/juice_logo-od.png',
-        })
-      }
-      alt="Juicebox logo"
-    />
-  )
+  const dropDownItem = (text: string, route?: string) => {
+    return (
+      <a className="nav-dropdown-item" href={route}>
+        {text}
+      </a>
+    )
+  }
 
   const menu = () => {
     return (
@@ -71,73 +49,38 @@ export default function Navbar() {
               ?.scrollIntoView({ behavior: 'smooth' })
           }, 0)
         })}
-        {menuItem(t`Docs`, 'https://docs.juicebox.money')}
-        {menuItem(t`Blog`, 'https://blog.juicebox.money')}
-        {menuItem('Discord', 'https://discord.gg/6jXrJSyDFf')}
-        {menuItem(t`Workspace`, 'https://juicebox.notion.site')}
+        {menuItem(t`Discord`, 'https://discord.gg/6jXrJSyDFf')}
+        <ItemDropdown
+          heading="Resources"
+          dropdownItems={[
+            dropDownItem(t`Docs`, 'https://docs.juicebox.money'),
+            dropDownItem(t`Blog`, 'https://blog.juicebox.money'),
+            dropDownItem(t`Workspace`, 'https://juicebox.notion.site'),
+            dropDownItem(
+              t`Podcast`,
+              'https://open.spotify.com/show/4G8ji7vofcOx2acXcjXIa4?si=1e5e6e171ed744e8',
+            ),
+          ]}
+        />
       </>
     )
   }
 
   return window.innerWidth > 900 ? (
-    <Header
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        background: colors.background.l0,
-      }}
-    >
-      <Space size="large" style={{ flex: 1 }}>
+    <Header className="top-nav">
+      <Space className="top-left-nav" size="large">
         <a href="/" style={{ display: 'inline-block' }}>
-          {logo()}
+          {<Logo />}
         </a>
         {menu()}
       </Space>
-      <Space size="middle">
-        <ThemePicker />
-        <LanguageSelector />
-        <div className="hide-mobile">
-          <Account />
-        </div>
+
+      <Space className="top-right-nav" size="middle">
+        <OptionsCollapse />
+        <Account />
       </Space>
     </Header>
   ) : (
-    <Header
-      style={{
-        background: colors.background.l0,
-        zIndex: 100,
-        padding: 8,
-      }}
-      onClick={e => {
-        setActiveKey(undefined)
-        e.stopPropagation()
-      }}
-    >
-      <Collapse style={{ border: 'none' }} activeKey={activeKey}>
-        <CollapsePanel
-          style={{ border: 'none' }}
-          key={0}
-          showArrow={false}
-          header={
-            <Space
-              onClick={e => {
-                setActiveKey(activeKey === 0 ? undefined : 0)
-                e.stopPropagation()
-              }}
-            >
-              {logo(30)}
-              <MenuOutlined style={{ color: colors.icon.primary }} />
-            </Space>
-          }
-          extra={<ThemePicker />}
-        >
-          <Space direction="vertical" size="middle">
-            {menu()}
-            <Account />
-          </Space>
-        </CollapsePanel>
-      </Collapse>
-    </Header>
+    <MobileCollapse menu={menu()} />
   )
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -95,8 +95,8 @@ export default function Navbar() {
         {menu()}
       </Space>
       <Space size="middle">
-        <LanguageSelector />
         <ThemePicker />
+        <LanguageSelector />
         <div className="hide-mobile">
           <Account />
         </div>

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -7,9 +7,11 @@ import { readNetwork } from 'constants/networks'
 export default function EtherscanLink({
   value,
   type,
+  showText,
 }: {
   value: string | undefined
   type: 'tx' | 'address'
+  showText?: boolean
 }) {
   if (!value) return null
 
@@ -21,12 +23,15 @@ export default function EtherscanLink({
 
   return (
     <a
-      className="quiet"
+      className={'quiet'}
       href={`https://${subdomain}etherscan.io/${type}/${value}`}
       target="_blank"
       rel="noopener noreferrer"
     >
       <LinkOutlined />
+      {showText ? (
+        <div style={{ margin: '0 0 2px 13px' }}>Etherscan</div>
+      ) : null}
     </a>
   )
 }

--- a/src/components/shared/FormattedAddress.tsx
+++ b/src/components/shared/FormattedAddress.tsx
@@ -28,9 +28,11 @@ const getEnsDict = () => {
 export default function FormattedAddress({
   address,
   label,
+  linkDisabled,
 }: {
   address: string | undefined
   label?: string
+  linkDisabled?: boolean
 }) {
   const [ensName, setEnsName] = useState<string | null>()
 
@@ -91,7 +93,13 @@ export default function FormattedAddress({
     (address
       ? address.substring(0, 6) + '...' + address.substr(address.length - 6, 6)
       : '')
-
+  if (linkDisabled) {
+    return (
+      <div style={{ cursor: 'default', userSelect: 'all', lineHeight: '22px' }}>
+        {formatted}
+      </div>
+    )
+  }
   return (
     <Tooltip
       trigger={['hover', 'click']}
@@ -102,7 +110,9 @@ export default function FormattedAddress({
         </span>
       }
     >
-      <span style={{ cursor: 'default', userSelect: 'all' }}>{formatted}</span>
+      <div style={{ cursor: 'default', userSelect: 'all', lineHeight: '22px' }}>
+        {formatted}
+      </div>
     </Tooltip>
   )
 }

--- a/src/constants/languages/language-options.ts
+++ b/src/constants/languages/language-options.ts
@@ -5,6 +5,6 @@ export const Languages: Language = {
   en: { code: 'en', name: 'english', short: 'EN', long: 'English' },
   zh: { code: 'zh', name: 'chinese', short: '中文', long: '中文' },
   ru: { code: 'ru', name: 'russian', short: 'RU', long: 'Pусский' },
-  es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
-  tr: { code: 'tr', name: 'turkish', short: 'TR', long: 'Türkçe' },
+  // es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
+  // tr: { code: 'tr', name: 'turkish', short: 'TR', long: 'Türkçe' },
 }

--- a/src/constants/languages/language-options.ts
+++ b/src/constants/languages/language-options.ts
@@ -1,0 +1,10 @@
+export type Language = Record<string, Record<string, string>>
+
+// List of languages supported on Juicebox
+export const Languages: Language = {
+  en: { value: 'en', name: 'english', short: 'EN', long: 'English' },
+  zh: { value: 'zh', name: 'chinese', short: '中文', long: '中文' },
+  ru: { value: 'ru', name: 'russian', short: 'RUS', long: 'Pусский' },
+  es: { value: 'es', name: 'spanish', short: 'ESP', long: 'Español' },
+  tr: { value: 'tr', name: 'turkish', short: 'TUR', long: 'Türkçe' },
+}

--- a/src/constants/languages/language-options.ts
+++ b/src/constants/languages/language-options.ts
@@ -2,9 +2,9 @@ export type Language = Record<string, Record<string, string>>
 
 // List of languages supported on Juicebox
 export const Languages: Language = {
-  en: { value: 'en', name: 'english', short: 'EN', long: 'English' },
-  zh: { value: 'zh', name: 'chinese', short: '中文', long: '中文' },
-  ru: { value: 'ru', name: 'russian', short: 'RUS', long: 'Pусский' },
-  es: { value: 'es', name: 'spanish', short: 'ESP', long: 'Español' },
-  tr: { value: 'tr', name: 'turkish', short: 'TUR', long: 'Türkçe' },
+  en: { code: 'en', name: 'english', short: 'EN', long: 'English' },
+  zh: { code: 'zh', name: 'chinese', short: '中文', long: '中文' },
+  ru: { code: 'ru', name: 'russian', short: 'RU', long: 'Pусский' },
+  es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
+  tr: { code: 'tr', name: 'turkish', short: 'TR', long: 'Türkçe' },
 }

--- a/src/styles/antd-overrides/collapse.scss
+++ b/src/styles/antd-overrides/collapse.scss
@@ -37,3 +37,147 @@
     }
   }
 }
+
+// Top Nav Select
+// Right side of the top nav
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--background-l0);
+
+  .nav-menu-item {
+    font-weight: 600;
+    color: var(--text-primary) !important;
+  }
+
+  // Resources dropdown and options (dotdotdot) menu
+  .ant-collapse-header {
+    color: var(--text-primary) !important;
+    padding-bottom: 8px !important;
+  }
+
+  .ant-collapse-content {
+    float: right;
+    margin-right: 21px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 2px;
+    background-color: var(--background-l0);
+    border-radius: 2px;
+  }
+  .ant-collapse-content-box {
+    border: 1px solid var(--stroke-secondary);
+    box-shadow: none !important;
+    padding: 0;
+    width: 100%;
+    background-color: var(--background-l0);
+  }
+  .ant-select-arrow {
+    display: none;
+  }
+  .nav-dropdown-item {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    border: none;
+    padding-left: 10px;
+    width: 100%;
+    height: 40px;
+    color: var(--text-primary);
+    font-weight: 400;
+    cursor: pointer;
+  }
+  .ant-collapse-content-inactive {
+    display: none;
+  }
+  .nav-dropdown-item:hover {
+    background-color: var(--background-l1);
+  }
+}
+
+.top-nav-mobile {
+  height: 50px;
+  padding: 8px;
+  .ant-collapse {
+    position: absolute; // collapses need absolutes
+    top: 0;
+    width: 100%;
+    height: 45px;
+  }
+  .ant-collapse-content {
+    float: left;
+    margin-left: 8px;
+    width: 150px;
+  }
+  .ant-collapse-content-box {
+    display: flex;
+    flex-direction: column;
+    z-index: 1000;
+    margin-top: -2px;
+    width: 150px;
+    padding: 7px 0;
+  }
+  .nav-menu-item {
+    padding: 10px 15px;
+  }
+  .resouces-dropdown {
+    top: 190px;
+    left: 12px;
+    .ant-collapse-content-box {
+      padding: 0 6px;
+      margin-left: 16px;
+    }
+  }
+  .account-badge {
+    margin: auto !important;
+    margin-top: 15px !important;
+  }
+}
+
+// Logo and links
+.top-left-nav {
+  flex: 1;
+}
+
+// Specific to the resources dropdown in the top nav
+.resouces-dropdown {
+  position: absolute;
+  top: 9px;
+  left: 320px;
+  .ant-collapse-header {
+    font-weight: 600 !important;
+    color: var(--text-primary) !important;
+  }
+  .ant-collapse-content {
+    width: 110px;
+  }
+  .ant-select-arrow {
+    display: block;
+  }
+}
+
+// Dotdotdot menu and wallet/balance
+.top-right-nav {
+  display: flex;
+  align-items: flex-start;
+  position: absolute;
+  top: 10px;
+  right: 50px;
+  margin-right: 10px;
+}
+
+// Dotdotdot menu in top right
+.top-nav-options {
+  .ant-collapse {
+    width: 110px;
+    text-align: right;
+    margin-right: -10px;
+  }
+  .ant-collapse-content {
+    width: 170px;
+    margin-right: -22px;
+  }
+}

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -184,8 +184,6 @@ input:-webkit-autofill-selected {
 }
 
 .language-selector:hover {
-  // border: var(--stroke-action-secondary) !important;
-
   .ant-select-selector {
     color: var(--stroke-action-primary);
     border: 1px solid var(--stroke-action-secondary) !important;

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -163,6 +163,28 @@ input:-webkit-autofill-selected {
   }
 }
 
+// Specific to language Select in top nav
+.language-selector {
+  .ant-select-selector {
+    height: 24px;
+    border-color: var(--stroke-action-secondary) !important;
+  }
+  .ant-select-arrow {
+    transition: 0.3s;
+  }
+}
+
+.language-selector:hover {
+  .ant-select-selector {
+    color: var(--stroke-action-primary);
+    border-color: var(--stroke-action-primary) !important;
+  }
+  .ant-select-arrow,
+  .ant-select-selection-item {
+    color: var(--stroke-action-primary);
+  }
+}
+
 .ant-upload-list,
 .ant-upload-list-text {
   color: var(--text-secondary);

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -165,32 +165,39 @@ input:-webkit-autofill-selected {
 
 // Specific to language Select in top nav
 .language-selector {
-  padding-left: 30px !important;
-  border: none !important;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  .ant-select {
+    border: none !important;
+    margin-left: 4px;
+    width: 100%;
+  }
 
   .ant-select-selector {
     height: 24px;
-    width: 50px !important;
     padding: 0 8px !important;
-    border: 1px solid transparent !important;
+    border: none !important;
   }
   .ant-select-arrow {
     display: none;
   }
   .ant-select-selection-item {
-    text-align: center;
+    text-align: left;
     padding: 0 !important;
+    font-weight: 400;
   }
 }
 
-.language-selector:hover {
-  .ant-select-selector {
-    color: var(--stroke-action-primary);
-    border: 1px solid var(--stroke-action-secondary) !important;
-  }
-  .ant-select-arrow,
-  .ant-select-selection-item {
-    color: var(--stroke-action-primary);
+.language-selector .ant-select-focused .ant-select-selector {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.top-nav-mobile {
+  .language-selector {
+    margin-top: 48px;
+    padding-left: 15px;
   }
 }
 

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -165,12 +165,21 @@ input:-webkit-autofill-selected {
 
 // Specific to language Select in top nav
 .language-selector {
+  padding-left: 30px !important;
+  border: none !important;
+
   .ant-select-selector {
     height: 24px;
-    border-color: var(--stroke-action-secondary) !important;
+    width: 50px !important;
+    padding: 0 8px !important;
+    border: none !important;
   }
   .ant-select-arrow {
-    transition: 0.3s;
+    display: none;
+  }
+  .ant-select-selection-item {
+    text-align: center;
+    padding: 1px 0 0 !important;
   }
 }
 

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -172,21 +172,23 @@ input:-webkit-autofill-selected {
     height: 24px;
     width: 50px !important;
     padding: 0 8px !important;
-    border: none !important;
+    border: 1px solid transparent !important;
   }
   .ant-select-arrow {
     display: none;
   }
   .ant-select-selection-item {
     text-align: center;
-    padding: 1px 0 0 !important;
+    padding: 0 !important;
   }
 }
 
 .language-selector:hover {
+  // border: var(--stroke-action-secondary) !important;
+
   .ant-select-selector {
     color: var(--stroke-action-primary);
-    border-color: var(--stroke-action-primary) !important;
+    border: 1px solid var(--stroke-action-secondary) !important;
   }
   .ant-select-arrow,
   .ant-select-selection-item {

--- a/src/styles/antd-overrides/layout.scss
+++ b/src/styles/antd-overrides/layout.scss
@@ -9,4 +9,5 @@
 
 .ant-layout-header {
   color: var(--text-primary);
+  z-index: 99;
 }


### PR DESCRIPTION
## What does this PR do and why?

Adds language selector to site nav and links for languages in the footer, only including English, Russian and Chinese at the moment. Not sure if we want to merge this yet since the translations are only about 50% complete, happy to put on hold until we've made more progress. 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/147800695-487c3130-d0dd-41c4-860d-3b4c93a0ff85.mp4

(video doesn't show the Russian translations that have since been implemented (see russian-translations branch). Most of the homepage is translated to Russian)


## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
