### PR TITLE
Add Tally integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "autolinker": "^3.14.3",
     "axios": "^0.21.1",
     "bnc-notify": "^1.9.1",
-    "bnc-onboard": "1.34.1",
+    "bnc-onboard": "1.36.0",
     "env-cmd": "^10.1.0",
     "erc-20-abi": "^1.0.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/utils/onboard.ts
+++ b/src/utils/onboard.ts
@@ -48,6 +48,7 @@ export function initOnboard(subscriptions: Subscriptions, darkMode: boolean) {
         { walletName: 'operaTouch' },
         { walletName: 'imToken', rpcUrl },
         { walletName: 'meetone' },
+        { walletName: 'tally' },
         { walletName: 'authereum', disableNotifications: true },
       ],
     },


### PR DESCRIPTION
## What does this PR do and why?

Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.


## Screenshots or screen recordings

N/A

## Acceptance checklist

- [x ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
