### PR TITLE
Replace uses of transactor() with unique hooks

### DIFF
--- a/src/components/Dashboard/IssueTickets.tsx
+++ b/src/components/Dashboard/IssueTickets.tsx
@@ -1,34 +1,23 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
-import { BigNumber } from '@ethersproject/bignumber'
 import { Button, Form, Input, Modal, Space, Tooltip } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
-import { UserContext } from 'contexts/userContext'
-import { useContext, useState } from 'react'
+import { useIssueTokensTx } from 'hooks/transactor/IssueTokensTx'
+import { useState } from 'react'
 
-export default function IssueTickets({
-  projectId,
-}: {
-  projectId: BigNumber | undefined
-}) {
-  const { transactor, contracts } = useContext(UserContext)
+export default function IssueTickets() {
   const [modalVisible, setModalVisible] = useState<boolean>()
   const [loading, setLoading] = useState<boolean>()
   const [form] = useForm<{ name: string; symbol: string }>()
+  const issueTokensTx = useIssueTokensTx()
 
   function issue() {
-    if (!projectId || !transactor || !contracts) return
-
     setLoading(true)
 
     const fields = form.getFieldsValue(true)
 
-    transactor(
-      contracts.TicketBooth,
-      'issue',
-      [projectId.toHexString(), fields.name, fields.symbol],
-      {
-        onDone: () => setModalVisible(false),
-      },
+    issueTokensTx(
+      { name: fields.name, symbol: fields.symbol },
+      { onDone: () => setModalVisible(false) },
     )
   }
 

--- a/src/components/Dashboard/ProjectHeader.tsx
+++ b/src/components/Dashboard/ProjectHeader.tsx
@@ -262,7 +262,6 @@ export default function ProjectHeader() {
 
       <EditProjectModal
         visible={editProjectModalVisible}
-        projectId={projectId}
         metadata={metadata}
         handle={handle}
         onSuccess={() => setEditProjectModalVisible(false)}

--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -1,6 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
-
 import { Button, Descriptions, Modal, Space, Statistic, Tooltip } from 'antd'
 import ConfirmUnstakeTokensModal from 'components/modals/ConfirmUnstakeTokensModal'
 import ParticipantsModal from 'components/modals/ParticipantsModal'
@@ -262,7 +261,7 @@ export default function Rewards({
         />
 
         {!ticketsIssued && hasIssueTicketsPermission && !isPreviewMode && (
-          <IssueTickets projectId={projectId} />
+          <IssueTickets />
         )}
       </Space>
 

--- a/src/components/FundingCycle/ReconfigureFundingModalTrigger.tsx
+++ b/src/components/FundingCycle/ReconfigureFundingModalTrigger.tsx
@@ -16,16 +16,7 @@ interface Props {}
 // are independent.
 
 const ReconfigureFundingModalTrigger: React.FC<Props> = () => {
-  const {
-    projectId,
-    currentFC,
-    queuedFC,
-    queuedPayoutMods,
-    queuedTicketMods,
-    currentPayoutMods,
-    currentTicketMods,
-    isPreviewMode,
-  } = useContext(ProjectContext)
+  const { isPreviewMode } = useContext(ProjectContext)
 
   const localStoreRef = useRef<typeof store>()
 
@@ -52,14 +43,6 @@ const ReconfigureFundingModalTrigger: React.FC<Props> = () => {
         <Provider store={localStoreRef.current}>
           <ReconfigureFCModal
             visible={reconfigureModalVisible}
-            fundingCycle={queuedFC?.number.gt(0) ? queuedFC : currentFC}
-            payoutMods={
-              queuedFC?.number.gt(0) ? queuedPayoutMods : currentPayoutMods
-            }
-            ticketMods={
-              queuedFC?.number.gt(0) ? queuedTicketMods : currentTicketMods
-            }
-            projectId={projectId}
             onDone={() => setReconfigureModalVisible(false)}
           />
         </Provider>

--- a/src/components/modals/BalancesModal.tsx
+++ b/src/components/modals/BalancesModal.tsx
@@ -5,8 +5,8 @@ import ERC20TokenBalance from 'components/shared/ERC20TokenBalance'
 import { FormItems } from 'components/shared/formItems'
 import ProjectTokenBalance from 'components/shared/ProjectTokenBalance'
 import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
 import { OperatorPermission, useHasPermission } from 'hooks/HasPermission'
+import { useSetProjectUriTx } from 'hooks/transactor/SetProjectUriTx'
 import { ProjectMetadataV3 } from 'models/project-metadata'
 import { TokenRef } from 'models/token-ref'
 import { useContext, useEffect, useState } from 'react'
@@ -24,8 +24,8 @@ export default function BalancesModal({
   const [editModalVisible, setEditModalVisible] = useState<boolean>()
   const [loading, setLoading] = useState<boolean>()
   const [editingTokenRefs, setEditingTokenRefs] = useState<TokenRef[]>([])
-  const { owner, projectId, metadata } = useContext(ProjectContext)
-  const { transactor, contracts } = useContext(UserContext)
+  const { owner, metadata } = useContext(ProjectContext)
+  const setProjectUriTx = useSetProjectUriTx()
 
   useEffect(() => {
     setEditingTokenRefs(
@@ -36,8 +36,6 @@ export default function BalancesModal({
   const hasEditPermission = useHasPermission([OperatorPermission.SetUri])
 
   async function updateTokenRefs() {
-    if (!transactor || !contracts || !projectId) return
-
     setLoading(true)
 
     const uploadedMetadata = await uploadProjectMetadata({
@@ -50,10 +48,8 @@ export default function BalancesModal({
       return
     }
 
-    transactor(
-      contracts.Projects,
-      'setUri',
-      [projectId.toHexString(), uploadedMetadata.cid],
+    setProjectUriTx(
+      { cid: uploadedMetadata.cid },
       {
         onDone: () => {
           setLoading(false)

--- a/src/components/modals/DistributeTokensModal.tsx
+++ b/src/components/modals/DistributeTokensModal.tsx
@@ -1,12 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Trans } from '@lingui/macro'
-
 import { Modal, Space } from 'antd'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import TicketModsList from 'components/shared/TicketModsList'
 import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
 import useContractReader from 'hooks/ContractReader'
+import { useDistributeTokensTx } from 'hooks/transactor/DistributeTokensTx'
 import { useContext, useState } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 import { formatWad } from 'utils/formatNumber'
@@ -22,7 +21,6 @@ export default function DistributeTokensModal({
   onConfirmed?: VoidFunction
 }) {
   const [loading, setLoading] = useState<boolean>()
-  const { contracts, transactor } = useContext(UserContext)
   const {
     tokenSymbol,
     currentFC,
@@ -31,6 +29,7 @@ export default function DistributeTokensModal({
     owner,
     terminal,
   } = useContext(ProjectContext)
+  const distributeTokensTx = useDistributeTokensTx()
 
   const terminalContractName = terminal?.name
 
@@ -50,16 +49,10 @@ export default function DistributeTokensModal({
   })
 
   function distribute() {
-    if (!transactor || !contracts || !projectId || !terminal) return
-
     setLoading(true)
 
-    transactor(
-      terminal.version === '1.1'
-        ? contracts.TerminalV1_1
-        : contracts.TerminalV1,
-      'printReservedTickets',
-      [projectId.toHexString()],
+    distributeTokensTx(
+      {},
       {
         onDone: () => setLoading(false),
         onConfirmed: () => onConfirmed && onConfirmed(),

--- a/src/contexts/userContext.ts
+++ b/src/contexts/userContext.ts
@@ -1,4 +1,4 @@
-import { Transactor } from 'hooks/Transactor'
+import { Transactor } from 'hooks/transactor/Transactor'
 import { Contracts } from 'models/contracts'
 import { createContext } from 'react'
 

--- a/src/hooks/transactor/AddToBalanceTx.ts
+++ b/src/hooks/transactor/AddToBalanceTx.ts
@@ -13,7 +13,7 @@ export function useAddToBalanceTx(): TransactorInstance<{
 
   return ({ value }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/AddToBalanceTx.ts
+++ b/src/hooks/transactor/AddToBalanceTx.ts
@@ -1,0 +1,30 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useAddToBalanceTx(): TransactorInstance<{
+  value: BigNumber
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ value }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.TerminalV1,
+      'addToBalance',
+      [projectId.toHexString()],
+      {
+        ...txOpts,
+        value: value.toHexString(),
+      },
+    )
+  }
+}

--- a/src/hooks/transactor/ConfigureProjectTx.ts
+++ b/src/hooks/transactor/ConfigureProjectTx.ts
@@ -1,0 +1,68 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber, constants } from 'ethers'
+import { FundingCycleMetadata } from 'models/funding-cycle-metadata'
+import { FCProperties } from 'models/funding-cycle-properties'
+import { PayoutMod, TicketMod } from 'models/mods'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useConfigureProjectTx(): TransactorInstance<{
+  fcProperties: FCProperties
+  fcMetadata: Omit<FundingCycleMetadata, 'version'>
+  payoutMods: PayoutMod[]
+  ticketMods: TicketMod[]
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId, terminal } = useContext(ProjectContext)
+
+  return ({ fcProperties, fcMetadata, payoutMods, ticketMods }, txOpts) => {
+    if (
+      !transactor ||
+      !projectId ||
+      !contracts?.Projects ||
+      !terminal?.version
+    ) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    const properties: Record<keyof FCProperties, string> = {
+      target: fcProperties.target.toHexString(),
+      currency: fcProperties.currency.toHexString(),
+      duration: fcProperties.duration.toHexString(),
+      discountRate: fcProperties.discountRate.toHexString(),
+      cycleLimit: fcProperties.cycleLimit.toHexString(),
+      ballot: fcProperties.ballot,
+    }
+
+    return transactor(
+      terminal.version === '1.1'
+        ? contracts.TerminalV1_1
+        : contracts.TerminalV1,
+      'configure',
+      [
+        projectId.toHexString(),
+        properties,
+        fcMetadata,
+        payoutMods.map(m => ({
+          preferUnstaked: false,
+          percent: BigNumber.from(m.percent).toHexString(),
+          lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
+          beneficiary: m.beneficiary || constants.AddressZero,
+          projectId: m.projectId || BigNumber.from(0).toHexString(),
+          allocator: constants.AddressZero,
+        })),
+        ticketMods.map(m => ({
+          preferUnstaked: false,
+          percent: BigNumber.from(m.percent).toHexString(),
+          lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
+          beneficiary: m.beneficiary || constants.AddressZero,
+          allocator: constants.AddressZero,
+        })),
+      ],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/ConfigureProjectTx.ts
+++ b/src/hooks/transactor/ConfigureProjectTx.ts
@@ -24,7 +24,7 @@ export function useConfigureProjectTx(): TransactorInstance<{
       !contracts?.Projects ||
       !terminal?.version
     ) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/DeployProjectTx.ts
+++ b/src/hooks/transactor/DeployProjectTx.ts
@@ -32,7 +32,7 @@ export function useDeployProjectTx(): TransactorInstance<{
     txOpts,
   ) => {
     if (!transactor || !userAddress || !contracts?.TerminalV1_1) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/DeployProjectTx.ts
+++ b/src/hooks/transactor/DeployProjectTx.ts
@@ -1,0 +1,80 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber, constants, utils } from 'ethers'
+import { FundingCycleMetadata } from 'models/funding-cycle-metadata'
+import { FCProperties } from 'models/funding-cycle-properties'
+import { PayoutMod, TicketMod } from 'models/mods'
+import { useContext } from 'react'
+import { hasFundingTarget } from 'utils/fundingCycle'
+
+import { TransactorInstance } from './Transactor'
+
+export function useDeployProjectTx(): TransactorInstance<{
+  handle: string
+  projectMetadataCid: string
+  properties: FCProperties
+  fundingCycleMetadata: Omit<FundingCycleMetadata, 'version'>
+  payoutMods: PayoutMod[]
+  ticketMods: TicketMod[]
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+
+  return (
+    {
+      handle,
+      projectMetadataCid,
+      properties,
+      fundingCycleMetadata,
+      payoutMods,
+      ticketMods,
+    },
+    txOpts,
+  ) => {
+    if (!transactor || !userAddress || !contracts?.TerminalV1_1) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    const _properties: Record<keyof FCProperties, string | number> = {
+      target: properties.target.toHexString(),
+      currency: hasFundingTarget({ target: properties.target })
+        ? properties.currency.toNumber()
+        : 0,
+      duration: properties.duration.toNumber(),
+      discountRate: properties.duration.gt(0)
+        ? properties.discountRate.toNumber()
+        : 0,
+      cycleLimit: properties.cycleLimit.toNumber(),
+      ballot: properties.ballot,
+    }
+
+    return transactor(
+      contracts.TerminalV1_1,
+      'deploy',
+      [
+        userAddress,
+        utils.formatBytes32String(handle),
+        projectMetadataCid,
+        _properties,
+        fundingCycleMetadata,
+        payoutMods.map(m => ({
+          preferUnstaked: false,
+          percent: BigNumber.from(m.percent).toHexString(),
+          lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
+          beneficiary: m.beneficiary || constants.AddressZero,
+          projectId: m.projectId || BigNumber.from(0).toHexString(),
+          allocator: constants.AddressZero,
+        })),
+        ticketMods.map(m => ({
+          preferUnstaked: false,
+          percent: BigNumber.from(m.percent).toHexString(),
+          lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
+          beneficiary: m.beneficiary || constants.AddressZero,
+          allocator: constants.AddressZero,
+        })),
+      ],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/DistributeTokensTx.ts
+++ b/src/hooks/transactor/DistributeTokensTx.ts
@@ -1,0 +1,26 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useDistributeTokensTx(): TransactorInstance<{}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { terminal, projectId } = useContext(ProjectContext)
+
+  return (_, txOpts) => {
+    if (!transactor || !terminal || !projectId || !contracts) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      terminal.version === '1.1'
+        ? contracts.TerminalV1_1
+        : contracts.TerminalV1,
+      'printReservedTickets',
+      [projectId.toHexString()],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/DistributeTokensTx.ts
+++ b/src/hooks/transactor/DistributeTokensTx.ts
@@ -10,7 +10,7 @@ export function useDistributeTokensTx(): TransactorInstance<{}> {
 
   return (_, txOpts) => {
     if (!transactor || !terminal || !projectId || !contracts) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/IssueTokensTx.ts
+++ b/src/hooks/transactor/IssueTokensTx.ts
@@ -13,7 +13,7 @@ export function useIssueTokensTx(): TransactorInstance<{
 
   return ({ name, symbol }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/IssueTokensTx.ts
+++ b/src/hooks/transactor/IssueTokensTx.ts
@@ -1,0 +1,27 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useIssueTokensTx(): TransactorInstance<{
+  name: string
+  symbol: string
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ name, symbol }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.TicketBooth,
+      'issue',
+      [projectId.toHexString(), name, symbol],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/MigrateV1ProjectTx.ts
+++ b/src/hooks/transactor/MigrateV1ProjectTx.ts
@@ -12,7 +12,7 @@ export function useMigrateV1ProjectTx(): TransactorInstance<{
 
   return ({ newTerminalAddress }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/MigrateV1ProjectTx.ts
+++ b/src/hooks/transactor/MigrateV1ProjectTx.ts
@@ -1,0 +1,26 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useMigrateV1ProjectTx(): TransactorInstance<{
+  newTerminalAddress: string
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ newTerminalAddress }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.TerminalV1,
+      'migrate',
+      [projectId.toHexString(), newTerminalAddress],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/PayProjectTx.ts
+++ b/src/hooks/transactor/PayProjectTx.ts
@@ -23,7 +23,7 @@ export function usePayProjectTx(): TransactorInstance<{
       !contracts?.TicketBooth ||
       !terminal?.version
     ) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/PayProjectTx.ts
+++ b/src/hooks/transactor/PayProjectTx.ts
@@ -1,0 +1,42 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function usePayProjectTx(): TransactorInstance<{
+  note: string
+  preferUnstaked: boolean
+  value: BigNumber
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { terminal, projectId } = useContext(ProjectContext)
+  const { userAddress } = useContext(NetworkContext)
+
+  return ({ note, preferUnstaked, value }, txOpts) => {
+    if (
+      !transactor ||
+      !projectId ||
+      !userAddress ||
+      !contracts?.TicketBooth ||
+      !terminal?.version
+    ) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      terminal.version === '1.1'
+        ? contracts.TerminalV1_1
+        : contracts.TerminalV1,
+      'pay',
+      [projectId.toHexString(), userAddress, note || '', preferUnstaked],
+      {
+        ...txOpts,
+        value: value.toHexString(),
+      },
+    )
+  }
+}

--- a/src/hooks/transactor/PrintTokensTx.ts
+++ b/src/hooks/transactor/PrintTokensTx.ts
@@ -1,0 +1,57 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber, Contract } from 'ethers'
+import { CurrencyOption } from 'models/currency-option'
+import { useContext } from 'react'
+import { parseWad } from 'utils/formatNumber'
+
+import { TransactorInstance } from './Transactor'
+
+export function usePrintTokensTx(): TransactorInstance<{
+  value: BigNumber
+  currency: CurrencyOption
+  beneficiary: string
+  memo: string
+  preferUnstaked: boolean
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { terminal, projectId } = useContext(ProjectContext)
+
+  return ({ value, currency, beneficiary, memo, preferUnstaked }, txOpts) => {
+    if (!transactor || !contracts || !projectId || !terminal?.version) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    let terminalContract: Contract
+    let functionName: string
+    let args: any[]
+
+    switch (terminal.version) {
+      case '1':
+        terminalContract = contracts.TerminalV1
+        functionName = 'printPreminedTickets'
+        args = [
+          projectId.toHexString(),
+          parseWad(value).toHexString(),
+          BigNumber.from(currency).toHexString(),
+          beneficiary,
+          memo,
+          preferUnstaked,
+        ]
+        break
+      case '1.1':
+        terminalContract = contracts.TerminalV1_1
+        functionName = 'printTickets'
+        args = [
+          projectId.toHexString(),
+          parseWad(value).toHexString(),
+          beneficiary,
+          memo,
+          preferUnstaked,
+        ]
+    }
+
+    return transactor(terminalContract, functionName, args, txOpts)
+  }
+}

--- a/src/hooks/transactor/PrintTokensTx.ts
+++ b/src/hooks/transactor/PrintTokensTx.ts
@@ -19,7 +19,7 @@ export function usePrintTokensTx(): TransactorInstance<{
 
   return ({ value, currency, beneficiary, memo, preferUnstaked }, txOpts) => {
     if (!transactor || !contracts || !projectId || !terminal?.version) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/PrintTokensTx.ts
+++ b/src/hooks/transactor/PrintTokensTx.ts
@@ -1,6 +1,7 @@
+import { Contract } from '@ethersproject/contracts'
 import { ProjectContext } from 'contexts/projectContext'
 import { UserContext } from 'contexts/userContext'
-import { BigNumber, Contract } from 'ethers'
+import { BigNumber } from 'ethers'
 import { CurrencyOption } from 'models/currency-option'
 import { useContext } from 'react'
 import { parseWad } from 'utils/formatNumber'

--- a/src/hooks/transactor/RedeemTokensTx.ts
+++ b/src/hooks/transactor/RedeemTokensTx.ts
@@ -1,0 +1,46 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useRedeemTokensTx(): TransactorInstance<{
+  redeemAmount: BigNumber
+  minAmount: BigNumber
+  preferConverted: boolean
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId, terminal } = useContext(ProjectContext)
+
+  return ({ redeemAmount, minAmount, preferConverted }, txOpts) => {
+    if (
+      !transactor ||
+      !userAddress ||
+      !projectId ||
+      !contracts?.Projects ||
+      !terminal?.version
+    ) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      terminal.version === '1.1'
+        ? contracts.TerminalV1_1
+        : contracts.TerminalV1,
+      'redeem',
+      [
+        userAddress,
+        projectId.toHexString(),
+        redeemAmount.toHexString(),
+        minAmount.toHexString(),
+        userAddress,
+        preferConverted,
+      ],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/RedeemTokensTx.ts
+++ b/src/hooks/transactor/RedeemTokensTx.ts
@@ -23,7 +23,7 @@ export function useRedeemTokensTx(): TransactorInstance<{
       !contracts?.Projects ||
       !terminal?.version
     ) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/transactor/SafeTransferFromTx.ts
@@ -1,0 +1,26 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useSafeTransferFromTx(): TransactorInstance<{
+  to: string
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId, owner } = useContext(ProjectContext)
+
+  return ({ to }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.Projects) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.Projects,
+      'safeTransferFrom(address,address,uint256)',
+      [owner, to, projectId.toHexString()],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/transactor/SafeTransferFromTx.ts
@@ -12,7 +12,7 @@ export function useSafeTransferFromTx(): TransactorInstance<{
 
   return ({ to }, txOpts) => {
     if (!transactor || !projectId || !contracts?.Projects) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/SetPayoutModsTx.ts
+++ b/src/hooks/transactor/SetPayoutModsTx.ts
@@ -1,0 +1,48 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber, constants } from 'ethers'
+import { PayoutMod } from 'models/mods'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useSetPayoutModsTx(): TransactorInstance<{
+  configured: BigNumber
+  payoutMods: PayoutMod[]
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId, terminal } = useContext(ProjectContext)
+
+  return ({ configured, payoutMods }, txOpts) => {
+    if (
+      !transactor ||
+      !userAddress ||
+      !projectId ||
+      !contracts?.Projects ||
+      !terminal?.version
+    ) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.ModStore,
+      'setPayoutMods',
+      [
+        projectId.toHexString(),
+        configured.toHexString(),
+        payoutMods.map(m => ({
+          preferUnstaked: false,
+          percent: BigNumber.from(m.percent).toHexString(),
+          lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
+          beneficiary: m.beneficiary || constants.AddressZero,
+          projectId: m.projectId || BigNumber.from(0).toHexString(),
+          allocator: constants.AddressZero,
+        })),
+      ],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/SetPayoutModsTx.ts
+++ b/src/hooks/transactor/SetPayoutModsTx.ts
@@ -23,7 +23,7 @@ export function useSetPayoutModsTx(): TransactorInstance<{
       !contracts?.Projects ||
       !terminal?.version
     ) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/SetProjectHandleTx.ts
+++ b/src/hooks/transactor/SetProjectHandleTx.ts
@@ -13,7 +13,7 @@ export function useSetProjectHandleTx(): TransactorInstance<{
 
   return ({ handle }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/SetProjectHandleTx.ts
+++ b/src/hooks/transactor/SetProjectHandleTx.ts
@@ -1,0 +1,27 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { utils } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useSetProjectHandleTx(): TransactorInstance<{
+  handle: string
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ handle }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.Projects,
+      'setHandle',
+      [projectId.toHexString(), utils.formatBytes32String(handle)],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/SetProjectUriTx.ts
+++ b/src/hooks/transactor/SetProjectUriTx.ts
@@ -1,0 +1,26 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useSetProjectUriTx(): TransactorInstance<{
+  cid: string
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ cid }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.Projects,
+      'setUri',
+      [projectId.toHexString(), cid],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/SetProjectUriTx.ts
+++ b/src/hooks/transactor/SetProjectUriTx.ts
@@ -12,7 +12,7 @@ export function useSetProjectUriTx(): TransactorInstance<{
 
   return ({ cid }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/SetTicketModsTx.ts
+++ b/src/hooks/transactor/SetTicketModsTx.ts
@@ -23,7 +23,7 @@ export function useSetTicketModsTx(): TransactorInstance<{
       !contracts?.Projects ||
       !terminal?.version
     ) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/SetTicketModsTx.ts
+++ b/src/hooks/transactor/SetTicketModsTx.ts
@@ -1,0 +1,46 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber, constants } from 'ethers'
+import { TicketMod } from 'models/mods'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useSetTicketModsTx(): TransactorInstance<{
+  configured: BigNumber
+  ticketMods: TicketMod[]
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId, terminal } = useContext(ProjectContext)
+
+  return ({ configured, ticketMods }, txOpts) => {
+    if (
+      !transactor ||
+      !userAddress ||
+      !projectId ||
+      !contracts?.Projects ||
+      !terminal?.version
+    ) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.ModStore,
+      'setTicketMods',
+      [
+        projectId.toHexString(),
+        configured.toHexString(),
+        ticketMods.map(m => ({
+          preferUnstaked: false,
+          percent: BigNumber.from(m.percent).toHexString(),
+          lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
+          beneficiary: m.beneficiary || constants.AddressZero,
+        })),
+      ],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/StakeTokensTx.ts
+++ b/src/hooks/transactor/StakeTokensTx.ts
@@ -15,7 +15,7 @@ export function useStakeTokensTx(): TransactorInstance<{
 
   return ({ amount }, txOpts) => {
     if (!transactor || !projectId || !userAddress || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/StakeTokensTx.ts
+++ b/src/hooks/transactor/StakeTokensTx.ts
@@ -1,0 +1,29 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useStakeTokensTx(): TransactorInstance<{
+  amount: BigNumber
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ amount }, txOpts) => {
+    if (!transactor || !projectId || !userAddress || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.TicketBooth,
+      'stake',
+      [userAddress, projectId.toHexString(), amount.toHexString()],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/TapProjectTx.ts
+++ b/src/hooks/transactor/TapProjectTx.ts
@@ -1,0 +1,46 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { CurrencyOption } from 'models/currency-option'
+
+import { TransactorInstance } from './Transactor'
+
+export function useTapProjectTx(): TransactorInstance<{
+  tapAmount: BigNumber
+  minAmount: BigNumber
+  currency: CurrencyOption
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId, terminal } = useContext(ProjectContext)
+
+  return ({ tapAmount, minAmount, currency }, txOpts) => {
+    if (
+      !transactor ||
+      !userAddress ||
+      !projectId ||
+      !contracts?.Projects ||
+      !terminal?.version
+    ) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      terminal.version === '1.1'
+        ? contracts.TerminalV1_1
+        : contracts.TerminalV1,
+      'tap',
+      [
+        projectId.toHexString(),
+        tapAmount.toHexString(),
+        currency,
+        minAmount?.toHexString(),
+      ],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/TapProjectTx.ts
+++ b/src/hooks/transactor/TapProjectTx.ts
@@ -25,7 +25,7 @@ export function useTapProjectTx(): TransactorInstance<{
       !contracts?.Projects ||
       !terminal?.version
     ) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/Transactor.ts
+++ b/src/hooks/transactor/Transactor.ts
@@ -6,10 +6,9 @@ import { JsonRpcSigner, TransactionRequest } from '@ethersproject/providers'
 import { parseUnits } from '@ethersproject/units'
 import { notification } from 'antd'
 import Notify, { InitOptions, TransactionEvent } from 'bnc-notify'
+import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useCallback, useContext } from 'react'
-
-import { NetworkContext } from '../contexts/networkContext'
 
 export type TransactorCallback = (
   e?: TransactionEvent,
@@ -30,6 +29,11 @@ export type Transactor = (
   options?: TransactorOptions,
 ) => Promise<boolean>
 
+export type TransactorInstance<T> = (
+  args: T,
+  txOpts?: Omit<TransactorOptions, 'value'>,
+) => ReturnType<Transactor>
+
 // wrapper around BlockNative's Notify.js
 // https://docs.blocknative.com/notify
 export function useTransactor({
@@ -37,9 +41,8 @@ export function useTransactor({
 }: {
   gasPrice?: BigNumber
 }): Transactor | undefined {
-  const { signingProvider: provider, onSelectWallet } = useContext(
-    NetworkContext,
-  )
+  const { signingProvider: provider, onSelectWallet } =
+    useContext(NetworkContext)
 
   const { isDarkMode } = useContext(ThemeContext)
 

--- a/src/hooks/transactor/TransferTokensTx.ts
+++ b/src/hooks/transactor/TransferTokensTx.ts
@@ -1,0 +1,30 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useTransferTokensTx(): TransactorInstance<{
+  amount: BigNumber
+  to: string
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ amount, to }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.Projects) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.TicketBooth,
+      'transfer',
+      [userAddress, projectId.toHexString(), amount.toHexString(), to],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/TransferTokensTx.ts
+++ b/src/hooks/transactor/TransferTokensTx.ts
@@ -16,7 +16,7 @@ export function useTransferTokensTx(): TransactorInstance<{
 
   return ({ amount, to }, txOpts) => {
     if (!transactor || !projectId || !contracts?.Projects) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/hooks/transactor/UnstakeTokensTx.ts
+++ b/src/hooks/transactor/UnstakeTokensTx.ts
@@ -1,0 +1,29 @@
+import { NetworkContext } from 'contexts/networkContext'
+import { ProjectContext } from 'contexts/projectContext'
+import { UserContext } from 'contexts/userContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+
+import { TransactorInstance } from './Transactor'
+
+export function useUnstakeTokensTx(): TransactorInstance<{
+  unstakeAmount: BigNumber
+}> {
+  const { transactor, contracts } = useContext(UserContext)
+  const { userAddress } = useContext(NetworkContext)
+  const { projectId } = useContext(ProjectContext)
+
+  return ({ unstakeAmount }, txOpts) => {
+    if (!transactor || !userAddress || !projectId || !contracts?.TicketBooth) {
+      if (txOpts?.onDone) txOpts.onDone()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.TicketBooth,
+      'unstake',
+      [userAddress, projectId.toHexString(), unstakeAmount.toHexString()],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/transactor/UnstakeTokensTx.ts
+++ b/src/hooks/transactor/UnstakeTokensTx.ts
@@ -15,7 +15,7 @@ export function useUnstakeTokensTx(): TransactorInstance<{
 
   return ({ unstakeAmount }, txOpts) => {
     if (!transactor || !userAddress || !projectId || !contracts?.TicketBooth) {
-      if (txOpts?.onDone) txOpts.onDone()
+      txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { UserContext } from 'contexts/userContext'
 import { useContractLoader } from 'hooks/ContractLoader'
 import { useGasPriceQuery } from 'hooks/GasPrice'
-import { useTransactor } from 'hooks/Transactor'
+import { useTransactor } from 'hooks/transactor/Transactor'
 import { ChildElems } from 'models/child-elems'
 
 export default function UserProvider({ children }: { children: ChildElems }) {


### PR DESCRIPTION
## What does this PR do and why?

Addresses #343 

This creates unique hooks for all current instances of `transactor()`, using a new `TransactorInstance<T>` type, where the arguments passed to the transactor are an object of type `T`. These hooks are named with the convention `use<transaction-name>Tx`.

This allows for:
- Typed arguments when creating transactions from components
- More logical separation of concern
- Less code repetition

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).