### PR TITLE
Timestamp tooltip on historical dates (e.g. x days ago)

### DIFF
--- a/src/utils/formatDate.tsx
+++ b/src/utils/formatDate.tsx
@@ -10,7 +10,7 @@ export const formatDate = (dateMillis: BigNumberish, format = 'M-D-YY h:mma') =>
 
 export function formatHistoricalDate(dateMillis: BigNumberish) {
   return (
-    <Tooltip title={formatDate(dateMillis)}>
+    <Tooltip title={`${formatDate(dateMillis)} UTC`}>
       {t`${moment(BigNumber.from(dateMillis).toNumber()).fromNow(true)} ago`}
     </Tooltip>
   )

--- a/src/utils/formatDate.tsx
+++ b/src/utils/formatDate.tsx
@@ -1,10 +1,17 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
 
+import { Tooltip } from 'antd'
+
 import moment from 'moment'
 
 export const formatDate = (dateMillis: BigNumberish, format = 'M-D-YY h:mma') =>
   moment(BigNumber.from(dateMillis).toNumber()).format(format)
 
-export const formatHistoricalDate = (dateMillis: BigNumberish) =>
-  t`${moment(BigNumber.from(dateMillis).toNumber()).fromNow(true)} ago`
+export function formatHistoricalDate(dateMillis: BigNumberish) {
+  return (
+    <Tooltip title={formatDate(dateMillis)}>
+      {t`${moment(BigNumber.from(dateMillis).toNumber()).fromNow(true)} ago`}
+    </Tooltip>
+  )
+}


### PR DESCRIPTION
## What does this PR do and why?

Adds a timestamp tooltip to historical date.  #330 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/149752212-97244bc2-0d23-43ac-bcfc-7c1e59e6a246.mp4


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
