### PR TITLE
Warn users about risky funding cycle configurations

### DIFF
--- a/src/components/Dashboard/FundingCycles.tsx
+++ b/src/components/Dashboard/FundingCycles.tsx
@@ -10,7 +10,7 @@ import {
 } from 'hooks/contractReader/HasPermission'
 import { useContext, useState } from 'react'
 
-import { isFundingCycleSafe } from 'utils/fundingCycle'
+import { fundingCycleRiskCount } from 'utils/fundingCycle'
 import { FundingCycle } from 'models/funding-cycle'
 
 import CurrentFundingCycle from '../FundingCycle/CurrentFundingCycle'
@@ -42,16 +42,22 @@ export default function FundingCycles({
     text: string
     fundingCycle: FundingCycle | undefined
   }) => {
-    return fundingCycle && isFundingCycleSafe(fundingCycle) ? (
-      text
-    ) : (
+    return fundingCycle && fundingCycleRiskCount(fundingCycle) ? (
       <Tooltip
         title={t`This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project.`}
       >
         <span>
-          {text} <WarningOutlined style={{ color: colors.text.warn }} />
+          {text}
+          <WarningOutlined
+            style={{
+              color: colors.text.warn,
+              marginLeft: 4,
+            }}
+          />
         </span>
       </Tooltip>
+    ) : (
+      text
     )
   }
 

--- a/src/components/Dashboard/FundingCycles.tsx
+++ b/src/components/Dashboard/FundingCycles.tsx
@@ -1,5 +1,6 @@
-import { Space } from 'antd'
+import { Space, Tooltip } from 'antd'
 import { t } from '@lingui/macro'
+import { WarningOutlined } from '@ant-design/icons'
 import { CardSection } from 'components/shared/CardSection'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -8,6 +9,9 @@ import {
   useHasPermission,
 } from 'hooks/contractReader/HasPermission'
 import { useContext, useState } from 'react'
+
+import { isFundingCycleSafe } from 'utils/fundingCycle'
+import { FundingCycle } from 'models/funding-cycle'
 
 import CurrentFundingCycle from '../FundingCycle/CurrentFundingCycle'
 import QueuedFundingCycle from '../FundingCycle/QueuedFundingCycle'
@@ -25,20 +29,40 @@ export default function FundingCycles({
   const [selectedTab, setSelectedTab] = useState<TabOption>('current')
   const [hoverTab, setHoverTab] = useState<TabOption>()
 
-  const { projectId, currentFC } = useContext(ProjectContext)
+  const { projectId, currentFC, queuedFC } = useContext(ProjectContext)
 
   const {
     theme: { colors },
   } = useContext(ThemeContext)
 
+  const tabText = ({
+    text,
+    fundingCycle,
+  }: {
+    text: string
+    fundingCycle: FundingCycle | undefined
+  }) => {
+    return fundingCycle && isFundingCycleSafe(fundingCycle) ? (
+      text
+    ) : (
+      <Tooltip
+        title={t`This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project.`}
+      >
+        <span>
+          {text} <WarningOutlined style={{ color: colors.text.warn }} />
+        </span>
+      </Tooltip>
+    )
+  }
+
   const tab = (option: TabOption) => {
-    let text: string
+    let text: string | JSX.Element
     switch (option) {
       case 'current':
-        text = t`Current`
+        text = tabText({ text: t`Current`, fundingCycle: currentFC })
         break
       case 'upcoming':
-        text = t`Upcoming`
+        text = tabText({ text: t`Upcoming`, fundingCycle: queuedFC })
         break
       case 'history':
         text = t`History`

--- a/src/components/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/FundingCycle/FundingCycleDetails.tsx
@@ -1,8 +1,7 @@
-import { parseEther } from '@ethersproject/units'
-import { Descriptions, Tooltip } from 'antd'
-import { t, Trans } from '@lingui/macro'
 import { WarningOutlined } from '@ant-design/icons'
-
+import { parseEther } from '@ethersproject/units'
+import { t, Trans } from '@lingui/macro'
+import { Descriptions, Tooltip } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 
 import { ProjectContext } from 'contexts/projectContext'
@@ -14,14 +13,14 @@ import { formatDate } from 'utils/formatDate'
 import { formatWad, fromPerbicent, fromPermille } from 'utils/formatNumber'
 import {
   decodeFundingCycleMetadata,
+  getUnsafeFundingCycleProperties,
   hasFundingTarget,
   isRecurring,
 } from 'utils/fundingCycle'
 import { weightedRate } from 'utils/math'
 
-import { getUnsafeFundingCycleProperties } from 'utils/fundingCycle'
-
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
+
 import TooltipLabel from '../shared/TooltipLabel'
 
 export default function FundingCycleDetails({
@@ -61,8 +60,9 @@ export default function FundingCycleDetails({
   }) => {
     return showWarning ? (
       <Tooltip title={tooltipTitle}>
+        <span style={{ fontWeight: 500 }}>{text} </span>
         <span style={{ color: colors.text.warn }}>
-          {text} <WarningOutlined />
+          <WarningOutlined />
         </span>
       </Tooltip>
     ) : (
@@ -87,11 +87,7 @@ export default function FundingCycleDetails({
                 {formatWad(fundingCycle.target)}
               </>
             ) : (
-              <WarningText
-                showWarning={true}
-                text={t`No target`}
-                tooltipTitle={t`This project won't have overflow. Contributors cannot redeem any funds that they contribute.`}
-              />
+              t`No target`
             )}
           </Descriptions.Item>
         }
@@ -103,7 +99,7 @@ export default function FundingCycleDetails({
             <WarningText
               showWarning={true}
               text={t`Not set`}
-              tooltipTitle={t`Funding reconfigurations can be made at any time, without notice.`}
+              tooltipTitle={t`The project owner may reconfigure this funding cycle at any time, without notice.`}
             />
           )}
         </Descriptions.Item>
@@ -158,7 +154,11 @@ export default function FundingCycleDetails({
           <WarningText
             showWarning={unsafeFundingCycleProperties.metadataReservedRate}
             text={`${fromPerbicent(metadata?.reservedRate)}%`}
-            tooltipTitle={t`Contributors will receive a relatively small portion of tokens (if any) in exchange for paying the project.`}
+            tooltipTitle={
+              metadata?.reservedRate === 200
+                ? t`Contributors will not receive any tokens in exchange for paying this project.`
+                : t`Contributors will receive a relatively small portion of tokens in exchange for paying this project.`
+            }
           />
         </Descriptions.Item>
 
@@ -217,7 +217,7 @@ export default function FundingCycleDetails({
             <WarningText
               showWarning={true}
               text={t`Allowed`}
-              tooltipTitle={t`Any supply of tokens could be minted at any time by the project owners, diluting the token share of all existing contributors.`}
+              tooltipTitle={t`The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors.`}
             />
           ) : (
             t`Disabled`
@@ -243,7 +243,7 @@ export default function FundingCycleDetails({
         <WarningText
           showWarning={unsafeFundingCycleProperties.ballot}
           text={ballotStrategy.name}
-          tooltipTitle={t`Funding cycle reconfigurations can be created moments before a new cycle begins. Project owners can take advantage of contributors, for example by withdrawing overflow.`}
+          tooltipTitle={t`The upcoming funding cycle can be reconfigured by the project owner moments before a new cycle begins. This makes it possibe to take advantage of contributors, for example by withdrawing all overflow.`}
         />
         <div style={{ color: colors.text.secondary }}>
           <div style={{ fontSize: '0.7rem' }}>

--- a/src/components/FundingCycle/FundingCyclePreview.tsx
+++ b/src/components/FundingCycle/FundingCyclePreview.tsx
@@ -1,11 +1,12 @@
-import { Collapse } from 'antd'
+import { WarningOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
+import { Collapse, Tooltip } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
 import { ThemeContext } from 'contexts/themeContext'
 import { FundingCycle } from 'models/funding-cycle'
 import { useContext } from 'react'
 import { detailedTimeString } from 'utils/formatTime'
-import { hasFundingTarget, isRecurring } from 'utils/fundingCycle'
+import { fundingCycleRiskCount, isRecurring } from 'utils/fundingCycle'
 
 import FundingCycleDetails from './FundingCycleDetails'
 
@@ -59,16 +60,35 @@ export default function FundingCyclePreview({
                 cursor: 'pointer',
               }}
             >
-              {hasFundingTarget(fundingCycle) && fundingCycle.duration.gt(0) ? (
-                <span>
-                  <Trans>Cycle #{fundingCycle.number.toString()}</Trans>
-                </span>
-              ) : (
-                <span>
-                  <Trans>Details</Trans>
-                </span>
-              )}
-              <span style={{ color: colors.text.secondary }}>{headerText}</span>
+              <span>
+                {fundingCycle.duration.gt(0) ? (
+                  <span>
+                    <Trans>Cycle #{fundingCycle.number.toString()}</Trans>
+                  </span>
+                ) : (
+                  <span>
+                    <Trans>Details</Trans>
+                  </span>
+                )}
+                {fundingCycleRiskCount(fundingCycle) > 0 && (
+                  <span
+                    style={{ marginLeft: 10, color: colors.text.secondary }}
+                  >
+                    <Tooltip
+                      title={t`Some funding cycle properties may indicate risk
+                    for project contributors.`}
+                    >
+                      <WarningOutlined style={{ marginRight: 2 }} />
+                      {fundingCycleRiskCount(fundingCycle)}
+                    </Tooltip>
+                  </span>
+                )}
+              </span>
+              <span style={{ color: colors.text.secondary }}>
+                {headerText.length > 0 && (
+                  <span style={{ marginLeft: 10 }}>{headerText}</span>
+                )}
+              </span>
             </div>
           }
         >

--- a/src/utils/fundingCycle.ts
+++ b/src/utils/fundingCycle.ts
@@ -1,7 +1,12 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
+
 import { constants } from 'ethers'
 import { FundingCycle } from 'models/funding-cycle'
 import { FundingCycleMetadata } from 'models/funding-cycle-metadata'
+
+import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
+
+import { fromPerbicent } from './formatNumber'
 
 import { EditingFundingCycle } from './serializers'
 
@@ -73,3 +78,83 @@ export const isRecurring = (fundingCycle: FundingCycle | EditingFundingCycle) =>
 export const hasFundingTarget = (
   fundingCycle: Pick<FundingCycle | EditingFundingCycle, 'target'>,
 ) => fundingCycle.target.lt(constants.MaxUint256)
+
+/**
+ * Mark various funding cycle properties as "unsafe",
+ * based on a subjective interpretation.
+ *
+ * If a value in the returned object is true, it is potentially unsafe.
+ */
+export const getUnsafeFundingCycleProperties = (fundingCycle: FundingCycle) => {
+  const metadata = decodeFundingCycleMetadata(fundingCycle.metadata)
+
+  // when we set one of these values to true, we're saying it's potentially unsafe.
+  // This object is based on type FundingCycle
+  const configFlags = {
+    target: false,
+    duration: false,
+    ballot: false,
+    metadataTicketPrintingIsAllowed: false,
+    metadataReservedRate: false,
+  }
+
+  /**
+   * Ballot address is 0x0000.
+   * Funding cycle reconfigurations can be created moments before a new cycle begins,
+   * giving project owners an opportunity to take advantage of contributors, for example by withdrawing overflow.
+   */
+  if (
+    getBallotStrategyByAddress(fundingCycle.ballot).address ===
+    constants.AddressZero
+  ) {
+    configFlags.ballot = true
+  }
+
+  /**
+   * Duration not set. Reconfigurations can be made at any point without notice.
+   */
+  if (
+    !fundingCycle.duration ||
+    fundingCycle.duration.eq(constants.AddressZero)
+  ) {
+    configFlags.duration = true
+  }
+
+  /**
+   * No funding target.
+   * Means a contributor can't redeem.
+   */
+  if (!fundingCycle.target) {
+    configFlags.target = true
+  }
+
+  /**
+   * Token minting is enabled (v1.1).
+   * Any supply of tokens could be minted at any time by the project owners, diluting the token share of all existing contributors.
+   */
+  if (metadata?.ticketPrintingIsAllowed) {
+    configFlags.metadataTicketPrintingIsAllowed = true
+  }
+
+  /**
+   * Reserved rate is very high.
+   * Contributors will receive a relatively small portion of tokens (if any) in exchange for paying the project.
+   *
+   * Note: max reserve rate is 200.
+   */
+  if (parseInt(fromPerbicent(metadata?.reservedRate ?? 0), 10) >= 90) {
+    configFlags.metadataReservedRate = true
+  }
+
+  return configFlags
+}
+
+/**
+ * Return false if a funding cycle has a risky property (or many).
+ * True if we deem a project "safe" to contribute to.
+ */
+export const isFundingCycleSafe = (fundingCycle: FundingCycle): Boolean => {
+  return !Object.values(getUnsafeFundingCycleProperties(fundingCycle)).some(
+    v => v === true,
+  )
+}

--- a/src/utils/fundingCycle.ts
+++ b/src/utils/fundingCycle.ts
@@ -91,7 +91,6 @@ export const getUnsafeFundingCycleProperties = (fundingCycle: FundingCycle) => {
   // when we set one of these values to true, we're saying it's potentially unsafe.
   // This object is based on type FundingCycle
   const configFlags = {
-    target: false,
     duration: false,
     ballot: false,
     metadataTicketPrintingIsAllowed: false,
@@ -121,14 +120,6 @@ export const getUnsafeFundingCycleProperties = (fundingCycle: FundingCycle) => {
   }
 
   /**
-   * No funding target.
-   * Means a contributor can't redeem.
-   */
-  if (!fundingCycle.target) {
-    configFlags.target = true
-  }
-
-  /**
    * Token minting is enabled (v1.1).
    * Any supply of tokens could be minted at any time by the project owners, diluting the token share of all existing contributors.
    */
@@ -150,11 +141,11 @@ export const getUnsafeFundingCycleProperties = (fundingCycle: FundingCycle) => {
 }
 
 /**
- * Return false if a funding cycle has a risky property (or many).
- * True if we deem a project "safe" to contribute to.
+ * Return number of risk indicators for a funding cycle.
+ * 0 if we deem a project "safe" to contribute to.
  */
-export const isFundingCycleSafe = (fundingCycle: FundingCycle): Boolean => {
-  return !Object.values(getUnsafeFundingCycleProperties(fundingCycle)).some(
+export const fundingCycleRiskCount = (fundingCycle: FundingCycle): number => {
+  return Object.values(getUnsafeFundingCycleProperties(fundingCycle)).filter(
     v => v === true,
-  )
+  ).length
 }


### PR DESCRIPTION
## What does this PR do and why?

Show some warnings when a funding cycle might configured in a risky way.  https://github.com/jbx-protocol/juice-interface/issues/423

## Screenshots or screen recordings

| project | screenshot | 
| --- | ---|
| JuiceboxDAO (no warnings) | <img width="518" alt="Screen Shot 2022-01-28 at 8 30 10 pm" src="https://user-images.githubusercontent.com/94939382/151535687-3cbce8e7-365f-42f1-9bf2-14d607e342c2.png"> |
| HDAO (light) |  <img width="521" alt="Screen Shot 2022-01-28 at 8 42 30 pm" src="https://user-images.githubusercontent.com/94939382/151537406-70afcd98-a626-414e-b9ef-b32ef4977762.png"> |
| HDAO (dark) |  <img width="531" alt="Screen Shot 2022-01-28 at 8 42 52 pm" src="https://user-images.githubusercontent.com/94939382/151537320-a00cde74-44ff-4a6f-8fc3-2ba2dc80ecc0.png">|
| Moondao | <img width="529" alt="Screen Shot 2022-01-28 at 8 40 45 pm" src="https://user-images.githubusercontent.com/94939382/151537110-1da3f078-ed79-4e87-8cf9-4b5b59042a5f.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
