### PR TITLE
[BUG] Populate fields in incentive form with default values

### DIFF
--- a/src/components/Create/IncentivesForm.tsx
+++ b/src/components/Create/IncentivesForm.tsx
@@ -78,7 +78,7 @@ export default function IncentivesForm({
         )}
         <FormItems.ProjectBondingCurveRate
           name="bondingCurveRate"
-          value={bondingCurveRate?.toString() ?? '0'}
+          value={bondingCurveRate?.toString() ?? '100'}
           onChange={(val?: number) => setBondingCurveRate(val?.toString())}
           disabled={!!disableBondingCurve}
         />

--- a/src/components/shared/formItems/ProjectBondingCurveRate.tsx
+++ b/src/components/shared/formItems/ProjectBondingCurveRate.tsx
@@ -195,7 +195,8 @@ export default function ProjectBondingCurveRate({
         max={100}
         step={0.5}
         name={name}
-        sliderValue={parseFloat(value ?? '0')}
+        defaultValue={100}
+        sliderValue={parseFloat(value ?? '100')}
         disabled={disabled}
         onChange={(val: number | undefined) => {
           graphCurve(val)

--- a/src/components/shared/formItems/ProjectDiscountRate.tsx
+++ b/src/components/shared/formItems/ProjectDiscountRate.tsx
@@ -24,6 +24,7 @@ export default function ProjectDiscountRate({
     >
       <NumberSlider
         max={20}
+        defaultValue={0}
         sliderValue={parseFloat(value ?? '0')}
         suffix="%"
         name={name}


### PR DESCRIPTION
## What does this PR do and why?

Shows default values in percent fields of 'Incentives' form (discount rate and bonding curve) rather than blank.

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/150639247-6ce165a9-d977-47ab-bb0f-641211fb4bad.mp4


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
