### PR TITLE
Abstract pay input subtext into component

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@ changes._
 
 ## Acceptance checklist
 
-- [ ] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
-- [ ] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
+- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
+- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).

--- a/src/components/Dashboard/Pay/PayInputSubText.tsx
+++ b/src/components/Dashboard/Pay/PayInputSubText.tsx
@@ -1,0 +1,60 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatWad } from 'utils/formatNumber'
+import { parseEther } from 'ethers/lib/utils'
+import { useCurrencyConverter } from 'hooks/CurrencyConverter'
+import { currencyName } from 'utils/currency'
+import { weightedRate } from 'utils/math'
+import { t, Trans } from '@lingui/macro'
+import { CurrencyOption } from 'models/currency-option'
+import { useContext, useMemo } from 'react'
+
+import { ProjectContext } from 'contexts/projectContext'
+
+import { CURRENCY_ETH } from 'constants/currency'
+
+/**
+ * Help text shown below the Pay input field.
+ *
+ * If the user has entered an amount, display
+ * the amount of project tokens they will recieve.
+ *
+ * Else, display the exchange rate of the user selected currency to project token.
+ */
+export default function InputSubText({
+  payInCurrrency,
+  weiPayAmt,
+}: {
+  payInCurrrency: CurrencyOption
+  weiPayAmt: BigNumber | undefined
+}) {
+  const { currentFC, tokenSymbol } = useContext(ProjectContext)
+  const converter = useCurrencyConverter()
+
+  const tokenText = tokenSymbol ?? t`tokens`
+
+  const receiveText = useMemo(() => {
+    const formatReceivedTickets = (wei: BigNumber) => {
+      const exchangeRate = weightedRate(currentFC, wei, 'payer')
+      return formatWad(exchangeRate, { precision: 0 })
+    }
+
+    if (weiPayAmt?.gt(0)) {
+      return `${formatReceivedTickets(weiPayAmt)} ${tokenText}`
+    }
+
+    const receivedTickets = formatReceivedTickets(
+      (payInCurrrency === CURRENCY_ETH
+        ? parseEther('1')
+        : converter.usdToWei('1')) ?? BigNumber.from(0),
+    )
+    return `${receivedTickets} ${tokenText}/${currencyName(payInCurrrency)}`
+  }, [converter, payInCurrrency, tokenText, weiPayAmt, currentFC])
+
+  return (
+    <div style={{ fontSize: '.7rem' }}>
+      <span>
+        <Trans>Receive {receiveText}</Trans>
+      </span>
+    </div>
+  )
+}

--- a/src/components/Dashboard/Pay/index.tsx
+++ b/src/components/Dashboard/Pay/index.tsx
@@ -1,4 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber'
 import { Button, Tooltip } from 'antd'
 import { t, Trans } from '@lingui/macro'
 
@@ -7,7 +6,6 @@ import PayWarningModal from 'components/modals/PayWarningModal'
 import AMMPrices from 'components/shared/AMMPrices'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-
 import { ProjectContext } from 'contexts/projectContext'
 import { parseEther } from 'ethers/lib/utils'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
@@ -16,13 +14,12 @@ import { useContext, useMemo, useState } from 'react'
 import { currencyName } from 'utils/currency'
 import { formatWad, fromWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
-import { weightedRate } from 'utils/math'
 
 import { disablePayOverrides } from 'constants/overrides'
 import { readNetwork } from 'constants/networks'
-import { CURRENCY_ETH } from 'constants/currency'
-
-import CurrencySymbol from '../shared/CurrencySymbol'
+import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
+import CurrencySymbol from '../../shared/CurrencySymbol'
+import PayInputSubText from './PayInputSubText'
 
 export default function Pay() {
   const [payIn, setPayIn] = useState<CurrencyOption>(0)
@@ -43,14 +40,13 @@ export default function Pay() {
   const converter = useCurrencyConverter()
 
   const weiPayAmt =
-    payIn === 1 ? converter.usdToWei(payAmount) : parseEther(payAmount ?? '0')
+    payIn === CURRENCY_USD
+      ? converter.usdToWei(payAmount)
+      : parseEther(payAmount ?? '0')
 
   function pay() {
     setPayWarningModalVisible(true)
   }
-
-  const formatReceivedTickets = (wei: BigNumber) =>
-    formatWad(weightedRate(currentFC, wei, 'payer'), { precision: 0 })
 
   const overridePayDisabled =
     projectId &&
@@ -146,26 +142,12 @@ export default function Pay() {
               />
             }
           />
-
-          <div style={{ fontSize: '.7rem' }}>
-            <Trans>Receive</Trans>{' '}
-            {weiPayAmt?.gt(0) ? (
-              formatReceivedTickets(weiPayAmt) + ' ' + (tokenSymbol ?? 'tokens')
-            ) : (
-              <span>
-                {formatReceivedTickets(
-                  (payIn === 0 ? parseEther('1') : converter.usdToWei('1')) ??
-                    BigNumber.from(0),
-                )}{' '}
-                {tokenSymbol ?? 'tokens'}/{currencyName(payIn)}
-              </span>
-            )}
-          </div>
+          <PayInputSubText payInCurrrency={payIn} weiPayAmt={weiPayAmt} />
         </div>
 
         <div style={{ textAlign: 'center', minWidth: 150 }}>
           {payButton}
-          {payIn === 1 && (
+          {payIn === CURRENCY_USD && (
             <div style={{ fontSize: '.7rem' }}>
               <Trans>
                 Paid as <CurrencySymbol currency={CURRENCY_ETH} />


### PR DESCRIPTION
## What does this PR do and why?

In preparation for the new AMM price design (https://github.com/jbx-protocol/juice-interface/issues/344), this PR creates an isolated component for the pay input subtext.

No user-facing changes, as demonstrated by the screenshots.

## Screenshots or screen recordings

| no value | with value | no token symbol |
| --- | --- | --- |
| <img width="355" alt="Screen Shot 2022-01-12 at 9 42 16 pm" src="https://user-images.githubusercontent.com/94939382/149138288-5a385792-8494-4e0d-89ba-f92b781e1ccf.png"> | <img width="356" alt="Screen Shot 2022-01-12 at 9 42 26 pm" src="https://user-images.githubusercontent.com/94939382/149138328-7ef4945a-8118-46fd-90d7-6cab55a100a9.png"> |  <img width="353" alt="Screen Shot 2022-01-12 at 9 45 56 pm" src="https://user-images.githubusercontent.com/94939382/149138680-91bed142-a4f0-4e6c-a78c-3a5326116976.png"> |


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
