### PR TITLE
Improve i18n robustness

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Extract translations
-        run: 'yarn i18n:compile'
+        run: 'yarn i18n:extract'
 
       - name: Upload to Crowdin
         uses: crowdin/github-action@1.4.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,5 +139,5 @@ Notion page.
    directory for the locale within the `./locale/` directory:
 
    ```bash
-   yarn i18n:compile
+   yarn i18n:extract && yarn i18n:compile
    ```

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint-staged": "lint-staged",
     "prepare": "husky install",
     "i18n:extract": "lingui extract --clean --locale en",
-    "i18n:compile": "yarn i18n:extract && lingui compile",
+    "i18n:compile": "lingui compile",
     "postinstall": "yarn i18n:compile",
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js'"
   },

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -29,7 +29,9 @@ export default function Footer() {
 
   // Renders language links
   const languageLink = (lang: string) => (
-    <span onClick={() => setLanguage(lang)}>{link(Languages[lang].long)}</span>
+    <span key={lang} onClick={() => setLanguage(lang)}>
+      {link(Languages[lang].long)}
+    </span>
   )
 
   // Sets the new language with localStorage and reloads the page

--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -24,6 +24,7 @@ export default function Payments() {
       'beneficiary',
       'note',
       'timestamp',
+      'id',
       { entity: 'project', keys: ['id'] },
     ],
     first: 20,

--- a/src/components/Navbar/MobileCollapse.tsx
+++ b/src/components/Navbar/MobileCollapse.tsx
@@ -16,7 +16,7 @@ import FeedbackFormLink from 'components/shared/FeedbackFormLink'
 import ThemePicker from './ThemePicker'
 import Logo from './Logo'
 import Account from './Account'
-import LanguageSelector from './NavLanguageSelector'
+import NavLanguageSelector from './NavLanguageSelector'
 import { menu } from './MenuItems'
 
 export default function MobileCollapse() {
@@ -60,7 +60,7 @@ export default function MobileCollapse() {
         >
           {menu(() => setActiveKey(activeKey === 0 ? undefined : 0))}
           <div className="nav-subsection">
-            <LanguageSelector />
+            <NavLanguageSelector />
             <ThemePicker mobile={true} />
             <FeedbackFormLink mobile={true} />
           </div>

--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -5,7 +5,7 @@ import { GlobalOutlined } from '@ant-design/icons'
 import { Languages } from 'constants/languages/language-options'
 
 // Language select tool seen in top nav
-export default function LanguageSelector({
+export default function NavLanguageSelector({
   disableLang,
 }: {
   disableLang?: string
@@ -25,7 +25,7 @@ export default function LanguageSelector({
       return null
     }
     return (
-      <Select.Option class="language-select-option" value={lang}>
+      <Select.Option key={lang} class="language-select-option" value={lang}>
         <div>{Languages[lang].long}</div>
       </Select.Option>
     )

--- a/src/components/Navbar/OptionsCollapse.tsx
+++ b/src/components/Navbar/OptionsCollapse.tsx
@@ -10,7 +10,7 @@ import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 
 import ThemePicker from './ThemePicker'
-import LanguageSelector from './NavLanguageSelector'
+import NavLanguageSelector from './NavLanguageSelector'
 
 export default function OptionsCollapse() {
   const [activeKey, setActiveKey] = useState<0 | undefined>()
@@ -53,7 +53,7 @@ export default function OptionsCollapse() {
               <ThemePicker />
             </div>
             <div className="nav-dropdown-item">
-              <LanguageSelector />
+              <NavLanguageSelector />
             </div>
             {signingProvider ? (
               <div


### PR DESCRIPTION
## What does this PR do and why?

This PR fulfills some of the corrective actions revealed in the root-cause analysis of our recent downtime: https://www.notion.so/juicebox/RCA-production-downtime-2022-01-29-ca703708b20543b3825f8dbaf0c1db25

### Main changes
- **always import the default locale `locale/en/messages`.** The app will fail at compile-time if this file doesn't exist, so we will catch it in development/in the Fleek CI, instead of at run-time 😉 
- **adds exception handling to the `dynamicActivate` function.** If a `messages` file for a given locale doesn't exist, we will always fall back to the default locale, meaning the app will always render in English in the worst case.
- **update the `i18n:compile` npm script to _only_ run `lingui compile`** (and _not_ `lingui extract`). Extract generates the `en/messages.po` file, which we don't want to run locally; we want that to be the responsibility of the Crowdin GitHub action. `lingui compile` generates the `{lang}/messages.js` files, _which the app depends on_, and which we definitely need to run post-install (or pre-build).

### Supplementary changes
- adds missing `key` attributes to kill some lingering console errors.
- make exported function name `NavLanguageSelector` match its filename.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
