### PR TITLE
Add tooltips to funding progress bar

### DIFF
--- a/src/components/Dashboard/FundingProgressBar.tsx
+++ b/src/components/Dashboard/FundingProgressBar.tsx
@@ -1,0 +1,116 @@
+import { Progress, Tooltip } from 'antd'
+import useContractReader from 'hooks/ContractReader'
+import { ContractName } from 'models/contract-name'
+import { CurrencyOption } from 'models/currency-option'
+import { useContext, useMemo } from 'react'
+import { bigNumbersDiff } from 'utils/bigNumbersDiff'
+import { fracDiv } from 'utils/formatNumber'
+import { ProjectContext } from 'contexts/projectContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { useCurrencyConverter } from 'hooks/CurrencyConverter'
+import { BigNumber } from '@ethersproject/bignumber'
+import { hasFundingTarget } from 'utils/fundingCycle'
+
+export default function FundingProgressBar() {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const converter = useCurrencyConverter()
+  const { projectId, currentFC, balanceInCurrency } = useContext(ProjectContext)
+
+  const totalOverflow = useContractReader<BigNumber>({
+    contract: ContractName.TerminalV1,
+    functionName: 'currentOverflowOf',
+    args: projectId ? [projectId.toHexString()] : null,
+    valueDidChange: bigNumbersDiff,
+    updateOn: useMemo(
+      () =>
+        projectId
+          ? [
+              {
+                contract: ContractName.TerminalV1,
+                eventName: 'Pay',
+                topics: [[], projectId.toHexString()],
+              },
+              {
+                contract: ContractName.TerminalV1,
+                eventName: 'Tap',
+                topics: [[], projectId.toHexString()],
+              },
+            ]
+          : undefined,
+      [projectId],
+    ),
+  })
+
+  const overflowInCurrency = converter.wadToCurrency(
+    totalOverflow ?? 0,
+    currentFC?.currency.toNumber() as CurrencyOption,
+    0,
+  )
+
+  const percentPaid = useMemo(
+    () =>
+      balanceInCurrency && currentFC?.target
+        ? fracDiv(balanceInCurrency.toString(), currentFC.target.toString()) *
+          100
+        : 0,
+    [balanceInCurrency, currentFC],
+  )
+
+  // Percent overflow of target
+  const percentOverflow = fracDiv(
+    (overflowInCurrency?.sub(currentFC?.target ?? 0) ?? 0).toString(),
+    (currentFC?.target ?? 0).toString(),
+  )
+
+  if (!currentFC || (hasFundingTarget(currentFC) && currentFC.target.gt(0))) {
+    return null
+  }
+
+  return (
+    <Tooltip title="">
+      {totalOverflow?.gt(0) ? (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Progress
+            style={{
+              width: (1 - percentOverflow) * 100 + '%',
+              minWidth: 10,
+            }}
+            percent={100}
+            showInfo={false}
+            strokeColor={colors.text.brand.primary}
+          />
+          <div
+            style={{
+              minWidth: 4,
+              height: 15,
+              borderRadius: 2,
+              background: colors.text.primary,
+              marginLeft: 5,
+              marginRight: 5,
+              marginTop: 3,
+            }}
+          ></div>
+
+          <Progress
+            style={{
+              width: percentOverflow * 100 + '%',
+              minWidth: 10,
+            }}
+            percent={100}
+            showInfo={false}
+            strokeColor={colors.text.brand.primary}
+          />
+        </div>
+      ) : (
+        <Progress
+          percent={percentPaid ? Math.max(percentPaid, 1) : 0}
+          showInfo={false}
+          strokeColor={colors.text.brand.primary}
+        />
+      )}
+    </Tooltip>
+  )
+}

--- a/src/components/Dashboard/Paid.tsx
+++ b/src/components/Dashboard/Paid.tsx
@@ -253,15 +253,21 @@ export default function Paid() {
         currentFC.target.gt(0) &&
         (totalOverflow?.gt(0) ? (
           <div style={{ display: 'flex', alignItems: 'center' }}>
-            <Progress
-              style={{
-                width: (1 - percentOverflow) * 100 + '%',
-                minWidth: 10,
-              }}
-              percent={100}
-              showInfo={false}
-              strokeColor={colors.text.brand.primary}
-            />
+            <Tooltip
+              title={
+                <>Funding target: {formatCurrencyAmount(currentFC.target)}</>
+              }
+            >
+              <Progress
+                style={{
+                  width: (1 - percentOverflow) * 100 + '%',
+                  minWidth: 10,
+                }}
+                percent={100}
+                showInfo={false}
+                strokeColor={colors.text.brand.primary}
+              />
+            </Tooltip>
             <div
               style={{
                 minWidth: 4,
@@ -273,15 +279,19 @@ export default function Paid() {
                 marginTop: 3,
               }}
             ></div>
-            <Progress
-              style={{
-                width: percentOverflow * 100 + '%',
-                minWidth: 10,
-              }}
-              percent={100}
-              showInfo={false}
-              strokeColor={colors.text.brand.primary}
-            />
+            <Tooltip
+              title={<>Overflow: {formatCurrencyAmount(overflowInCurrency)}</>}
+            >
+              <Progress
+                style={{
+                  width: percentOverflow * 100 + '%',
+                  minWidth: 10,
+                }}
+                percent={100}
+                showInfo={false}
+                strokeColor={colors.text.brand.primary}
+              />
+            </Tooltip>
           </div>
         ) : (
           <Progress


### PR DESCRIPTION
## What does this PR do and why?

Adds 2 basic tooltips to the funding progress bar on the project page. The aim is to help folks understand the progress bar easier.

## Screenshots or screen recordings

| target tooltip | overflow tooltip |
| --- | --- |
| <img width="642" alt="Screen Shot 2022-01-04 at 9 42 25 pm" src="https://user-images.githubusercontent.com/94939382/148057672-fa6bd8f8-9ec7-48b0-98e3-67e3b60d3a26.png"> | <img width="540" alt="Screen Shot 2022-01-04 at 9 42 19 pm" src="https://user-images.githubusercontent.com/94939382/148057700-ab7a2d62-91ef-4c66-8a20-28ac70baff5f.png"> |

## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
