### PR TITLE
Integrate Crowdin to Juicebox

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,0 +1,36 @@
+name: Crowdin download
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # every day at 1am we download translations from Crowdin and make PR to main
+
+  # manual trigger from Github UI - Action tab
+  workflow_dispatch:
+
+jobs:
+  download-translations:
+    name: Download translations from Crowdin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Extract translations
+        run: 'yarn i18n:extract'
+
+      - name: Download from Crowdin
+        uses: crowdin/github-action@1.4.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_translations: false
+          download_translations: true
+          create_pull_request: true
+          project_id: '492549'
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          source: 'src/locales/en/messages.po'
+          translation: 'src/locales/%two_letters_code%/%original_file_name%'

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,13 +1,8 @@
 name: Crowdin download
 
-# on:
-#   schedule:
-#     - cron: '0 1 * * *' # every day at 1am we download translations from Crowdin and make PR to main
-
 on:
-  push:
-    branches:
-      - crowdin-integration
+  schedule:
+    - cron: '0 1 * * *' # every day at 1am we download translations from Crowdin and make PR to main
 
   # manual trigger from Github UI - Action tab
   workflow_dispatch:
@@ -36,7 +31,6 @@ jobs:
           download_translations: true
           create_pull_request: true
           project_id: '492549'
-          # token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ3UUVxdmhVM3ZMT2EyWGljbVV5VCIsImp0aSI6ImE1ODFlMTZlMjRmYzAwOWVlMzgzYjVlYTE4Mzg3YjlhNmQ5MjVjZmVkNzg3M2UyMmU4ZDIxOGM4MDI0ZDMwOWJlMzY3ZmUyN2VmZjc3YmUxIiwiaWF0IjoxNjQxMTc4NDE0LCJuYmYiOjE2NDExNzg0MTQsImV4cCI6MTY0Mzc3MDQxNCwic3ViIjoiMTUwODc4NDciLCJkb21haW4iOm51bGwsInNjb3BlcyI6WyJwcm9qZWN0Il0sImFzc29jaWF0aW9ucyI6WyIqIl0sInNlc3Npb24iOjB9.hJ-PPDgbqGqEQnA4RKR1PaLaSZJ-vYYwCkJvvi4vdaxRJTjHgG7Y3u6vA32TH3fUDtWaLpqr52HYMdVSgvDvFOK_wQwqxurPqJ4SPhntWjHJfoF2d22CFcIMn7HIzYVD7cqWLXUGlgHQggiHsU-WKU42PzVGst-7nKtvlSYjPVZj_-XsZUbH0iHYF7AutXZcY1P0eeD2z6dLPhl252J5GYTwMXuWSAZjNeiZq3RtZkrflmgyWOlva_aoGGy15A6iZI2VXs7qhvkq4FebXrYBrUMWO3x_gwg_Oi2rN6Q8Ay_tw7ZtqWMjk_LYIweQtX6U9d_tvGO1Fr6N9xDe8MErAp_pSWICLpHpTpMujWo5UUXZfJq_HL8N1tU9ycTa-MOOQVKBI8zissCVB0eem7f4izfb2_D14xD90l-sd_uoTEyyyksEE3Hl3-kcD49nykkfZp0XucaafDxDkWmKLtn9XcCk4Sf2juPYrCv5nd--md0JblYa1gduhvo98lGb1gmdKEF1SHrPD5Joalm48WP9A0dvNCkQ6jRKV5Qp27iZakGoUL8UNNRC_-V0o6uOtiwr4tu-P_c_saCPisep71JHfj8keoBSMsrzD2ktP2DmJheouEjan7GGmBOMhJNfob-VN0jbckk5avBbpuZyKBCUHmRuhihekarfEy5i_765ABw'
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           source: 'src/locales/en/messages.po'
           translation: 'src/locales/%two_letters_code%/%original_file_name%'

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,8 +1,13 @@
 name: Crowdin download
 
+# on:
+#   schedule:
+#     - cron: '0 1 * * *' # every day at 1am we download translations from Crowdin and make PR to main
+
 on:
