### PR TITLE
Terminal fee contracts from context

### DIFF
--- a/src/components/Create/BudgetForm.tsx
+++ b/src/components/Create/BudgetForm.tsx
@@ -1,6 +1,5 @@
-import { Button, Divider, Form, Space, Switch } from 'antd'
 import { Trans } from '@lingui/macro'
-
+import { Button, Divider, Form, Space, Switch } from 'antd'
 import { FormItems } from 'components/shared/formItems'
 import {
   targetSubFeeToTargetFormatted,
@@ -8,7 +7,6 @@ import {
 } from 'components/shared/formItems/formHelpers'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
-import { UserContext } from 'contexts/userContext'
 import { constants } from 'ethers'
 import { useAppDispatch } from 'hooks/AppDispatch'
 import { useEditingFundingCycleSelector } from 'hooks/AppSelector'
@@ -46,9 +44,8 @@ export default function BudgetForm({
   const dispatch = useAppDispatch()
   const { terminal } = useContext(ProjectContext)
   const editingFC = useEditingFundingCycleSelector()
-  const { contracts } = useContext(UserContext)
 
-  const terminalFee = useTerminalFee(terminal?.version, contracts)
+  const terminalFee = useTerminalFee(terminal?.version)
 
   useLayoutEffect(() => {
     setCurrency(initialCurrency)

--- a/src/components/Create/ConfirmDeployProject.tsx
+++ b/src/components/Create/ConfirmDeployProject.tsx
@@ -1,12 +1,11 @@
-import { Space, Statistic } from 'antd'
 import { t, Trans } from '@lingui/macro'
+import { Space, Statistic } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import PayoutModsList from 'components/shared/PayoutModsList'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import TicketModsList from 'components/shared/TicketModsList'
 
 import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
 import {
   useAppSelector,
   useEditingFundingCycleSelector,
@@ -30,11 +29,10 @@ export default function ConfirmDeployProject() {
   const editingFC = useEditingFundingCycleSelector()
   const editingProject = useAppSelector(state => state.editingProject.info)
   const { terminal } = useContext(ProjectContext)
-  const { contracts } = useContext(UserContext)
   const { payoutMods, ticketMods } = useAppSelector(
     state => state.editingProject,
   )
-  const terminalFee = useTerminalFee(terminal?.version, contracts)
+  const terminalFee = useTerminalFee(terminal?.version)
 
   return (
     <Space size="large" direction="vertical">

--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -91,7 +91,7 @@ export default function Create() {
   } = useAppSelector(state => state.editingProject)
   const dispatch = useAppDispatch()
 
-  const terminalFee = useTerminalFee(terminalVersion, contracts)
+  const terminalFee = useTerminalFee(terminalVersion)
 
   useEffect(() => {
     if (terminalFee) {

--- a/src/components/modals/ReconfigureFCModal.tsx
+++ b/src/components/modals/ReconfigureFCModal.tsx
@@ -1,6 +1,6 @@
 import { CaretRightFilled } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
 import { BigNumber } from '@ethersproject/bignumber'
+import { t, Trans } from '@lingui/macro'
 import { Drawer, DrawerProps, Space, Statistic } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import Modal from 'antd/lib/modal/Modal'
@@ -89,7 +89,7 @@ export default function ReconfigureFCModal({
   const dispatch = useAppDispatch()
   const { currentFC, terminal, isPreviewMode } = useContext(ProjectContext)
   const editingFC = useEditingFundingCycleSelector()
-  const terminalFee = useTerminalFee(terminal?.version, contracts)
+  const terminalFee = useTerminalFee(terminal?.version)
 
   const resetTicketingForm = () =>
     ticketingForm.setFieldsValue({

--- a/src/hooks/TerminalFee.ts
+++ b/src/hooks/TerminalFee.ts
@@ -1,14 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { Contracts } from 'models/contracts'
+import { UserContext } from 'contexts/userContext'
 import { TerminalVersion } from 'models/terminal-version'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 
-export function useTerminalFee(
-  version?: TerminalVersion,
-  contracts?: Contracts,
-) {
+export function useTerminalFee(version?: TerminalVersion) {
   const [fee, setFee] = useState<BigNumber>()
+  const { contracts } = useContext(UserContext)
 
   useEffect(() => {
     async function fetchData() {


### PR DESCRIPTION
## What does this PR do and why?

`useTerminalFee` now gets `contracts` from `UserContext`, instead of needing to be passed as an argument.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
