### PR TITLE
formatNumberConfig decimals > precision

### DIFF
--- a/src/components/Create/ConfirmDeployProject.tsx
+++ b/src/components/Create/ConfirmDeployProject.tsx
@@ -90,7 +90,7 @@ export default function ConfirmDeployProject() {
                       }
                     />
                     {formatWad(amountSubFee(editingFC.target, terminalFee), {
-                      decimals: 4,
+                      precision: 4,
                     })}{' '}
                     <Trans>after JBX fee</Trans>)
                   </span>

--- a/src/components/Dashboard/FundingHistory.tsx
+++ b/src/components/Dashboard/FundingHistory.tsx
@@ -94,11 +94,11 @@ export default function FundingHistory({
                 />
                 {hasFundingTarget(cycle) ? (
                   <>
-                    {formatWad(cycle.tapped, { decimals: 2 })}/
-                    {formatWad(cycle.target, { decimals: 2 })} withdrawn
+                    {formatWad(cycle.tapped, { precision: 2 })}/
+                    {formatWad(cycle.target, { precision: 2 })} withdrawn
                   </>
                 ) : (
-                  <>{formatWad(cycle.tapped, { decimals: 2 })} withdrawn</>
+                  <>{formatWad(cycle.tapped, { precision: 2 })} withdrawn</>
                 )}
               </div>
             </Space>

--- a/src/components/Dashboard/Paid.tsx
+++ b/src/components/Dashboard/Paid.tsx
@@ -118,20 +118,20 @@ export default function Paid() {
                 <span>
                   <CurrencySymbol currency={CURRENCY_ETH} />
                   {formatWad(converter.usdToWei(fromWad(amt)), {
-                    decimals: 2,
+                    precision: 2,
                     padEnd: true,
                   })}
                 </span>
               }
             >
               <CurrencySymbol currency={CURRENCY_USD} />
-              {formatWad(amt, { decimals: 2, padEnd: true })}
+              {formatWad(amt, { precision: 2, padEnd: true })}
             </Tooltip>
           </span>
         ) : (
           <span>
             <CurrencySymbol currency={CURRENCY_ETH} />
-            {formatWad(amt, { decimals: 2, padEnd: true })}
+            {formatWad(amt, { precision: 2, padEnd: true })}
           </span>
         )}
       </>
@@ -161,7 +161,7 @@ export default function Paid() {
             <span style={secondaryTextStyle}>
               <CurrencySymbol currency={CURRENCY_USD} />
               {formatWad(converter.wadToCurrency(earned, 1, 0), {
-                decimals: 2,
+                precision: 2,
                 padEnd: true,
               })}{' '}
             </span>
@@ -176,7 +176,7 @@ export default function Paid() {
             <CurrencySymbol currency={CURRENCY_ETH} />
             {earned?.lt(parseWad('1')) && earned.gt(0)
               ? '<1'
-              : formatWad(earned, { decimals: 0 })}
+              : formatWad(earned, { precision: 0 })}
           </span>
         </span>
       </div>
@@ -208,7 +208,7 @@ export default function Paid() {
           {currentFC.currency.eq(CURRENCY_USD) ? (
             <span style={secondaryTextStyle}>
               <CurrencySymbol currency={CURRENCY_ETH} />
-              {formatWad(balance, { decimals: 2, padEnd: true })}{' '}
+              {formatWad(balance, { precision: 2, padEnd: true })}{' '}
             </span>
           ) : (
             ''
@@ -335,7 +335,7 @@ export default function Paid() {
           </span>
           <span style={primaryTextStyle}>
             <CurrencySymbol currency={CURRENCY_ETH} />
-            {formatWad(ownerBalance, { decimals: 2, padEnd: true })}
+            {formatWad(ownerBalance, { precision: 2, padEnd: true })}
           </span>
         </span>
       </div>

--- a/src/components/Dashboard/Pay.tsx
+++ b/src/components/Dashboard/Pay.tsx
@@ -50,7 +50,7 @@ export default function Pay() {
   }
 
   const formatReceivedTickets = (wei: BigNumber) =>
-    formatWad(weightedRate(currentFC, wei, 'payer'), { decimals: 0 })
+    formatWad(weightedRate(currentFC, wei, 'payer'), { precision: 0 })
 
   const overridePayDisabled =
     projectId &&

--- a/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
@@ -109,7 +109,7 @@ export function PaymentActivity({ pageSize }: { pageSize: number }) {
                     }}
                   >
                     <CurrencySymbol currency={CURRENCY_ETH} />
-                    {formatWad(e.amount, { decimals: 4 })}
+                    {formatWad(e.amount, { precision: 4 })}
                   </div>
                 </div>
 

--- a/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
@@ -81,7 +81,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                       fontSize: '1rem',
                     }}
                   >
-                    {formatWad(e.amount, { decimals: 0 })}{' '}
+                    {formatWad(e.amount, { precision: 0 })}{' '}
                     {tokenSymbol ?? 'tokens'}
                   </div>
                 </div>
@@ -111,7 +111,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
 
               <div style={{ color: colors.text.secondary }}>
                 <CurrencySymbol currency={CURRENCY_ETH} />
-                {formatWad(e.returnAmount, { decimals: 4 })} overflow received
+                {formatWad(e.returnAmount, { precision: 4 })} overflow received
               </div>
             </div>
           ))}

