### PR TITLE
Improve project card HTML semantics

### DIFF
--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -46,8 +46,7 @@ export default function ProjectCard({
         overflow: 'hidden',
       }}
       key={project?.handle}
-      href={`/p/${project.handle}`}
-      onClick={() => (window.location.hash = '/p/' + project.handle)}
+      href={`/#/p/${project.handle}`}
     >
       {metadata ? (
         <div

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -39,14 +39,14 @@ export default function ProjectCard({
   const terminalVersion = getTerminalVersion(project.terminal)
 
   return (
-    <div
+    <a
       style={{
         borderRadius: radii.lg,
         cursor: 'pointer',
         overflow: 'hidden',
       }}
-      className="clickable-border"
       key={project?.handle}
+      href={`/p/${project.handle}`}
       onClick={() => (window.location.hash = '/p/' + project.handle)}
     >
       {metadata ? (
@@ -58,6 +58,7 @@ export default function ProjectCard({
             overflow: 'hidden',
             padding: 20,
           }}
+          className="clickable-border"
         >
           <div style={{ marginRight: 20 }}>
             <ProjectLogo
@@ -71,6 +72,7 @@ export default function ProjectCard({
             style={{
               flex: 1,
               minWidth: 0,
+              fontWeight: 400,
             }}
           >
             <h2
@@ -138,6 +140,6 @@ export default function ProjectCard({
           {project.handle} <Loading />
         </div>
       )}
-    </div>
+    </a>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Changed wrapping <div> on project cards to an <a> so we use it like a link (e.g. see the URL in bottom-left on hover, open in new tab, etc.)


**Vid shows two clicks:** first click (while holding Command/Control key) opens in new tab, second click without any keys down. Also see URL in bottom-right on hover

https://user-images.githubusercontent.com/96150256/150235381-bc5f4340-00af-4360-9704-7481da83a7a2.mp4


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