-  schedule:
-    - cron: '0 1 * * *' # every day at 1am we download translations from Crowdin and make PR to main
+  push:
+    branches:
+      - crowdin-integration
 
   # manual trigger from Github UI - Action tab
   workflow_dispatch:
@@ -31,6 +36,7 @@ jobs:
           download_translations: true
           create_pull_request: true
           project_id: '492549'
-          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          # token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ3UUVxdmhVM3ZMT2EyWGljbVV5VCIsImp0aSI6ImE1ODFlMTZlMjRmYzAwOWVlMzgzYjVlYTE4Mzg3YjlhNmQ5MjVjZmVkNzg3M2UyMmU4ZDIxOGM4MDI0ZDMwOWJlMzY3ZmUyN2VmZjc3YmUxIiwiaWF0IjoxNjQxMTc4NDE0LCJuYmYiOjE2NDExNzg0MTQsImV4cCI6MTY0Mzc3MDQxNCwic3ViIjoiMTUwODc4NDciLCJkb21haW4iOm51bGwsInNjb3BlcyI6WyJwcm9qZWN0Il0sImFzc29jaWF0aW9ucyI6WyIqIl0sInNlc3Npb24iOjB9.hJ-PPDgbqGqEQnA4RKR1PaLaSZJ-vYYwCkJvvi4vdaxRJTjHgG7Y3u6vA32TH3fUDtWaLpqr52HYMdVSgvDvFOK_wQwqxurPqJ4SPhntWjHJfoF2d22CFcIMn7HIzYVD7cqWLXUGlgHQggiHsU-WKU42PzVGst-7nKtvlSYjPVZj_-XsZUbH0iHYF7AutXZcY1P0eeD2z6dLPhl252J5GYTwMXuWSAZjNeiZq3RtZkrflmgyWOlva_aoGGy15A6iZI2VXs7qhvkq4FebXrYBrUMWO3x_gwg_Oi2rN6Q8Ay_tw7ZtqWMjk_LYIweQtX6U9d_tvGO1Fr6N9xDe8MErAp_pSWICLpHpTpMujWo5UUXZfJq_HL8N1tU9ycTa-MOOQVKBI8zissCVB0eem7f4izfb2_D14xD90l-sd_uoTEyyyksEE3Hl3-kcD49nykkfZp0XucaafDxDkWmKLtn9XcCk4Sf2juPYrCv5nd--md0JblYa1gduhvo98lGb1gmdKEF1SHrPD5Joalm48WP9A0dvNCkQ6jRKV5Qp27iZakGoUL8UNNRC_-V0o6uOtiwr4tu-P_c_saCPisep71JHfj8keoBSMsrzD2ktP2DmJheouEjan7GGmBOMhJNfob-VN0jbckk5avBbpuZyKBCUHmRuhihekarfEy5i_765ABw'
           source: 'src/locales/en/messages.po'
           translation: 'src/locales/%two_letters_code%/%original_file_name%'

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -3,7 +3,7 @@ name: Crowdin upload
 on:
   push:
     branches:
-      - main
+      - crowdin-integration
 
   # manual trigger from Github UI - Action tab
   workflow_dispatch:
@@ -31,6 +31,7 @@ jobs:
           upload_translations: true
           download_translations: false
           project_id: '492549'
