### PR TITLE
[BUG] fix styling on button type="link"

### DIFF
--- a/src/styles/antd-overrides/button.scss
+++ b/src/styles/antd-overrides/button.scss
@@ -80,6 +80,7 @@
 
 .ant-btn-link {
   color: var(--text-action-primary);
+  border: none;
 
   &:hover {
     color: var(--text-action-highlight);


### PR DESCRIPTION
## What does this PR do and why?

Fixes issue #353. Removes border from `<Button type="link"/>`

Reopened to we can get it out quickly

## Screenshots or screen recordings

<img width="909" alt="Screen Shot 2022-01-14 at 12 48 47 pm" src="https://user-images.githubusercontent.com/96150256/149443113-11d78626-32d7-404d-bf62-9a705c3c0e68.png">


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
