### PR TITLE
Refactor redux localstorage

### DIFF
--- a/src/redux/localStoragePreload.ts
+++ b/src/redux/localStoragePreload.ts
@@ -1,33 +1,14 @@
-import { Middleware } from '@reduxjs/toolkit'
-
 import { defaultProjectState } from './slices/editingProject'
 
-import { RootState } from './store'
-
-const KEY = 'jb_redux_preloadedState'
+import { RootState, REDUX_STATE_LOCALSTORAGE_KEY } from './store'
 
 interface PreloadedState {
   reduxState: RootState
 }
 
-export const localStoragePreloadMiddleware: Middleware =
-  store => next => action => {
-    if (typeof localStorage === 'undefined') {
-      return
-    }
-    localStorage.setItem(
-      KEY,
-      JSON.stringify({
-        reduxState: store.getState(),
-      } as PreloadedState),
-    )
-
-    return next(action)
-  }
-
 export default function getLocalStoragePreloadedState(): RootState | undefined {
   try {
-    const stateString = localStorage.getItem(KEY)
+    const stateString = localStorage.getItem(REDUX_STATE_LOCALSTORAGE_KEY)
     if (!stateString) {
       return undefined
     }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,9 +1,9 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 
 import editingProjectReducer from './slices/editingProject'
-import getLocalStoragePreloadedState, {
-  localStoragePreloadMiddleware,
-} from './localStoragePreload'
+import getLocalStoragePreloadedState from './localStoragePreload'
+
+export const REDUX_STATE_LOCALSTORAGE_KEY = 'jb_redux_preloadedState'
 
 const rootReducer = combineReducers({
   editingProject: editingProjectReducer,
@@ -14,14 +14,19 @@ export function createStore() {
     reducer: rootReducer,
     devTools: process.env.NODE_ENV !== 'production',
     preloadedState: getLocalStoragePreloadedState(),
-    middleware: getDefaultMiddleware => [
-      ...getDefaultMiddleware(),
-      localStoragePreloadMiddleware,
-    ],
   })
 }
 
 const store = createStore()
+
+store.subscribe(() => {
+  localStorage.setItem(
+    REDUX_STATE_LOCALSTORAGE_KEY,
+    JSON.stringify({
+      reduxState: store.getState(),
+    }),
+  )
+})
 
 export type RootState = ReturnType<typeof rootReducer>
 export type AppDispatch = typeof store.dispatch


### PR DESCRIPTION
## What does this PR do and why?

Fixes https://github.com/jbx-protocol/juice-interface/issues/411

Previously we were updating localStorage in a redux middleware. The problem with this approach is that redux middleware is invoked _before_ the reducer (between the `dispatch` call and the reducer), so the state in the middleware is a tick behind.

Using a redux subscription appears to be the preferred approach. This is invoked after the reducer, so localStorage is always in sync with the latest state.

This illustrates the difference:

```diff
- dispatch(resetState()) --> middleware (with old state) --> localstorage is set (with old state) --> reducer (state updated)
+ dispatch(resetState()) --> middleware (with old state) --> reducer (state updated) --> subscriber (with new state) --> localstorage is set (with new state)
```

This approach is described here: https://stackoverflow.com/questions/35305661/where-to-write-to-localstorage-in-a-redux-app.

https://user-images.githubusercontent.com/94939382/151093697-87347857-5a2f-481c-9f81-81be0127d783.mp4


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
