### PR TITLE
Add constants for currencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@ changes._
 
 ## Acceptance checklist
 
-- [ ] I have evaluted the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
+- [ ] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
 - [ ] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).

--- a/src/components/Dashboard/BalanceTimeline.tsx
+++ b/src/components/Dashboard/BalanceTimeline.tsx
@@ -30,6 +30,7 @@ import { querySubgraph } from 'utils/graph'
 import { readProvider } from 'constants/readProvider'
 
 import SectionHeader from './SectionHeader'
+import { CURRENCY_ETH } from 'constants/currency'
 
 const now = moment.now() - 5 * 60 * 1000 // 5 min ago
 
@@ -488,7 +489,7 @@ export default function BalanceTimeline({ height }: { height: number }) {
                     </div>
                     {payload[0].payload.tapped ? (
                       <div>
-                        -<CurrencySymbol currency={0} />
+                        -<CurrencySymbol currency={CURRENCY_ETH} />
                         {payload[0].payload.tapped}
                         <div
                           style={{
@@ -502,7 +503,7 @@ export default function BalanceTimeline({ height }: { height: number }) {
                       </div>
                     ) : (
                       <div>
-                        <CurrencySymbol currency={0} />
+                        <CurrencySymbol currency={CURRENCY_ETH} />
                         {payload[0].payload.value}
                       </div>
                     )}

--- a/src/components/Dashboard/Paid.tsx
+++ b/src/components/Dashboard/Paid.tsx
@@ -22,6 +22,7 @@ import { hasFundingTarget } from 'utils/fundingCycle'
 import { readNetwork } from 'constants/networks'
 
 import BalancesModal from '../modals/BalancesModal'
+import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
 
 export default function Paid() {
   const [balancesModalVisible, setBalancesModalVisible] = useState<boolean>()
@@ -103,12 +104,12 @@ export default function Paid() {
   const formatCurrencyAmount = (amt: BigNumber | undefined) =>
     amt ? (
       <>
-        {currentFC.currency.eq(1) ? (
+        {currentFC.currency.eq(CURRENCY_USD) ? (
           <span>
             <Tooltip
               title={
                 <span>
-                  <CurrencySymbol currency={0} />
+                  <CurrencySymbol currency={CURRENCY_ETH} />
                   {formatWad(converter.usdToWei(fromWad(amt)), {
                     decimals: 2,
                     padEnd: true,
@@ -116,13 +117,13 @@ export default function Paid() {
                 </span>
               }
             >
-              <CurrencySymbol currency={1} />
+              <CurrencySymbol currency={CURRENCY_USD} />
               {formatWad(amt, { decimals: 2, padEnd: true })}
             </Tooltip>
           </span>
         ) : (
           <span>
-            <CurrencySymbol currency={0} />
+            <CurrencySymbol currency={CURRENCY_ETH} />
             {formatWad(amt, { decimals: 2, padEnd: true })}
           </span>
         )}
@@ -151,7 +152,7 @@ export default function Paid() {
         <span style={primaryTextStyle}>
           {isConstitutionDAO && (
             <span style={secondaryTextStyle}>
-              <CurrencySymbol currency={1} />
+              <CurrencySymbol currency={CURRENCY_USD} />
               {formatWad(converter.wadToCurrency(earned, 1, 0), {
                 decimals: 2,
                 padEnd: true,
@@ -165,7 +166,7 @@ export default function Paid() {
                 : colors.text.primary,
             }}
           >
-            <CurrencySymbol currency={0} />
+            <CurrencySymbol currency={CURRENCY_ETH} />
             {earned?.lt(parseWad('1')) && earned.gt(0)
               ? '<1'
               : formatWad(earned, { decimals: 0 })}
@@ -197,9 +198,9 @@ export default function Paid() {
             marginLeft: 10,
           }}
         >
-          {currentFC.currency.eq(1) ? (
+          {currentFC.currency.eq(CURRENCY_USD) ? (
             <span style={secondaryTextStyle}>
-              <CurrencySymbol currency={0} />
+              <CurrencySymbol currency={CURRENCY_ETH} />
               {formatWad(balance, { decimals: 2, padEnd: true })}{' '}
             </span>
           ) : (
@@ -324,7 +325,7 @@ export default function Paid() {
             +{' '}
           </span>
           <span style={primaryTextStyle}>
-            <CurrencySymbol currency={0} />
+            <CurrencySymbol currency={CURRENCY_ETH} />
             {formatWad(ownerBalance, { decimals: 2, padEnd: true })}
           </span>
         </span>

--- a/src/components/Dashboard/Pay.tsx
+++ b/src/components/Dashboard/Pay.tsx
@@ -20,6 +20,7 @@ import { disablePayOverrides } from 'constants/overrides'
 import { readNetwork } from 'constants/networks'
 
 import CurrencySymbol from '../shared/CurrencySymbol'
+import { CURRENCY_ETH } from 'constants/currency'
 
 export default function Pay() {
   const [payIn, setPayIn] = useState<CurrencyOption>(0)
@@ -162,7 +163,7 @@ export default function Pay() {
           {payButton}
           {payIn === 1 && (
             <div style={{ fontSize: '.7rem' }}>
-              Paid as <CurrencySymbol currency={0} />
+              Paid as <CurrencySymbol currency={CURRENCY_ETH} />
               {formatWad(weiPayAmt) || '0'}
             </div>
           )}

--- a/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
@@ -12,6 +12,7 @@ import RichNote from './RichNote'
 import { contentLineHeight, smallHeaderStyle } from './styles'
 import { useInfiniteSubgraphQuery } from '../../../hooks/SubgraphQuery'
 import ActivityTabContent from './ActivityTabContent'
+import { CURRENCY_ETH } from 'constants/currency'
 
 // Maps a project id to an internal map of payment event overrides.
 let payEventOverrides = new Map<string, Map<string, string>>([
@@ -108,7 +109,7 @@ export function PaymentActivity({ pageSize }: { pageSize: number }) {
                       fontSize: '1rem',
                     }}
                   >
-                    <CurrencySymbol currency={0} />
+                    <CurrencySymbol currency={CURRENCY_ETH} />
                     {formatWad(e.amount, { decimals: 4 })}
                   </div>
                 </div>

--- a/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
@@ -10,6 +10,7 @@ import { formatWad } from 'utils/formatNumber'
 import { contentLineHeight, smallHeaderStyle } from './styles'
 import { useInfiniteSubgraphQuery } from '../../../hooks/SubgraphQuery'
 import ActivityTabContent from './ActivityTabContent'
+import { CURRENCY_ETH } from 'constants/currency'
 
 export function RedeemActivity({ pageSize }: { pageSize: number }) {
   const { projectId, tokenSymbol } = useContext(ProjectContext)
@@ -111,7 +112,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
               </div>
 
               <div style={{ color: colors.text.secondary }}>
-                <CurrencySymbol currency={0} />
+                <CurrencySymbol currency={CURRENCY_ETH} />
                 {formatWad(e.returnAmount, { decimals: 4 })} overflow received
               </div>
             </div>

--- a/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
@@ -10,6 +10,7 @@ import { formatWad } from 'utils/formatNumber'
 
 import { smallHeaderStyle } from '../styles'
 import useSubgraphQuery from '../../../hooks/SubgraphQuery'
+import { CURRENCY_ETH } from 'constants/currency'
 
 export default function TapEventElem({
   tapEvent,
@@ -98,7 +99,7 @@ export default function TapEventElem({
             </div>
 
             <div style={{ color: colors.text.secondary }}>
-              <CurrencySymbol currency={0} />
+              <CurrencySymbol currency={CURRENCY_ETH} />
               {formatWad(e.modCut, { decimals: 4 })}
             </div>
           </div>
@@ -126,7 +127,7 @@ export default function TapEventElem({
                   : { fontWeight: 500 }
               }
             >
-              <CurrencySymbol currency={0} />
+              <CurrencySymbol currency={CURRENCY_ETH} />
               {formatWad(tapEvent.beneficiaryTransferAmount, { decimals: 4 })}
             </div>
           </div>
@@ -141,7 +142,7 @@ export default function TapEventElem({
             textAlign: 'right',
           }}
         >
-          <CurrencySymbol currency={0} />
+          <CurrencySymbol currency={CURRENCY_ETH} />
           {formatWad(tapEvent.netTransferAmount, { decimals: 4 })}
         </div>
       ) : null}

--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -9,6 +9,7 @@ import { ThemeContext } from 'contexts/themeContext'
 import FormattedAddress from 'components/shared/FormattedAddress'
 
 import useSubgraphQuery from '../../hooks/SubgraphQuery'
+import { CURRENCY_ETH } from 'constants/currency'
 
 export default function Payments() {
   const {
@@ -69,7 +70,7 @@ export default function Payments() {
                 }}
               >
                 <span style={{ fontSize: '1rem', fontWeight: 500 }}>
-                  <CurrencySymbol currency={0} />
+                  <CurrencySymbol currency={CURRENCY_ETH} />
                   {formatWad(e.amount, { decimals: 4 })}
                 </span>
                 <span>

--- a/src/components/Navbar/Balance.tsx
+++ b/src/components/Navbar/Balance.tsx
@@ -1,8 +1,11 @@
 import EthPrice from 'components/Navbar/EthPrice'
+
 import { ThemeContext } from 'contexts/themeContext'
 import { useEthBalanceQuery } from 'hooks/EthBalance'
 import { useContext } from 'react'
 import { formatWad } from 'utils/formatNumber'
+
+import { CURRENCY_ETH } from 'constants/currency'
 
 import CurrencySymbol from '../shared/CurrencySymbol'
 
@@ -26,7 +29,7 @@ export default function Balance({
         lineHeight: 1,
       }}
     >
-      <CurrencySymbol currency={0} />
+      <CurrencySymbol currency={CURRENCY_ETH} />
       {formatWad(balance, { decimals: 4 }) ?? '--'}
       {showEthPrice && (
         <div style={{ color: colors.text.tertiary }}>

--- a/src/components/Navbar/EthPrice.tsx
+++ b/src/components/Navbar/EthPrice.tsx
@@ -1,12 +1,15 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
+
 import { useEtherPrice } from 'hooks/EtherPrice'
 import { currencyName } from 'utils/currency'
+
+import { CURRENCY_USD } from 'constants/currency'
 
 export default function EthPrice() {
   const price = useEtherPrice()
   return (
     <div>
-      <CurrencySymbol currency={1} />
+      <CurrencySymbol currency={CURRENCY_USD} />
       {price?.toFixed(2)}/{currencyName(0)}
     </div>
   )

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -28,6 +28,7 @@ import { OrderDirection, querySubgraph } from 'utils/graph'
 import { indexedProjectERC20s } from 'constants/indexed-project-erc20s'
 
 import DownloadParticipantsModal from './DownloadParticipantsModal'
+import { CURRENCY_ETH } from 'constants/currency'
 
 const pageSize = 100
 
@@ -105,7 +106,7 @@ export default function ParticipantsModal({
 
   const formattedPaid = (amount: BigNumber | undefined) => (
     <span>
-      <CurrencySymbol currency={0} />
+      <CurrencySymbol currency={CURRENCY_ETH} />
       {formatWad(amount, { decimals: 6 })}
     </span>
   )

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -2,6 +2,7 @@ import { Modal, Space } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -13,6 +14,8 @@ import { CSSProperties, useContext, useMemo, useState } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
 import { decodeFCMetadata } from 'utils/fundingCycle'
+
+import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
 
 import { useRedeemRate } from '../../hooks/RedeemRate'
 
@@ -75,7 +78,7 @@ export default function RedeemModal({
   })
 
   // 0.5% slippage for USD-denominated projects
-  const minAmount = currentFC?.currency.eq(1)
+  const minAmount = currentFC?.currency.eq(CURRENCY_USD)
     ? rewardAmount?.mul(1000).div(1005)
     : rewardAmount
 
@@ -167,7 +170,7 @@ export default function RedeemModal({
           <p style={statsStyle}>
             Currently worth:{' '}
             <span>
-              <CurrencySymbol currency={0} />
+              <CurrencySymbol currency={CURRENCY_ETH} />
               {formatWad(maxClaimable, { decimals: 4 })}
             </span>
           </p>
@@ -201,7 +204,8 @@ export default function RedeemModal({
               onChange={val => setRedeemAmount(val)}
             />
             <div style={{ fontWeight: 500, marginTop: 20 }}>
-              You will receive {currentFC?.currency.eq(1) ? 'minimum ' : ' '}
+              You will receive{' '}
+              {currentFC?.currency.eq(CURRENCY_USD) ? 'minimum ' : ' '}
               {formatWad(minAmount, { decimals: 8 }) || '--'} ETH
             </div>
           </div>

--- a/src/components/modals/WithdrawModal.tsx
+++ b/src/components/modals/WithdrawModal.tsx
@@ -15,6 +15,8 @@ import { currencyName } from 'utils/currency'
 import { formatWad, fromPerbicent, fromWad, parseWad } from 'utils/formatNumber'
 import { amountSubFee, feeForAmount } from 'utils/math'
 
+import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
+
 export default function WithdrawModal({
   visible,
   onCancel,
@@ -66,7 +68,7 @@ export default function WithdrawModal({
     }
 
     const minAmount = (
-      currentFC.currency.eq(1)
+      currentFC.currency.eq(CURRENCY_USD)
         ? converter.usdToWei(tapAmount)
         : parseWad(tapAmount)
     )?.sub(1e12) // Arbitrary value subtracted
@@ -173,10 +175,10 @@ export default function WithdrawModal({
 
           <div style={{ color: colors.text.primary, marginBottom: 10 }}>
             <span style={{ fontWeight: 500 }}>
-              <CurrencySymbol currency={0} />
+              <CurrencySymbol currency={CURRENCY_ETH} />
               {formatWad(
                 amountSubFee(
-                  currentFC.currency.eq(1)
+                  currentFC.currency.eq(CURRENCY_USD)
                     ? converter.usdToWei(tapAmount)
                     : parseWad(tapAmount),
                   currentFC.fee,
@@ -201,10 +203,10 @@ export default function WithdrawModal({
           </div>
         ) : (
           <p>
-            <CurrencySymbol currency={0} />
+            <CurrencySymbol currency={CURRENCY_ETH} />
             {formatWad(
               amountSubFee(
-                currentFC.currency.eq(1)
+                currentFC.currency.eq(CURRENCY_USD)
                   ? converter.usdToWei(tapAmount)
                   : parseWad(tapAmount),
                 currentFC.fee,

--- a/src/components/shared/PayoutModsList.tsx
+++ b/src/components/shared/PayoutModsList.tsx
@@ -16,6 +16,7 @@ import { amountSubFee } from 'utils/math'
 import { getTotalPercentage } from './FormHelpers'
 
 import ProjectPayoutMods from './formItems/ProjectPayoutMods'
+import { CURRENCY_ETH } from 'constants/currency'
 
 export default function PayoutModsList({
   mods,
@@ -127,7 +128,9 @@ export default function PayoutModsList({
                             }
                           />
                           {formatWad(baseTotal?.mul(mod.percent).div(10000), {
-                            decimals: fundingCycle.currency.eq(0) ? 4 : 0,
+                            decimals: fundingCycle.currency.eq(CURRENCY_ETH)
+                              ? 4
+                              : 0,
                             padEnd: true,
                           })}
                           )
@@ -156,7 +159,7 @@ export default function PayoutModsList({
                     }
                   />
                   {formatWad(baseTotal?.mul(ownerPercent).div(10000), {
-                    decimals: fundingCycle.currency.eq(0) ? 4 : 0,
+                    decimals: fundingCycle.currency.eq(CURRENCY_ETH) ? 4 : 0,
                     padEnd: true,
                   })}
                   )

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from 'antd'
+
 import { ThemeContext } from 'contexts/themeContext'
 import { BigNumber } from 'ethers'
 
@@ -7,6 +8,8 @@ import { Project } from 'models/subgraph-entities/project'
 import { useContext } from 'react'
 import { formatDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
+
+import { CURRENCY_ETH } from 'constants/currency'
 
 import CurrencySymbol from './CurrencySymbol'
 import Loading from './Loading'
@@ -71,7 +74,7 @@ export default function ProjectCard({
 
             <div style={{ color: colors.text.tertiary }}>
               <span style={{ color: colors.text.primary, fontWeight: 500 }}>
-                <CurrencySymbol currency={0} />
+                <CurrencySymbol currency={CURRENCY_ETH} />
                 {formatWad(project.totalPaid, { decimals })}{' '}
               </span>
               since{' '}

--- a/src/constants/currency.ts
+++ b/src/constants/currency.ts
@@ -1,0 +1,4 @@
+import { CurrencyETH, CurrencyUSD } from 'models/currency-option'
+
+export const CURRENCY_ETH: CurrencyETH = 0
+export const CURRENCY_USD: CurrencyUSD = 1

--- a/src/models/currency-option.ts
+++ b/src/models/currency-option.ts
@@ -1,1 +1,3 @@
-export type CurrencyOption = 1 | 0
+export type CurrencyETH = 0
+export type CurrencyUSD = 1
+export type CurrencyOption = CurrencyETH | CurrencyUSD

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,18 +1,20 @@
 import { CurrencyOption } from 'models/currency-option'
 import { CSSProperties } from 'react'
 
+import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
+
 const currencies: Record<
   CurrencyOption,
   { name: 'ETH' | 'USD'; symbol: 'Ξ' | '$'; style?: CSSProperties }
 > = {
-  '0': {
+  [CURRENCY_ETH]: {
     name: 'ETH',
     symbol: 'Ξ',
     style: {
       fontFamily: 'sans-serif',
     },
   },
-  '1': {
+  [CURRENCY_USD]: {
     name: 'USD',
     symbol: '$',
   },


### PR DESCRIPTION
## What does this PR do and why?

When working on https://github.com/jbx-protocol/juice-interface/pull/321 I found it difficult to remember which currency was `0` and which was `1`.

This PR creates constants for these values ([in this file](https://github.com/jbx-protocol/juice-interface/pull/334/files#diff-59da7d045d0a68f4f5dd5002596eaa1277948140874bea0dd143ee1eb7d68018)), and uses them everywhere where we previously used `0` or `1`.

## Screenshots or screen recordings

No changes.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
