### PR TITLE
[BUG] Prompt wallet connect on pay project if no wallet connected

### DIFF
--- a/src/components/modals/ConfirmPayOwnerModal/index.tsx
+++ b/src/components/modals/ConfirmPayOwnerModal/index.tsx
@@ -44,7 +44,9 @@ export default function ConfirmPayOwnerModal({
 
     await form.validateFields()
 
-    setLoading(true)
+    if (userAddress) {
+      setLoading(true)
+    }
 
     payProjectTx(
       {

--- a/src/hooks/transactor/PayProjectTx.ts
+++ b/src/hooks/transactor/PayProjectTx.ts
@@ -13,19 +13,26 @@ export function usePayProjectTx(): TransactorInstance<{
 }> {
   const { transactor, contracts } = useContext(UserContext)
   const { terminal, projectId } = useContext(ProjectContext)
-  const { userAddress } = useContext(NetworkContext)
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+
+  const checkWalletConnected = () => {
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+  }
 
   return ({ note, preferUnstaked, value }, txOpts) => {
     if (
       !transactor ||
       !projectId ||
-      !userAddress ||
       !contracts?.TicketBooth ||
       !terminal?.version
     ) {
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }
+
+    checkWalletConnected() //TODO: make this async
 
     return transactor(
       terminal.version === '1.1'

--- a/src/hooks/transactor/PayProjectTx.ts
+++ b/src/hooks/transactor/PayProjectTx.ts
@@ -13,13 +13,7 @@ export function usePayProjectTx(): TransactorInstance<{
 }> {
   const { transactor, contracts } = useContext(UserContext)
   const { terminal, projectId } = useContext(ProjectContext)
-  const { userAddress, onSelectWallet } = useContext(NetworkContext)
-
-  const checkWalletConnected = () => {
-    if (!userAddress && onSelectWallet) {
-      onSelectWallet()
-    }
-  }
+  const { userAddress } = useContext(NetworkContext)
 
   return ({ note, preferUnstaked, value }, txOpts) => {
     if (
@@ -31,8 +25,6 @@ export function usePayProjectTx(): TransactorInstance<{
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }
-
-    checkWalletConnected() //TODO: make this async
 
     return transactor(
       terminal.version === '1.1'

--- a/src/hooks/transactor/Transactor.ts
+++ b/src/hooks/transactor/Transactor.ts
@@ -34,6 +34,16 @@ export type TransactorInstance<T> = (
   txOpts?: Omit<TransactorOptions, 'value'>,
 ) => ReturnType<Transactor>
 
+// Check user has their wallet connected. If not, show select wallet prompt
+const checkWalletConnected = (
+  onSelectWallet: VoidFunction,
+  userAddress?: string,
+) => {
+  if (!userAddress && onSelectWallet) {
+    onSelectWallet()
+  }
+}
+
 // wrapper around BlockNative's Notify.js
 // https://docs.blocknative.com/notify
 export function useTransactor({
@@ -41,8 +51,11 @@ export function useTransactor({
 }: {
   gasPrice?: BigNumber
 }): Transactor | undefined {
-  const { signingProvider: provider, onSelectWallet } =
-    useContext(NetworkContext)
+  const {
+    signingProvider: provider,
+    onSelectWallet,
+    userAddress,
+  } = useContext(NetworkContext)
 
   const { isDarkMode } = useContext(ThemeContext)
 
@@ -60,6 +73,8 @@ export function useTransactor({
         if (options?.onDone) options.onDone()
         return false
       }
+
+      checkWalletConnected(onSelectWallet, userAddress)
 
       if (!provider) return false
 
@@ -182,6 +197,6 @@ export function useTransactor({
         return false
       }
     },
-    [onSelectWallet, provider, isDarkMode, gasPrice],
+    [onSelectWallet, provider, isDarkMode, gasPrice, userAddress],
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Prompts wallet connect on pay project if no wallet connected. 

Still not ideal, would be nice to not have to click the pay button twice, but I had trouble getting the usePayProjectTx() hook async so just went with this. 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/151794110-7524c6c3-8ae5-4ab1-a82b-41e220f3a4ba.mp4

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
