### PR TITLE
Lock Uniswap SDK versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/react-redux": "^7.1.16",
-    "@uniswap/sdk": "^3.0.3",
-    "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/v3-sdk": "^3.6.3",
+    "@uniswap/sdk": "3.0.3",
+    "@uniswap/sdk-core": "3.0.1",
+    "@uniswap/v3-sdk": "3.6.3",
     "@walletconnect/web3-provider": "^1.5.4",
     "antd": "4.16.13",
     "autolinker": "^3.14.3",
@@ -56,7 +56,6 @@
     "prepare": "husky install",
     "i18n:extract": "lingui extract --clean --locale en",
     "i18n:compile": "yarn i18n:extract && lingui compile",
-    "postinstall": "yarn i18n:compile",
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js'"
   },
   "lint-staged": {

--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -1,2 +1,0 @@
-// https://docs.uniswap.org/protocol/reference/deployments
-export const UNISWAP_V3_FACTORY = '0x1F98431c8aD98523631AE4a59f267346ea31F984'

--- a/src/hooks/ERC20UniswapPrice.ts
+++ b/src/hooks/ERC20UniswapPrice.ts
@@ -5,13 +5,12 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
 import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 import { abi as IUniswapV3FactoryABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Factory.sol/IUniswapV3Factory.json'
-
+import { FACTORY_ADDRESS as UNISWAP_V3_FACTORY_ADDRESS } from '@uniswap/v3-sdk'
 import { constants as ethersConstants } from 'ethers'
 
 import { readProvider } from 'constants/readProvider'
 import { readNetwork } from 'constants/networks'
 import { WETH } from 'constants/tokens'
-import { UNISWAP_V3_FACTORY } from 'constants/contracts'
 import { WAD_DECIMALS } from 'constants/numbers'
 
 interface Immutables {
@@ -52,7 +51,7 @@ const networkId = readNetwork.chainId
  */
 export function useUniswapPriceQuery({ tokenSymbol, tokenAddress }: Props) {
   const factoryContract = new Contract(
-    UNISWAP_V3_FACTORY,
+    UNISWAP_V3_FACTORY_ADDRESS,
     IUniswapV3FactoryABI,
     readProvider,
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,7 +3827,7 @@
   resolved "https://registry.yarnpkg.com/@uniswap/lib/-/lib-4.0.1-alpha.tgz#2881008e55f075344675b3bca93f020b028fbd02"
   integrity sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==
 
-"@uniswap/sdk-core@^3.0.1":
+"@uniswap/sdk-core@3.0.1", "@uniswap/sdk-core@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-3.0.1.tgz#d08dd68257983af64b9a5f4d6b9cf26124b4138f"
   integrity sha512-WbeDkhZ9myVR0VnHOdTrb8nHKKkqTFa5uE9RvUbG3eyDt2NWWDwhhqGHwAWJEHG405l30Fa1u3PogHDFsIOQlA==
@@ -3839,7 +3839,7 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/sdk@^3.0.3":
+"@uniswap/sdk@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@uniswap/sdk/-/sdk-3.0.3.tgz#8201c7c72215d0030cb99acc7e661eff895c18a9"
   integrity sha512-t4s8bvzaCFSiqD2qfXIm3rWhbdnXp+QjD3/mRaeVDHK7zWevs6RGEb1ohMiNgOCTZANvBayb4j8p+XFdnMBadQ==
@@ -3874,7 +3874,7 @@
     base64-sol "1.0.1"
     hardhat-watcher "^2.1.1"
 
-"@uniswap/v3-sdk@^3.6.3":
+"@uniswap/v3-sdk@3.6.3":
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/@uniswap/v3-sdk/-/v3-sdk-3.6.3.tgz#f2fca86cfde1450976581028195fc0ee4b11036d"
   integrity sha512-nepNTZMpM1uwLJAlQaUUEDMFrSujS1sOqyVD739zoPWsVHAUPvqVAKQN0GlgZcLXOqeCMKjO3lteaNHEXef1XA==


### PR DESCRIPTION
## What does this PR do and why?

This PR:
- locks/fixes the version all the Uniswap SDK dependencies.
- sources the Uniswap factory contract address from the SDK, and removes a constants file.
- Removes the LinguiJS compilation script on `postinstall`. We don't need this anymore as compilation happens as part of the crowdin upload/download workflows.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
