### PR TITLE
Add Portuguese to the language selector

### DIFF
--- a/.linguirc.json
+++ b/.linguirc.json
@@ -13,6 +13,6 @@
   "fallbackLocales": {
     "default": "en"
   },
-  "locales": ["en", "zh", "ru", "tr", "es"],
+  "locales": ["en", "zh", "ru", "tr", "es", "pt"],
   "sourceLocale": "en"
 }

--- a/src/constants/languages/language-options.ts
+++ b/src/constants/languages/language-options.ts
@@ -6,6 +6,6 @@ export const Languages: Language = {
   zh: { code: 'zh', name: 'chinese', short: '中文', long: '中文' },
   ru: { code: 'ru', name: 'russian', short: 'RU', long: 'Pусский' },
   tr: { code: 'tr', name: 'turkish', short: 'TR', long: 'Türkçe' },
-  // pt: { code: 'pt', name: 'portuguese', short: 'PT', long: 'Português' },
+  pt: { code: 'pt', name: 'portuguese', short: 'PT', long: 'Português' },
   es: { code: 'es', name: 'spanish', short: 'ES', long: 'Español' },
 }

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ['en', 'zh', 'ru', 'tr', 'es']
+export const SUPPORTED_LOCALES = ['en', 'zh', 'ru', 'tr', 'es', 'pt']
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 
 export const DEFAULT_LOCALE: SupportedLocale = 'en'

--- a/src/providers/LanguageProvider.tsx
+++ b/src/providers/LanguageProvider.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lingui/detect-locale'
 import { I18nProvider } from '@lingui/react'
 import { ReactNode, useEffect } from 'react'
-import { en, zh, ru, tr, es } from 'make-plural/plurals'
+import { en, zh, ru, tr, es, pt } from 'make-plural/plurals'
 import defaultLocale from 'locales/en/messages'
 
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE } from 'constants/locale'
@@ -18,7 +18,7 @@ i18n.loadLocaleData({
   zh: { plurals: zh },
   ru: { plurals: ru },
   tr: { plurals: tr },
-  // pt: { plurals: pt },
+  pt: { plurals: pt },
   es: { plurals: es },
 })
 


### PR DESCRIPTION
## What does this PR do and why?

Adds Portuguese to the language selector with 62% of its translations completed

## Screenshots or screen recordings

<img width="1334" alt="Screen Shot 2022-02-03 at 11 41 29 am" src="https://user-images.githubusercontent.com/96150256/152267191-d0a6fcab-a4a1-4263-bdf9-1e5300fd4582.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
