### PR TITLE
Close nav options collapse when clicking anywhere else in window

### DIFF
--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -16,6 +16,9 @@ export function ItemDropdown({
   const [activeKey, setActiveKey] = useState<0 | undefined>()
   const iconSize = 12
 
+  // Close dropdown when clicking anywhere in the window
+  window.addEventListener('click', () => setActiveKey(undefined), false)
+
   return (
     <div className="resources-dropdown">
       <Collapse style={{ border: 'none' }} activeKey={activeKey}>

--- a/src/components/Navbar/OptionsCollapse.tsx
+++ b/src/components/Navbar/OptionsCollapse.tsx
@@ -18,6 +18,10 @@ export default function OptionsCollapse() {
     theme: { colors },
   } = useContext(ThemeContext)
   const { signingProvider, onLogOut } = useContext(NetworkContext)
+
+  // Close collapse when clicking anywhere in the window except the collapse items
+  window.addEventListener('click', () => setActiveKey(undefined), false)
+
   return (
     <div className="top-nav-options">
       <Collapse style={{ border: 'none' }} activeKey={activeKey}>
@@ -43,22 +47,30 @@ export default function OptionsCollapse() {
             </Space>
           }
         >
-          <div className="nav-dropdown-item">
-            <ThemePicker />
-          </div>
-          <div className="nav-dropdown-item">
-            <LanguageSelector disableLang="zh" />
-          </div>
-          {signingProvider ? (
+          {/* Do not close collapse when clicking its items*/}
+          <div
+            onClick={e => {
+              setActiveKey(0)
+              e.stopPropagation()
+            }}
+          >
             <div className="nav-dropdown-item">
-              <LogoutOutlined />
-              <div onClick={onLogOut}>
-                <div style={{ margin: '0 0 2px 13px' }}>
-                  <Trans>Disconnect</Trans>
+              <ThemePicker />
+            </div>
+            <div className="nav-dropdown-item">
+              <LanguageSelector disableLang="zh" />
+            </div>
+            {signingProvider ? (
+              <div className="nav-dropdown-item">
+                <LogoutOutlined />
+                <div onClick={onLogOut}>
+                  <div style={{ margin: '0 0 2px 13px' }}>
+                    <Trans>Disconnect</Trans>
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
         </CollapsePanel>
       </Collapse>
     </div>


### PR DESCRIPTION
## What does this PR do and why?

Previously, only way to close nav collapses was by clicking where you clicked to open it. With this PR, they close when clicking anywhere else in the window. 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/149440269-e5f22113-ff5a-4671-8545-2745eea924ce.mp4



## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