--- a/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
@@ -91,7 +91,7 @@ export default function ReservesEventElem({
                   : { fontWeight: 500 }
               }
             >
-              {formatWad(e.modCut, { decimals: 0 })}
+              {formatWad(e.modCut, { precision: 0 })}
             </div>
           </div>
         ))}
@@ -109,7 +109,7 @@ export default function ReservesEventElem({
             </div>
             <div style={{ color: colors.text.secondary }}>
               {formatWad(printReservesEvent.beneficiaryTicketAmount, {
-                decimals: 0,
+                precision: 0,
               })}
             </div>
           </div>
@@ -124,7 +124,7 @@ export default function ReservesEventElem({
             textAlign: 'right',
           }}
         >
-          {formatWad(printReservesEvent.count, { decimals: 0 })}
+          {formatWad(printReservesEvent.count, { precision: 0 })}
         </div>
       ) : null}
     </div>

--- a/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
@@ -98,7 +98,7 @@ export default function TapEventElem({
 
             <div style={{ color: colors.text.secondary }}>
               <CurrencySymbol currency={CURRENCY_ETH} />
-              {formatWad(e.modCut, { decimals: 4 })}
+              {formatWad(e.modCut, { precision: 4 })}
             </div>
           </div>
         ))}
@@ -126,7 +126,7 @@ export default function TapEventElem({
               }
             >
               <CurrencySymbol currency={CURRENCY_ETH} />
-              {formatWad(tapEvent.beneficiaryTransferAmount, { decimals: 4 })}
+              {formatWad(tapEvent.beneficiaryTransferAmount, { precision: 4 })}
             </div>
           </div>
         )}
@@ -141,7 +141,7 @@ export default function TapEventElem({
           }}
         >
           <CurrencySymbol currency={CURRENCY_ETH} />
-          {formatWad(tapEvent.netTransferAmount, { decimals: 4 })}
+          {formatWad(tapEvent.netTransferAmount, { precision: 4 })}
         </div>
       ) : null}
     </div>

--- a/src/components/Dashboard/ReservedTokens.tsx
+++ b/src/components/Dashboard/ReservedTokens.tsx
@@ -121,7 +121,7 @@ export default function ReservedTokens({
           }}
         >
           <span>
-            {formatWad(reservedTickets, { decimals: 0 }) || 0}{' '}
+            {formatWad(reservedTickets, { precision: 0 }) || 0}{' '}
             {tokenSymbol ?? 'tokens'}
           </span>
           <Button

--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -192,7 +192,7 @@ export default function Rewards({
                       width: '100%',
                     }}
                   >
-                    {formatWad(totalSupply, { decimals: 0 })}
+                    {formatWad(totalSupply, { precision: 0 })}
                     <Button
                       size="small"
                       onClick={() => setParticipantsModalVisible(true)}
