### PR TITLE
Improve form for individual payout 

### DIFF
--- a/src/components/Create/BudgetForm.tsx
+++ b/src/components/Create/BudgetForm.tsx
@@ -107,7 +107,11 @@ export default function BudgetForm({
             <Switch
               checked={showFundingFields}
               onChange={checked => {
-                setTarget(checked ? '10000' : maxIntStr || '0')
+                let target = checked ? '10000' : maxIntStr || '0'
+                setTarget(target)
+                setTargetSubFee(
+                  targetToTargetSubFeeFormatted(target, adminFeePercent),
+                )
                 setCurrency(1)
                 setShowFundingFields(checked)
               }}

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -23,6 +23,8 @@ import {
 } from 'utils/formatNumber'
 import { amountSubFee } from 'utils/math'
 
+import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+
 import { FormItems } from '.'
 import CurrencySymbol from '../CurrencySymbol'
 import FormattedAddress from '../FormattedAddress'
@@ -61,6 +63,7 @@ export default function ProjectPayoutMods({
   const [editingModProjectId, setEditingModProjectId] = useState<BigNumber>()
   const [editingModIndex, setEditingModIndex] = useState<number>()
   const [editingPercent, setEditingPercent] = useState<number>()
+  const [editingAmount, setEditingAmount] = useState<string>()
   const [settingHandleIndex, setSettingHandleIndex] = useState<number>()
   const [editingModType, setEditingModType] = useState<ModType>('address')
   const [settingHandle, setSettingHandle] = useState<string>()
@@ -96,6 +99,15 @@ export default function ProjectPayoutMods({
   } = useContext(ThemeContext)
 
   const gutter = 10
+
+  // const getAmountFromPercent = (percent : number) => {
+  //   return formatWad(
+  //     amountSubFee(parseWad(target), fee)
+  //       ?.mul(Math.floor((percent ?? 0) * 100))
+  //       .div(10000),
+  //     { decimals: 4, padEnd: true },
+  //   )
+  // }
 
   const modInput = useCallback(
     (mod: EditingPayoutMod, index: number, locked?: boolean) => {
@@ -140,6 +152,7 @@ export default function ProjectPayoutMods({
               setModalMode('Edit')
               setEditingModIndex(index)
               setEditingPercent(percent)
+              setEditingAmount(getAmountFromPercent(percent, target, fee))
               setEditingModProjectId(mod.projectId)
             }}
           >
@@ -340,6 +353,11 @@ export default function ProjectPayoutMods({
     )
   }
 
+  const onAmountChange = (amount: string | undefined) => {
+    console.log('changing: ', amount)
+    setEditingAmount(amount ?? '0')
+  }
+
   return (
     <Form.Item {...formItemProps}>
       <Space direction="vertical" style={{ width: '100%' }} size="large">
@@ -480,7 +498,12 @@ export default function ProjectPayoutMods({
                   }}
                 />
               </span>
-
+              <FormattedNumberInput
+                value={editingAmount}
+                placeholder={'0'}
+                // disabled={disabled}
+                onChange={target => onAmountChange(target?.toString())}
+              />
               {parseWad(target).lt(constants.MaxUint256) && (
                 <span style={{ color: colors.text.primary, marginBottom: 22 }}>
                   <CurrencySymbol currency={currency} />

--- a/src/components/shared/formItems/ProjectTicketMods.tsx
+++ b/src/components/shared/formItems/ProjectTicketMods.tsx
@@ -2,7 +2,7 @@ import { CloseCircleOutlined, LockOutlined } from '@ant-design/icons'
 import { Button, Col, DatePicker, Form, Modal, Row, Space } from 'antd'
 import {
   validateEthAddress,
-  validateGreaterThanZero,
+  validatePercentage,
 } from 'components/shared/formItems/formHelpers'
 
 import { useForm } from 'antd/lib/form/Form'
@@ -223,9 +223,9 @@ export default function ProjectTicketMods({
     )
   }
 
-  // Validates slider (ensures percent !== 0)
+  // Validates slider (ensures percent !== 0 && percent <= 100)
   const validateSlider = () => {
-    return validateGreaterThanZero(form.getFieldValue('percent'))
+    return validatePercentage(form.getFieldValue('percent'))
   }
 
   return (

--- a/src/components/shared/formItems/formHelpers.tsx
+++ b/src/components/shared/formItems/formHelpers.tsx
@@ -16,8 +16,10 @@ export function getTotalPercentage(mods: PayoutMod[] | undefined) {
   )
 }
 
-export function validateGreaterThanZero(percent: number | undefined) {
+// Ensures value is greater than 0 and less than 100
+export function validatePercentage(percent: number | undefined) {
   if (percent === undefined || percent === 0) return Promise.reject('Required')
+  else if (percent > 100) return Promise.reject('Invalid')
   return Promise.resolve()
 }
 
@@ -48,17 +50,17 @@ export function validateEthAddress(
 
 export const targetToTargetSubFeeFormatted = (
   target: string,
-  adminFeePercent: BigNumber | undefined,
+  fee: BigNumber | undefined,
 ) => {
-  let newTargetSubFee = amountSubFee(parseWad(target ?? '0'), adminFeePercent)
+  let newTargetSubFee = amountSubFee(parseWad(target ?? ''), fee)
   return stripCommas(formatWad(newTargetSubFee, { decimals: 4 }) || '0') // formatWad returns formatted bigNum with commas, must remove
 }
 
 export const targetSubFeeToTargetFormatted = (
   targetSubFee: string,
-  adminFeePercent: BigNumber | undefined,
+  fee: BigNumber | undefined,
 ) => {
-  let newTarget = amountAddFee(parseWad(targetSubFee ?? '0'), adminFeePercent)
+  let newTarget = amountAddFee(parseWad(targetSubFee ?? '0'), fee)
   return stripCommas(formatWad(newTarget, { decimals: 4 }) || '0')
 }
 
@@ -67,10 +69,25 @@ export function getAmountFromPercent(
   target: string,
   fee: BigNumber | undefined,
 ) {
-  return formatWad(
-    amountSubFee(parseWad(target), fee)
-      ?.mul(Math.floor((percent ?? 0) * 100))
-      .div(10000),
-    { decimals: 4, padEnd: true },
+  return parseInt(
+    stripCommas(
+      formatWad(
+        amountSubFee(parseWad(stripCommas(target)), fee)
+          ?.mul(Math.floor((percent ?? 0) * 100))
+          .div(10000),
+        { decimals: 4, padEnd: true },
+      ) ?? '0',
+    ),
   )
+}
+
+export function getPercentFromAmount(
+  amount: number | undefined,
+  target: string,
+  fee: BigNumber | undefined,
+) {
+  let targetSubFeeBN = amountSubFee(parseWad(stripCommas(target)), fee)
+  let targetSubFee = parseInt(stripCommas(formatWad(targetSubFeeBN) ?? '0'))
+  let percent = amount ?? 0 / (targetSubFee ?? 1)
+  return percent / 1000
 }

--- a/src/components/shared/formItems/formHelpers.tsx
+++ b/src/components/shared/formItems/formHelpers.tsx
@@ -61,3 +61,16 @@ export const targetSubFeeToTargetFormatted = (
   let newTarget = amountAddFee(parseWad(targetSubFee ?? '0'), adminFeePercent)
   return stripCommas(formatWad(newTarget, { decimals: 4 }) || '0')
 }
+
+export function getAmountFromPercent(
+  percent: number,
+  target: string,
+  fee: BigNumber | undefined,
+) {
+  return formatWad(
+    amountSubFee(parseWad(target), fee)
+      ?.mul(Math.floor((percent ?? 0) * 100))
+      .div(10000),
+    { decimals: 4, padEnd: true },
+  )
+}


### PR DESCRIPTION
## What does this PR do and why?

Added an amount field to individual payout which links to percentage, so can now set a payout amount in a currency value instead of just by a percentage of the funding target.  Requested by @mejango 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/147845165-4e8b47c7-360d-4107-a231-f1f8aacd3ca9.mp4


## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
