### PR TITLE
Add Spanish to language selector

### DIFF
--- a/.linguirc.json
+++ b/.linguirc.json
@@ -13,6 +13,6 @@
   "fallbackLocales": {
     "default": "en"
   },
-  "locales": ["en", "zh", "ru", "tr", "pt"],
+  "locales": ["en", "zh", "ru", "tr", "es"],
   "sourceLocale": "en"
 }

--- a/.linguirc.json
+++ b/.linguirc.json
@@ -13,6 +13,6 @@
   "fallbackLocales": {
     "default": "en"
   },
-  "locales": ["en", "zh", "ru", "tr"],
+  "locales": ["en", "zh", "ru", "tr", "pt"],
   "sourceLocale": "en"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,14 +118,14 @@ Notion page.
    + export const SUPPORTED_LOCALES = ['en', 'zh', 'af']
    ```
 
-1. Import the locale plurals in `./src/i18n.tsx`.
+1. Import the locale plurals in `./src/providers/LanguageProvider.tsx`.
 
    ```diff
    - import { en, zh } from 'make-plural/plurals'
    + import { en, zh, af } from 'make-plural/plurals'
    ```
 
-1. Load the locale plurals in `./src/i18n.tsx`
+1. Load the locale plurals in `./src/providers/LanguageProvider.tsx`
 
    ```diff
    i18n.loadLocaleData({

--- a/src/components/Create/RestrictedActionsForm.tsx
+++ b/src/components/Create/RestrictedActionsForm.tsx
@@ -33,7 +33,7 @@ export default function RestrictedActionsForm({
           name="payIsPaused"
           label={t`Pause payments`}
           extra={t`Your project cannot receive direct payments while paused.`}
-          valuePropName={t`checked`}
+          valuePropName={'checked'}
         >
           <Switch />
         </Form.Item>

--- a/src/components/Landing/QAs.tsx
+++ b/src/components/Landing/QAs.tsx
@@ -5,6 +5,8 @@ import { t } from '@lingui/macro'
 // Saw the suggestion to separate the store and render into 2 files here:
 // https://github.com/lingui/js-lingui/issues/707#issuecomment-657199843
 // Not sure why but this fixed the problem.
+// Take-away: If you're storing a list of t`` strings in a list,
+// make sure you're not rendering it from the same file.
 export default function QAs() {
   return [
     {

--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -48,7 +48,7 @@ export default function LanguageSelector({
         style={{
           ...selectStyle,
         }}
-        value={Languages[currentSelectedLanguage].long}
+        value={Languages[currentSelectedLanguage]?.long ?? 'English'}
         onChange={newLanguage => {
           setLanguage(newLanguage)
         }}

--- a/src/constants/languages/language-options.ts
+++ b/src/constants/languages/language-options.ts
@@ -6,5 +6,6 @@ export const Languages: Language = {
   zh: { code: 'zh', name: 'chinese', short: '中文', long: '中文' },
   ru: { code: 'ru', name: 'russian', short: 'RU', long: 'Pусский' },
   tr: { code: 'tr', name: 'turkish', short: 'TR', long: 'Türkçe' },
+  pt: { code: 'pt', name: 'portuguese', short: 'PT', long: 'Português' },
   // es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
 }

--- a/src/constants/languages/language-options.ts
+++ b/src/constants/languages/language-options.ts
@@ -6,6 +6,6 @@ export const Languages: Language = {
   zh: { code: 'zh', name: 'chinese', short: '中文', long: '中文' },
   ru: { code: 'ru', name: 'russian', short: 'RU', long: 'Pусский' },
   tr: { code: 'tr', name: 'turkish', short: 'TR', long: 'Türkçe' },
-  pt: { code: 'pt', name: 'portuguese', short: 'PT', long: 'Português' },
-  // es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
+  // pt: { code: 'pt', name: 'portuguese', short: 'PT', long: 'Português' },
+  es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
 }

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ['en', 'zh', 'ru', 'tr', 'pt']
+export const SUPPORTED_LOCALES = ['en', 'zh', 'ru', 'tr', 'es']
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 
 export const DEFAULT_LOCALE: SupportedLocale = 'en'

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ['en', 'zh', 'ru', 'tr']
+export const SUPPORTED_LOCALES = ['en', 'zh', 'ru', 'tr', 'pt']
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 
 export const DEFAULT_LOCALE: SupportedLocale = 'en'

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -29,7 +29,7 @@ msgstr ""
 msgid "3-day delay"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "5% of all money made by projects is sent to help pay for the maintenance and development of Juicebox itself. In exchange, projects get Juicebox tokens ($JBX), which will be worth more as the ecosystem grows over time."
 msgstr ""
 
@@ -75,19 +75,19 @@ msgstr ""
 msgid "@"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "A bonding curve rewards people who wait longer to redeem your tokens for overflow."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "A project owner can propose changes to any part of the contract at any time, with changes taking effect after the current budgeting time frame has ended."
 msgstr ""
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Anyone can deploy and use another governance smart contract to override this scheme."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "At the start, power over the governance smart contract is held by Juicebox's founding contributors. The intent is to soon transfer the power to a community of token holders."
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 
 #: src/components/Dashboard/index.tsx
 msgid "Back to top"
-msgstr ""
+msgstr "Back to top"
 
 #: src/components/Landing/index.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
@@ -248,11 +248,11 @@ msgstr ""
 msgid "Built for:"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Can I delete a project?"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr ""
 msgid "Created"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed."
 msgstr ""
 
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Distribution"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr ""
 
@@ -372,11 +372,11 @@ msgstr ""
 msgid "Docs"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Due to their public nature, any exploits to the contracts may have irreversable consequences, including loss of funds. Please use Juicebox with caution."
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "ERC20 community tokens"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Each project has its own tokens. Everyone who funds a project gets a newly minted supply of tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are issued by the project owner"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Ethereum protocols and DAOs"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Ethereum provides a public environment where internet apps like Juicebox can run permissionlessly, trustlessly, and unstoppably."
 msgstr ""
 
@@ -433,15 +433,15 @@ msgstr ""
 msgid "FAQs"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "For now, a minimum of 14 days must pass from the time of a proposed reconfiguration for it to take effect. This gives token holders time to react to the decision."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive Tokens in return."
 msgstr ""
 
@@ -498,11 +498,11 @@ msgstr ""
 msgid "Holders"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Holding these tokens entitles a project to a portion of its own overflow."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "How do I archive a project?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "If you have a project you'd like to archive, let the Juicebox team know in Discord."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for burning their tokens."
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "Issue rate"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it—just let us know in Discord. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr ""
 
@@ -572,19 +572,23 @@ msgstr ""
 msgid "Juicebox contracts"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
+msgid "Juicebox doesn't support {exchangeName} yet."
+msgstr "Juicebox doesn't support {exchangeName} yet."
+
+#: src/components/Landing/QAs.tsx
 msgid "Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs at https://juicebox.money/#/p/juicebox."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Juicebox is experimental software. Although the founding contributors have done their part to shape the smart contracts for public use and have run the code through tons of tests, there still may be bugs."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business."
 msgstr ""
 
@@ -604,10 +608,6 @@ msgstr ""
 #: src/components/Projects/index.tsx
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Load more"
-msgstr ""
-
-#: src/components/shared/TokenAMMPriceBadge.tsx
-msgid "Loading {exchangeName} price for {tokenSymbol}..."
 msgstr ""
 
 #: src/components/shared/formItems/ProjectLogoUri.tsx
@@ -650,6 +650,10 @@ msgstr ""
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr ""
 
+#: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
+msgid "No liquidity"
+msgstr "No liquidity"
+
 #: src/components/Create/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr ""
@@ -674,6 +678,10 @@ msgstr ""
 #: src/components/FundingCycle/FundingCycleDetails.tsx
 msgid "Not set"
 msgstr ""
+
+#: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
+msgid "Not supported"
+msgstr "Not supported"
 
 #: src/components/Landing/index.tsx
 msgid "Note: Juicebox is new, unaudited, and not guaranteed to work perfectly. Before spending money, do your own research: <0>ask questions</0>, <1>check out the code</1>, and understand the risks!"
@@ -768,7 +776,7 @@ msgstr ""
 msgid "Peach's Juicebox Stand"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange."
 msgstr ""
 
@@ -831,7 +839,7 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Projects can be created with an optional discount rate to incentivize funding it earlier than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr ""
 
@@ -906,6 +914,10 @@ msgstr ""
 msgid "Reserves"
 msgstr ""
 
+#: src/components/Navbar/MenuItems.tsx
+msgid "Resources"
+msgstr "Resources"
+
 #: src/components/Create/RestrictedActionsForm.tsx
 #: src/components/Create/index.tsx
 msgid "Restricted actions"
@@ -970,6 +982,10 @@ msgstr ""
 msgid "Search projects by handle"
 msgstr ""
 
+#: src/components/shared/EtherscanLink.tsx
+msgid "See transaction"
+msgstr "See transaction"
+
 #: src/components/shared/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr ""
@@ -1028,7 +1044,7 @@ msgstr ""
 msgid "Text displayed on your project's \"pay\" button. Leave this blank to use the default."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet."
 msgstr ""
 
@@ -1052,11 +1068,11 @@ msgstr ""
 msgid "The balance of the wallet that owns this Juicebox project."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "The code could always use more eyes and more critique to further the community's confidence. Join our Discord and peek the code on Github to work with us."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "The founding contributors will then be working on L2 payment terminals for Juicebox projects."
 msgstr ""
 
@@ -1068,7 +1084,7 @@ msgstr ""
 msgid "The project's entire balance will be considered overflow."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The distribution schedule is proportional to payments recieved, weighted by the project's discount rate over time."
 msgstr ""
 
@@ -1077,7 +1093,7 @@ msgstr ""
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "The rest is left to share between token hodlers."
 msgstr ""
 
@@ -1089,11 +1105,11 @@ msgstr ""
 msgid "The total amount received by this project through Juicebox since it was created."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "There was also a script written for iteratively running the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 millions test cases through this stress-testing script."
 msgstr ""
 
@@ -1105,7 +1121,7 @@ msgstr ""
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down."
 msgstr ""
 
@@ -1122,7 +1138,7 @@ msgstr ""
 msgid "This text will be displayed to your supporters before they complete their payment."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol.)"
 msgstr ""
 
@@ -1158,7 +1174,7 @@ msgstr ""
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's overflow, letting you benefit from its success. After all, you helped it get there."
 msgstr ""
 
@@ -1221,7 +1237,7 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app)."
 msgstr ""
 
@@ -1245,31 +1261,31 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What are community tokens?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What are the risks?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What is overflow?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What's a discount rate?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr ""
 
@@ -1286,19 +1302,19 @@ msgstr ""
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Why Ethereum?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr ""
 
-#: src/components/Landing/Faq.tsx
+#: src/components/Landing/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr ""
 
@@ -1398,6 +1414,10 @@ msgstr ""
 msgid "juiceboxETH\""
 msgstr ""
 
+#: src/components/Dashboard/Pay/PayInputSubText.tsx
+msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
+msgstr "or <0><1>buy {tokenText} on exchange<2/></1></0>"
+
 #: src/components/Create/RulesForm.tsx
 msgid "this interface"
 msgstr ""
@@ -1419,7 +1439,7 @@ msgstr ""
 msgid "until"
 msgstr ""
 
-#: src/utils/formatDate.ts
+#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr ""
 
@@ -1495,18 +1515,14 @@ msgstr ""
 msgid "{count} total"
 msgstr ""
 
-#: src/components/shared/TokenAMMPriceBadge.tsx
-msgid "{exchangeName} has no liquidity pool for {tokenSymbol}."
-msgstr ""
+#: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
+msgid "{exchangeName} has no market for {tokenSymbol}."
+msgstr "{exchangeName} has no market for {tokenSymbol}."
 
 #: src/components/Dashboard/index.tsx
 msgid "{handle} not found"
-msgstr ""
+msgstr "{handle} not found"
 
-#: src/components/Landing/Faq.tsx
-msgid "{p}"
-msgstr ""
-
-#: src/components/shared/TokenAMMPriceBadge.tsx
+#: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr ""

--- a/src/providers/LanguageProvider.tsx
+++ b/src/providers/LanguageProvider.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lingui/detect-locale'
 import { I18nProvider } from '@lingui/react'
 import { ReactNode, useEffect } from 'react'
-import { en, zh, ru, tr } from 'make-plural/plurals'
+import { en, zh, ru, tr, pt } from 'make-plural/plurals'
 
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE } from 'constants/locale'
 
@@ -17,6 +17,8 @@ i18n.loadLocaleData({
   zh: { plurals: zh },
   ru: { plurals: ru },
   tr: { plurals: tr },
+  pt: { plurals: pt },
+  //es: { plurals: es }
 })
 
 const getLocale = (): string => {

--- a/src/providers/LanguageProvider.tsx
+++ b/src/providers/LanguageProvider.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lingui/detect-locale'
 import { I18nProvider } from '@lingui/react'
 import { ReactNode, useEffect } from 'react'
-import { en, zh, ru, tr, pt } from 'make-plural/plurals'
+import { en, zh, ru, tr, es } from 'make-plural/plurals'
 
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE } from 'constants/locale'
 
@@ -17,8 +17,8 @@ i18n.loadLocaleData({
   zh: { plurals: zh },
   ru: { plurals: ru },
   tr: { plurals: tr },
-  pt: { plurals: pt },
-  //es: { plurals: es }
+  // pt: { plurals: pt },
+  es: { plurals: es },
 })
 
 const getLocale = (): string => {


### PR DESCRIPTION
## What does this PR do and why?

- Adds Spanish to languages selector and lingui.js configuration
- Fixes bug when user's localStorage is setting to something not in the language selector. Was causing an error when opening language selector but now it defaults to English 
- Update Contribution.MD


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
