### PR TITLE
Add warning text to pay modal

### DIFF
--- a/src/components/Dashboard/FundingCycles.tsx
+++ b/src/components/Dashboard/FundingCycles.tsx
@@ -1,6 +1,6 @@
 import { Space, Tooltip } from 'antd'
 import { t } from '@lingui/macro'
-import { WarningOutlined } from '@ant-design/icons'
+import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { CardSection } from 'components/shared/CardSection'
 import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -48,7 +48,7 @@ export default function FundingCycles({
       >
         <span>
           {text}
-          <WarningOutlined
+          <ExclamationCircleOutlined
             style={{
               color: colors.text.warn,
               marginLeft: 4,

--- a/src/components/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/FundingCycle/FundingCycleDetails.tsx
@@ -1,4 +1,4 @@
-import { WarningOutlined } from '@ant-design/icons'
+import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { parseEther } from '@ethersproject/units'
 import { t, Trans } from '@lingui/macro'
 import { Descriptions, Tooltip } from 'antd'
@@ -22,6 +22,7 @@ import { weightedRate } from 'utils/math'
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
 
 import TooltipLabel from '../shared/TooltipLabel'
+import { FUNDING_CYCLE_WARNING_TEXT } from 'constants/fundingWarningText'
 
 export default function FundingCycleDetails({
   fundingCycle,
@@ -62,7 +63,7 @@ export default function FundingCycleDetails({
       <Tooltip title={tooltipTitle}>
         <span style={{ fontWeight: 500 }}>{text} </span>
         <span style={{ color: colors.text.warn }}>
-          <WarningOutlined />
+          <ExclamationCircleOutlined />
         </span>
       </Tooltip>
     ) : (
@@ -99,7 +100,7 @@ export default function FundingCycleDetails({
             <WarningText
               showWarning={true}
               text={t`Not set`}
-              tooltipTitle={t`The project owner may reconfigure this funding cycle at any time, without notice.`}
+              tooltipTitle={FUNDING_CYCLE_WARNING_TEXT(fundingCycle).duration}
             />
           )}
         </Descriptions.Item>
@@ -155,9 +156,7 @@ export default function FundingCycleDetails({
             showWarning={unsafeFundingCycleProperties.metadataReservedRate}
             text={`${fromPerbicent(metadata?.reservedRate)}%`}
             tooltipTitle={
-              metadata?.reservedRate === 200
-                ? t`Contributors will not receive any tokens in exchange for paying this project.`
-                : t`Contributors will receive a relatively small portion of tokens in exchange for paying this project.`
+              FUNDING_CYCLE_WARNING_TEXT(fundingCycle).metadataReservedRate
             }
           />
         </Descriptions.Item>
@@ -217,7 +216,10 @@ export default function FundingCycleDetails({
             <WarningText
               showWarning={true}
               text={t`Allowed`}
-              tooltipTitle={t`The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors.`}
+              tooltipTitle={
+                FUNDING_CYCLE_WARNING_TEXT(fundingCycle)
+                  .metadataTicketPrintingIsAllowed
+              }
             />
           ) : (
             t`Disabled`
@@ -243,7 +245,7 @@ export default function FundingCycleDetails({
         <WarningText
           showWarning={unsafeFundingCycleProperties.ballot}
           text={ballotStrategy.name}
-          tooltipTitle={t`The upcoming funding cycle can be reconfigured by the project owner moments before a new cycle begins. This makes it possible to take advantage of contributors, for example by withdrawing all overflow.`}
+          tooltipTitle={FUNDING_CYCLE_WARNING_TEXT(fundingCycle).ballot}
         />
         <div style={{ color: colors.text.secondary }}>
           <div style={{ fontSize: '0.7rem' }}>

--- a/src/components/FundingCycle/FundingCyclePreview.tsx
+++ b/src/components/FundingCycle/FundingCyclePreview.tsx
@@ -1,4 +1,4 @@
-import { WarningOutlined } from '@ant-design/icons'
+import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Collapse, Tooltip } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
@@ -78,7 +78,7 @@ export default function FundingCyclePreview({
                       title={t`Some funding cycle properties may indicate risk
                     for project contributors.`}
                     >
-                      <WarningOutlined style={{ marginRight: 2 }} />
+                      <ExclamationCircleOutlined style={{ marginRight: 2 }} />
                       {fundingCycleRiskCount(fundingCycle)}
                     </Tooltip>
                   </span>

--- a/src/components/modals/ConfirmPayOwnerModal/ProjectRiskNotice.tsx
+++ b/src/components/modals/ConfirmPayOwnerModal/ProjectRiskNotice.tsx
@@ -1,0 +1,48 @@
+import { ProjectContext } from 'contexts/projectContext'
+import { useContext } from 'react'
+import { ExclamationCircleOutlined } from '@ant-design/icons'
+import {
+  fundingCycleRiskCount,
+  getUnsafeFundingCycleProperties,
+} from 'utils/fundingCycle'
+
+import { ThemeContext } from 'contexts/themeContext'
+
+import {
+  FundingCycleRiskFlags,
+  FUNDING_CYCLE_WARNING_TEXT,
+} from 'constants/fundingWarningText'
+
+export default function ProjectRiskNotice() {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  const { currentFC } = useContext(ProjectContext)
+  if (!currentFC || fundingCycleRiskCount(currentFC) === 0) return null
+
+  const unsafeProperties = getUnsafeFundingCycleProperties(currentFC)
+  const unsafePropertyKeys = Object.keys(
+    unsafeProperties,
+  ) as (keyof FundingCycleRiskFlags)[]
+
+  const warnings = unsafePropertyKeys
+    .filter(k => unsafeProperties[k] === true)
+    .map(k => FUNDING_CYCLE_WARNING_TEXT(currentFC)[k])
+
+  return (
+    <div style={{ backgroundColor: colors.background.l1, padding: '1rem' }}>
+      <h4 style={{ color: colors.text.primary, fontWeight: 600 }}>
+        <ExclamationCircleOutlined /> Potential risks
+      </h4>
+      <p style={{ color: colors.text.secondary }}>
+        Some properties of the project's current funding cycle may indicate risk
+        for contributors.
+      </p>
+      <ul>
+        {warnings.map(text => (
+          <li>{text}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/modals/ConfirmPayOwnerModal/index.tsx
+++ b/src/components/modals/ConfirmPayOwnerModal/index.tsx
@@ -14,6 +14,8 @@ import { currencyName } from 'utils/currency'
 import { formattedNum, formatWad } from 'utils/formatNumber'
 import { weightedRate } from 'utils/math'
 
+import ProjectRiskNotice from './ProjectRiskNotice'
+
 export default function ConfirmPayOwnerModal({
   visible,
   weiAmount,
@@ -94,6 +96,8 @@ export default function ConfirmPayOwnerModal({
             <p>{metadata.payDisclosure}</p>
           </div>
         )}
+
+        <ProjectRiskNotice />
 
         <Descriptions column={1} bordered>
           <Descriptions.Item label={t`Pay amount`} className="content-right">

--- a/src/constants/fundingWarningText.ts
+++ b/src/constants/fundingWarningText.ts
@@ -1,0 +1,27 @@
+import { t } from '@lingui/macro'
+import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
+
+import { FundingCycle } from '../models/funding-cycle'
+
+export type FundingCycleRiskFlags = {
+  duration: boolean
+  ballot: boolean
+  metadataTicketPrintingIsAllowed: boolean
+  metadataReservedRate: boolean
+}
+
+export const FUNDING_CYCLE_WARNING_TEXT: (fc: FundingCycle) => {
+  [k in keyof FundingCycleRiskFlags]: string
+} = fc => {
+  const metadata = decodeFundingCycleMetadata(fc.metadata)
+
+  return {
+    duration: t`The project owner may reconfigure this funding cycle at any time, without notice.`,
+    ballot: t`Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors.`,
+    metadataTicketPrintingIsAllowed: t`The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors.`,
+    metadataReservedRate:
+      metadata?.reservedRate === 200
+        ? t`Contributors will not receive any tokens in exchange for paying this project.`
+        : t`Contributors will receive a relatively small portion of tokens in exchange for paying this project.`,
+  }
+}

--- a/src/utils/fundingCycle.ts
+++ b/src/utils/fundingCycle.ts
@@ -9,6 +9,7 @@ import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallot
 import { fromPerbicent } from './formatNumber'
 
 import { EditingFundingCycle } from './serializers'
+import { FundingCycleRiskFlags } from 'constants/fundingWarningText'
 
 // packed `metadata` format: 0btTPRRRRRRRRBBBBBBBBrrrrrrrrVVVVVVVV
 // V: version (bits 0-7)
@@ -85,7 +86,9 @@ export const hasFundingTarget = (
  *
  * If a value in the returned object is true, it is potentially unsafe.
  */
-export const getUnsafeFundingCycleProperties = (fundingCycle: FundingCycle) => {
+export const getUnsafeFundingCycleProperties = (
+  fundingCycle: FundingCycle,
+): FundingCycleRiskFlags => {
   const metadata = decodeFundingCycleMetadata(fundingCycle.metadata)
 
   // when we set one of these values to true, we're saying it's potentially unsafe.


### PR DESCRIPTION
## What does this PR do and why?

⚠️ this PR targets branch `risky-project-warning` for https://github.com/jbx-protocol/juice-interface/pull/429

Add FC risks to "pay" modal.

## Screenshots or screen recordings

| light | dark |
| --- | --- |
| <img width="637" alt="Screen Shot 2022-01-28 at 9 38 14 pm" src="https://user-images.githubusercontent.com/94939382/151544907-e9092310-35fc-4bd5-89ef-04616d1167f6.png"> | <img width="617" alt="Screen Shot 2022-01-28 at 9 38 36 pm" src="https://user-images.githubusercontent.com/94939382/151544934-be07f712-fca9-48ed-b584-667197880974.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
