### PR TITLE
Fix uniswap logo size in Firefox

### DIFF
--- a/src/components/icons/Uniswap.tsx
+++ b/src/components/icons/Uniswap.tsx
@@ -9,7 +9,7 @@ export default function UniswapLogo({ size, fill }: Props): JSX.Element {
 
   return (
     <svg
-      style={{ height: `${height}`, width: `${widthToHeight * height}` }}
+      style={{ height: `${height}px`, width: `${widthToHeight * height}px` }}
       width="168.3"
       height="193.8"
       enableBackground="new 0 0 168.3 193.8"


### PR DESCRIPTION
Specify px in style

## What does this PR do and why?

Fixes bug where Uniswap logo wasn't sized correctly in FF.

## Screenshots or screen recordings

<img width="934" alt="Screen Shot 2022-01-08 at 8 24 44 am" src="https://user-images.githubusercontent.com/94939382/148617577-2193981a-1f17-4c58-889d-e0eb79fd3eaa.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
