### PR TITLE
[BUG] Reinstate transaction links in Activity section

### DIFF
--- a/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
@@ -1,5 +1,6 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
+import EtherscanLink from 'components/shared/EtherscanLink'
 
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -119,6 +120,7 @@ export function PaymentActivity({ pageSize }: { pageSize: number }) {
                   {e.timestamp && (
                     <div style={smallHeaderStyle(colors)}>
                       {formatHistoricalDate(e.timestamp * 1000)}{' '}
+                      <EtherscanLink value={e.txHash} type="tx" />
                     </div>
                   )}
                   <div

--- a/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
@@ -1,5 +1,6 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
+import EtherscanLink from 'components/shared/EtherscanLink'
 
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -98,6 +99,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                     {e.timestamp && (
                       <span>{formatHistoricalDate(e.timestamp * 1000)}</span>
                     )}{' '}
+                    <EtherscanLink value={e.txHash} type="tx" />
                   </div>
                   <div
                     style={{

--- a/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
@@ -1,5 +1,7 @@
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { ProjectContext } from 'contexts/projectContext'
+import EtherscanLink from 'components/shared/EtherscanLink'
+
 import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { PrintReservesEvent } from 'models/subgraph-entities/print-reserves-event'
@@ -63,6 +65,7 @@ export default function ReservesEventElem({
                 {formatHistoricalDate(printReservesEvent.timestamp * 1000)}
               </span>
             )}{' '}
+            <EtherscanLink value={printReservesEvent.txHash} type="tx" />
           </div>
           <div style={smallHeaderStyle(colors)}>
             called by <FormattedAddress address={printReservesEvent.caller} />

--- a/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/TapEventElem.tsx
@@ -1,6 +1,7 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import ProjectHandle from 'components/shared/ProjectHandle'
+import EtherscanLink from 'components/shared/EtherscanLink'
 
 import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
@@ -69,6 +70,7 @@ export default function TapEventElem({
             {tapEvent.timestamp && (
               <span>{formatHistoricalDate(tapEvent.timestamp * 1000)}</span>
             )}{' '}
+            <EtherscanLink value={tapEvent.txHash} type="tx" />
           </div>
           <div style={smallHeaderStyle(colors)}>
             called by <FormattedAddress address={tapEvent.caller} />

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -4,6 +4,8 @@ import { t } from '@lingui/macro'
 
 import { NetworkName } from 'models/network-name'
 
+import { LinkOutlined } from '@ant-design/icons'
+
 import { readNetwork } from 'constants/networks'
 
 export default function EtherscanLink({
@@ -27,6 +29,22 @@ export default function EtherscanLink({
     window.open(`https://${subdomain}etherscan.io/${type}/${value}`)
   }
 
+  if (type === 'tx') {
+    return (
+      <Tooltip trigger={['hover', 'click']} title={t`See transaction`}>
+        <a
+          className="hover-action"
+          style={{ fontWeight: 400 }}
+          onClick={goToEtherscan}
+          href={`https://${subdomain}etherscan.io/${type}/${value}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <LinkOutlined />
+        </a>
+      </Tooltip>
+    )
+  }
   return (
     <Tooltip trigger={['hover', 'click']} title={t`Go to Etherscan`}>
       <a


### PR DESCRIPTION
## What does this PR do and why?

Adds transaction links back to Activity section. 

My bad here. Seems I removed instances of the EtherscanLink (type='tx') that I wasn't supposed to when moving instances of type='address' into the FormattedAddress tooltip. See #346 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/149770492-38c02492-8f6d-4e19-b3f1-964dac00ace8.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