-          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          # token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ3UUVxdmhVM3ZMT2EyWGljbVV5VCIsImp0aSI6ImE1ODFlMTZlMjRmYzAwOWVlMzgzYjVlYTE4Mzg3YjlhNmQ5MjVjZmVkNzg3M2UyMmU4ZDIxOGM4MDI0ZDMwOWJlMzY3ZmUyN2VmZjc3YmUxIiwiaWF0IjoxNjQxMTc4NDE0LCJuYmYiOjE2NDExNzg0MTQsImV4cCI6MTY0Mzc3MDQxNCwic3ViIjoiMTUwODc4NDciLCJkb21haW4iOm51bGwsInNjb3BlcyI6WyJwcm9qZWN0Il0sImFzc29jaWF0aW9ucyI6WyIqIl0sInNlc3Npb24iOjB9.hJ-PPDgbqGqEQnA4RKR1PaLaSZJ-vYYwCkJvvi4vdaxRJTjHgG7Y3u6vA32TH3fUDtWaLpqr52HYMdVSgvDvFOK_wQwqxurPqJ4SPhntWjHJfoF2d22CFcIMn7HIzYVD7cqWLXUGlgHQggiHsU-WKU42PzVGst-7nKtvlSYjPVZj_-XsZUbH0iHYF7AutXZcY1P0eeD2z6dLPhl252J5GYTwMXuWSAZjNeiZq3RtZkrflmgyWOlva_aoGGy15A6iZI2VXs7qhvkq4FebXrYBrUMWO3x_gwg_Oi2rN6Q8Ay_tw7ZtqWMjk_LYIweQtX6U9d_tvGO1Fr6N9xDe8MErAp_pSWICLpHpTpMujWo5UUXZfJq_HL8N1tU9ycTa-MOOQVKBI8zissCVB0eem7f4izfb2_D14xD90l-sd_uoTEyyyksEE3Hl3-kcD49nykkfZp0XucaafDxDkWmKLtn9XcCk4Sf2juPYrCv5nd--md0JblYa1gduhvo98lGb1gmdKEF1SHrPD5Joalm48WP9A0dvNCkQ6jRKV5Qp27iZakGoUL8UNNRC_-V0o6uOtiwr4tu-P_c_saCPisep71JHfj8keoBSMsrzD2ktP2DmJheouEjan7GGmBOMhJNfob-VN0jbckk5avBbpuZyKBCUHmRuhihekarfEy5i_765ABw'
           source: 'src/locales/en/messages.po'
           translation: 'src/locales/%two_letters_code%/%original_file_name%'

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -3,7 +3,7 @@ name: Crowdin upload
 on:
   push:
     branches:
-      - crowdin-integration
+      - main
 
   # manual trigger from Github UI - Action tab
   workflow_dispatch:
@@ -31,7 +31,6 @@ jobs:
           upload_translations: true
           download_translations: false
           project_id: '492549'
-          # token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ3UUVxdmhVM3ZMT2EyWGljbVV5VCIsImp0aSI6ImE1ODFlMTZlMjRmYzAwOWVlMzgzYjVlYTE4Mzg3YjlhNmQ5MjVjZmVkNzg3M2UyMmU4ZDIxOGM4MDI0ZDMwOWJlMzY3ZmUyN2VmZjc3YmUxIiwiaWF0IjoxNjQxMTc4NDE0LCJuYmYiOjE2NDExNzg0MTQsImV4cCI6MTY0Mzc3MDQxNCwic3ViIjoiMTUwODc4NDciLCJkb21haW4iOm51bGwsInNjb3BlcyI6WyJwcm9qZWN0Il0sImFzc29jaWF0aW9ucyI6WyIqIl0sInNlc3Npb24iOjB9.hJ-PPDgbqGqEQnA4RKR1PaLaSZJ-vYYwCkJvvi4vdaxRJTjHgG7Y3u6vA32TH3fUDtWaLpqr52HYMdVSgvDvFOK_wQwqxurPqJ4SPhntWjHJfoF2d22CFcIMn7HIzYVD7cqWLXUGlgHQggiHsU-WKU42PzVGst-7nKtvlSYjPVZj_-XsZUbH0iHYF7AutXZcY1P0eeD2z6dLPhl252J5GYTwMXuWSAZjNeiZq3RtZkrflmgyWOlva_aoGGy15A6iZI2VXs7qhvkq4FebXrYBrUMWO3x_gwg_Oi2rN6Q8Ay_tw7ZtqWMjk_LYIweQtX6U9d_tvGO1Fr6N9xDe8MErAp_pSWICLpHpTpMujWo5UUXZfJq_HL8N1tU9ycTa-MOOQVKBI8zissCVB0eem7f4izfb2_D14xD90l-sd_uoTEyyyksEE3Hl3-kcD49nykkfZp0XucaafDxDkWmKLtn9XcCk4Sf2juPYrCv5nd--md0JblYa1gduhvo98lGb1gmdKEF1SHrPD5Joalm48WP9A0dvNCkQ6jRKV5Qp27iZakGoUL8UNNRC_-V0o6uOtiwr4tu-P_c_saCPisep71JHfj8keoBSMsrzD2ktP2DmJheouEjan7GGmBOMhJNfob-VN0jbckk5avBbpuZyKBCUHmRuhihekarfEy5i_765ABw'
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           source: 'src/locales/en/messages.po'
           translation: 'src/locales/%two_letters_code%/%original_file_name%'

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  synchronize-with-crowdin:
+  upload-translations:
     name: Upload sources to Crowdin
     runs-on: ubuntu-latest
 

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,36 @@
+name: Crowdin upload
+
+on:
+  push:
+    branches:
+      - main
+
+  # manual trigger from Github UI - Action tab
+  workflow_dispatch:
+
+jobs:
+  synchronize-with-crowdin:
+    name: Upload sources to Crowdin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Extract translations
+        run: 'yarn i18n:compile'
+
+      - name: Upload to Crowdin
+        uses: crowdin/github-action@1.4.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_translations: true
+          download_translations: false
+          project_id: '492549'
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          source: 'src/locales/en/messages.po'
+          translation: 'src/locales/%two_letters_code%/%original_file_name%'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,10 @@ about the differences between merge and rebase Git workflows.
 
 #### Rebase procedure
 
