### PR TITLE
Namespace Juicebox V1 contexts and providers

### DIFF
--- a/src/components/Create/BudgetForm.tsx
+++ b/src/components/Create/BudgetForm.tsx
@@ -5,7 +5,7 @@ import {
   targetSubFeeToTargetFormatted,
   targetToTargetSubFeeFormatted,
 } from 'components/shared/formItems/formHelpers'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
 import { useAppDispatch } from 'hooks/AppDispatch'
@@ -42,7 +42,7 @@ export default function BudgetForm({
   const [showFundingFields, setShowFundingFields] = useState<boolean>()
   // TODO budgetForm should not depend on dispatch
   const dispatch = useAppDispatch()
-  const { terminal } = useContext(ProjectContext)
+  const { terminal } = useContext(V1ProjectContext)
   const editingFC = useEditingFundingCycleSelector()
 
   const terminalFee = useTerminalFee(terminal?.version)

--- a/src/components/Create/ConfirmDeployProject.tsx
+++ b/src/components/Create/ConfirmDeployProject.tsx
@@ -5,7 +5,7 @@ import PayoutModsList from 'components/shared/PayoutModsList'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import TicketModsList from 'components/shared/TicketModsList'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import {
   useAppSelector,
   useEditingFundingCycleSelector,
@@ -28,7 +28,7 @@ import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallot
 export default function ConfirmDeployProject() {
   const editingFC = useEditingFundingCycleSelector()
   const editingProject = useAppSelector(state => state.editingProject.info)
-  const { terminal } = useContext(ProjectContext)
+  const { terminal } = useContext(V1ProjectContext)
   const { payoutMods, ticketMods } = useAppSelector(
     state => state.editingProject,
   )

--- a/src/components/Create/index.tsx
+++ b/src/components/Create/index.tsx
@@ -6,7 +6,10 @@ import { useForm } from 'antd/lib/form/Form'
 import Modal from 'antd/lib/modal/Modal'
 import Project from 'components/Dashboard/Project'
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext, ProjectContextType } from 'contexts/projectContext'
+import {
+  V1ProjectContext,
+  V1ProjectContextType,
+} from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
 import { useAppDispatch } from 'hooks/AppDispatch'
@@ -433,7 +436,7 @@ export default function Create() {
     [editingFC],
   )
 
-  const project = useMemo<ProjectContextType>(
+  const project = useMemo<V1ProjectContextType>(
     () => ({
       createdAt: new Date().valueOf() / 1000,
       projectType: 'standard',
@@ -474,7 +477,7 @@ export default function Create() {
   const spacing = 40
 
   return (
-    <ProjectContext.Provider value={project}>
+    <V1ProjectContext.Provider value={project}>
       <Row style={{ marginTop: 40 }}>
         <Col
           xs={24}
@@ -742,6 +745,6 @@ export default function Create() {
           This will erase of your all changes.
         </Modal>
       </Row>
-    </ProjectContext.Provider>
+    </V1ProjectContext.Provider>
   )
 }

--- a/src/components/Dashboard/BalanceTimeline.tsx
+++ b/src/components/Dashboard/BalanceTimeline.tsx
@@ -2,7 +2,7 @@ import { Select, Space } from 'antd'
 import { t, Trans } from '@lingui/macro'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import EthDater from 'ethereum-block-by-date'
 import { parseProjectJson, Project } from 'models/subgraph-entities/project'
@@ -54,7 +54,7 @@ export default function BalanceTimeline({ height }: { height: number }) {
   const [domain, setDomain] = useState<[number, number]>()
   const [duration, setDuration] = useState<Duration>()
   const [showGraph, setShowGraph] = useState<ShowGraph>('volume')
-  const { projectId, projectType, createdAt } = useContext(ProjectContext)
+  const { projectId, projectType, createdAt } = useContext(V1ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/Dashboard/FundingCycles.tsx
+++ b/src/components/Dashboard/FundingCycles.tsx
@@ -2,7 +2,7 @@ import { Space, Tooltip } from 'antd'
 import { t } from '@lingui/macro'
 import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { CardSection } from 'components/shared/CardSection'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import {
   OperatorPermission,
@@ -29,7 +29,7 @@ export default function FundingCycles({
   const [selectedTab, setSelectedTab] = useState<TabOption>('current')
   const [hoverTab, setHoverTab] = useState<TabOption>()
 
-  const { projectId, currentFC, queuedFC } = useContext(ProjectContext)
+  const { projectId, currentFC, queuedFC } = useContext(V1ProjectContext)
 
   const {
     theme: { colors },

--- a/src/components/Dashboard/Paid.tsx
+++ b/src/components/Dashboard/Paid.tsx
@@ -7,7 +7,7 @@ import EtherscanLink from 'components/shared/EtherscanLink'
 import ProjectTokenBalance from 'components/shared/ProjectTokenBalance'
 import TooltipLabel from 'components/shared/TooltipLabel'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
 import { useEthBalanceQuery } from 'hooks/EthBalance'
@@ -37,7 +37,7 @@ export default function Paid() {
     owner,
     earned,
     overflow,
-  } = useContext(ProjectContext)
+  } = useContext(V1ProjectContext)
 
   const converter = useCurrencyConverter()
   const overflowInCurrency = converter.wadToCurrency(

--- a/src/components/Dashboard/Pay/PayInputSubText.tsx
+++ b/src/components/Dashboard/Pay/PayInputSubText.tsx
@@ -8,7 +8,7 @@ import { t, Trans } from '@lingui/macro'
 import { CurrencyOption } from 'models/currency-option'
 import { useContext, useMemo } from 'react'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { Tooltip } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { ThemeContext } from 'contexts/themeContext'
@@ -31,7 +31,7 @@ export default function PayInputSubText({
   payInCurrrency: CurrencyOption
   weiPayAmt: BigNumber | undefined
 }) {
-  const { currentFC, tokenSymbol, tokenAddress } = useContext(ProjectContext)
+  const { currentFC, tokenSymbol, tokenAddress } = useContext(V1ProjectContext)
   const converter = useCurrencyConverter()
   const {
     theme: { colors },

--- a/src/components/Dashboard/Pay/index.tsx
+++ b/src/components/Dashboard/Pay/index.tsx
@@ -5,7 +5,7 @@ import ConfirmPayOwnerModal from 'components/modals/ConfirmPayOwnerModal'
 import PayWarningModal from 'components/modals/PayWarningModal'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { parseEther } from 'ethers/lib/utils'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
 import { CurrencyOption } from 'models/currency-option'
@@ -29,7 +29,7 @@ export default function Pay() {
     useState<boolean>(false)
 
   const { projectId, currentFC, metadata, isArchived, terminal } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
 
   const converter = useCurrencyConverter()
 

--- a/src/components/Dashboard/Project.tsx
+++ b/src/components/Dashboard/Project.tsx
@@ -1,5 +1,5 @@
 import { Col, Row } from 'antd'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { CSSProperties, useContext } from 'react'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
 
@@ -20,7 +20,7 @@ export default function Project({
   showCurrentDetail?: boolean
   column?: boolean
 }) {
-  const { projectId, currentFC } = useContext(ProjectContext)
+  const { projectId, currentFC } = useContext(V1ProjectContext)
 
   const fcMetadata = decodeFundingCycleMetadata(currentFC?.metadata)
 

--- a/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/PaymentActivity.tsx
@@ -2,7 +2,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import EtherscanLink from 'components/shared/EtherscanLink'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import { PayEvent } from 'models/subgraph-entities/pay-event'
@@ -27,7 +27,7 @@ let payEventOverrides = new Map<string, Map<string, string>>([
 ])
 
 export function PaymentActivity({ pageSize }: { pageSize: number }) {
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/RedeemActivity.tsx
@@ -2,7 +2,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import EtherscanLink from 'components/shared/EtherscanLink'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import React, { useContext } from 'react'
@@ -15,7 +15,7 @@ import ActivityTabContent from './ActivityTabContent'
 import { contentLineHeight, smallHeaderStyle } from './styles'
 
 export function RedeemActivity({ pageSize }: { pageSize: number }) {
-  const { projectId, tokenSymbol } = useContext(ProjectContext)
+  const { projectId, tokenSymbol } = useContext(V1ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/Dashboard/ProjectActivity/ReservesActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/ReservesActivity.tsx
@@ -1,4 +1,4 @@
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import React, { useContext } from 'react'
 
@@ -6,7 +6,7 @@ import ActivityTabContent from './ActivityTabContent'
 import ReservesEventElem from './ReservesEventElem'
 
 export function ReservesActivity({ pageSize }: { pageSize: number }) {
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   const {
     data: printReservesEvents,

--- a/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/Dashboard/ProjectActivity/ReservesEventElem.tsx
@@ -1,5 +1,5 @@
 import FormattedAddress from 'components/shared/FormattedAddress'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import EtherscanLink from 'components/shared/EtherscanLink'
 
 import { ThemeContext } from 'contexts/themeContext'
@@ -19,7 +19,7 @@ export default function ReservesEventElem({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const { tokenSymbol } = useContext(ProjectContext)
+  const { tokenSymbol } = useContext(V1ProjectContext)
 
   const { data: distributeEvents } = useSubgraphQuery(
     {

--- a/src/components/Dashboard/ProjectActivity/TapActivity.tsx
+++ b/src/components/Dashboard/ProjectActivity/TapActivity.tsx
@@ -1,4 +1,4 @@
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import React, { useContext } from 'react'
 
@@ -6,7 +6,7 @@ import ActivityTabContent from './ActivityTabContent'
 import TapEventElem from './TapEventElem'
 
 export function TapActivity({ pageSize }: { pageSize: number }) {
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   const {
     data: tapEvents,

--- a/src/components/Dashboard/ProjectActivity/index.tsx
+++ b/src/components/Dashboard/ProjectActivity/index.tsx
@@ -1,7 +1,7 @@
 import { Space } from 'antd'
 import { t } from '@lingui/macro'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 
@@ -18,7 +18,7 @@ export default function ProjectActivity() {
   const [initialized, setInitialized] = useState<boolean>()
   const [tabOption, setTabOption] = useState<TabOption>()
 
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   const pageSize = 50
 

--- a/src/components/Dashboard/ProjectHeader.tsx
+++ b/src/components/Dashboard/ProjectHeader.tsx
@@ -12,7 +12,7 @@ import MigrateV1Pt1Modal from 'components/modals/MigrateV1Pt1Modal'
 import ProjectToolDrawerModal from 'components/modals/ProjectToolDrawerModal'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import {
   OperatorPermission,
@@ -38,7 +38,7 @@ export default function ProjectHeader() {
     isArchived,
     terminal,
     owner,
-  } = useContext(ProjectContext)
+  } = useContext(V1ProjectContext)
 
   const {
     theme: { colors },

--- a/src/components/Dashboard/ReservedTokens.tsx
+++ b/src/components/Dashboard/ReservedTokens.tsx
@@ -2,7 +2,7 @@ import { Button } from 'antd'
 import { t, Trans } from '@lingui/macro'
 import TooltipLabel from 'components/shared/TooltipLabel'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import useReservedTokensOfProject from 'hooks/contractReader/ReservedTokensOfProject'
 import { FundingCycle } from 'models/funding-cycle'
 import { TicketMod } from 'models/mods'
@@ -28,7 +28,7 @@ export default function ReservedTokens({
 }) {
   const [modalIsVisible, setModalIsVisible] = useState<boolean>()
 
-  const { projectId, tokenSymbol, isPreviewMode } = useContext(ProjectContext)
+  const { projectId, tokenSymbol, isPreviewMode } = useContext(V1ProjectContext)
 
   const metadata = decodeFundingCycleMetadata(fundingCycle?.metadata)
 

--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -6,7 +6,7 @@ import ParticipantsModal from 'components/modals/ParticipantsModal'
 import RedeemModal from 'components/modals/RedeemModal'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
 import useCanPrintPreminedTokens from 'hooks/contractReader/CanPrintPreminedTokens'
@@ -43,7 +43,7 @@ export default function Rewards() {
     isPreviewMode,
     currentFC,
     terminal,
-  } = useContext(ProjectContext)
+  } = useContext(V1ProjectContext)
 
   const {
     theme: { colors },

--- a/src/components/Dashboard/Spending.tsx
+++ b/src/components/Dashboard/Spending.tsx
@@ -6,7 +6,7 @@ import WithdrawModal from 'components/modals/WithdrawModal'
 import Balance from 'components/Navbar/Balance'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import TooltipLabel from 'components/shared/TooltipLabel'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { CurrencyOption } from 'models/currency-option'
 import { PayoutMod } from 'models/mods'
@@ -26,7 +26,7 @@ export default function Spending({
   } = useContext(ThemeContext)
 
   const { balanceInCurrency, projectId, owner, currentFC, isPreviewMode } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
 
   const [withdrawModalVisible, setWithdrawModalVisible] = useState<boolean>()
 

--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -1,7 +1,10 @@
 import { Trans } from '@lingui/macro'
 import FeedbackFormLink from 'components/shared/FeedbackFormLink'
 
-import { ProjectContext, ProjectContextType } from 'contexts/projectContext'
+import {
+  V1ProjectContext,
+  V1ProjectContextType,
+} from 'contexts/v1/projectContext'
 import useBalanceOfProject from 'hooks/contractReader/BalanceOfProject'
 import useCurrentFundingCycleOfProject from 'hooks/contractReader/CurrentFundingCycleOfProject'
 import useCurrentPayoutModsOfProject from 'hooks/contractReader/CurrentPayoutModsOfProject'
@@ -94,7 +97,7 @@ export default function Dashboard() {
   const createdAt = projects?.[0]?.createdAt
   const earned = projects?.[0]?.totalPaid
 
-  const project = useMemo<ProjectContextType>(() => {
+  const project = useMemo<V1ProjectContextType>(() => {
     const projectType = projectId
       ? projectTypes[projectId.toNumber()]
       : 'standard'
@@ -174,7 +177,7 @@ export default function Dashboard() {
   if (!projectId || !handle || !metadata) return null
 
   return (
-    <ProjectContext.Provider value={project}>
+    <V1ProjectContext.Provider value={project}>
       <div style={layouts.maxWidth}>
         <Project />
         <div
@@ -185,6 +188,6 @@ export default function Dashboard() {
         </div>
         <FeedbackFormLink projectHandle={handle} />
       </div>
-    </ProjectContext.Provider>
+    </V1ProjectContext.Provider>
   )
 }

--- a/src/components/FundingCycle/CurrentFundingCycle.tsx
+++ b/src/components/FundingCycle/CurrentFundingCycle.tsx
@@ -1,5 +1,5 @@
 import { CardSection } from 'components/shared/CardSection'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 
@@ -13,7 +13,7 @@ export default function CurrentFundingCycle({
   showCurrentDetail?: boolean
 }) {
   const { projectId, currentFC, currentPayoutMods, currentTicketMods } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
 
   const {
     theme: { colors },

--- a/src/components/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/FundingCycle/FundingCycleDetails.tsx
@@ -4,7 +4,7 @@ import { t, Trans } from '@lingui/macro'
 import { Descriptions, Tooltip } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { CurrencyOption } from 'models/currency-option'
 import { FundingCycle } from 'models/funding-cycle'
@@ -33,7 +33,7 @@ export default function FundingCycleDetails({
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const { tokenSymbol } = useContext(ProjectContext)
+  const { tokenSymbol } = useContext(V1ProjectContext)
 
   if (!fundingCycle) return null
 

--- a/src/components/FundingCycle/QueuedFundingCycle.tsx
+++ b/src/components/FundingCycle/QueuedFundingCycle.tsx
@@ -1,5 +1,5 @@
 import { CardSection } from 'components/shared/CardSection'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 
@@ -13,7 +13,7 @@ export default function QueuedFundingCycle() {
   } = useContext(ThemeContext)
 
   const { projectId, queuedFC, queuedPayoutMods, queuedTicketMods } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
 
   if (!projectId) return null
 

--- a/src/components/FundingCycle/ReconfigureFundingModalTrigger.tsx
+++ b/src/components/FundingCycle/ReconfigureFundingModalTrigger.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from 'antd'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import React, { useContext, useRef, useState } from 'react'
 import { Provider } from 'react-redux'
 import store, { createStore } from 'redux/store'
@@ -19,7 +19,7 @@ export default function ReconfigureFundingModalTrigger({
 }: {
   fundingDuration?: BigNumber
 }) {
-  const { isPreviewMode } = useContext(ProjectContext)
+  const { isPreviewMode } = useContext(V1ProjectContext)
 
   const localStoreRef = useRef<typeof store>()
 

--- a/src/components/modals/BalancesModal.tsx
+++ b/src/components/modals/BalancesModal.tsx
@@ -4,7 +4,7 @@ import { Button, Modal, Space } from 'antd'
 import ERC20TokenBalance from 'components/shared/ERC20TokenBalance'
 import { FormItems } from 'components/shared/formItems'
 import ProjectTokenBalance from 'components/shared/ProjectTokenBalance'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import {
   OperatorPermission,
   useHasPermission,
@@ -27,7 +27,7 @@ export default function BalancesModal({
   const [editModalVisible, setEditModalVisible] = useState<boolean>()
   const [loading, setLoading] = useState<boolean>()
   const [editingTokenRefs, setEditingTokenRefs] = useState<TokenRef[]>([])
-  const { owner, metadata } = useContext(ProjectContext)
+  const { owner, metadata } = useContext(V1ProjectContext)
   const setProjectUriTx = useSetProjectUriTx()
 
   useEffect(() => {

--- a/src/components/modals/ConfirmPayOwnerModal/ProjectRiskNotice.tsx
+++ b/src/components/modals/ConfirmPayOwnerModal/ProjectRiskNotice.tsx
@@ -1,4 +1,4 @@
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { useContext } from 'react'
 import { ExclamationCircleOutlined } from '@ant-design/icons'
 import {
@@ -17,7 +17,7 @@ export default function ProjectRiskNotice() {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const { currentFC } = useContext(ProjectContext)
+  const { currentFC } = useContext(V1ProjectContext)
   if (!currentFC || fundingCycleRiskCount(currentFC) === 0) return null
 
   const unsafeProperties = getUnsafeFundingCycleProperties(currentFC)

--- a/src/components/modals/ConfirmPayOwnerModal/index.tsx
+++ b/src/components/modals/ConfirmPayOwnerModal/index.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'antd/lib/form/Form'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import ImageUploader from 'components/shared/inputs/ImageUploader'
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { constants } from 'ethers'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
 import { usePayProjectTx } from 'hooks/transactor/PayProjectTx'
@@ -32,7 +32,7 @@ export default function ConfirmPayOwnerModal({
   const [form] = useForm<{ note: string }>()
   const { userAddress } = useContext(NetworkContext)
   const { tokenSymbol, tokenAddress, currentFC, metadata } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
   const payProjectTx = usePayProjectTx()
 
   const converter = useCurrencyConverter()

--- a/src/components/modals/ConfirmStakeTokensModal.tsx
+++ b/src/components/modals/ConfirmStakeTokensModal.tsx
@@ -3,7 +3,7 @@ import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import useTotalBalanceOf from 'hooks/contractReader/TotalBalanceOf'
 import { useStakeTokensTx } from 'hooks/transactor/StakeTokensTx'
 import { useContext, useLayoutEffect, useState } from 'react'
@@ -19,7 +19,7 @@ export default function ConfirmStakeTokensModal({
   const [loading, setLoading] = useState<boolean>()
   const [stakeAmount, setStakeAmount] = useState<string>()
   const { userAddress } = useContext(NetworkContext)
-  const { tokenSymbol, projectId, terminal } = useContext(ProjectContext)
+  const { tokenSymbol, projectId, terminal } = useContext(V1ProjectContext)
   const stakeTokensTx = useStakeTokensTx()
 
   const ticketsBalance = useTotalBalanceOf(

--- a/src/components/modals/ConfirmUnstakeTokensModal.tsx
+++ b/src/components/modals/ConfirmUnstakeTokensModal.tsx
@@ -3,7 +3,7 @@ import { Form, Modal, Space } from 'antd'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
 import useUnclaimedBalanceOfUser from 'hooks/contractReader/UnclaimedBalanceOfUser'
@@ -23,7 +23,7 @@ export default function ConfirmUnstakeTokensModal({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const { tokenSymbol, tokenAddress } = useContext(ProjectContext)
+  const { tokenSymbol, tokenAddress } = useContext(V1ProjectContext)
   const unstakeTokensTx = useUnstakeTokensTx()
 
   const unclaimedBalance = useUnclaimedBalanceOfUser()

--- a/src/components/modals/DistributeTokensModal.tsx
+++ b/src/components/modals/DistributeTokensModal.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Modal, Space } from 'antd'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import TicketModsList from 'components/shared/TicketModsList'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import useReservedTokensOfProject from 'hooks/contractReader/ReservedTokensOfProject'
 import { useDistributeTokensTx } from 'hooks/transactor/DistributeTokensTx'
 import { useContext, useState } from 'react'
@@ -22,7 +22,7 @@ export default function DistributeTokensModal({
 }) {
   const [loading, setLoading] = useState<boolean>()
   const { tokenSymbol, currentFC, projectId, currentTicketMods, owner } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
   const distributeTokensTx = useDistributeTokensTx()
 
   const metadata = decodeFundingCycleMetadata(currentFC?.metadata)

--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -4,7 +4,7 @@ import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
 import UntrackedErc20Notice from 'components/shared/UntrackedErc20Notice'
 import { t, Trans } from '@lingui/macro'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { NetworkName } from 'models/network-name'
 import { parseParticipantJson } from 'models/subgraph-entities/participant'
@@ -25,7 +25,7 @@ export default function DownloadParticipantsModal({
   const [latestBlockNumber, setLatestBlockNumber] = useState<number>()
   const [blockNumber, setBlockNumber] = useState<number>()
   const [loading, setLoading] = useState<boolean>()
-  const { projectId, tokenSymbol, handle } = useContext(ProjectContext)
+  const { projectId, tokenSymbol, handle } = useContext(V1ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/modals/MigrateV1Pt1Modal.tsx
+++ b/src/components/modals/MigrateV1Pt1Modal.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Button, Modal } from 'antd'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import { useAddToBalanceTx } from 'hooks/transactor/AddToBalanceTx'
 import { useMigrateV1ProjectTx } from 'hooks/transactor/MigrateV1ProjectTx'
@@ -16,7 +16,7 @@ export default function MigrateV1Pt1Modal({
 }) {
   const [loadingAddToBalance, setLoadingAddToBalance] = useState<boolean>()
   const [loadingMigrate, setLoadingMigrate] = useState<boolean>()
-  const { balance, handle } = useContext(ProjectContext)
+  const { balance, handle } = useContext(V1ProjectContext)
   const migrateV1ProjectTx = useMigrateV1ProjectTx()
   const addToBalanceTx = useAddToBalanceTx()
 

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -11,7 +11,7 @@ import FormattedAddress from 'components/shared/FormattedAddress'
 import Loading from 'components/shared/Loading'
 import UntrackedErc20Notice from 'components/shared/UntrackedErc20Notice'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
 import useTotalSupplyOfProjectToken from 'hooks/contractReader/TotalSupplyOfProjectToken'
@@ -45,7 +45,7 @@ export default function ParticipantsModal({
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
   const [sortPayerReportsDirection, setSortPayerReportsDirection] =
     useState<OrderDirection>('desc')
-  const { projectId, tokenSymbol, tokenAddress } = useContext(ProjectContext)
+  const { projectId, tokenSymbol, tokenAddress } = useContext(V1ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/modals/PrintPreminedModal.tsx
+++ b/src/components/modals/PrintPreminedModal.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'antd/lib/form/Form'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { constants, utils } from 'ethers'
 import { usePrintTokensTx } from 'hooks/transactor/PrintTokensTx'
 import { useContext, useMemo, useState } from 'react'
@@ -18,7 +18,7 @@ export default function PrintPreminedModal({
   visible: boolean | undefined
   onCancel: VoidFunction
 }) {
-  const { tokenSymbol, tokenAddress, terminal } = useContext(ProjectContext)
+  const { tokenSymbol, tokenAddress, terminal } = useContext(V1ProjectContext)
   const printTokensTx = usePrintTokensTx()
   const [form] = useForm<{
     beneficary: string

--- a/src/components/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/modals/ProjectToolDrawerModal.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'antd/lib/form/Form'
 import { FormItems } from 'components/shared/formItems'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import useUnclaimedBalanceOfUser from 'hooks/contractReader/UnclaimedBalanceOfUser'
 import { useAddToBalanceTx } from 'hooks/transactor/AddToBalanceTx'
 import { useSafeTransferFromTx } from 'hooks/transactor/SafeTransferFromTx'
@@ -19,7 +19,7 @@ export default function ProjectToolDrawerModal({
   visible?: boolean
   onClose?: VoidFunction
 }) {
-  const { tokenSymbol, owner } = useContext(ProjectContext)
+  const { tokenSymbol, owner } = useContext(V1ProjectContext)
   const safeTransferFromTx = useSafeTransferFromTx()
   const transferTokensTx = useTransferTokensTx()
   const addToBalanceTx = useAddToBalanceTx()

--- a/src/components/modals/ReconfigureFCModal.tsx
+++ b/src/components/modals/ReconfigureFCModal.tsx
@@ -12,7 +12,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import PayoutModsList from 'components/shared/PayoutModsList'
 import TicketModsList from 'components/shared/TicketModsList'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { constants } from 'ethers'
 import { useAppDispatch } from 'hooks/AppDispatch'
@@ -90,7 +90,7 @@ export default function ReconfigureFCModal({
     currentPayoutMods,
     queuedTicketMods,
     currentTicketMods,
-  } = useContext(ProjectContext)
+  } = useContext(V1ProjectContext)
   const editingFC = useEditingFundingCycleSelector()
   const terminalFee = useTerminalFee(terminal?.version)
   const configureProjectTx = useConfigureProjectTx()

--- a/src/components/modals/RedeemModal.tsx
+++ b/src/components/modals/RedeemModal.tsx
@@ -5,7 +5,7 @@ import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
 
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import useClaimableOverflowOf from 'hooks/contractReader/ClaimableOverflowOf'
 import { useRedeemRate } from 'hooks/contractReader/RedeemRate'
@@ -35,7 +35,7 @@ export default function RedeemModal({
   } = useContext(ThemeContext)
   const { userAddress } = useContext(NetworkContext)
   const { projectId, tokenSymbol, currentFC, terminal, overflow } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
 
   const fcMetadata = decodeFundingCycleMetadata(currentFC?.metadata)
 

--- a/src/components/modals/WithdrawModal.tsx
+++ b/src/components/modals/WithdrawModal.tsx
@@ -8,7 +8,7 @@ import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
 import PayoutModsList from 'components/shared/PayoutModsList'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
 import { useTapProjectTx } from 'hooks/transactor/TapProjectTx'
@@ -32,7 +32,7 @@ export default function WithdrawModal({
   const [loading, setLoading] = useState<boolean>()
   const [tapAmount, setTapAmount] = useState<string>()
   const { balanceInCurrency, projectId, currentFC, currentPayoutMods, owner } =
-    useContext(ProjectContext)
+    useContext(V1ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)

--- a/src/components/shared/Mod.tsx
+++ b/src/components/shared/Mod.tsx
@@ -2,7 +2,7 @@ import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Tooltip } from 'antd'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { PayoutMod, TicketMod } from 'models/mods'
 import { useContext } from 'react'
@@ -22,7 +22,7 @@ export default function Mod({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const { owner } = useContext(ProjectContext)
+  const { owner } = useContext(V1ProjectContext)
 
   if (!mod) return null
 

--- a/src/components/shared/PayoutModsList.tsx
+++ b/src/components/shared/PayoutModsList.tsx
@@ -5,7 +5,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import { getTotalPercentage } from 'components/shared/formItems/formHelpers'
 import Mod from 'components/shared/Mod'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber, constants } from 'ethers'
 import {
   OperatorPermission,
@@ -43,7 +43,7 @@ export default function PayoutModsList({
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
   const [editingMods, setEditingMods] = useState<PayoutMod[]>()
-  const { owner } = useContext(ProjectContext)
+  const { owner } = useContext(V1ProjectContext)
   const setPayoutModsTx = useSetPayoutModsTx()
 
   const { editableMods, lockedMods } = useMemo(() => {

--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Modal } from 'antd'
 import ProjectTicketMods from 'components/shared/formItems/ProjectTicketMods'
 import Mod from 'components/shared/Mod'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import {
   OperatorPermission,
@@ -30,7 +30,7 @@ export default function TicketModsList({
   const [modalVisible, setModalVisible] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
   const [editingMods, setEditingMods] = useState<TicketMod[]>()
-  const { owner, tokenSymbol } = useContext(ProjectContext)
+  const { owner, tokenSymbol } = useContext(V1ProjectContext)
   const setTicketModsTx = useSetTicketModsTx()
 
   const { editableMods, lockedMods } = useMemo(() => {

--- a/src/components/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
+++ b/src/components/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
@@ -2,7 +2,7 @@ import { Input } from 'antd'
 import { t } from '@lingui/macro'
 
 import { useContext, useState, useEffect, useCallback } from 'react'
-import { UserContext } from 'contexts/userContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { normalizeHandle } from 'utils/formatHandle'
 import { BigNumber } from '@ethersproject/bignumber'
 import { isBigNumberish } from '@ethersproject/bignumber/lib/bignumber'
@@ -32,7 +32,7 @@ export function ProjectHandleInput({
   suffix,
   initialValue,
 }: ProjectHandleProps) {
-  const { contracts } = useContext(UserContext)
+  const { contracts } = useContext(V1UserContext)
   const [inputContents, setInputContents] = useState<string>()
 
   const triggerChange = useCallback(

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -11,7 +11,7 @@ import {
   ModalMode,
 } from 'components/shared/formItems/formHelpers'
 import { useForm } from 'antd/lib/form/Form'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { BigNumber, constants, utils } from 'ethers'
 import useContractReader from 'hooks/contractReader/ContractReader'
@@ -76,7 +76,7 @@ export default function ProjectPayoutMods({
   const [editingModType, setEditingModType] = useState<ModType>('address')
   const [settingHandle, setSettingHandle] = useState<string>()
 
-  const { owner } = useContext(ProjectContext)
+  const { owner } = useContext(V1ProjectContext)
 
   useContractReader<BigNumber>({
     contract: V1ContractName.Projects,

--- a/src/components/shared/formItems/ProjectTicketMods.tsx
+++ b/src/components/shared/formItems/ProjectTicketMods.tsx
@@ -11,7 +11,7 @@ import { useCallback, useContext, useState } from 'react'
 import { formatDate } from 'utils/formatDate'
 import { fromPermyriad, parsePermyriad } from 'utils/formatNumber'
 
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 
 import ReservedTokenReceiverModal from 'components/modals/ReservedTokenReceiverModal'
 import {
@@ -44,7 +44,7 @@ export default function ProjectTicketMods({
   }>()
   const [editingModIndex, setEditingModIndex] = useState<number>() // index of the mod currently being edited (edit modal open)
   const [modalMode, setModalMode] = useState<ModalMode>() //either 'Add', 'Edit' or undefined
-  const { owner } = useContext(ProjectContext)
+  const { owner } = useContext(V1ProjectContext)
 
   const {
     theme: { colors, radii },

--- a/src/contexts/v1/projectContext.ts
+++ b/src/contexts/v1/projectContext.ts
@@ -7,7 +7,7 @@ import { V1TerminalName } from 'models/v1/terminals'
 import { V1TerminalVersion } from 'models/v1/terminals'
 import { createContext } from 'react'
 
-export type ProjectContextType = {
+export type V1ProjectContextType = {
   projectId: BigNumber | undefined
   projectType: ProjectType | undefined
   createdAt: number | undefined
@@ -37,7 +37,7 @@ export type ProjectContextType = {
     | undefined
 }
 
-export const ProjectContext = createContext<ProjectContextType>({
+export const V1ProjectContext = createContext<V1ProjectContextType>({
   projectId: undefined,
   projectType: 'standard',
   createdAt: undefined,

--- a/src/contexts/v1/userContext.ts
+++ b/src/contexts/v1/userContext.ts
@@ -2,7 +2,7 @@ import { Transactor } from 'hooks/transactor/Transactor'
 import { V1Contracts } from 'models/v1/contracts'
 import { createContext } from 'react'
 
-export const UserContext: React.Context<{
+export const V1UserContext: React.Context<{
   contracts?: V1Contracts
   transactor?: Transactor
 }> = createContext({})

--- a/src/hooks/TerminalFee.ts
+++ b/src/hooks/TerminalFee.ts
@@ -1,12 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { UserContext } from 'contexts/userContext'
 import { V1TerminalVersion } from 'models/v1/terminals'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext, useEffect, useState } from 'react'
 
 export function useTerminalFee(version?: V1TerminalVersion) {
   const [fee, setFee] = useState<BigNumber>()
-  const { contracts } = useContext(UserContext)
+  const { contracts } = useContext(V1UserContext)
 
   useEffect(() => {
     async function fetchData() {

--- a/src/hooks/contractReader/CanPrintPreminedTokens.ts
+++ b/src/hooks/contractReader/CanPrintPreminedTokens.ts
@@ -1,4 +1,4 @@
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import { V1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
@@ -7,7 +7,7 @@ import useContractReader from './ContractReader'
 
 /** Returns true if premine tokens can be printed for `projectId`. */
 export default function useCanPrintPreminedTokens() {
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return useContractReader<boolean>({
     contract: V1ContractName.TerminalV1,

--- a/src/hooks/contractReader/ClaimableOverflowOf.ts
+++ b/src/hooks/contractReader/ClaimableOverflowOf.ts
@@ -1,5 +1,5 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import { useContext, useMemo } from 'react'
 import { bigNumbersDiff } from 'utils/bigNumbersDiff'
@@ -9,7 +9,7 @@ import useTotalBalanceOf from './TotalBalanceOf'
 
 /** Returns claimable amount of project tokens for user with address `userAddress` and balance `totalBalance`. */
 export default function useClaimableOverflowOf() {
-  const { terminal, projectId } = useContext(ProjectContext)
+  const { terminal, projectId } = useContext(V1ProjectContext)
   const { userAddress } = useContext(NetworkContext)
 
   const totalBalance = useTotalBalanceOf(userAddress, projectId, terminal?.name)

--- a/src/hooks/contractReader/ContractReader.ts
+++ b/src/hooks/contractReader/ContractReader.ts
@@ -1,5 +1,5 @@
 import { Contract, EventFilter } from '@ethersproject/contracts'
-import { UserContext } from 'contexts/userContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { V1ContractName } from 'models/v1/contracts'
 import { V1Contracts } from 'models/v1/contracts'
 import { useCallback, useContext, useState } from 'react'
@@ -32,7 +32,7 @@ export default function useContractReader<V>({
 }): V | undefined {
   const [value, setValue] = useState<V | undefined>()
 
-  const { contracts } = useContext(UserContext)
+  const { contracts } = useContext(V1UserContext)
 
   const _formatter = useCallback(
     (val: any) => (formatter ? formatter(val) : val),

--- a/src/hooks/contractReader/HasPermission.ts
+++ b/src/hooks/contractReader/HasPermission.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
 import { V1ContractName } from 'models/v1/contracts'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { useContext } from 'react'
 
 import useContractReader from './ContractReader'
@@ -29,7 +29,7 @@ export function useHasPermission(
   permission: OperatorPermission | OperatorPermission[],
 ) {
   const { userAddress } = useContext(NetworkContext)
-  const { projectId, owner } = useContext(ProjectContext)
+  const { projectId, owner } = useContext(V1ProjectContext)
 
   const hasOperatorPermission = useContractReader<boolean>({
     contract: V1ContractName.OperatorStore,

--- a/src/hooks/contractReader/RedeemRate.ts
+++ b/src/hooks/contractReader/RedeemRate.ts
@@ -1,4 +1,4 @@
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import { BallotState } from 'models/ballot-state'
 import { V1ContractName } from 'models/v1/contracts'
@@ -18,7 +18,7 @@ export function useRedeemRate({
   tokenAmount: string | undefined
   fundingCycle: FundingCycle | undefined
 }) {
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   const metadata = decodeFundingCycleMetadata(fundingCycle?.metadata)
 

--- a/src/hooks/contractReader/ReservedTokensOfProject.ts
+++ b/src/hooks/contractReader/ReservedTokensOfProject.ts
@@ -1,4 +1,4 @@
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber, BigNumberish } from 'ethers'
 import { V1ContractName } from 'models/v1/contracts'
 import { useContext, useMemo } from 'react'
@@ -10,7 +10,7 @@ import useContractReader from './ContractReader'
 export default function useReservedTokensOfProject(
   reservedRate: BigNumberish | undefined,
 ) {
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   const _projectId = projectId?.toHexString()
 

--- a/src/hooks/contractReader/UnclaimedBalanceOfUser.ts
+++ b/src/hooks/contractReader/UnclaimedBalanceOfUser.ts
@@ -1,5 +1,5 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import { V1ContractName } from 'models/v1/contracts'
 import { useContext } from 'react'
@@ -11,7 +11,7 @@ import useShouldUpdateTokens from './ShouldUpdateTokens'
 /** Returns unclaimed balance of user with `userAddress`. */
 export default function useUnclaimedBalanceOfUser() {
   const { userAddress } = useContext(NetworkContext)
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   return useContractReader<BigNumber>({
     contract: V1ContractName.TicketBooth,

--- a/src/hooks/transactor/AddToBalanceTx.ts
+++ b/src/hooks/transactor/AddToBalanceTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -8,8 +8,8 @@ import { TransactorInstance } from './Transactor'
 export function useAddToBalanceTx(): TransactorInstance<{
   value: BigNumber
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ value }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {

--- a/src/hooks/transactor/ConfigureProjectTx.ts
+++ b/src/hooks/transactor/ConfigureProjectTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber, constants } from 'ethers'
 import { FundingCycleMetadata } from 'models/funding-cycle-metadata'
 import { FCProperties } from 'models/funding-cycle-properties'
@@ -14,8 +14,8 @@ export function useConfigureProjectTx(): TransactorInstance<{
   payoutMods: PayoutMod[]
   ticketMods: TicketMod[]
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   return ({ fcProperties, fcMetadata, payoutMods, ticketMods }, txOpts) => {
     if (

--- a/src/hooks/transactor/DeployProjectTx.ts
+++ b/src/hooks/transactor/DeployProjectTx.ts
@@ -1,5 +1,5 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { UserContext } from 'contexts/userContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber, constants, utils } from 'ethers'
 import { FundingCycleMetadata } from 'models/funding-cycle-metadata'
 import { FCProperties } from 'models/funding-cycle-properties'
@@ -17,7 +17,7 @@ export function useDeployProjectTx(): TransactorInstance<{
   payoutMods: PayoutMod[]
   ticketMods: TicketMod[]
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
 
   return (

--- a/src/hooks/transactor/DistributeTokensTx.ts
+++ b/src/hooks/transactor/DistributeTokensTx.ts
@@ -1,12 +1,12 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
 
 import { TransactorInstance } from './Transactor'
 
 export function useDistributeTokensTx(): TransactorInstance<{}> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { terminal, projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { terminal, projectId } = useContext(V1ProjectContext)
 
   return (_, txOpts) => {
     if (!transactor || !terminal || !projectId || !contracts) {

--- a/src/hooks/transactor/IssueTokensTx.ts
+++ b/src/hooks/transactor/IssueTokensTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
 
 import { TransactorInstance } from './Transactor'
@@ -8,8 +8,8 @@ export function useIssueTokensTx(): TransactorInstance<{
   name: string
   symbol: string
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ name, symbol }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {

--- a/src/hooks/transactor/MigrateV1ProjectTx.ts
+++ b/src/hooks/transactor/MigrateV1ProjectTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
 
 import { TransactorInstance } from './Transactor'
@@ -7,8 +7,8 @@ import { TransactorInstance } from './Transactor'
 export function useMigrateV1ProjectTx(): TransactorInstance<{
   newTerminalAddress: string
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ newTerminalAddress }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {

--- a/src/hooks/transactor/PayProjectTx.ts
+++ b/src/hooks/transactor/PayProjectTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -11,8 +11,8 @@ export function usePayProjectTx(): TransactorInstance<{
   preferUnstaked: boolean
   value: BigNumber
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { terminal, projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { terminal, projectId } = useContext(V1ProjectContext)
   const { userAddress } = useContext(NetworkContext)
 
   return ({ note, preferUnstaked, value }, txOpts) => {

--- a/src/hooks/transactor/PrintTokensTx.ts
+++ b/src/hooks/transactor/PrintTokensTx.ts
@@ -1,6 +1,6 @@
 import { Contract } from '@ethersproject/contracts'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { CurrencyOption } from 'models/currency-option'
 import { useContext } from 'react'
@@ -14,8 +14,8 @@ export function usePrintTokensTx(): TransactorInstance<{
   memo: string
   preferUnstaked: boolean
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { terminal, projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { terminal, projectId } = useContext(V1ProjectContext)
 
   return ({ value, currency, beneficiary, memo, preferUnstaked }, txOpts) => {
     if (!transactor || !contracts || !projectId || !terminal?.version) {

--- a/src/hooks/transactor/RedeemTokensTx.ts
+++ b/src/hooks/transactor/RedeemTokensTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -11,9 +11,9 @@ export function useRedeemTokensTx(): TransactorInstance<{
   minAmount: BigNumber
   preferConverted: boolean
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   return ({ redeemAmount, minAmount, preferConverted }, txOpts) => {
     if (

--- a/src/hooks/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/transactor/SafeTransferFromTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
 
 import { TransactorInstance } from './Transactor'
@@ -7,8 +7,8 @@ import { TransactorInstance } from './Transactor'
 export function useSafeTransferFromTx(): TransactorInstance<{
   to: string
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId, owner } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId, owner } = useContext(V1ProjectContext)
 
   return ({ to }, txOpts) => {
     if (!transactor || !projectId || !contracts?.Projects) {

--- a/src/hooks/transactor/SetPayoutModsTx.ts
+++ b/src/hooks/transactor/SetPayoutModsTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber, constants } from 'ethers'
 import { PayoutMod } from 'models/mods'
 import { useContext } from 'react'
@@ -11,9 +11,9 @@ export function useSetPayoutModsTx(): TransactorInstance<{
   configured: BigNumber
   payoutMods: PayoutMod[]
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   return ({ configured, payoutMods }, txOpts) => {
     if (

--- a/src/hooks/transactor/SetProjectHandleTx.ts
+++ b/src/hooks/transactor/SetProjectHandleTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { utils } from 'ethers'
 import { useContext } from 'react'
 
@@ -8,8 +8,8 @@ import { TransactorInstance } from './Transactor'
 export function useSetProjectHandleTx(): TransactorInstance<{
   handle: string
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ handle }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {

--- a/src/hooks/transactor/SetProjectUriTx.ts
+++ b/src/hooks/transactor/SetProjectUriTx.ts
@@ -1,5 +1,5 @@
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
 
 import { TransactorInstance } from './Transactor'
@@ -7,8 +7,8 @@ import { TransactorInstance } from './Transactor'
 export function useSetProjectUriTx(): TransactorInstance<{
   cid: string
 }> {
-  const { transactor, contracts } = useContext(UserContext)
-  const { projectId } = useContext(ProjectContext)
+  const { transactor, contracts } = useContext(V1UserContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ cid }, txOpts) => {
     if (!transactor || !projectId || !contracts?.TicketBooth) {

--- a/src/hooks/transactor/SetTicketModsTx.ts
+++ b/src/hooks/transactor/SetTicketModsTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber, constants } from 'ethers'
 import { TicketMod } from 'models/mods'
 import { useContext } from 'react'
@@ -11,9 +11,9 @@ export function useSetTicketModsTx(): TransactorInstance<{
   configured: BigNumber
   ticketMods: TicketMod[]
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   return ({ configured, ticketMods }, txOpts) => {
     if (

--- a/src/hooks/transactor/StakeTokensTx.ts
+++ b/src/hooks/transactor/StakeTokensTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -9,9 +9,9 @@ import { TransactorInstance } from './Transactor'
 export function useStakeTokensTx(): TransactorInstance<{
   amount: BigNumber
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ amount }, txOpts) => {
     if (!transactor || !projectId || !userAddress || !contracts?.TicketBooth) {

--- a/src/hooks/transactor/TapProjectTx.ts
+++ b/src/hooks/transactor/TapProjectTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -13,9 +13,9 @@ export function useTapProjectTx(): TransactorInstance<{
   minAmount: BigNumber
   currency: CurrencyOption
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId, terminal } = useContext(ProjectContext)
+  const { projectId, terminal } = useContext(V1ProjectContext)
 
   return ({ tapAmount, minAmount, currency }, txOpts) => {
     if (

--- a/src/hooks/transactor/TransferTokensTx.ts
+++ b/src/hooks/transactor/TransferTokensTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -10,9 +10,9 @@ export function useTransferTokensTx(): TransactorInstance<{
   amount: BigNumber
   to: string
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ amount, to }, txOpts) => {
     if (!transactor || !projectId || !contracts?.Projects) {

--- a/src/hooks/transactor/UnstakeTokensTx.ts
+++ b/src/hooks/transactor/UnstakeTokensTx.ts
@@ -1,6 +1,6 @@
 import { NetworkContext } from 'contexts/networkContext'
-import { ProjectContext } from 'contexts/projectContext'
-import { UserContext } from 'contexts/userContext'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { BigNumber } from 'ethers'
 import { useContext } from 'react'
 
@@ -9,9 +9,9 @@ import { TransactorInstance } from './Transactor'
 export function useUnstakeTokensTx(): TransactorInstance<{
   unstakeAmount: BigNumber
 }> {
-  const { transactor, contracts } = useContext(UserContext)
+  const { transactor, contracts } = useContext(V1UserContext)
   const { userAddress } = useContext(NetworkContext)
-  const { projectId } = useContext(ProjectContext)
+  const { projectId } = useContext(V1ProjectContext)
 
   return ({ unstakeAmount }, txOpts) => {
     if (!transactor || !userAddress || !projectId || !contracts?.TicketBooth) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux'
 import App from 'App'
 import NetworkProvider from 'providers/NetworkProvider'
 import ThemeProvider from 'providers/ThemeProvider'
-import UserProvider from 'providers/UserProvider'
+import V1UserProvider from 'providers/v1/UserProvider'
 import LanguageProvider from 'providers/LanguageProvider'
 import ReactQueryProvier from 'providers/ReactQueryProvider'
 
@@ -22,9 +22,9 @@ ReactDOM.render(
         <LanguageProvider>
           <ThemeProvider>
             <NetworkProvider>
-              <UserProvider>
+              <V1UserProvider>
                 <App />
-              </UserProvider>
+              </V1UserProvider>
             </NetworkProvider>
           </ThemeProvider>
         </LanguageProvider>

--- a/src/providers/v1/UserProvider.tsx
+++ b/src/providers/v1/UserProvider.tsx
@@ -1,11 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { UserContext } from 'contexts/userContext'
+import { V1UserContext } from 'contexts/v1/userContext'
 import { useContractLoader } from 'hooks/ContractLoader'
 import { useGasPriceQuery } from 'hooks/GasPrice'
 import { useTransactor } from 'hooks/transactor/Transactor'
 import { ChildElems } from 'models/child-elems'
 
-export default function UserProvider({ children }: { children: ChildElems }) {
+export default function V1UserProvider({ children }: { children: ChildElems }) {
   const contracts = useContractLoader()
 
   const { data: gasPrice } = useGasPriceQuery('average')
@@ -15,13 +15,13 @@ export default function UserProvider({ children }: { children: ChildElems }) {
   })
 
   return (
-    <UserContext.Provider
+    <V1UserContext.Provider
       value={{
         contracts,
         transactor,
       }}
     >
       {children}
-    </UserContext.Provider>
+    </V1UserContext.Provider>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

⚠️ this PR targets #436

- Rename `UserContext` to `V1UserContext`
- Rename `ProjectContextType` to `V1ProjectContextType`
- Rename `ProjectContext` to `V1ProjectContext`
- Rename `UserProvider` to `V1UserProvider`
- move `userContext.ts` and `projectContext.ts` to `contexts/v1` directory
- move `UserProvider.ts` to `providers/v1` directory

| iteration | PR |
| --- | --- |
| 1. Namespace Juicebox V1 contract constants | https://github.com/jbx-protocol/juice-interface/pull/435 |
| 2. Namespace Juicebox V1 terminal code | https://github.com/jbx-protocol/juice-interface/pull/436 |
| 3. Namespace contexts and providers | 👇 you are here |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
