### PR TITLE
Copy ETH addresses to clipboard 

### DIFF
--- a/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
@@ -1,5 +1,4 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
-import EtherscanLink from 'components/shared/EtherscanLink'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -118,7 +117,6 @@ export function PaymentActivity({ pageSize }: { pageSize: number }) {
                   {e.timestamp && (
                     <div style={smallHeaderStyle(colors)}>
                       {formatHistoricalDate(e.timestamp * 1000)}{' '}
-                      <EtherscanLink value={e.txHash} type="tx" />
                     </div>
                   )}
                   <div

--- a/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
@@ -1,5 +1,4 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
-import EtherscanLink from 'components/shared/EtherscanLink'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -97,7 +96,6 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                     {e.timestamp && (
                       <span>{formatHistoricalDate(e.timestamp * 1000)}</span>
                     )}{' '}
-                    <EtherscanLink value={e.txHash} type="tx" />
                   </div>
                   <div
                     style={{

--- a/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
@@ -1,4 +1,3 @@
-import EtherscanLink from 'components/shared/EtherscanLink'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -64,7 +63,6 @@ export default function ReservesEventElem({
                 {formatHistoricalDate(printReservesEvent.timestamp * 1000)}
               </span>
             )}{' '}
-            <EtherscanLink value={printReservesEvent.txHash} type="tx" />
           </div>
           <div style={smallHeaderStyle(colors)}>
             called by <FormattedAddress address={printReservesEvent.caller} />

--- a/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
@@ -1,5 +1,4 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
-import EtherscanLink from 'components/shared/EtherscanLink'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import ProjectHandle from 'components/shared/ProjectHandle'
 import { ThemeContext } from 'contexts/themeContext'
@@ -68,7 +67,6 @@ export default function TapEventElem({
             {tapEvent.timestamp && (
               <span>{formatHistoricalDate(tapEvent.timestamp * 1000)}</span>
             )}{' '}
-            <EtherscanLink value={tapEvent.txHash} type="tx" />
           </div>
           <div style={smallHeaderStyle(colors)}>
             called by <FormattedAddress address={tapEvent.caller} />

--- a/src/components/shared/CopyTextButton.tsx
+++ b/src/components/shared/CopyTextButton.tsx
@@ -1,0 +1,26 @@
+import { CopyOutlined } from '@ant-design/icons'
+import { Tooltip } from 'antd'
+import { useState } from 'react'
+
+// Copies a given text to clipboard when clicked
+export default function CopyTextButton({
+  value,
+}: {
+  value: string | undefined
+}) {
+  const [copied, setCopied] = useState<boolean>(false)
+  const copyText = () => {
+    navigator.clipboard.writeText(value ?? '')
+    setCopied(true)
+    setTimeout(() => setCopied(false), 3000)
+  }
+
+  return (
+    <Tooltip
+      trigger={['hover']}
+      title={<span>{copied ? 'Copied!' : 'Copy to clipboard'}</span>}
+    >
+      <CopyOutlined onClick={copyText} />
+    </Tooltip>
+  )
+}

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -1,4 +1,3 @@
-// import { LinkOutlined } from '@ant-design/icons'
 import { Tooltip } from 'antd'
 
 import { NetworkName } from 'models/network-name'

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -1,4 +1,5 @@
 import { LinkOutlined } from '@ant-design/icons'
+import { Tooltip } from 'antd'
 
 import { NetworkName } from 'models/network-name'
 
@@ -20,13 +21,15 @@ export default function EtherscanLink({
   }
 
   return (
-    <a
-      className="quiet"
-      href={`https://${subdomain}etherscan.io/${type}/${value}`}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <LinkOutlined />
-    </a>
+    <Tooltip trigger={['hover', 'click']} title={'Go to Etherscan'}>
+      <a
+        className="quiet"
+        href={`https://${subdomain}etherscan.io/${type}/${value}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <LinkOutlined />
+      </a>
+    </Tooltip>
   )
 }

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -23,7 +23,7 @@ export default function EtherscanLink({
   return (
     <Tooltip trigger={['hover', 'click']} title={'Go to Etherscan'}>
       <a
-        className="quiet"
+        className="etherscan-link"
         style={{ fontWeight: 400 }}
         href={`https://${subdomain}etherscan.io/${type}/${value}`}
         target="_blank"

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -1,4 +1,4 @@
-import { LinkOutlined } from '@ant-design/icons'
+// import { LinkOutlined } from '@ant-design/icons'
 import { Tooltip } from 'antd'
 
 import { NetworkName } from 'models/network-name'
@@ -24,11 +24,12 @@ export default function EtherscanLink({
     <Tooltip trigger={['hover', 'click']} title={'Go to Etherscan'}>
       <a
         className="quiet"
+        style={{ fontWeight: 400 }}
         href={`https://${subdomain}etherscan.io/${type}/${value}`}
         target="_blank"
         rel="noopener noreferrer"
       >
-        <LinkOutlined />
+        {value}
       </a>
     </Tooltip>
   )

--- a/src/components/shared/FormattedAddress.tsx
+++ b/src/components/shared/FormattedAddress.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { readProvider } from 'constants/readProvider'
 
 import EtherscanLink from './EtherscanLink'
+import CopyTextButton from './CopyTextButton'
 
 type EnsRecord = {
   name: string | null
@@ -98,7 +99,8 @@ export default function FormattedAddress({
       title={
         <span>
           <span style={{ userSelect: 'all' }}>{address}</span>{' '}
-          <EtherscanLink value={address} type="address" />
+          <EtherscanLink value={address} type="address" />{' '}
+          <CopyTextButton value={address} />
         </span>
       }
     >

--- a/src/components/shared/FormattedAddress.tsx
+++ b/src/components/shared/FormattedAddress.tsx
@@ -101,7 +101,6 @@ export default function FormattedAddress({
           <span style={{ userSelect: 'all' }}>
             <EtherscanLink value={address} type="address" />
           </span>{' '}
-          {/* <EtherscanLink value={address} type="address" />{' '} */}
           <CopyTextButton value={address} />
         </span>
       }

--- a/src/components/shared/FormattedAddress.tsx
+++ b/src/components/shared/FormattedAddress.tsx
@@ -98,8 +98,10 @@ export default function FormattedAddress({
       trigger={['hover', 'click']}
       title={
         <span>
-          <span style={{ userSelect: 'all' }}>{address}</span>{' '}
-          <EtherscanLink value={address} type="address" />{' '}
+          <span style={{ userSelect: 'all' }}>
+            <EtherscanLink value={address} type="address" />
+          </span>{' '}
+          {/* <EtherscanLink value={address} type="address" />{' '} */}
           <CopyTextButton value={address} />
         </span>
       }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -51,6 +51,14 @@ a.quiet {
   }
 }
 
+a.etherscan-link {
+  color: var(--text-primary);
+  &:hover {
+    color: var(--text-action-primary);
+    text-decoration: underline;
+  }
+}
+
 input {
   background: var(--background-l0);
   color: var(--text-primary);


### PR DESCRIPTION
## What does this PR do and why?

Adds icon to ETH address tooltips to copy address to clipboard. 

Design channel thread: https://discord.com/channels/775859454780244028/930063712444887071

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/149033340-310ec0e9-1ed0-49f0-ad95-da36b3fd4b09.mp4

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
