### PR TITLE
Warn on using risky configurations in create + reconfigure

### DIFF
--- a/src/components/Create/BudgetForm.tsx
+++ b/src/components/Create/BudgetForm.tsx
@@ -261,7 +261,13 @@ export default function BudgetForm({
             <Trans>
               Funding can be reconfigured at any time. Reconfigurations will
               start a new funding cycle.
-            </Trans>
+            </Trans>{' '}
+            <span style={{ color: colors.text.warn }}>
+              <Trans>
+                Using a duration is recommended. Allowing funding cycles to be
+                reconfigured at any time will appear risky to contributors.
+              </Trans>
+            </span>
           </p>
         )}
 

--- a/src/components/Create/RestrictedActionsForm.tsx
+++ b/src/components/Create/RestrictedActionsForm.tsx
@@ -2,7 +2,7 @@ import { Button, Form, FormInstance, Space, Switch } from 'antd'
 import { t, Trans } from '@lingui/macro'
 
 import { ThemeContext } from 'contexts/themeContext'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 
 export type RestrictedActionsFormFields = {
   payIsPaused: boolean
@@ -16,6 +16,13 @@ export default function RestrictedActionsForm({
   form: FormInstance<RestrictedActionsFormFields>
   onSave: VoidFunction
 }) {
+  const [showTicketPrintingWarning, setShowTicketPrintingWarning] =
+    useState<boolean>()
+
+  useEffect(() => {
+    setShowTicketPrintingWarning(form.getFieldValue('ticketPrintingIsAllowed'))
+  }, [form])
+
   const {
     theme: { colors },
   } = useContext(ThemeContext)
@@ -43,8 +50,22 @@ export default function RestrictedActionsForm({
           extra={t`Enabling this allows the project owner to manually mint any amount of tokens to any address.`}
           valuePropName="checked"
         >
-          <Switch />
+          <Switch
+            onChange={val => {
+              setShowTicketPrintingWarning(val)
+            }}
+          />
         </Form.Item>
+        {showTicketPrintingWarning && (
+          <Form.Item>
+            <p style={{ color: colors.text.warn }}>
+              <Trans>
+                Enabling tokens to be minted will appear risky to contributors,
+                and should only be used when necessary.
+              </Trans>
+            </p>
+          </Form.Item>
+        )}
         <Form.Item>
           <Button htmlType="submit" type="primary" onClick={() => onSave()}>
             <Trans>Save</Trans>

--- a/src/components/Create/RulesForm.tsx
+++ b/src/components/Create/RulesForm.tsx
@@ -81,11 +81,23 @@ export default function RulesForm({
         <Trans>Reconfiguration</Trans>
       </h1>
 
-      <p style={{ color: colors.text.secondary }}>
-        <Trans>
-          Rules for how this project's funding cycles can be reconfigured.
-        </Trans>
-      </p>
+      <div>
+        <p style={{ color: colors.text.secondary }}>
+          <Trans>
+            Rules for how this project's funding cycles can be reconfigured.
+          </Trans>
+        </p>
+
+        {ballotStrategies()[selectedIndex ?? 0].address ===
+          constants.AddressZero && (
+          <p style={{ color: colors.text.warn }}>
+            <Trans>
+              Using a reconfiguration strategy is recommended. Projects with no
+              strategy will appear risky to contributors.
+            </Trans>
+          </p>
+        )}
+      </div>
 
       <Space direction="vertical">
         {ballotStrategies().map((s, i) =>

--- a/src/components/Create/TicketingForm.tsx
+++ b/src/components/Create/TicketingForm.tsx
@@ -5,6 +5,8 @@ import { ThemeContext } from 'contexts/themeContext'
 import { TicketMod } from 'models/mods'
 import { useContext, useLayoutEffect, useState } from 'react'
 
+import { reservedRateRiskyMin } from 'constants/fundingWarningText'
+
 export type TicketingFormFields = {
   reserved: number
 }
@@ -19,6 +21,8 @@ export default function TicketingForm({
   onSave: (mods: TicketMod[]) => void
 }) {
   const [mods, setMods] = useState<TicketMod[]>([])
+  const [showReservedRateWarning, setShowReservedRateWarning] =
+    useState<boolean>()
 
   const {
     theme: { colors },
@@ -55,8 +59,23 @@ export default function TicketingForm({
         <FormItems.ProjectReserved
           value={form.getFieldValue('reserved')}
           name="reserved"
-          onChange={(val?: number) => form.setFieldsValue({ reserved: val })}
+          onChange={(val?: number) => {
+            form.setFieldsValue({ reserved: val })
+            setShowReservedRateWarning(!!(val && val >= reservedRateRiskyMin))
+          }}
         />
+        {showReservedRateWarning && (
+          <Form.Item>
+            <p style={{ color: colors.text.warn }}>
+              <Trans>
+                Projects using a reserved rate of {reservedRateRiskyMin}% or
+                more will appear risky to contributors, as a relatively small
+                number of tokens will be received in exchange for paying your
+                project.
+              </Trans>
+            </p>
+          </Form.Item>
+        )}
         <FormItems.ProjectTicketMods
           name="ticketMods"
           mods={mods}

--- a/src/constants/fundingWarningText.ts
+++ b/src/constants/fundingWarningText.ts
@@ -3,6 +3,8 @@ import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
 
 import { FundingCycle } from '../models/funding-cycle'
 
+export const reservedRateRiskyMin = 90
+
 export type FundingCycleRiskFlags = {
   duration: boolean
   ballot: boolean

--- a/src/utils/fundingCycle.ts
+++ b/src/utils/fundingCycle.ts
@@ -9,7 +9,10 @@ import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallot
 import { fromPerbicent } from './formatNumber'
 
 import { EditingFundingCycle } from './serializers'
-import { FundingCycleRiskFlags } from 'constants/fundingWarningText'
+import {
+  FundingCycleRiskFlags,
+  reservedRateRiskyMin,
+} from 'constants/fundingWarningText'
 
 // packed `metadata` format: 0btTPRRRRRRRRBBBBBBBBrrrrrrrrVVVVVVVV
 // V: version (bits 0-7)
@@ -136,7 +139,10 @@ export const getUnsafeFundingCycleProperties = (
    *
    * Note: max reserve rate is 200.
    */
-  if (parseInt(fromPerbicent(metadata?.reservedRate ?? 0), 10) >= 90) {
+  if (
+    parseInt(fromPerbicent(metadata?.reservedRate ?? 0), 10) >=
+    reservedRateRiskyMin
+  ) {
     configFlags.metadataReservedRate = true
   }
 


### PR DESCRIPTION
## What does this PR do and why?

Adds warnings to the Create and Reconfigure forms whenever a "risky" property is being used. This gives the project owner the opportunity to double check their decision making before setting a property that will display a risk icon in the UI.

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/79433522/151633795-026ca21d-07ae-4773-9f29-52d7b9a1254f.png)
![image](https://user-images.githubusercontent.com/79433522/151633822-0a9a8349-c669-4a5f-a5cd-5c70464aa04f.png)
![image](https://user-images.githubusercontent.com/79433522/151633835-bf988156-43e2-4f98-b308-26e2a4d36831.png)
![image](https://user-images.githubusercontent.com/79433522/151633868-49bca391-6dff-4d87-8182-d8672f64355f.png)

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
