### PR TITLE
[BUG] Fix resources dropdown styling for non-English languages

### DIFF
--- a/src/styles/antd-overrides/collapse.scss
+++ b/src/styles/antd-overrides/collapse.scss
@@ -167,12 +167,16 @@
   position: absolute;
   top: 9px;
   margin-left: -8px;
+  width: 100%;
   .ant-collapse-header {
     font-weight: 600 !important;
     color: var(--text-primary) !important;
   }
   .ant-collapse-content {
-    width: 120px;
+    float: left;
+  }
+  .nav-dropdown-item {
+    padding-right: 10px;
   }
   .ant-select-arrow {
     display: block;

--- a/src/styles/antd-overrides/collapse.scss
+++ b/src/styles/antd-overrides/collapse.scss
@@ -174,6 +174,7 @@
   }
   .ant-collapse-content {
     float: left;
+    min-width: 120px;
   }
   .nav-dropdown-item {
     padding-right: 10px;


### PR DESCRIPTION
## What does this PR do and why?

1. Makes dropdown box width linked to length of longest dropdown item (rather than overflowing or wrapping as it currently does)
2. Fixes heading going vertical in Chinese

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/150675334-b9282c1d-2f6a-449f-96b0-a03865c716a2.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
