### PR TITLE
Update import order eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
       }
     ],
     "import/order": [
-      "warn",
+      "error",
       {
         "groups": ["external", "internal"],
         "newlines-between": "always-and-inside-groups"

--- a/src/components/Create/ConfirmDeployProject.tsx
+++ b/src/components/Create/ConfirmDeployProject.tsx
@@ -4,7 +4,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import PayoutModsList from 'components/shared/PayoutModsList'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import TicketModsList from 'components/shared/TicketModsList'
-import { getBallotStrategyByAddress } from 'constants/ballot-strategies'
+
 import { ProjectContext } from 'contexts/projectContext'
 import { UserContext } from 'contexts/userContext'
 import {
@@ -24,6 +24,8 @@ import { hasFundingTarget, isRecurring } from 'utils/fundingCycle'
 import { amountSubFee } from 'utils/math'
 import { orEmpty } from 'utils/orEmpty'
 
+import { getBallotStrategyByAddress } from 'constants/ballot-strategies'
+
 export default function ConfirmDeployProject() {
   const editingFC = useEditingFundingCycleSelector()
   const editingProject = useAppSelector(state => state.editingProject.info)
@@ -32,7 +34,6 @@ export default function ConfirmDeployProject() {
   const { payoutMods, ticketMods } = useAppSelector(
     state => state.editingProject,
   )
-
   const terminalFee = useTerminalFee(terminal?.version, contracts)
 
   return (

--- a/src/components/Dashboard/Pay.tsx
+++ b/src/components/Dashboard/Pay.tsx
@@ -7,9 +7,7 @@ import PayWarningModal from 'components/modals/PayWarningModal'
 import AMMPrices from 'components/shared/AMMPrices'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { CURRENCY_ETH } from 'constants/currency'
-import { readNetwork } from 'constants/networks'
-import { disablePayOverrides } from 'constants/overrides'
+
 import { ProjectContext } from 'contexts/projectContext'
 import { parseEther } from 'ethers/lib/utils'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
@@ -19,6 +17,10 @@ import { currencyName } from 'utils/currency'
 import { formatWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
 import { weightedRate } from 'utils/math'
+
+import { disablePayOverrides } from 'constants/overrides'
+import { readNetwork } from 'constants/networks'
+import { CURRENCY_ETH } from 'constants/currency'
 
 import CurrencySymbol from '../shared/CurrencySymbol'
 

--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -3,12 +3,14 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import Loading from 'components/shared/Loading'
 import ProjectHandle from 'components/shared/ProjectHandle'
-import { CURRENCY_ETH } from 'constants/currency'
+
 import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
+
+import { CURRENCY_ETH } from 'constants/currency'
 
 export default function Payments() {
   const {

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -4,12 +4,14 @@ import { Button, Checkbox, Select, Space, Tooltip } from 'antd'
 import Search from 'antd/lib/input/Search'
 import Loading from 'components/shared/Loading'
 import ProjectsGrid from 'components/shared/ProjectsGrid'
-import { layouts } from 'constants/styles/layouts'
+
 import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteProjectsQuery, useProjectsSearch } from 'hooks/Projects'
 import { ProjectState } from 'models/project-visibility'
 import { TerminalVersion } from 'models/terminal-version'
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
+
+import { layouts } from 'constants/styles/layouts'
 
 type OrderByOption = 'createdAt' | 'totalPaid'
 

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -9,7 +9,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import Loading from 'components/shared/Loading'
 import UntrackedErc20Notice from 'components/shared/UntrackedErc20Notice'
-import { indexedProjectERC20s } from 'constants/indexed-project-erc20s'
+
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
@@ -24,6 +24,8 @@ import { useContext, useEffect, useMemo, useState } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { OrderDirection, querySubgraph } from 'utils/graph'
+
+import { indexedProjectERC20s } from 'constants/indexed-project-erc20s'
 
 import DownloadParticipantsModal from './DownloadParticipantsModal'
 

--- a/src/components/modals/ReconfigureFCModal.tsx
+++ b/src/components/modals/ReconfigureFCModal.tsx
@@ -11,7 +11,7 @@ import RulesForm from 'components/Create/RulesForm'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import PayoutModsList from 'components/shared/PayoutModsList'
 import TicketModsList from 'components/shared/TicketModsList'
-import { getBallotStrategyByAddress } from 'constants/ballot-strategies'
+
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { UserContext } from 'contexts/userContext'
@@ -40,6 +40,8 @@ import {
 } from 'utils/fundingCycle'
 import { amountSubFee } from 'utils/math'
 import { serializeFundingCycle } from 'utils/serializers'
+
+import { getBallotStrategyByAddress } from 'constants/ballot-strategies'
 
 import BudgetForm from '../Create/BudgetForm'
 import IncentivesForm from '../Create/IncentivesForm'

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
+
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -14,6 +14,8 @@ import { CSSProperties, useContext, useMemo, useState } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
+
+import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
 
 import { useRedeemRate } from '../../hooks/RedeemRate'
 

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -8,12 +8,13 @@ import { useContext } from 'react'
 import { formatDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 
+import { getTerminalVersion } from 'utils/terminal-versions'
+
 import { CURRENCY_ETH } from 'constants/currency'
 
 import CurrencySymbol from './CurrencySymbol'
 import Loading from './Loading'
 import ProjectLogo from './ProjectLogo'
-import { getTerminalVersion } from 'utils/terminal-versions'
 
 export default function ProjectCard({
   project,

--- a/src/hooks/SubgraphQuery.ts
+++ b/src/hooks/SubgraphQuery.ts
@@ -7,6 +7,11 @@ import {
 } from 'react-query'
 
 import { ProjectContext } from 'contexts/projectContext'
+
+import { useContext } from 'react'
+
+import { NetworkName } from 'models/network-name'
+
 import {
   EntityKey,
   EntityKeys,
@@ -18,9 +23,7 @@ import {
   SubgraphError,
   SubgraphQueryReturnTypes,
 } from '../utils/graph'
-import { useContext } from 'react'
 import { readNetwork } from 'constants/networks'
-import { NetworkName } from 'models/network-name'
 
 const subgraphUrl = process.env.REACT_APP_SUBGRAPH_URL
 

--- a/src/redux/localStoragePreload.ts
+++ b/src/redux/localStoragePreload.ts
@@ -1,4 +1,5 @@
 import { Middleware } from '@reduxjs/toolkit'
+
 import { defaultProjectState } from './slices/editingProject'
 
 import { RootState } from './store'

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,5 +1,6 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { formatUnits, parseUnits } from '@ethersproject/units'
+
 import { WAD_PRECISION } from 'constants/numbers'
 
 type FormatConfig = {


### PR DESCRIPTION
## What does this PR do and why?

We consistently get eslint import order warnings when developing the project locally.

<img width="755" alt="Screen Shot 2022-01-14 at 9 56 41 pm" src="https://user-images.githubusercontent.com/94939382/149515439-54e29efd-ed7d-4cde-8a3f-c8eef52cace5.png">

To prevent this, I think it makes sense to update this rule from `warning` to `error`.

This PR updates the rule from `warning` to `error`, and also includes changes resulting from `yarn lint:fix`

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
