### PR TITLE
Add pre-commit hook for translation extraction

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
+yarn i18n:lint

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prepare": "husky install",
     "i18n:extract": "lingui extract --clean --locale en",
     "i18n:compile": "yarn i18n:extract && lingui compile",
+    "i18n:lint": "bash ./scripts/lint-externalization.sh",
     "postinstall": "yarn i18n:compile",
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js'"
   },

--- a/scripts/lint-externalization.sh
+++ b/scripts/lint-externalization.sh
@@ -1,0 +1,23 @@
+# If no changes to source files, don't run the i18n extraction.
+SRC_CHANGED_FILES=$(git diff --name-only src/**/*)
+if [ -z "$SRC_CHANGED_FILES" ]; then
+  echo "🍏 Source files haven't changed. No changes to translation source file are necessary."
+  exit 0
+fi
+
+# extract new strings
+yarn i18n:extract
+
+# get all translation files that were updated
+# from `yarn i18n:extract`
+LOCALE_CHANGED_FILES=$(git diff --name-only src/locales)
+
+# Bail if there were changes to translation files
+# that weren't included in the commit.
+if ! [ -z "$LOCALE_CHANGED_FILES" ]; then
+  echo "🍎 Translation source file is out of date. Review and commit changes to $LOCALE_CHANGED_FILES."
+  exit 1
+else
+  echo "🍏 Translation source file is up to date."
+  exit 0
+fi


### PR DESCRIPTION
## What does this PR do and why?

Adds a pre-commit hook for `yarn i18n:extract`. See below for how it works, and please test it yourself!

## Screenshots or screen recordings

I made a single change to a string, but did not run `yarn i18n:extract`:

<img width="777" alt="Screen Shot 2022-01-15 at 12 42 13 pm" src="https://user-images.githubusercontent.com/94939382/149606869-1c7c7bfa-0a45-4bc6-9cdc-1cf841d14d69.png">

I tried to commit the file, and husky prevented my from doing so:

<img width="688" alt="Screen Shot 2022-01-15 at 12 42 32 pm" src="https://user-images.githubusercontent.com/94939382/149606887-382a916d-ad1b-4952-a621-919ed2eaf456.png">

Husky already generated a new source translation file for me already:

<img width="355" alt="Screen Shot 2022-01-15 at 12 43 03 pm" src="https://user-images.githubusercontent.com/94939382/149606961-a6d67ad7-5d58-43d1-bb44-335ca403e77e.png">

So, I reviewed those changes, and tried to commit again. It was successful:

<img width="436" alt="Screen Shot 2022-01-15 at 12 43 22 pm" src="https://user-images.githubusercontent.com/94939382/149606980-a7d6ac6d-eb51-47af-b9e1-ea0a41789ae8.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
