### PR TITLE
Namespace Juicebox V1 contract constants

### DIFF
--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -16,7 +16,7 @@ import {
 } from 'hooks/AppSelector'
 import { useTerminalFee } from 'hooks/TerminalFee'
 import { useDeployProjectTx } from 'hooks/transactor/DeployProjectTx'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
 import { PayoutMod, TicketMod } from 'models/mods'
@@ -457,7 +457,7 @@ export default function Create() {
       isArchived: false,
       terminal: {
         version: terminalVersion,
-        name: JuiceboxV1ContractName.TerminalV1_1,
+        name: V1ContractName.TerminalV1_1,
         address: getTerminalAddress(terminalVersion),
       },
     }),

--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -16,7 +16,7 @@ import {
 } from 'hooks/AppSelector'
 import { useTerminalFee } from 'hooks/TerminalFee'
 import { useDeployProjectTx } from 'hooks/transactor/DeployProjectTx'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
 import { PayoutMod, TicketMod } from 'models/mods'
@@ -457,7 +457,7 @@ export default function Create() {
       isArchived: false,
       terminal: {
         version: terminalVersion,
-        name: ContractName.TerminalV1_1,
+        name: JuiceboxV1ContractName.TerminalV1_1,
         address: getTerminalAddress(terminalVersion),
       },
     }),

--- a/src/components/Dashboard/FundingHistory.tsx
+++ b/src/components/Dashboard/FundingHistory.tsx
@@ -8,7 +8,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import Loading from 'components/shared/Loading'
 import { ThemeContext } from 'contexts/themeContext'
 import useContractReader from 'hooks/contractReader/ContractReader'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
 import { useCallback, useContext, useState } from 'react'