@@ -221,7 +221,7 @@ export default function Rewards({
                           {ticketsBalance?.gt(0) ? (
                             <>
                               {`${formatWad(ticketsBalance ?? 0, {
-                                decimals: 0,
+                                precision: 0,
                               })} ${tokenSymbol}`}
                             </>
                           ) : (
@@ -231,7 +231,7 @@ export default function Rewards({
                       )}
                       <div>
                         <Trans>
-                          {formatWad(iouBalance ?? 0, { decimals: 0 })}
+                          {formatWad(iouBalance ?? 0, { precision: 0 })}
                           {ticketsIssued ? <> claimable</> : null}
                         </Trans>
                       </div>

--- a/src/components/Dashboard/Spending.tsx
+++ b/src/components/Dashboard/Spending.tsx
@@ -66,7 +66,7 @@ export default function Spending({
                 <CurrencySymbol
                   currency={currentFC.currency.toNumber() as CurrencyOption}
                 />
-                {formatWad(withdrawable, { decimals: 4 }) || '0'}{' '}
+                {formatWad(withdrawable, { precision: 4 }) || '0'}{' '}
               </span>
               <TooltipLabel
                 style={smallHeaderStyle}
@@ -91,9 +91,9 @@ export default function Spending({
                 <CurrencySymbol
                   currency={currentFC.currency.toNumber() as CurrencyOption}
                 />
-                {formatWad(currentFC.tapped, { decimals: 4 }) || '0'}
+                {formatWad(currentFC.tapped, { precision: 4 }) || '0'}
                 {hasFundingTarget(currentFC) && (
-                  <span>/{formatWad(currentFC.target, { decimals: 4 })} </span>
+                  <span>/{formatWad(currentFC.target, { precision: 4 })} </span>
                 )}{' '}
                 withdrawn
               </Trans>

--- a/src/components/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/FundingCycle/FundingCycleDetails.tsx
@@ -134,13 +134,13 @@ export default function FundingCycleDetails({
           span={2}
         >
           {formatWad(weightedRate(fundingCycle, parseEther('1'), 'payer'), {
-            decimals: 0,
+            precision: 0,
           })}{' '}
           {metadata?.reservedRate
             ? t`(+${formatWad(
                 weightedRate(fundingCycle, parseEther('1'), 'reserved'),
                 {
-                  decimals: 0,
+                  precision: 0,
                 },
               )} reserved)`
             : ''}{' '}

--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -72,7 +72,7 @@ export default function Payments() {
               >
                 <span style={{ fontSize: '1rem', fontWeight: 500 }}>
                   <CurrencySymbol currency={CURRENCY_ETH} />
-                  {formatWad(e.amount, { decimals: 4 })}
+                  {formatWad(e.amount, { precision: 4 })}
                 </span>
                 <span>
                   <FormattedAddress address={e.beneficiary} />

--- a/src/components/Navbar/Balance.tsx
+++ b/src/components/Navbar/Balance.tsx
@@ -31,7 +31,7 @@ export default function Balance({
       }}
     >
       <CurrencySymbol currency={CURRENCY_ETH} />
-      {formatWad(balance, { decimals: 4 }) ?? '--'}
+      {formatWad(balance, { precision: 4 }) ?? '--'}
       {showEthPrice && (
         <div style={{ color: colors.text.tertiary }}>
           <EthPrice />

--- a/src/components/modals/ConfirmPayOwnerModal.tsx
+++ b/src/components/modals/ConfirmPayOwnerModal.tsx
@@ -117,7 +117,7 @@ export default function ConfirmPayOwnerModal({
             label={(tokenSymbol ?? 'Tokens') + ' for you'}
             className="content-right"
           >
-            <div>{formatWad(receivedTickets, { decimals: 0 })}</div>
+            <div>{formatWad(receivedTickets, { precision: 0 })}</div>
             <div>
               <Trans>
                 To: <FormattedAddress address={userAddress} />
@@ -128,7 +128,7 @@ export default function ConfirmPayOwnerModal({
             label={(tokenSymbol ?? 'Tokens') + ' reserved'}
             className="content-right"
           >
-            {formatWad(ownerTickets, { decimals: 0 })}
+            {formatWad(ownerTickets, { precision: 0 })}
           </Descriptions.Item>
         </Descriptions>
         <Form form={form} layout="vertical">

--- a/src/components/modals/ConfirmUnstakeTokensModal.tsx
+++ b/src/components/modals/ConfirmUnstakeTokensModal.tsx
@@ -113,7 +113,7 @@ export default function ConfirmUnstakeTokensModal({
         <div>
           <div>
             <label>Your unclaimed {tokenSymbol} tokens:</label>{' '}
-            {formatWad(iouBalance, { decimals: 8 })}
+            {formatWad(iouBalance, { precision: 8 })}
           </div>
           {ticketsIssued && (
             <div>

--- a/src/components/modals/DistributeTokensModal.tsx
+++ b/src/components/modals/DistributeTokensModal.tsx
@@ -67,7 +67,7 @@ export default function DistributeTokensModal({
     )
   }
 
-  const reservedTokensFormatted = formatWad(reservedTokens, { decimals: 0 })
+  const reservedTokensFormatted = formatWad(reservedTokens, { precision: 0 })
 
   return (
     <Modal

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -210,7 +210,7 @@ export default function ParticipantsModal({
                 <div style={smallHeaderStyle}>
                   <CurrencySymbol currency={0} />
                   <Trans>
-                    {formatWad(p.totalPaid, { decimals: 6 })} contributed
+                    {formatWad(p.totalPaid, { precision: 6 })} contributed
                   </Trans>
                 </div>
               </div>
@@ -221,12 +221,12 @@ export default function ParticipantsModal({
                     lineHeight: contentLineHeight,
                   }}
                 >
-                  {formatWad(p.balance, { decimals: 0 })}{' '}
+                  {formatWad(p.balance, { precision: 0 })}{' '}
                   {tokenSymbol ?? 'tokens'} (
                   {formatPercent(p.balance, totalTokenSupply)}%)
                 </div>
                 <div style={smallHeaderStyle}>
-                  {formatWad(p.stakedBalance, { decimals: 0 })}{' '}
+                  {formatWad(p.stakedBalance, { precision: 0 })}{' '}
                   <Trans>{tokenSymbol ?? 'tokens'} staked</Trans>
                 </div>
               </div>

--- a/src/components/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/modals/ProjectToolDrawerModal.tsx
@@ -159,7 +159,7 @@ export default function ProjectToolDrawerModal({
           </h3>
           <p>
             <Trans>
-              Your balance: {formatWad(stakedTokenBalance, { decimals: 0 })}
+              Your balance: {formatWad(stakedTokenBalance, { precision: 0 })}
             </Trans>
           </p>
           <Form

--- a/src/components/modals/ReconfigureFCModal.tsx
+++ b/src/components/modals/ReconfigureFCModal.tsx
@@ -412,7 +412,7 @@ export default function ReconfigureFCModal({
                           />
                           {formatWad(
                             amountSubFee(editingFC.target, terminalFee),
-                            { decimals: 4 },
+                            { precision: 4 },
                           )}{' '}
                           after JBX fee
                         </span>

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -134,7 +134,7 @@ export default function RedeemModal({
         if (onCancel) onCancel()
       }}
       okText={`Burn ${formattedNum(redeemAmount, {
-        decimals: 2,
+        precision: 2,
       })} ${tokenSymbol ?? 'tokens'} for ETH`}
       okButtonProps={{
         disabled:
@@ -166,7 +166,7 @@ export default function RedeemModal({
           <p style={statsStyle}>
             {tokenSymbol ?? 'Token'} balance:{' '}
             <span>
-              {formatWad(totalBalance ?? 0, { decimals: 0 })}{' '}
+              {formatWad(totalBalance ?? 0, { precision: 0 })}{' '}
               {tokenSymbol ?? 'tokens'}
             </span>
           </p>
@@ -174,7 +174,7 @@ export default function RedeemModal({
             Currently worth:{' '}
             <span>
               <CurrencySymbol currency={CURRENCY_ETH} />
-              {formatWad(maxClaimable, { decimals: 4 })}
+              {formatWad(maxClaimable, { precision: 4 })}
             </span>
           </p>
         </div>
@@ -211,7 +211,7 @@ export default function RedeemModal({
             <div style={{ fontWeight: 500, marginTop: 20 }}>
               You will receive{' '}
               {currentFC?.currency.eq(CURRENCY_USD) ? 'minimum ' : ' '}
-              {formatWad(minAmount, { decimals: 8 }) || '--'} ETH
+              {formatWad(minAmount, { precision: 8 }) || '--'} ETH
             </div>
           </div>
         )}

--- a/src/components/modals/WithdrawModal.tsx
+++ b/src/components/modals/WithdrawModal.tsx
@@ -131,7 +131,7 @@ export default function WithdrawModal({
               <CurrencySymbol
                 currency={currentFC.currency.toNumber() as CurrencyOption}
               />
-              {formatWad(withdrawable, { decimals: 4 })}
+              {formatWad(withdrawable, { precision: 4 })}
             </div>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -144,7 +144,7 @@ export default function WithdrawModal({
                 currency={currentFC.currency.toNumber() as CurrencyOption}
               />
               {formatWad(feeForAmount(withdrawable, currentFC.fee) ?? 0, {
-                decimals: 4,
+                precision: 4,
               })}
             </div>
           </div>
@@ -163,7 +163,7 @@ export default function WithdrawModal({
                 currency={currentFC.currency.toNumber() as CurrencyOption}
               />
               {formatWad(amountSubFee(withdrawable, currentFC.fee) ?? 0, {
-                decimals: 4,
+                precision: 4,
               })}
             </div>
           </div>
@@ -203,7 +203,7 @@ export default function WithdrawModal({
                     : parseWad(tapAmount),
                   currentFC.fee,
                 ),
-                { decimals: 4 },
+                { precision: 4 },
               )}
             </span>{' '}
             <Trans>
@@ -236,7 +236,7 @@ export default function WithdrawModal({
                     : parseWad(tapAmount),
                   currentFC.fee,
                 ),
-                { decimals: 4 },
+                { precision: 4 },
               )}{' '}
               will go to the project owner: <FormattedAddress address={owner} />
             </Trans>

--- a/src/components/shared/ERC20TokenBalance.tsx
+++ b/src/components/shared/ERC20TokenBalance.tsx
@@ -10,12 +10,12 @@ export default function ERC20TokenBalance({
   tokenAddress,
   wallet,
   style,
-  decimals,
+  precision,
 }: {
   tokenAddress: string | undefined
   wallet: string | undefined
   style?: CSSProperties
-  decimals?: number
+  precision?: number
 }) {
   const contract = useErc20Contract(tokenAddress)
 
@@ -30,11 +30,19 @@ export default function ERC20TokenBalance({
     functionName: 'symbol',
   })
 
+  const decimals = useContractReader<number>({
+    contract,
+    functionName: 'decimals',
+  })
+
   if (balance === undefined) return null
 
   return (
     <div style={style}>
-      {formatWad(balance, { decimals: decimals ?? 0 })}{' '}
+      {formatWad(balance, {
+        precision: precision ?? 0,
+        decimals,
+      })}{' '}
       <FormattedAddress label={symbol} address={tokenAddress} />
     </div>
   )

--- a/src/components/shared/PayoutModsList.tsx
+++ b/src/components/shared/PayoutModsList.tsx
@@ -128,7 +128,7 @@ export default function PayoutModsList({
                             }
                           />
                           {formatWad(baseTotal?.mul(mod.percent).div(10000), {
-                            decimals: fundingCycle.currency.eq(CURRENCY_ETH)
+                            precision: fundingCycle.currency.eq(CURRENCY_ETH)
                               ? 4
                               : 0,
                             padEnd: true,
@@ -159,7 +159,7 @@ export default function PayoutModsList({
                     }
                   />
                   {formatWad(baseTotal?.mul(ownerPercent).div(10000), {
-                    decimals: fundingCycle.currency.eq(CURRENCY_ETH) ? 4 : 0,
+                    precision: fundingCycle.currency.eq(CURRENCY_ETH) ? 4 : 0,
                     padEnd: true,
                   })}
                   )

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -30,7 +30,7 @@ export default function ProjectCard({
 
   const { data: metadata } = useProjectMetadata(project.uri)
   // If the total paid is greater than 0, but less than 10 ETH, show two decimal places.
-  const decimals =
+  const precision =
     project.totalPaid?.gt(0) &&
     project.totalPaid.lt(BigNumber.from('10000000000000000000'))
       ? 2
@@ -103,7 +103,7 @@ export default function ProjectCard({
             <div style={{ color: colors.text.secondary }}>
               <span>
                 <CurrencySymbol currency={CURRENCY_ETH} />
-                {formatWad(project.totalPaid, { decimals })}{' '}
+                {formatWad(project.totalPaid, { precision })}{' '}
               </span>
               since{' '}
               {!!project.createdAt &&

--- a/src/components/shared/ProjectHandle.tsx
+++ b/src/components/shared/ProjectHandle.tsx
@@ -27,7 +27,7 @@ export default function ProjectHandle({
       title={
         <a
           style={{ fontWeight: 400 }}
-          href={`https://juicebox.money/#/${handle}`}
+          href={`/#/${handle}`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/components/shared/ProjectTokenBalance.tsx
+++ b/src/components/shared/ProjectTokenBalance.tsx
@@ -14,13 +14,13 @@ export default function ProjectTokenBalance({
   projectId,
   wallet,
   style,
-  decimals,
+  precision,
   hideHandle,
 }: {
   projectId: BigNumber
   wallet: string | undefined
   style?: CSSProperties
-  decimals?: number
+  precision?: number
   hideHandle?: boolean
 }) {
   const {
@@ -41,7 +41,7 @@ export default function ProjectTokenBalance({
     formatter: symbol => symbol ?? null,
   })
 
-  const balance = useContractReader<string>({
+  const balance = useContractReader<BigNumber>({
     contract: ContractName.TicketBooth,
     functionName: 'balanceOf',
     args:
@@ -55,7 +55,7 @@ export default function ProjectTokenBalance({
       <span>
         {symbol !== undefined ? (
           <>
-            {formatWad(balance, { decimals: decimals ?? 0 })}{' '}
+            {formatWad(balance, { precision: precision ?? 0 })}{' '}
             {symbol ?? 'tokens'}
           </>
         ) : (

--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -98,7 +98,7 @@ export default function TicketModsList({
                     '%' +
                     (total
                       ? ` (${formatWad(total?.mul(mod.percent).div(10000), {
-                          decimals: 0,
+                          precision: 0,
                         })} ${tokenSymbol ?? ' tokens'})`
                       : '')
                   }
@@ -115,7 +115,7 @@ export default function TicketModsList({
               {fromPermyriad(ownerPercent)}%
               {total
                 ? ` (${formatWad(total?.mul(ownerPercent).div(10000), {
-                    decimals: 0,
+                    precision: 0,
                   })} ${tokenSymbol ?? ' tokens'})`
                 : ''}
             </span>

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -242,7 +242,7 @@ export default function ProjectPayoutMods({
                             amountSubFee(parseWad(target), fee)
                               ?.mul(mod.percent)
                               .div(10000),
-                            { decimals: 4, padEnd: true },
+                            { precision: 4, padEnd: true },
                           )}
                         </span>
                       )}

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -1,1 +1,1 @@
-export const WAD_PRECISION = 18
+export const WAD_DECIMALS = 18

--- a/src/hooks/ERC20UniswapPrice.ts
+++ b/src/hooks/ERC20UniswapPrice.ts
@@ -12,7 +12,7 @@ import { readProvider } from 'constants/readProvider'
 import { readNetwork } from 'constants/networks'
 import { WETH } from 'constants/tokens'
 import { UNISWAP_V3_FACTORY } from 'constants/contracts'
-import { WAD_PRECISION } from 'constants/numbers'
+import { WAD_DECIMALS } from 'constants/numbers'
 
 interface Immutables {
   factory: string
@@ -146,13 +146,13 @@ export function useUniswapPriceQuery({ tokenSymbol, tokenAddress }: Props) {
         const PROJECT_TOKEN = new Token(
           networkId,
           immutables.token0,
-          WAD_PRECISION,
+          WAD_DECIMALS,
           tokenSymbol,
         )
         const WETH = new Token(
           networkId,
           immutables.token1,
-          WAD_PRECISION,
+          WAD_DECIMALS,
           'WETH',
         )
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -119,7 +119,7 @@ export const formattedNum = (
     if (post === '0') return formatNearZero(pre)
 
     const formattedPost = post
-      .substring(0, config?.precision ?? 18)
+      .substring(0, config?.precision ?? WAD_DECIMALS)
       .padEnd(config?.padEnd ? config?.precision ?? 0 : 0, '0')
 
     // If we can ignore postDecimal

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,28 +1,34 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { formatUnits, parseUnits } from '@ethersproject/units'
 
-import { WAD_PRECISION } from 'constants/numbers'
+import { WAD_DECIMALS } from 'constants/numbers'
 
 type FormatConfig = {
   empty?: string
   thousandsSeparator?: string
   decimalSeparator?: string
-  decimals?: number
+  precision?: number
   padEnd?: boolean
+  decimals?: number
 }
 
 const decimalSeparator = '.'
 const thousandsSeparator = ','
 
-// Wad: x/1e18
+// Wad: 1e-18
 export const parseWad = (amt?: BigNumberish) =>
-  parseUnits(amt?.toString() || '0', WAD_PRECISION)
-export const fromWad = (amt?: BigNumberish) => {
-  const result = formatUnits(amt ?? '0', WAD_PRECISION)
+  parseUnits(amt?.toString() || '0', WAD_DECIMALS)
+
+export const fromWad = (
+  amt?: BigNumberish,
+  decimals: number = WAD_DECIMALS,
+) => {
+  const result = formatUnits(amt ?? '0', decimals)
   return result.substring(result.length - 2) === '.0'
     ? result.substring(0, result.length - 2)
     : result
 }
+
 export const formatWad = (amt?: BigNumberish, config?: FormatConfig) => {
   if (amt === undefined && amt === null && amt === '') return
 
@@ -31,7 +37,7 @@ export const formatWad = (amt?: BigNumberish, config?: FormatConfig) => {
     _amt = _amt.toString().split('.')[0]
   }
 
-  return formattedNum(fromWad(_amt), config)
+  return formattedNum(fromWad(_amt, config?.decimals), config)
 }
 
 // Strips string of all commas
@@ -82,7 +88,7 @@ export const formattedNum = (
 
   // Trim leading zeros
   while (str.length && str[0] === '0') {
-    str = str.substr(1)
+    str = str.substring(1)
   }
 
   if (!str.length) return _empty
@@ -113,11 +119,11 @@ export const formattedNum = (
     if (post === '0') return formatNearZero(pre)
 
     const formattedPost = post
-      .substr(0, config?.decimals ?? 18)
-      .padEnd(config?.padEnd ? config?.decimals ?? 0 : 0, '0')
+      .substring(0, config?.precision ?? 18)
+      .padEnd(config?.padEnd ? config?.precision ?? 0 : 0, '0')
 
     // If we can ignore postDecimal
-    if (!formattedPost || config?.decimals === 0) {
+    if (!formattedPost || config?.precision === 0) {
       return formatNearZero(formattedPre)
     }
 


### PR DESCRIPTION
## What does this PR do and why?

Previously the `formatNumber` util assumed the number to format used 18 decimal places. Although this is standard, not all ERC20s use 18 decimal places, and formatting non-standard token balances requires specifying the number of decimal places to use.

The `decimals` property has been renamed to `precision`, and a new `decimals` property is now used to specify the decimal length of the number to be formatted.

For consistency, the `WAD_PRECISION` constant is now named `WAD_DECIMALS`.

Currently the only place this new `decimals` property is used is in the `ERC20TokenBalance` component, which reads the decimal places from the ERC20 contract.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
