### PR TITLE
formatGraphQuery Tests

### DIFF
--- a/src/utils/__tests__/graph.test.ts
+++ b/src/utils/__tests__/graph.test.ts
@@ -9,15 +9,6 @@ test('format basic queries', () => {
   expect(query).toBe('{ projects { id creator uri } }')
 })
 
-test('includes id key by default', () => {
-  const query = formatGraphQuery({
-    entity: 'project',
-    keys: [],
-  })
-
-  expect(query).toBe('{ projects { id } }')
-})
-
 test('format with first & skip', () => {
   const query = formatGraphQuery({
     entity: 'project',

--- a/src/utils/__tests__/graph.test.ts
+++ b/src/utils/__tests__/graph.test.ts
@@ -1,0 +1,79 @@
+import { formatGraphQuery } from '../graph'
+
+test('format basic queries', () => {
+  const query = formatGraphQuery({
+    entity: 'project',
+    keys: ['id', 'creator', 'uri'],
+  })
+
+  expect(query).toBe('{ projects { id creator uri } }')
+})
+
+test('includes id key by default', () => {
+  const query = formatGraphQuery({
+    entity: 'project',
+    keys: [],
+  })
+
+  expect(query).toBe('{ projects { id } }')
+})
+
+test('format with first & skip', () => {
+  const query = formatGraphQuery({
+    entity: 'project',
+    keys: ['id', 'creator', 'uri'],
+    first: 100,
+    skip: 10,
+  })
+
+  expect(query).toBe('{ projects(first: 100, skip: 10) { id creator uri } }')
+})
+
+test('format with single where', () => {
+  const query = formatGraphQuery({
+    entity: 'project',
+    keys: ['id', 'creator', 'uri'],
+    where: {
+      key: 'id',
+      value: '1',
+    },
+  })
+
+  expect(query).toBe('{ projects(where: { id: "1" }) { id creator uri } }')
+})
+
+test('format with multiple where', () => {
+  const query = formatGraphQuery({
+    entity: 'project',
+    keys: ['id', 'creator', 'uri'],
+    where: [
+      {
+        key: 'id',
+        value: '1',
+      },
+      {
+        key: 'creator',
+        value: '123',
+      },
+    ],
+  })
+
+  expect(query).toBe(
+    '{ projects(where: { id: "1", creator: "123" }) { id creator uri } }',
+  )
+})
+
+test('format nested entitites', () => {
+  const query = formatGraphQuery({
+    entity: 'project',
+    keys: [
+      'id',
+      {
+        entity: 'participant',
+        keys: ['id'],
+      },
+    ],
+  })
+
+  expect(query).toBe('{ projects { id participant { id } } }')
+})

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -77,8 +77,8 @@ export interface SubgraphError {
 
 export type OrderDirection = 'asc' | 'desc'
 
-export type WhereConfig = {
-  key: string
+export type WhereConfig<E extends EntityKey> = {
+  key: EntityKeys<E>
   value: string | number | boolean
   operator?:
     | 'not'
@@ -119,7 +119,7 @@ export interface GraphQueryOpts<E extends EntityKey, K extends EntityKeys<E>> {
       }
   )[]
   orderDirection?: OrderDirection
-  where?: WhereConfig | WhereConfig[]
+  where?: WhereConfig<E> | WhereConfig<E>[]
 }
 
 // https://thegraph.com/docs/graphql-api#filtering

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -136,6 +136,8 @@ export const formatGraphQuery = <E extends EntityKey, K extends EntityKeys<E>>(
     args += (args.length ? ', ' : '') + `${name}: ` + value
   }
 
+  if (!opts.keys.includes('id' as K)) opts.keys.push('id' as K)
+
   addArg('first', opts.first)
   addArg('skip', opts.skip)
   addArg('orderBy', opts.orderBy)
@@ -151,8 +153,8 @@ export const formatGraphQuery = <E extends EntityKey, K extends EntityKeys<E>>(
     'where',
     opts.where
       ? Array.isArray(opts.where)
-        ? `{ ${opts.where.map(
-            w => `${w.key}${w.operator ? '_' + w.operator : ''}: "${w.value}" `,
+        ? `{${opts.where.map(
+            w => ` ${w.key}${w.operator ? '_' + w.operator : ''}: "${w.value}"`,
           )} }`
         : `{ ${opts.where.key}${
             opts.where.operator ? '_' + opts.where.operator : ''
@@ -160,13 +162,13 @@ export const formatGraphQuery = <E extends EntityKey, K extends EntityKeys<E>>(
       : undefined,
   )
 
-  return `{ ${opts.entity}s${args ? `(${args})` : ''} { id${opts.keys.reduce(
+  return `{ ${opts.entity}s${args ? `(${args})` : ''} {${opts.keys.reduce(
     (acc, key) =>
       typeof key === 'string' ||
       typeof key === 'number' ||
       typeof key === 'symbol'
         ? acc + ' ' + key.toString()
-        : acc + ` ${key.entity}{ ${key.keys.map(k => k + ' ')} }`,
+        : acc + ` ${key.entity} { ${key.keys.join(' ')} }`,
     '',
   )} } }`
 }

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -136,8 +136,6 @@ export const formatGraphQuery = <E extends EntityKey, K extends EntityKeys<E>>(
     args += (args.length ? ', ' : '') + `${name}: ` + value
   }
 
-  if (!opts.keys.includes('id' as K)) opts.keys.push('id' as K)
-
   addArg('first', opts.first)
   addArg('skip', opts.skip)
   addArg('orderBy', opts.orderBy)


### PR DESCRIPTION
## What does this PR do and why?

While working on #312 , I noticed a couple oddities with the graph queries created by the `formatGraphQuery` util function, in particular that they would often include a redundant "id" key, e.g. `project { id id }`.

While the redundant key doesn't break things, it was an easy fix to make while still keeping the current behavior of always including at least `id`, so I did that. I also took this as an opportunity to write a couple of first tests, using Jest since it's already bundled in with react-scripts.

In the process of writing those tests, I noticed little quirks with formatting, so I addressed those as well. Example of a change:
```
# before:
projects(where: { id: "1" ,creator: "123"  }) { id }
                          ^               ^

# after:
projects(where: { id: "1", creator: "123" }) { id }
```

**One extra thing**, slightly unrelated to the above (if you'd prefer I split this lmk, I included it since it was a 2 line change in the same file): I updated `WhereConfig` to have context of the type it's filtering on, so that `key` is type aware, and only supports keys that exist on the entity being queried.

## Screenshots or screen recordings

Not applicable.

## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