@@ -41,7 +41,7 @@ export default function FundingHistory({
     selectedIndex !== undefined ? fundingCycles[selectedIndex] : undefined
 
   useContractReader<FundingCycle>({
-    contract: ContractName.FundingCycles,
+    contract: JuiceboxV1ContractName.FundingCycles,
     functionName: 'get',
     args: cycleNumber ? [cycleNumber] : null,
     valueDidChange: useCallback((a, b) => !deepEqFundingCycles(a, b), []),

--- a/src/components/Dashboard/FundingHistory.tsx
+++ b/src/components/Dashboard/FundingHistory.tsx
@@ -8,7 +8,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import Loading from 'components/shared/Loading'
 import { ThemeContext } from 'contexts/themeContext'
 import useContractReader from 'hooks/contractReader/ContractReader'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
 import { useCallback, useContext, useState } from 'react'
@@ -41,7 +41,7 @@ export default function FundingHistory({
     selectedIndex !== undefined ? fundingCycles[selectedIndex] : undefined
 
   useContractReader<FundingCycle>({
-    contract: JuiceboxV1ContractName.FundingCycles,
+    contract: V1ContractName.FundingCycles,
     functionName: 'get',
     args: cycleNumber ? [cycleNumber] : null,
     valueDidChange: useCallback((a, b) => !deepEqFundingCycles(a, b), []),

--- a/src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
+++ b/src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
@@ -8,7 +8,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { ThemeContext } from 'contexts/themeContext'
 import { utils } from 'ethers'
 import useContractReader from 'hooks/contractReader/ContractReader'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { normalizeHandle } from 'utils/formatHandle'
 
 import {
@@ -62,7 +62,7 @@ export default function ProjectHandleFormItem({
   }, [inputContents]) // 0xabc...
 
   const idForHandle = useContractReader<BigNumber>({
-    contract: ContractName.Projects,
+    contract: JuiceboxV1ContractName.Projects,
     functionName: 'projectFor',
     args: handleHex && requireState ? [handleHex] : null,
     callback: useCallback(

--- a/src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
+++ b/src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
@@ -8,7 +8,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { ThemeContext } from 'contexts/themeContext'
 import { utils } from 'ethers'
 import useContractReader from 'hooks/contractReader/ContractReader'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { normalizeHandle } from 'utils/formatHandle'
 
 import {
@@ -62,7 +62,7 @@ export default function ProjectHandleFormItem({
   }, [inputContents]) // 0xabc...
 
   const idForHandle = useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.Projects,
+    contract: V1ContractName.Projects,
     functionName: 'projectFor',
     args: handleHex && requireState ? [handleHex] : null,
     callback: useCallback(

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -15,7 +15,7 @@ import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { BigNumber, constants, utils } from 'ethers'
 import useContractReader from 'hooks/contractReader/ContractReader'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { CurrencyOption } from 'models/currency-option'
 import { PayoutMod } from 'models/mods'
 import * as moment from 'moment'
@@ -79,7 +79,7 @@ export default function ProjectPayoutMods({
   const { owner } = useContext(ProjectContext)
 
   useContractReader<BigNumber>({
-    contract: ContractName.Projects,
+    contract: JuiceboxV1ContractName.Projects,
     functionName: 'projectFor',
     args: settingHandle ? [utils.formatBytes32String(settingHandle)] : null,
     callback: useCallback(

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -15,7 +15,7 @@ import { ProjectContext } from 'contexts/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { BigNumber, constants, utils } from 'ethers'
 import useContractReader from 'hooks/contractReader/ContractReader'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { CurrencyOption } from 'models/currency-option'
 import { PayoutMod } from 'models/mods'
 import * as moment from 'moment'
@@ -79,7 +79,7 @@ export default function ProjectPayoutMods({
   const { owner } = useContext(ProjectContext)
 
   useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.Projects,
+    contract: V1ContractName.Projects,
     functionName: 'projectFor',
     args: settingHandle ? [utils.formatBytes32String(settingHandle)] : null,
     callback: useCallback(

--- a/src/contexts/userContext.ts
+++ b/src/contexts/userContext.ts
@@ -1,8 +1,8 @@
 import { Transactor } from 'hooks/transactor/Transactor'
-import { Contracts } from 'models/contracts'
+import { JuiceboxV1Contracts } from 'models/v1/contracts'
 import { createContext } from 'react'
 
 export const UserContext: React.Context<{
-  contracts?: Contracts
+  contracts?: JuiceboxV1Contracts
   transactor?: Transactor
 }> = createContext({})

--- a/src/contexts/userContext.ts
+++ b/src/contexts/userContext.ts
@@ -1,8 +1,8 @@
 import { Transactor } from 'hooks/transactor/Transactor'
-import { JuiceboxV1Contracts } from 'models/v1/contracts'
+import { V1Contracts } from 'models/v1/contracts'
 import { createContext } from 'react'
 
 export const UserContext: React.Context<{
-  contracts?: JuiceboxV1Contracts
+  contracts?: V1Contracts
   transactor?: Transactor
 }> = createContext({})

--- a/src/hooks/ContractLoader.ts
+++ b/src/hooks/ContractLoader.ts
@@ -2,8 +2,8 @@ import { Contract } from '@ethersproject/contracts'
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 
 import { NetworkContext } from 'contexts/networkContext'
-import { ContractName } from 'models/contract-name'
-import { Contracts } from 'models/contracts'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { JuiceboxV1Contracts } from 'models/v1/contracts'
 import { NetworkName } from 'models/network-name'
 import { useContext, useEffect, useState } from 'react'
 
@@ -11,7 +11,7 @@ import { readProvider } from 'constants/readProvider'
 import { readNetwork } from 'constants/networks'
 
 export function useContractLoader() {
-  const [contracts, setContracts] = useState<Contracts>()
+  const [contracts, setContracts] = useState<JuiceboxV1Contracts>()
 
   const { signingProvider } = useContext(NetworkContext)
 
@@ -23,16 +23,16 @@ export function useContractLoader() {
         // Contracts can be used read-only without a signer, but require a signer to create transactions.
         const signerOrProvider = signingProvider?.getSigner() ?? readProvider
 
-        const newContracts = Object.values(ContractName).reduce(
-          (accumulator, contractName) => ({
+        const newContracts = Object.values(JuiceboxV1ContractName).reduce(
+          (accumulator, JuiceboxV1ContractName) => ({
             ...accumulator,
-            [contractName]: loadContract(
-              contractName,
+            [JuiceboxV1ContractName]: loadContract(
+              JuiceboxV1ContractName,
               network,
               signerOrProvider,
             ),
           }),
-          {} as Contracts,
+          {} as JuiceboxV1Contracts,
         )
 
         setContracts(newContracts)
@@ -48,7 +48,7 @@ export function useContractLoader() {
 }
 
 const loadContract = (
-  contractName: string,
+  contractName: keyof typeof JuiceboxV1ContractName,
   network: NetworkName,
   signerOrProvider: JsonRpcSigner | JsonRpcProvider,
 ): Contract => {

--- a/src/hooks/ContractLoader.ts
+++ b/src/hooks/ContractLoader.ts
@@ -2,8 +2,8 @@ import { Contract } from '@ethersproject/contracts'
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 
 import { NetworkContext } from 'contexts/networkContext'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
-import { JuiceboxV1Contracts } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
+import { V1Contracts } from 'models/v1/contracts'
 import { NetworkName } from 'models/network-name'
 import { useContext, useEffect, useState } from 'react'
 
@@ -11,7 +11,7 @@ import { readProvider } from 'constants/readProvider'
 import { readNetwork } from 'constants/networks'
 
 export function useContractLoader() {
-  const [contracts, setContracts] = useState<JuiceboxV1Contracts>()
+  const [contracts, setContracts] = useState<V1Contracts>()
 
   const { signingProvider } = useContext(NetworkContext)
 
@@ -23,16 +23,16 @@ export function useContractLoader() {
         // Contracts can be used read-only without a signer, but require a signer to create transactions.
         const signerOrProvider = signingProvider?.getSigner() ?? readProvider
 
-        const newContracts = Object.values(JuiceboxV1ContractName).reduce(
-          (accumulator, JuiceboxV1ContractName) => ({
+        const newContracts = Object.values(V1ContractName).reduce(
+          (accumulator, V1ContractName) => ({
             ...accumulator,
-            [JuiceboxV1ContractName]: loadContract(
-              JuiceboxV1ContractName,
+            [V1ContractName]: loadContract(
+              V1ContractName,
               network,
               signerOrProvider,
             ),
           }),
-          {} as JuiceboxV1Contracts,
+          {} as V1Contracts,
         )
 
         setContracts(newContracts)
@@ -48,7 +48,7 @@ export function useContractLoader() {
 }
 
 const loadContract = (
-  contractName: keyof typeof JuiceboxV1ContractName,
+  contractName: keyof typeof V1ContractName,
   network: NetworkName,
   signerOrProvider: JsonRpcSigner | JsonRpcProvider,
 ): Contract => {

--- a/src/hooks/EtherPrice.ts
+++ b/src/hooks/EtherPrice.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useCallback, useState } from 'react'
 import { fromWad } from 'utils/formatNumber'
 
@@ -9,7 +9,7 @@ export function useEtherPrice() {
   const [price, setPrice] = useState<number>()
 
   useContractReader({
-    contract: ContractName.Prices,
+    contract: JuiceboxV1ContractName.Prices,
     functionName: 'getETHPriceFor',
     args: ['1'], // USD
     callback: useCallback(

--- a/src/hooks/EtherPrice.ts
+++ b/src/hooks/EtherPrice.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useCallback, useState } from 'react'
 import { fromWad } from 'utils/formatNumber'
 
@@ -9,7 +9,7 @@ export function useEtherPrice() {
   const [price, setPrice] = useState<number>()
 
   useContractReader({
-    contract: JuiceboxV1ContractName.Prices,
+    contract: V1ContractName.Prices,
     functionName: 'getETHPriceFor',
     args: ['1'], // USD
     callback: useCallback(

--- a/src/hooks/EventListener.ts
+++ b/src/hooks/EventListener.ts
@@ -1,7 +1,7 @@
 import { Listener } from '@ethersproject/providers'
 
 import { useContractLoader } from 'hooks/ContractLoader'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useEffect, useMemo, useState } from 'react'
 
 import { readProvider } from 'constants/readProvider'
@@ -13,7 +13,7 @@ export default function useEventListener<E>({
   topics,
   includeHistory,
 }: {
-  contractName?: ContractName
+  contractName?: JuiceboxV1ContractName
   eventName?: string
   startBlock?: number
   topics?: (any | any[])[]

--- a/src/hooks/EventListener.ts
+++ b/src/hooks/EventListener.ts
@@ -1,7 +1,7 @@
 import { Listener } from '@ethersproject/providers'
 
 import { useContractLoader } from 'hooks/ContractLoader'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useEffect, useMemo, useState } from 'react'
 
 import { readProvider } from 'constants/readProvider'
@@ -13,7 +13,7 @@ export default function useEventListener<E>({
   topics,
   includeHistory,
 }: {
-  contractName?: JuiceboxV1ContractName
+  contractName?: V1ContractName
   eventName?: string
   startBlock?: number
   topics?: (any | any[])[]

--- a/src/hooks/contractReader/CanPrintPreminedTokens.ts
+++ b/src/hooks/contractReader/CanPrintPreminedTokens.ts
@@ -1,6 +1,6 @@
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
 
 import useContractReader from './ContractReader'
@@ -10,7 +10,7 @@ export default function useCanPrintPreminedTokens() {
   const { projectId } = useContext(ProjectContext)
 
   return useContractReader<boolean>({
-    contract: ContractName.TerminalV1,
+    contract: JuiceboxV1ContractName.TerminalV1,
     functionName: 'canPrintPreminedTickets',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
   })

--- a/src/hooks/contractReader/CanPrintPreminedTokens.ts
+++ b/src/hooks/contractReader/CanPrintPreminedTokens.ts
@@ -1,6 +1,6 @@
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
 
 import useContractReader from './ContractReader'
@@ -10,7 +10,7 @@ export default function useCanPrintPreminedTokens() {
   const { projectId } = useContext(ProjectContext)
 
   return useContractReader<boolean>({
-    contract: JuiceboxV1ContractName.TerminalV1,
+    contract: V1ContractName.TerminalV1,
     functionName: 'canPrintPreminedTickets',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
   })

--- a/src/hooks/contractReader/ContractReader.ts
+++ b/src/hooks/contractReader/ContractReader.ts
@@ -1,7 +1,7 @@
 import { Contract, EventFilter } from '@ethersproject/contracts'
 import { UserContext } from 'contexts/userContext'
-import { ContractName } from 'models/contract-name'
-import { Contracts } from 'models/contracts'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { JuiceboxV1Contracts } from 'models/v1/contracts'
 import { useCallback, useContext, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 
@@ -11,7 +11,7 @@ export type ContractUpdateOn = {
   topics?: EventFilter['topics']
 }[]
 
-export type ContractConfig = ContractName | Contract | undefined
+export type ContractConfig = JuiceboxV1ContractName | Contract | undefined
 
 export default function useContractReader<V>({
   contract,
@@ -134,7 +134,7 @@ export default function useContractReader<V>({
 
 function contractToRead(
   contractConfig?: ContractConfig,
-  contracts?: Contracts,
+  contracts?: JuiceboxV1Contracts,
 ): Contract | undefined {
   if (!contractConfig) return
 

--- a/src/hooks/contractReader/ContractReader.ts
+++ b/src/hooks/contractReader/ContractReader.ts
@@ -1,7 +1,7 @@
 import { Contract, EventFilter } from '@ethersproject/contracts'
 import { UserContext } from 'contexts/userContext'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
-import { JuiceboxV1Contracts } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
+import { V1Contracts } from 'models/v1/contracts'
 import { useCallback, useContext, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 
@@ -11,7 +11,7 @@ export type ContractUpdateOn = {
   topics?: EventFilter['topics']
 }[]
 
-export type ContractConfig = JuiceboxV1ContractName | Contract | undefined
+export type ContractConfig = V1ContractName | Contract | undefined
 
 export default function useContractReader<V>({
   contract,
@@ -134,7 +134,7 @@ export default function useContractReader<V>({
 
 function contractToRead(
   contractConfig?: ContractConfig,
-  contracts?: JuiceboxV1Contracts,
+  contracts?: V1Contracts,
 ): Contract | undefined {
   if (!contractConfig) return
 

--- a/src/hooks/contractReader/CurrentFundingCycleOfProject.ts
+++ b/src/hooks/contractReader/CurrentFundingCycleOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { FundingCycle } from 'models/funding-cycle'
 import { TerminalName } from 'models/terminal-name'
 import { useCallback, useMemo } from 'react'
@@ -13,7 +13,7 @@ export default function useCurrentFundingCycleOfProject(
   terminalName: TerminalName | undefined,
 ) {
   return useContractReader<FundingCycle>({
-    contract: ContractName.FundingCycles,
+    contract: JuiceboxV1ContractName.FundingCycles,
     functionName: 'currentOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     valueDidChange: useCallback((a, b) => !deepEqFundingCycles(a, b), []),
@@ -22,7 +22,7 @@ export default function useCurrentFundingCycleOfProject(
         projectId
           ? [
               {
-                contract: ContractName.FundingCycles,
+                contract: JuiceboxV1ContractName.FundingCycles,
                 eventName: 'Configure',
                 topics: [[], BigNumber.from(projectId).toHexString()],
               },

--- a/src/hooks/contractReader/CurrentFundingCycleOfProject.ts
+++ b/src/hooks/contractReader/CurrentFundingCycleOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { FundingCycle } from 'models/funding-cycle'
 import { TerminalName } from 'models/terminal-name'
 import { useCallback, useMemo } from 'react'
@@ -13,7 +13,7 @@ export default function useCurrentFundingCycleOfProject(
   terminalName: TerminalName | undefined,
 ) {
   return useContractReader<FundingCycle>({
-    contract: JuiceboxV1ContractName.FundingCycles,
+    contract: V1ContractName.FundingCycles,
     functionName: 'currentOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     valueDidChange: useCallback((a, b) => !deepEqFundingCycles(a, b), []),
@@ -22,7 +22,7 @@ export default function useCurrentFundingCycleOfProject(
         projectId
           ? [
               {
-                contract: JuiceboxV1ContractName.FundingCycles,
+                contract: V1ContractName.FundingCycles,
                 eventName: 'Configure',
                 topics: [[], BigNumber.from(projectId).toHexString()],
               },

--- a/src/hooks/contractReader/CurrentPayoutModsOfProject.ts
+++ b/src/hooks/contractReader/CurrentPayoutModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { PayoutMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useCurrentPayoutModsOfProject(
   currentConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<PayoutMod[]>({
-    contract: ContractName.ModStore,
+    contract: JuiceboxV1ContractName.ModStore,
     functionName: 'payoutModsOf',
     args:
       projectId && currentConfigured
@@ -25,7 +25,7 @@ export default function useCurrentPayoutModsOfProject(
         projectId && currentConfigured
           ? [
               {
-                contract: ContractName.ModStore,
+                contract: JuiceboxV1ContractName.ModStore,
                 eventName: 'SetPayoutMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/CurrentPayoutModsOfProject.ts
+++ b/src/hooks/contractReader/CurrentPayoutModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { PayoutMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useCurrentPayoutModsOfProject(
   currentConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<PayoutMod[]>({
-    contract: JuiceboxV1ContractName.ModStore,
+    contract: V1ContractName.ModStore,
     functionName: 'payoutModsOf',
     args:
       projectId && currentConfigured
@@ -25,7 +25,7 @@ export default function useCurrentPayoutModsOfProject(
         projectId && currentConfigured
           ? [
               {
-                contract: JuiceboxV1ContractName.ModStore,
+                contract: V1ContractName.ModStore,
                 eventName: 'SetPayoutMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/CurrentTicketModsOfProject.ts
+++ b/src/hooks/contractReader/CurrentTicketModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { TicketMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useCurrentTicketModsOfProject(
   currentConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<TicketMod[]>({
-    contract: ContractName.ModStore,
+    contract: JuiceboxV1ContractName.ModStore,
     functionName: 'ticketModsOf',
     args:
       projectId && currentConfigured
@@ -25,7 +25,7 @@ export default function useCurrentTicketModsOfProject(
         projectId && currentConfigured
           ? [
               {
-                contract: ContractName.ModStore,
+                contract: JuiceboxV1ContractName.ModStore,
                 eventName: 'SetTicketMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/CurrentTicketModsOfProject.ts
+++ b/src/hooks/contractReader/CurrentTicketModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { TicketMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useCurrentTicketModsOfProject(
   currentConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<TicketMod[]>({
-    contract: JuiceboxV1ContractName.ModStore,
+    contract: V1ContractName.ModStore,
     functionName: 'ticketModsOf',
     args:
       projectId && currentConfigured
@@ -25,7 +25,7 @@ export default function useCurrentTicketModsOfProject(
         projectId && currentConfigured
           ? [
               {
-                contract: JuiceboxV1ContractName.ModStore,
+                contract: V1ContractName.ModStore,
                 eventName: 'SetTicketMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/HandleForProjectId.ts
+++ b/src/hooks/contractReader/HandleForProjectId.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish, utils } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useCallback } from 'react'
 
 import useContractReader from './ContractReader'
@@ -9,7 +9,7 @@ export default function useHandleForProjectId(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<string>({
-    contract: ContractName.Projects,
+    contract: JuiceboxV1ContractName.Projects,
     functionName: 'handleOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     formatter: useCallback(val => utils.parseBytes32String(val), []),

--- a/src/hooks/contractReader/HandleForProjectId.ts
+++ b/src/hooks/contractReader/HandleForProjectId.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish, utils } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useCallback } from 'react'
 
 import useContractReader from './ContractReader'
@@ -9,7 +9,7 @@ export default function useHandleForProjectId(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<string>({
-    contract: JuiceboxV1ContractName.Projects,
+    contract: V1ContractName.Projects,
     functionName: 'handleOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     formatter: useCallback(val => utils.parseBytes32String(val), []),

--- a/src/hooks/contractReader/HasPermission.ts
+++ b/src/hooks/contractReader/HasPermission.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
 
 import useContractReader from './ContractReader'
@@ -32,7 +32,7 @@ export function useHasPermission(
   const { projectId, owner } = useContext(ProjectContext)
 
   const hasOperatorPermission = useContractReader<boolean>({
-    contract: ContractName.OperatorStore,
+    contract: JuiceboxV1ContractName.OperatorStore,
     functionName: 'hasPermissions',
     args:
       userAddress && owner && projectId

--- a/src/hooks/contractReader/HasPermission.ts
+++ b/src/hooks/contractReader/HasPermission.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
 
 import useContractReader from './ContractReader'
@@ -32,7 +32,7 @@ export function useHasPermission(
   const { projectId, owner } = useContext(ProjectContext)
 
   const hasOperatorPermission = useContractReader<boolean>({
-    contract: JuiceboxV1ContractName.OperatorStore,
+    contract: V1ContractName.OperatorStore,
     functionName: 'hasPermissions',
     args:
       userAddress && owner && projectId

--- a/src/hooks/contractReader/OwnerOfProject.ts
+++ b/src/hooks/contractReader/OwnerOfProject.ts
@@ -1,12 +1,12 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 
 import useContractReader from './ContractReader'
 
 /** Returns address of project owner. */
 export default function useOwnerOfProject(projectId: BigNumberish | undefined) {
   return useContractReader<string>({
-    contract: ContractName.Projects,
+    contract: JuiceboxV1ContractName.Projects,
     functionName: 'ownerOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
   })

--- a/src/hooks/contractReader/OwnerOfProject.ts
+++ b/src/hooks/contractReader/OwnerOfProject.ts
@@ -1,12 +1,12 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 
 import useContractReader from './ContractReader'
 
 /** Returns address of project owner. */
 export default function useOwnerOfProject(projectId: BigNumberish | undefined) {
   return useContractReader<string>({
-    contract: JuiceboxV1ContractName.Projects,
+    contract: V1ContractName.Projects,
     functionName: 'ownerOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
   })

--- a/src/hooks/contractReader/ProjectIdForHandle.ts
+++ b/src/hooks/contractReader/ProjectIdForHandle.ts
@@ -1,5 +1,5 @@
 import { BigNumber, utils } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { normalizeHandle } from 'utils/formatHandle'
 
 import useContractReader from './ContractReader'
@@ -7,7 +7,7 @@ import useContractReader from './ContractReader'
 /** Returns ID of project with `handle`. */
 export default function useProjectIdForHandle(handle: string | undefined) {
   return useContractReader<BigNumber>({
-    contract: ContractName.Projects,
+    contract: JuiceboxV1ContractName.Projects,
     functionName: 'projectFor',
     args: handle ? [utils.formatBytes32String(normalizeHandle(handle))] : null,
   })

--- a/src/hooks/contractReader/ProjectIdForHandle.ts
+++ b/src/hooks/contractReader/ProjectIdForHandle.ts
@@ -1,5 +1,5 @@
 import { BigNumber, utils } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { normalizeHandle } from 'utils/formatHandle'
 
 import useContractReader from './ContractReader'
@@ -7,7 +7,7 @@ import useContractReader from './ContractReader'
 /** Returns ID of project with `handle`. */
 export default function useProjectIdForHandle(handle: string | undefined) {
   return useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.Projects,
+    contract: V1ContractName.Projects,
     functionName: 'projectFor',
     args: handle ? [utils.formatBytes32String(normalizeHandle(handle))] : null,
   })

--- a/src/hooks/contractReader/QueuedFundingCycleOfProject.ts
+++ b/src/hooks/contractReader/QueuedFundingCycleOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { FundingCycle } from 'models/funding-cycle'
 
 import useContractReader from './ContractReader'
@@ -9,13 +9,13 @@ export default function useQueuedFundingCycleOfProject(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<FundingCycle>({
-    contract: ContractName.FundingCycles,
+    contract: JuiceboxV1ContractName.FundingCycles,
     functionName: 'queuedOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     updateOn: projectId
       ? [
           {
-            contract: ContractName.FundingCycles,
+            contract: JuiceboxV1ContractName.FundingCycles,
             eventName: 'Configure',
             topics: [[], BigNumber.from(projectId).toHexString()],
           },

--- a/src/hooks/contractReader/QueuedFundingCycleOfProject.ts
+++ b/src/hooks/contractReader/QueuedFundingCycleOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { FundingCycle } from 'models/funding-cycle'
 
 import useContractReader from './ContractReader'
@@ -9,13 +9,13 @@ export default function useQueuedFundingCycleOfProject(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<FundingCycle>({
-    contract: JuiceboxV1ContractName.FundingCycles,
+    contract: V1ContractName.FundingCycles,
     functionName: 'queuedOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     updateOn: projectId
       ? [
           {
-            contract: JuiceboxV1ContractName.FundingCycles,
+            contract: V1ContractName.FundingCycles,
             eventName: 'Configure',
             topics: [[], BigNumber.from(projectId).toHexString()],
           },

--- a/src/hooks/contractReader/QueuedPayoutModsOfProject.ts
+++ b/src/hooks/contractReader/QueuedPayoutModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { PayoutMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useQueuedPayoutModsOfProject(
   queuedConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<PayoutMod[]>({
-    contract: ContractName.ModStore,
+    contract: JuiceboxV1ContractName.ModStore,
     functionName: 'payoutModsOf',
     args:
       projectId && queuedConfigured
@@ -25,7 +25,7 @@ export default function useQueuedPayoutModsOfProject(
         projectId && queuedConfigured
           ? [
               {
-                contract: ContractName.ModStore,
+                contract: JuiceboxV1ContractName.ModStore,
                 eventName: 'SetPayoutMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/QueuedPayoutModsOfProject.ts
+++ b/src/hooks/contractReader/QueuedPayoutModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { PayoutMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useQueuedPayoutModsOfProject(
   queuedConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<PayoutMod[]>({
-    contract: JuiceboxV1ContractName.ModStore,
+    contract: V1ContractName.ModStore,
     functionName: 'payoutModsOf',
     args:
       projectId && queuedConfigured
@@ -25,7 +25,7 @@ export default function useQueuedPayoutModsOfProject(
         projectId && queuedConfigured
           ? [
               {
-                contract: JuiceboxV1ContractName.ModStore,
+                contract: V1ContractName.ModStore,
                 eventName: 'SetPayoutMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/QueuedTicketModsOfProject.ts
+++ b/src/hooks/contractReader/QueuedTicketModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { TicketMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useQueuedTicketModsOfProject(
   queuedConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<TicketMod[]>({
-    contract: ContractName.ModStore,
+    contract: JuiceboxV1ContractName.ModStore,
     functionName: 'ticketModsOf',
     args:
       projectId && queuedConfigured
@@ -25,7 +25,7 @@ export default function useQueuedTicketModsOfProject(
         projectId && queuedConfigured
           ? [
               {
-                contract: ContractName.ModStore,
+                contract: JuiceboxV1ContractName.ModStore,
                 eventName: 'SetTicketMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/QueuedTicketModsOfProject.ts
+++ b/src/hooks/contractReader/QueuedTicketModsOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { TicketMod } from 'models/mods'
 import { useMemo } from 'react'
 
@@ -11,7 +11,7 @@ export default function useQueuedTicketModsOfProject(
   queuedConfigured: BigNumberish | undefined,
 ) {
   return useContractReader<TicketMod[]>({
-    contract: JuiceboxV1ContractName.ModStore,
+    contract: V1ContractName.ModStore,
     functionName: 'ticketModsOf',
     args:
       projectId && queuedConfigured
@@ -25,7 +25,7 @@ export default function useQueuedTicketModsOfProject(
         projectId && queuedConfigured
           ? [
               {
-                contract: JuiceboxV1ContractName.ModStore,
+                contract: V1ContractName.ModStore,
                 eventName: 'SetTicketMod',
                 topics: [
                   BigNumber.from(projectId).toHexString(),

--- a/src/hooks/contractReader/RedeemRate.ts
+++ b/src/hooks/contractReader/RedeemRate.ts
@@ -1,7 +1,7 @@
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber } from 'ethers'
 import { BallotState } from 'models/ballot-state'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { FundingCycle } from 'models/funding-cycle'
 import { useContext, useMemo } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
@@ -40,14 +40,14 @@ export function useRedeemRate({
   })
 
   const totalSupply = useContractReader<BigNumber>({
-    contract: ContractName.TicketBooth,
+    contract: JuiceboxV1ContractName.TicketBooth,
     functionName: 'totalSupplyOf',
     args: projectId ? [projectId?.toHexString()] : null,
     valueDidChange: bigNumbersDiff,
   })?.add(reservedTicketBalance ? reservedTicketBalance : BigNumber.from(0))
 
   const currentBallotState = useContractReader<BallotState>({
-    contract: ContractName.FundingCycles,
+    contract: JuiceboxV1ContractName.FundingCycles,
     functionName: 'currentBallotStateOf',
     args: projectId ? [projectId.toHexString()] : null,
   })

--- a/src/hooks/contractReader/RedeemRate.ts
+++ b/src/hooks/contractReader/RedeemRate.ts
@@ -1,7 +1,7 @@
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber } from 'ethers'
 import { BallotState } from 'models/ballot-state'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { FundingCycle } from 'models/funding-cycle'
 import { useContext, useMemo } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
@@ -40,14 +40,14 @@ export function useRedeemRate({
   })
 
   const totalSupply = useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.TicketBooth,
+    contract: V1ContractName.TicketBooth,
     functionName: 'totalSupplyOf',
     args: projectId ? [projectId?.toHexString()] : null,
     valueDidChange: bigNumbersDiff,
   })?.add(reservedTicketBalance ? reservedTicketBalance : BigNumber.from(0))
 
   const currentBallotState = useContractReader<BallotState>({
-    contract: JuiceboxV1ContractName.FundingCycles,
+    contract: V1ContractName.FundingCycles,
     functionName: 'currentBallotStateOf',
     args: projectId ? [projectId.toHexString()] : null,
   })

--- a/src/hooks/contractReader/ReservedTokensOfProject.ts
+++ b/src/hooks/contractReader/ReservedTokensOfProject.ts
@@ -1,6 +1,6 @@
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useContext, useMemo } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
@@ -35,7 +35,7 @@ export default function useReservedTokensOfProject(
           topics: _projectId ? [_projectId] : undefined,
         },
         {
-          contract: ContractName.TicketBooth,
+          contract: JuiceboxV1ContractName.TicketBooth,
           eventName: 'Redeem',
           topics: _projectId ? [_projectId] : undefined,
         },

--- a/src/hooks/contractReader/ReservedTokensOfProject.ts
+++ b/src/hooks/contractReader/ReservedTokensOfProject.ts
@@ -1,6 +1,6 @@
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useContext, useMemo } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
@@ -35,7 +35,7 @@ export default function useReservedTokensOfProject(
           topics: _projectId ? [_projectId] : undefined,
         },
         {
-          contract: JuiceboxV1ContractName.TicketBooth,
+          contract: V1ContractName.TicketBooth,
           eventName: 'Redeem',
           topics: _projectId ? [_projectId] : undefined,
         },

--- a/src/hooks/contractReader/ShouldUpdateTokens.ts
+++ b/src/hooks/contractReader/ShouldUpdateTokens.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { TerminalName } from 'models/terminal-name'
 import { useMemo } from 'react'
 
@@ -27,12 +27,12 @@ export default function useShouldUpdateTokens(
               topics: _projectId ? [_projectId] : undefined,
             },
             {
-              contract: ContractName.TicketBooth,
+              contract: JuiceboxV1ContractName.TicketBooth,
               eventName: 'Redeem',
               topics: _projectId ? [_projectId] : undefined,
             },
             {
-              contract: ContractName.TicketBooth,
+              contract: JuiceboxV1ContractName.TicketBooth,
               eventName: 'Convert',
               topics:
                 userAddress && _projectId

--- a/src/hooks/contractReader/ShouldUpdateTokens.ts
+++ b/src/hooks/contractReader/ShouldUpdateTokens.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { TerminalName } from 'models/terminal-name'
 import { useMemo } from 'react'
 
@@ -27,12 +27,12 @@ export default function useShouldUpdateTokens(
               topics: _projectId ? [_projectId] : undefined,
             },
             {
-              contract: JuiceboxV1ContractName.TicketBooth,
+              contract: V1ContractName.TicketBooth,
               eventName: 'Redeem',
               topics: _projectId ? [_projectId] : undefined,
             },
             {
-              contract: JuiceboxV1ContractName.TicketBooth,
+              contract: V1ContractName.TicketBooth,
               eventName: 'Convert',
               topics:
                 userAddress && _projectId

--- a/src/hooks/contractReader/TerminalOfProject.ts
+++ b/src/hooks/contractReader/TerminalOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 
 import useContractReader from './ContractReader'
 
@@ -8,7 +8,7 @@ export default function useTerminalOfProject(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<string>({
-    contract: ContractName.TerminalDirectory,
+    contract: JuiceboxV1ContractName.TerminalDirectory,
     functionName: 'terminalOf',
     args:
       projectId !== undefined

--- a/src/hooks/contractReader/TerminalOfProject.ts
+++ b/src/hooks/contractReader/TerminalOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 
 import useContractReader from './ContractReader'
 
@@ -8,7 +8,7 @@ export default function useTerminalOfProject(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<string>({
-    contract: JuiceboxV1ContractName.TerminalDirectory,
+    contract: V1ContractName.TerminalDirectory,
     functionName: 'terminalOf',
     args:
       projectId !== undefined

--- a/src/hooks/contractReader/TokenAddressOfProject.ts
+++ b/src/hooks/contractReader/TokenAddressOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useMemo } from 'react'
 
 import useContractReader from './ContractReader'
@@ -9,13 +9,13 @@ export default function useTokenAddressOfProject(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<string>({
-    contract: ContractName.TicketBooth,
+    contract: JuiceboxV1ContractName.TicketBooth,
     functionName: 'ticketsOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     updateOn: useMemo(
       () => [
         {
-          contract: ContractName.TicketBooth,
+          contract: JuiceboxV1ContractName.TicketBooth,
           eventName: 'Issue',
           topics: projectId
             ? [BigNumber.from(projectId).toHexString()]

--- a/src/hooks/contractReader/TokenAddressOfProject.ts
+++ b/src/hooks/contractReader/TokenAddressOfProject.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useMemo } from 'react'
 
 import useContractReader from './ContractReader'
@@ -9,13 +9,13 @@ export default function useTokenAddressOfProject(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<string>({
-    contract: JuiceboxV1ContractName.TicketBooth,
+    contract: V1ContractName.TicketBooth,
     functionName: 'ticketsOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     updateOn: useMemo(
       () => [
         {
-          contract: JuiceboxV1ContractName.TicketBooth,
+          contract: V1ContractName.TicketBooth,
           eventName: 'Issue',
           topics: projectId
             ? [BigNumber.from(projectId).toHexString()]

--- a/src/hooks/contractReader/TotalBalanceOf.ts
+++ b/src/hooks/contractReader/TotalBalanceOf.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { TerminalName } from 'models/terminal-name'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
@@ -13,7 +13,7 @@ export default function useTotalBalanceOf(
   terminalName: TerminalName | undefined,
 ) {
   return useContractReader<BigNumber>({
-    contract: ContractName.TicketBooth,
+    contract: JuiceboxV1ContractName.TicketBooth,
     functionName: 'balanceOf',
     args:
       userAddress && projectId

--- a/src/hooks/contractReader/TotalBalanceOf.ts
+++ b/src/hooks/contractReader/TotalBalanceOf.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { TerminalName } from 'models/terminal-name'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
@@ -13,7 +13,7 @@ export default function useTotalBalanceOf(
   terminalName: TerminalName | undefined,
 ) {
   return useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.TicketBooth,
+    contract: V1ContractName.TicketBooth,
     functionName: 'balanceOf',
     args:
       userAddress && projectId

--- a/src/hooks/contractReader/TotalSupplyOfProjectToken.ts
+++ b/src/hooks/contractReader/TotalSupplyOfProjectToken.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
 import useContractReader from './ContractReader'
@@ -9,7 +9,7 @@ export default function useTotalSupplyOfProjectToken(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<BigNumber>({
-    contract: ContractName.TicketBooth,
+    contract: JuiceboxV1ContractName.TicketBooth,
     functionName: 'totalSupplyOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     valueDidChange: bigNumbersDiff,

--- a/src/hooks/contractReader/TotalSupplyOfProjectToken.ts
+++ b/src/hooks/contractReader/TotalSupplyOfProjectToken.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
 import useContractReader from './ContractReader'
@@ -9,7 +9,7 @@ export default function useTotalSupplyOfProjectToken(
   projectId: BigNumberish | undefined,
 ) {
   return useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.TicketBooth,
+    contract: V1ContractName.TicketBooth,
     functionName: 'totalSupplyOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
     valueDidChange: bigNumbersDiff,

--- a/src/hooks/contractReader/UnclaimedBalanceOfUser.ts
+++ b/src/hooks/contractReader/UnclaimedBalanceOfUser.ts
@@ -1,7 +1,7 @@
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
@@ -14,7 +14,7 @@ export default function useUnclaimedBalanceOfUser() {
   const { projectId, terminal } = useContext(ProjectContext)
 
   return useContractReader<BigNumber>({
-    contract: ContractName.TicketBooth,
+    contract: JuiceboxV1ContractName.TicketBooth,
     functionName: 'stakedBalanceOf',
     args:
       userAddress && projectId

--- a/src/hooks/contractReader/UnclaimedBalanceOfUser.ts
+++ b/src/hooks/contractReader/UnclaimedBalanceOfUser.ts
@@ -1,7 +1,7 @@
 import { NetworkContext } from 'contexts/networkContext'
 import { ProjectContext } from 'contexts/projectContext'
 import { BigNumber } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
 
@@ -14,7 +14,7 @@ export default function useUnclaimedBalanceOfUser() {
   const { projectId, terminal } = useContext(ProjectContext)
 
   return useContractReader<BigNumber>({
-    contract: JuiceboxV1ContractName.TicketBooth,
+    contract: V1ContractName.TicketBooth,
     functionName: 'stakedBalanceOf',
     args:
       userAddress && projectId

--- a/src/hooks/contractReader/UriOfProject.ts
+++ b/src/hooks/contractReader/UriOfProject.ts
@@ -1,12 +1,12 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 
 import useContractReader from './ContractReader'
 
 /** Returns URI for project with `projectId`. */
 export default function useUriOfProject(projectId: BigNumberish | undefined) {
   return useContractReader<string>({
-    contract: ContractName.Projects,
+    contract: JuiceboxV1ContractName.Projects,
     functionName: 'uriOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
   })

--- a/src/hooks/contractReader/UriOfProject.ts
+++ b/src/hooks/contractReader/UriOfProject.ts
@@ -1,12 +1,12 @@
 import { BigNumber, BigNumberish } from 'ethers'
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 
 import useContractReader from './ContractReader'
 
 /** Returns URI for project with `projectId`. */
 export default function useUriOfProject(projectId: BigNumberish | undefined) {
   return useContractReader<string>({
-    contract: JuiceboxV1ContractName.Projects,
+    contract: V1ContractName.Projects,
     functionName: 'uriOf',
     args: projectId ? [BigNumber.from(projectId).toHexString()] : null,
   })

--- a/src/models/contracts.ts
+++ b/src/models/contracts.ts
@@ -1,4 +1,0 @@
-import { Contract } from '@ethersproject/contracts'
-import { ContractName } from 'models/contract-name'
-
-export type Contracts = Record<ContractName, Contract>

--- a/src/models/terminal-name.ts
+++ b/src/models/terminal-name.ts
@@ -1,3 +1,5 @@
-import { ContractName } from './contract-name'
+import { JuiceboxV1ContractName } from './v1/contracts'
 
-export type TerminalName = ContractName.TerminalV1 | ContractName.TerminalV1_1
+export type TerminalName =
+  | JuiceboxV1ContractName.TerminalV1
+  | JuiceboxV1ContractName.TerminalV1_1

--- a/src/models/terminal-name.ts
+++ b/src/models/terminal-name.ts
@@ -1,5 +1,5 @@
-import { JuiceboxV1ContractName } from './v1/contracts'
+import { V1ContractName } from './v1/contracts'
 
 export type TerminalName =
-  | JuiceboxV1ContractName.TerminalV1
-  | JuiceboxV1ContractName.TerminalV1_1
+  | V1ContractName.TerminalV1
+  | V1ContractName.TerminalV1_1

--- a/src/models/v1/contracts.ts
+++ b/src/models/v1/contracts.ts
@@ -1,4 +1,6 @@
-export enum ContractName {
+import { Contract } from '@ethersproject/contracts'
+
+export enum JuiceboxV1ContractName {
   FundingCycles = 'FundingCycles',
   TerminalV1 = 'TerminalV1',
   TerminalV1_1 = 'TerminalV1_1',
@@ -9,3 +11,5 @@ export enum ContractName {
   Projects = 'Projects',
   TicketBooth = 'TicketBooth',
 }
+
+export type JuiceboxV1Contracts = Record<JuiceboxV1ContractName, Contract>

--- a/src/models/v1/contracts.ts
+++ b/src/models/v1/contracts.ts
@@ -1,6 +1,6 @@
 import { Contract } from '@ethersproject/contracts'
 
-export enum JuiceboxV1ContractName {
+export enum V1ContractName {
   FundingCycles = 'FundingCycles',
   TerminalV1 = 'TerminalV1',
   TerminalV1_1 = 'TerminalV1_1',
@@ -12,4 +12,4 @@ export enum JuiceboxV1ContractName {
   TicketBooth = 'TicketBooth',
 }
 
-export type JuiceboxV1Contracts = Record<JuiceboxV1ContractName, Contract>
+export type V1Contracts = Record<V1ContractName, Contract>

--- a/src/utils/terminal-versions.ts
+++ b/src/utils/terminal-versions.ts
@@ -1,4 +1,4 @@
-import { ContractName } from 'models/contract-name'
+import { JuiceboxV1ContractName } from 'models/v1/contracts'
 import { NetworkName } from 'models/network-name'
 import { TerminalVersion } from 'models/terminal-version'
 
@@ -8,7 +8,7 @@ import { readNetwork } from 'constants/networks'
 
 const loadTerminalAddress = (
   network: NetworkName,
-  terminal: ContractName,
+  terminal: TerminalName,
 ): string =>
   require(`@jbx-protocol/contracts-v1/deployments/${network}/${terminal}.json`)
     .address
@@ -28,7 +28,10 @@ export const getTerminalVersion = (
 
   if (
     address.toLowerCase() ===
-    loadTerminalAddress(readNetwork.name, ContractName.TerminalV1).toLowerCase()
+    loadTerminalAddress(
+      readNetwork.name,
+      JuiceboxV1ContractName.TerminalV1,
+    ).toLowerCase()
   ) {
     return '1'
   }
@@ -37,7 +40,7 @@ export const getTerminalVersion = (
     address.toLowerCase() ===
     loadTerminalAddress(
       readNetwork.name,
-      ContractName.TerminalV1_1,
+      JuiceboxV1ContractName.TerminalV1_1,
     ).toLowerCase()
   ) {
     return '1.1'
@@ -60,8 +63,8 @@ export const getTerminalName = ({
 
   switch (_version) {
     case '1':
-      return ContractName.TerminalV1
+      return JuiceboxV1ContractName.TerminalV1
     case '1.1':
-      return ContractName.TerminalV1_1
+      return JuiceboxV1ContractName.TerminalV1_1
   }
 }

--- a/src/utils/terminal-versions.ts
+++ b/src/utils/terminal-versions.ts
@@ -1,4 +1,4 @@
-import { JuiceboxV1ContractName } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { NetworkName } from 'models/network-name'
 import { TerminalVersion } from 'models/terminal-version'
 
@@ -30,7 +30,7 @@ export const getTerminalVersion = (
     address.toLowerCase() ===
     loadTerminalAddress(
       readNetwork.name,
-      JuiceboxV1ContractName.TerminalV1,
+      V1ContractName.TerminalV1,
     ).toLowerCase()
   ) {
     return '1'
@@ -40,7 +40,7 @@ export const getTerminalVersion = (
     address.toLowerCase() ===
     loadTerminalAddress(
       readNetwork.name,
-      JuiceboxV1ContractName.TerminalV1_1,
+      V1ContractName.TerminalV1_1,
     ).toLowerCase()
   ) {
     return '1.1'
@@ -63,8 +63,8 @@ export const getTerminalName = ({
 
   switch (_version) {
     case '1':
-      return JuiceboxV1ContractName.TerminalV1
+      return V1ContractName.TerminalV1
     case '1.1':
-      return JuiceboxV1ContractName.TerminalV1_1
+      return V1ContractName.TerminalV1_1
   }
 }


### PR DESCRIPTION
## What does this PR do and why?

- Move `constants/contracts.ts` to `constants/v1/contracts.ts`
- Move `ContractName` typedef to `constants/v1/contracts.ts`. Delete `contract-name.ts` file.
- Rename `ContractName` type to `V1ContractName`
- Rename `Contracts` type to `V1Contracts`

| iteration | PR |
| --- | --- |
| 1. Namespace Juicebox V1 contract constants | 👉 you are here |
| 2. Namespace Juicebox V1 terminal code | https://github.com/jbx-protocol/juice-interface/pull/436 |
| 3. Namespace contexts and providers | https://github.com/jbx-protocol/juice-interface/pull/438 |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
