### PR TITLE
Fix ethers contract compilation exception

### DIFF
--- a/src/components/modals/PrintPreminedModal.tsx
+++ b/src/components/modals/PrintPreminedModal.tsx
@@ -1,14 +1,16 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { Contract } from '@ethersproject/contracts'
 import { Form, Input, Modal, Switch } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { CURRENCY_ETH } from 'constants/currency'
 import { ProjectContext } from 'contexts/projectContext'
 import { UserContext } from 'contexts/userContext'
-import { constants, Contract, utils } from 'ethers'
+import { constants, utils } from 'ethers'
 import { useContext, useMemo, useState } from 'react'
 import { parseWad } from 'utils/formatNumber'
+
+import { CURRENCY_ETH } from 'constants/currency'
 
 export default function PrintPreminedModal({
   visible,


### PR DESCRIPTION
## What does this PR do and why?

Fixes the following compilation error:

```
Type 'import("/Users/redacted/code/aeolianeth/juice-interface/node_modules/@ethersproject/contracts/lib/index").Contract' is not assignable to type 'import("/Users/redacted/code/aeolianeth/juice-interface/node_modules/ethers/node_modules/@ethersproject/contracts/lib/index").Contract'.
```

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
