### PR TITLE
Proposal: terminology improvements

### DIFF
--- a/src/components/Create/BudgetForm.tsx
+++ b/src/components/Create/BudgetForm.tsx
@@ -67,7 +67,7 @@ export default function BudgetForm({
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
       <h1>
-        <Trans>Funding</Trans>
+        <Trans>Funding cycle</Trans>
       </h1>
 
       <p>

--- a/src/components/Create/PayModsForm.tsx
+++ b/src/components/Create/PayModsForm.tsx
@@ -1,4 +1,4 @@
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 
 import { Button, Form, Space, Input } from 'antd'
 import { FormItems } from 'components/shared/formItems'
@@ -61,22 +61,21 @@ export default function PayModsForm({
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
       <div style={{ color: colors.text.secondary }}>
         <h1>
-          <Trans>Distribution</Trans>
+          <Trans>Funding distribution</Trans>
         </h1>
 
         <p>
           <Trans>
-            Payouts let you commit portions of every withdrawal to other
-            Ethereum wallets or Juicebox projects. Use this to pay contributors,
-            charities, other projects you depend on, or anyone else. Payouts
-            will be distributed automatically whenever a withdrawal is made from
-            your project.
+            Distribute available funds to other Ethereum wallets or Juicebox
+            projects as payouts. Use this to pay contributors, charities,
+            Juicebox projects you depend on, or anyone else. Funds are
+            distributed whenever a withdrawal is made from your project.
           </Trans>
         </p>
         <p>
           <Trans>
-            Payouts are optional. By default, all unallocated revenue will be
-            withdrawable to the project owner's wallet.
+            By default, all unallocated funds can be distributed to the project
+            owner's wallet.
           </Trans>
         </p>
       </div>
@@ -106,6 +105,9 @@ export default function PayModsForm({
             })
           }}
           fee={fee}
+          formItemProps={{
+            label: t`Payouts (optional)`,
+          }}
         />
         <Form.Item>
           <Button
@@ -114,7 +116,7 @@ export default function PayModsForm({
             type="primary"
             onClick={validateAndSaveMods}
           >
-            <Trans>Save</Trans>
+            <Trans>Save payouts</Trans>
           </Button>
         </Form.Item>
       </Form>

--- a/src/components/Create/TicketingForm.tsx
+++ b/src/components/Create/TicketingForm.tsx
@@ -62,8 +62,8 @@ export default function TicketingForm({
           mods={mods}
           onModsChanged={setMods}
           formItemProps={{
-            label: t`Allocate reserved tokens (optional)`,
-            extra: t`Automatically distribute a portion of your project's reserved tokens to other Juicebox projects or ETH wallets.`,
+            label: t`Reserved token allocation (optional)`,
+            extra: t`Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects.`,
           }}
         />
         <Form.Item>

--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -495,17 +495,17 @@ export default function Create() {
               callback: () => setProjectFormModalVisible(true),
             },
             {
-              title: t`Funding`,
+              title: t`Funding cycle`,
               description: t`Your project's funding cycle target and duration.`,
               callback: () => setBudgetFormModalVisible(true),
             },
             {
-              title: t`Distribution`,
+              title: t`Funding distribution`,
               description: t`How your project will distribute funds.`,
               callback: () => setPayModsFormModalVisible(true),
             },
             {
-              title: t`Reserved Tokens`,
+              title: t`Reserved tokens`,
               description: t`Reward specific community members with tokens.`,
               callback: () => setTicketingFormModalVisible(true),
             },

--- a/src/components/Dashboard/ReservedTokens.tsx
+++ b/src/components/Dashboard/ReservedTokens.tsx
@@ -48,21 +48,13 @@ export default function ReservedTokens({
         <TooltipLabel
           label={
             <h4 style={{ display: 'inline-block' }}>
-              <Trans>Reserved</Trans> {tokenSymbol ?? t`tokens`}(
+              <Trans>Reserved {tokenSymbol ?? t`tokens`}</Trans> (
               {fromPerbicent(metadata?.reservedRate)}%)
             </h4>
           }
-          tip={t`A project can reserve a percentage of tokens minted from every payment it receives. They can be distributed to the receivers below at any time.`}
+          tip={t`A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time.`}
         />
       </div>
-
-      {metadata?.reservedRate ? (
-        <TicketModsList
-          mods={ticketMods}
-          fundingCycle={fundingCycle}
-          projectId={projectId}
-        />
-      ) : null}
 
       {!hideActions && !isConstitutionDAO && !isSharkDAO && (
         <div
@@ -70,12 +62,14 @@ export default function ReservedTokens({
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'baseline',
-            marginTop: 20,
+            marginBottom: 20,
           }}
         >
           <span>
-            {formatWad(reservedTokens, { precision: 0 }) || 0}{' '}
-            {tokenSymbol ?? t`tokens`}
+            <Trans>
+              {formatWad(reservedTokens, { precision: 0 }) || 0}{' '}
+              {tokenSymbol ?? t`tokens`} reserved
+            </Trans>
           </span>
           <Button
             style={{ marginLeft: 10 }}
@@ -83,7 +77,7 @@ export default function ReservedTokens({
             onClick={() => setModalIsVisible(true)}
             disabled={isPreviewMode}
           >
-            <Trans>Distribute</Trans>
+            <Trans>Distribute {tokenSymbol ?? t`tokens`}</Trans>
           </Button>
 
           <DistributeTokensModal
@@ -93,6 +87,14 @@ export default function ReservedTokens({
           />
         </div>
       )}
+
+      {metadata?.reservedRate ? (
+        <TicketModsList
+          mods={ticketMods}
+          fundingCycle={fundingCycle}
+          projectId={projectId}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/Dashboard/Spending.tsx
+++ b/src/components/Dashboard/Spending.tsx
@@ -71,7 +71,7 @@ export default function Spending({
               <TooltipLabel
                 style={smallHeaderStyle}
                 label={t`AVAILABLE`}
-                tip={`The funds available to withdraw for this funding cycle after the ${fromPerbicent(
+                tip={t`The funds available to withdraw for this funding cycle after the ${fromPerbicent(
                   currentFC.fee,
                 )}% JBX fee is subtracted. This number won't roll over to the next funding cycle, so funds should be withdrawn before it ends.`}
               />
@@ -82,7 +82,7 @@ export default function Spending({
               onClick={() => setWithdrawModalVisible(true)}
               disabled={isPreviewMode}
             >
-              <Trans>Distribute</Trans>
+              <Trans>Distribute funds</Trans>
             </Button>
           </div>
           <div style={{ ...smallHeaderStyle, color: colors.text.tertiary }}>
@@ -117,10 +117,10 @@ export default function Spending({
             <TooltipLabel
               label={
                 <h4 style={{ display: 'inline-block' }}>
-                  <Trans>Distribution</Trans>
+                  <Trans>Funding Distribution</Trans>
                 </h4>
               }
-              tip={t`Available funds are distributed according to any payouts below.`}
+              tip={t`Available funds are distributed according to the payouts below.`}
             />
             <PayoutModsList
               mods={payoutMods}

--- a/src/components/FundingCycle/ReconfigureFundingModalTrigger.tsx
+++ b/src/components/FundingCycle/ReconfigureFundingModalTrigger.tsx
@@ -36,7 +36,7 @@ const ReconfigureFundingModalTrigger: React.FC<Props> = () => {
         size="small"
         disabled={isPreviewMode}
       >
-        <Trans>Reconfigure funding</Trans>
+        <Trans>Reconfigure funding cycle</Trans>
       </Button>
 
       {localStoreRef.current && (

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -262,13 +262,13 @@ export default function Landing() {
             <Col xs={24} sm={13}>
               <div style={{ display: 'grid', rowGap: 20, marginBottom: 40 }}>
                 {fourthCol(t`Programmable spending`, [
-                  t`Commit portions of your revenue to go to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they.`,
+                  t`Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they.`,
                 ])}
                 {fourthCol(t`ERC20 community tokens`, [
-                  t`When someone pays your project either as a patron or a user of your app, they earn a proportional amount of your project's token. When you win, your token holders win, so they'll want you to win even more.`,
+                  t`When someone pays your project as a patron or a user of your app, they earn a portion of your project's token. When you win, your token holders win, so they'll want you to win even more.`,
                 ])}
                 {fourthCol(t`Redistributable surplus`, [
-                  t`Set a funding target to cover predictable expenses. Any extra revenue can be claimed by anyone holding your project's tokens alongside you.`,
+                  t`Set a funding target to cover predictable expenses. Any extra funds can be claimed by anyone holding your project's tokens alongside you.`,
                 ])}
                 {fourthCol(t`Transparency & accountability`, [
                   t`Changes to your project's funding require a community approval period to take effect. Your supporters don't have to trust you—even though they already do.`,

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -129,7 +129,7 @@ export default function Projects() {
 
           <a href="/#/create">
             <Button>
-              <Trans>New project</Trans>
+              <Trans>Create project</Trans>
             </Button>
           </a>
         </div>

--- a/src/components/modals/ReconfigureFCModal.tsx
+++ b/src/components/modals/ReconfigureFCModal.tsx
@@ -309,7 +309,7 @@ export default function ReconfigureFCModal({
     >
       <div>
         <h1 style={{ marginBottom: 20 }}>
-          <Trans>Reconfigure funding</Trans>
+          <Trans>Reconfigure funding cycle</Trans>
         </h1>
 
         {currentFC?.duration.gt(0) && (
@@ -324,13 +324,13 @@ export default function ReconfigureFCModal({
           <div>
             {buildSteps([
               {
-                title: t`Funding`,
+                title: t`Funding cycle`,
                 callback: () => setBudgetFormModalVisible(true),
               },
               ...(editingFC.target.gt(0)
                 ? [
                     {
-                      title: t`Spending`,
+                      title: t`Funding distribution`,
                       callback: () => setPayModsFormModalVisible(true),
                     },
                   ]

--- a/src/components/shared/PayoutModsList.tsx
+++ b/src/components/shared/PayoutModsList.tsx
@@ -187,15 +187,14 @@ export default function PayoutModsList({
           >
             <div>
               <p>
-                Payouts let you commit portions of every withdrawal to other
-                Ethereum wallets or Juicebox projects. Use this to pay
-                contributors, charities, other projects you depend on, or anyone
-                else. Payouts will be distributed automatically whenever a
-                withdrawal is made from your project.
+                Distribute available funds to other Ethereum wallets or Juicebox
+                projects as payouts. Use this to pay contributors, charities,
+                Juicebox projects you depend on, or anyone else. Funds are
+                distributed whenever a withdrawal is made from your project.
               </p>
               <p>
-                Payouts are optional. By default, all unallocated revenue will
-                be withdrawable to the project owner's wallet.
+                By default, all unallocated funds can be distributed to the
+                project owner's wallet.
               </p>
             </div>
 

--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -113,7 +113,7 @@ export default function TicketModsList({
       {fundingCycle && projectId?.gt(0) && hasEditPermission ? (
         <div style={{ marginTop: 10 }}>
           <Button size="small" onClick={() => setModalVisible(true)}>
-            <Trans>Edit token receivers</Trans>
+            <Trans>Edit token allocation</Trans>
           </Button>
         </div>
       ) : null}
@@ -121,8 +121,8 @@ export default function TicketModsList({
       {fundingCycle ? (
         <Modal
           visible={modalVisible}
-          title={t`Edit reserved token receivers`}
-          okText={t`Save token receivers`}
+          title={t`Edit reserved token allocation`}
+          okText={t`Save token allocation`}
           onOk={() => setMods()}
           onCancel={() => {
             setEditingMods(mods)


### PR DESCRIPTION
## What does this PR do and why?

This PR is a response to an investigation into the terms used throughout Juicebox: https://juicebox.notion.site/Consolidate-Juicebox-lexicon-24aaa2b1936a4416a213ddb36dca67e4

I identified a few terms that seemed ambiguous, or that could be consolidated. This mostly related to `Distributions`, `Payouts`, `Distribute`, `Withdrawal` and `Revenue`.

Some of these changes came out of a discussion between @JayZeeDesign and me.

## Proposed changes

The following is a summary of the key changes (not exhaustive, see screenshots below for exact changes):

### ⚠️ Major changes 

| Change | Motivation |
| --- | --- |
|  Renaming `Distribution` to `Funding distribution` on the project create page and project page | "Distribution" can refer to the distribution of funds or the distribution of reserved tokens. This is an attempt to make them clearly distinct. |
| Rename `Distribute` button to `Distribute JBX` and `Distribute funds` respectively. | Related to the above |
| Move `Distribute JBX` button to the top of the Reserved JBX card on the project page| To be consistent with the funding distribution card. |
| Replace references to `revenue` with `funds` on the homepage | We don't use the word `revenue` anywhere in the app. | 
### Minor changes

**Create project page**:
- Rename `Funding` to `Funding cycle` on the project page
- Alter copy on `Funding distribution` section of project page

**Project page**
- Change `Edit token receivers` to `Edit token allocation` to be consistent with project page

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="693" alt="before" src="https://user-images.githubusercontent.com/94939382/149613988-788ba5df-fcff-44ae-82e3-62f79b6bfb2a.png"> | <img width="692" alt="after_create" src="https://user-images.githubusercontent.com/94939382/149613825-7d3851eb-785d-4c32-a247-00c221543160.png"> |
| <img width="620" alt="Screen Shot 2022-01-15 at 5 11 00 pm" src="https://user-images.githubusercontent.com/94939382/149613991-41cf6147-2a9b-401c-99d1-54fc1afccd80.png"> | <img width="626" alt="Screen Shot 2022-01-15 at 5 00 23 pm" src="https://user-images.githubusercontent.com/94939382/149613842-aebc30a8-f546-42f0-9af0-5f9a96646537.png"> |
| <img width="624" alt="Screen Shot 2022-01-15 at 5 11 10 pm" src="https://user-images.githubusercontent.com/94939382/149613997-bdb9ed6e-bd48-47e6-83ef-629298a23b3a.png"> | <img width="632" alt="Screen Shot 2022-01-15 at 5 00 33 pm" src="https://user-images.githubusercontent.com/94939382/149613855-fd1b879b-b651-4ad3-9d03-24714357f8e0.png"> |
| <img width="622" alt="Screen Shot 2022-01-15 at 5 11 22 pm" src="https://user-images.githubusercontent.com/94939382/149614004-f7e5d96d-6aaf-40ed-9d9b-c1cffc93a078.png"> | <img width="628" alt="Screen Shot 2022-01-15 at 5 00 46 pm" src="https://user-images.githubusercontent.com/94939382/149613862-1d33f6fb-ff2e-4eb6-a173-59232a3bf144.png"> |
| <img width="511" alt="Screen Shot 2022-01-15 at 5 11 42 pm" src="https://user-images.githubusercontent.com/94939382/149614026-6d9d719f-6aca-4cdf-a54d-a3638f3d85e7.png"> | <img width="511" alt="Screen Shot 2022-01-15 at 5 01 37 pm" src="https://user-images.githubusercontent.com/94939382/149613870-45a7dc4e-fdb9-484d-bfaa-009b9364f14d.png"> |
| <img width="501" alt="Screen Shot 2022-01-15 at 5 11 52 pm" src="https://user-images.githubusercontent.com/94939382/149614033-ea17c546-6bd8-4267-8ab6-8d2c10668a3d.png">| <img width="511" alt="Screen Shot 2022-01-15 at 5 01 50 pm" src="https://user-images.githubusercontent.com/94939382/149613875-028161f2-0053-4cf4-bd94-6996bb33bc9d.png"> |
| <img width="701" alt="Screen Shot 2022-01-15 at 5 12 19 pm" src="https://user-images.githubusercontent.com/94939382/149614045-a4ae6893-abde-4dca-9c74-6bfaf3b6bb15.png">| <img width="713" alt="Screen Shot 2022-01-15 at 5 03 41 pm" src="https://user-images.githubusercontent.com/94939382/149613888-046057fb-cea3-4d85-92ab-c6b39c6c449c.png">
| <img width="578" alt="Screen Shot 2022-01-15 at 5 12 30 pm" src="https://user-images.githubusercontent.com/94939382/149614056-f7e3b00d-007e-43cb-b698-0b5a0354c29a.png"> | <img width="586" alt="Screen Shot 2022-01-15 at 5 04 21 pm" src="https://user-images.githubusercontent.com/94939382/149613891-63267a0a-dd96-4a72-9e85-90b210f7a3ca.png"> |
| <img width="591" alt="Screen Shot 2022-01-15 at 5 12 34 pm" src="https://user-images.githubusercontent.com/94939382/149614059-9fed98e8-4168-4472-85c4-c94ebb83c817.png"> | <img width="603" alt="Screen Shot 2022-01-15 at 5 04 27 pm" src="https://user-images.githubusercontent.com/94939382/149613892-236a0b61-e8a1-42ab-a71d-89cdfb6fb818.png"> |
| <img width="609" alt="Screen Shot 2022-01-15 at 5 12 37 pm" src="https://user-images.githubusercontent.com/94939382/149614068-e5502570-1ed1-4e47-8f48-4b6e831f7dfd.png"> | <img width="599" alt="Screen Shot 2022-01-15 at 5 04 37 pm" src="https://user-images.githubusercontent.com/94939382/149613894-a3ec54c3-a7fa-47e4-9e1a-b624c1c01070.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../../CONTRIBUTING.md#browser-support).