-You can rebase your feature branch with the following procedure, where `feature-branch` is the name of your branch. Further explanation of rebase and its options can be found [here](https://docs.gitlab.com/ee/topics/git/git_rebase.html).
+You can rebase your feature branch with the following procedure, where
+`feature-branch` is the name of your branch. Further explanation of rebase and
+its options can be found
+[here](https://docs.gitlab.com/ee/topics/git/git_rebase.html).
 
 1. `git checkout feature-branch`
 2. `git fetch origin main`
@@ -60,50 +63,26 @@ All changes to the `main` branch will be automatically deployed via
 
 ## Translations
 
-Juicebox uses [`lingui.js`](https://lingui.js.org) for internationlization
-(i18n). Languages we support are defined in `.linguirc.json`. `en` is our source
-language.
+Juicebox uses [Crowdin](https://crowdin.com/project/juicebox-interface) for
+managing translations. This workflow uploads new strings for translation to the
+Crowdin project whenever code using the lingui translation macros is merged into
+main.
 
-Developers should mark strings for translation using one of the `lingui.js`
-[macros](https://lingui.js.org/ref/macro.html). Strings marked for translation
-will be extracted at build-time and added to `messages.po` files within the
-`./locale` directory.
+Every day, translations are synced back down from Crowdin to a pull request to
+`main`. We then merge these PR's into `main` manually.
+
+If you are a developer, please mark any new text that you add in the interface
+for translation with the lingui [macros](https://lingui.js.org/ref/macro.html)
+(`` t`Example text`  `` or `<Trans>Text</Trans>`). Feel free to edit any
+existing text that hasn't yet been marked for translations.
 
 ### Contributing translations
 
-The following steps describe how to contribute translations for a given
-language. You will contribute translations directly to this repository. This
-means you need a GitHub account.
+For details of how to contribute as a translator, see our
+[How to become a Juicebox translator](https://www.notion.so/juicebox/How-to-become-a-Juicebox-translator-81fdd9344ef043909a48bd7373ef73d7)
+Notion page.
 
-1. Create a
-   [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of this
-   repository.
-1. Clone your fork to your local machine.
-
-1. Open the `messages.po` file for the locale you want to add translations for.
-   For example, to add Chinese translations, open the `./locale/zh/messages.po`
-   file.
-
-1. Locate the string you want translate in the `msgid` field.
-
-   > For strings where a `msgid` has been manually set, find the `msgstr` for
-   > the given `msgid` in the `./locales/en/messages.po` file (the source
-   > locale).
-
-1. Add the translation in the `msgstr` field.
-
-   ```diff
-   msgid "Community funding for people and projects"
-   - msgstr ""
-   + msgstr "为个人和项目提供社区资助"
-   ```
-
-1. Commit the changes and create a pull request on GitHub.
-
-If you need help at any stage, reach out in the
-[Discord](https://discord.gg/6jXrJSyDFf).
-
-### Adding a language
+### Adding a language (for devs)
 
 1. Add the locale code to `./linguirc.json`.
 
@@ -136,9 +115,9 @@ If you need help at any stage, reach out in the
    })
    ```
 
-1. Extract the strings marked for translation. This creates a directory for the
-   locale within the `./locale/` directory:
+1. Extract the strings marked for translation and compile them. This creates a
+   directory for the locale within the `./locale/` directory:
 
    ```bash
-   yarn i18n:extract
+   yarn i18n:compile
    ```

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "lint-staged": "lint-staged",
     "prepare": "husky install",
     "i18n:extract": "lingui extract",
-    "i18n:compile": "lingui compile",
-    "postinstall": "yarn i18n:extract && yarn i18n:compile",
+    "i18n:compile": "yarn i18n:extract && lingui compile",
+    "postinstall": "yarn i18n:compile",
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js'"
   },
   "lint-staged": {

--- a/src/components/Create/ConfirmDeployProject.tsx
+++ b/src/components/Create/ConfirmDeployProject.tsx
@@ -1,4 +1,5 @@
 import { Space, Statistic } from 'antd'
+import { t } from '@lingui/macro'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import PayoutModsList from 'components/shared/PayoutModsList'
 import ProjectLogo from 'components/shared/ProjectLogo'
@@ -166,7 +167,7 @@ export default function ConfirmDeployProject() {
         )}
       />
       <Statistic
-        title="Reserved token allocations"
+        title={t`Reserved token allocations`}
         valueRender={() => (
           <TicketModsList
             mods={ticketMods}

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -54,7 +54,7 @@ export default function Navbar() {
           [ThemeOption.dark]: '/assets/juice_logo-od.png',
         })
       }
-      alt="Juicebox logo"
+      alt={t`Juicebox logo`}
     />
   )
 

--- a/src/components/shared/UntrackedErc20Notice.tsx
+++ b/src/components/shared/UntrackedErc20Notice.tsx
@@ -1,3 +1,5 @@
+import { Trans } from '@lingui/macro'
+
 export default function UntrackedErc20Notice({
   tokenSymbol,
 }: {
@@ -5,9 +7,11 @@ export default function UntrackedErc20Notice({
 }) {
   return (
     <div>
-      <b>Notice:</b> These balances will not reflect transfers of claimed tokens
-      because the {tokenSymbol} ERC-20 token has not yet been indexed by
-      Juicebox.
+      <Trans>
+        <b>Notice:</b> These balances will not reflect transfers of claimed
+        tokens because the {tokenSymbol} ERC-20 token has not yet been indexed
+        by Juicebox.
+      </Trans>
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

This is ready to go. Upload and download actions are functioning perfectly. 

Adds two Github action files to upload to and download from Crowdin. `crowdin-upload.yml` uploads all new text marked for translation to Crowdin whenever something is pushed to `main`. `crowdin-download.yml` runs once a day at 1am UTC and creates a PR to `main` with all the new translations marked in Crowdin from a branch called `l10n_crowdin_action` (see example PR [#337](https://github.com/jbx-protocol/juice-interface/pull/337)). 

Also updated the Translation section in CONTRIBUTION.md. Any other files in this PR just have some pieces of text marked for translation for me to test the actions. 

### For info on how translators will make their translations with Crowdin:
https://www.notion.so/juicebox/How-to-become-a-Juicebox-translator-81fdd9344ef043909a48bd7373ef73d7

### For info on how managers will operate Crowdin:
https://www.notion.so/juicebox/Crowdin-for-translation-managers-371ae195395740f5a5bced8f312ca71e

## Acceptance checklist

- [x] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
