### PR TITLE
[BUGish] Make options menu close when disconnecting wallet

### DIFF
--- a/src/components/Navbar/OptionsCollapse.tsx
+++ b/src/components/Navbar/OptionsCollapse.tsx
@@ -47,13 +47,8 @@ export default function OptionsCollapse() {
             </Space>
           }
         >
-          {/* Do not close collapse when clicking its items*/}
-          <div
-            onClick={e => {
-              setActiveKey(0)
-              e.stopPropagation()
-            }}
-          >
+          {/* Do not close collapse when clicking its items (except on wallet disconnect)*/}
+          <div onClick={e => e.stopPropagation()}>
             <div className="nav-dropdown-item">
               <ThemePicker />
             </div>
@@ -61,7 +56,10 @@ export default function OptionsCollapse() {
               <LanguageSelector disableLang="zh" />
             </div>
             {signingProvider ? (
-              <div className="nav-dropdown-item">
+              <div
+                className="nav-dropdown-item"
+                onClick={() => setActiveKey(undefined)}
+              >
                 <LogoutOutlined />
                 <div onClick={onLogOut}>
                   <div style={{ margin: '0 0 2px 13px' }}>


### PR DESCRIPTION
## What does this PR do and why?

At the moment the options menu stays open disconnecting wallet - looks dodgy. 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/149507545-c58472f1-ce41-4cf9-886c-d05f15830a18.mp4

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
