### PR TITLE
[BUG] ETH address formatting issues

### DIFF
--- a/src/components/Navbar/Wallet.tsx
+++ b/src/components/Navbar/Wallet.tsx
@@ -36,7 +36,7 @@ export default function Wallet({ userAddress }: { userAddress: string }) {
           userSelect: 'all',
         }}
       >
-        <FormattedAddress address={userAddress} />
+        <FormattedAddress address={userAddress} tooltipDisabled={true} />
         <Balance address={userAddress} />
       </div>
     </Tooltip>

--- a/src/components/shared/FormattedAddress.tsx
+++ b/src/components/shared/FormattedAddress.tsx
@@ -1,5 +1,11 @@
 import { utils } from 'ethers'
+
+import { Tooltip } from 'antd'
+
 import { useEffect, useState } from 'react'
+
+import EtherscanLink from 'components/shared/EtherscanLink'
+import CopyTextButton from 'components/shared/CopyTextButton'
 
 import { readProvider } from 'constants/readProvider'
 
@@ -24,9 +30,11 @@ const getEnsDict = () => {
 export default function FormattedAddress({
   address,
   label,
+  tooltipDisabled,
 }: {
   address: string | undefined
   label?: string
+  tooltipDisabled?: boolean
 }) {
   const [ensName, setEnsName] = useState<string | null>()
 
@@ -88,9 +96,31 @@ export default function FormattedAddress({
       ? address.substring(0, 6) + '...' + address.substr(address.length - 6, 6)
       : '')
 
+  if (tooltipDisabled) {
+    return (
+      <span
+        style={{ cursor: 'default', userSelect: 'all', lineHeight: '22px' }}
+      >
+        {formatted}
+      </span>
+    )
+  }
+
   return (
-    <div style={{ cursor: 'default', userSelect: 'all', lineHeight: '22px' }}>
-      {formatted}
-    </div>
+    <Tooltip
+      trigger={['hover', 'click']}
+      title={
+        <span>
+          <EtherscanLink value={address} type="address" />{' '}
+          <CopyTextButton value={address} />
+        </span>
+      }
+    >
+      <span
+        style={{ cursor: 'default', userSelect: 'all', lineHeight: '22px' }}
+      >
+        {formatted}
+      </span>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Pretty urgent one here @peripheralist 

1. Fixes formatting issue in distribution list (#355)
       - Make formatted back into a span after changing it to a div
2. Gives the new Copy Address/Etherscan tooltip to all ETH addresses in the site 

## Screenshots or screen recordings

1.

<img width="577" alt="Screen Shot 2022-01-13 at 9 17 52 pm" src="https://user-images.githubusercontent.com/96150256/149320704-eb6ec8fd-da9f-48df-bc4a-fe3fcbf234c2.png">

2.

https://user-images.githubusercontent.com/96150256/149320831-2c460e0b-17d3-4aa1-9cd5-856cb44409c8.mp4


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
