### PR TITLE
Improve URL syncing on projects page

### DIFF
--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -12,6 +12,8 @@ import Grid from 'components/shared/Grid'
 
 import ProjectCard from 'components/shared/ProjectCard'
 
+import { Link } from 'react-router-dom'
+
 import { ThemeOption } from 'constants/theme/theme-option'
 
 import Faq from './Faq'
@@ -276,11 +278,11 @@ export default function Landing() {
                 )}
               </div>
               <div style={{ textAlign: 'center', marginTop: 20 }}>
-                <a href="/#/projects?tab=all">
+                <Link to="/projects?tab=all">
                   <Button>
                     <Trans>All projects</Trans>
                   </Button>
-                </a>
+                </Link>
               </div>
             </Col>
             <Col xs={24} md={12} style={{ marginBottom: 100 }}>

--- a/src/components/Projects/ProjectsTabs.tsx
+++ b/src/components/Projects/ProjectsTabs.tsx
@@ -3,14 +3,19 @@ import { Space } from 'antd'
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { ProjectCategory } from 'models/project-visibility'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
+import { Link } from 'react-router-dom'
+
+const TAB_TYPE_NAMES: { [k in ProjectCategory]: string } = {
+  all: t`All`,
+  myprojects: t`My projects`,
+  trending: t`Trending`,
+}
 
 export default function ProjectsTabs({
   selectedTab,
-  setSelectedTab,
 }: {
   selectedTab: ProjectCategory
-  setSelectedTab: Function
 }) {
   const { signingProvider } = useContext(NetworkContext)
 
@@ -18,28 +23,16 @@ export default function ProjectsTabs({
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const tab = (tab: ProjectCategory) => {
-    let text: string = ''
-    // Need this switch for translations
-    switch (tab) {
-      case 'all':
-        text = t`All`
-        break
-      case 'myprojects':
-        text = t`My projects`
-        break
-      case 'trending':
-        text = t`Trending`
-        break
-    }
+  const Tab = ({ type }: { type: ProjectCategory }) => {
     return (
-      <div
+      <Link
+        to={`/projects?tab=${type}`}
         style={{
           textTransform: 'uppercase',
           cursor: 'pointer',
           borderBottom: '2px solid transparent',
           paddingBottom: 6,
-          ...(tab === selectedTab
+          ...(type === selectedTab
             ? {
                 color: colors.text.primary,
                 fontWeight: 500,
@@ -50,22 +43,19 @@ export default function ProjectsTabs({
                 borderColor: 'transparent',
               }),
         }}
-        onClick={() => {
-          window.location.href = `/#/projects?tab=${tab}`
-          setSelectedTab(tab)
-        }}
       >
-        {text}
-      </div>
+        {TAB_TYPE_NAMES[type]}
+      </Link>
     )
   }
 
   return (
     <div style={{ height: 40, marginTop: 15 }}>
       <Space direction="horizontal" size="large">
-        {tab('trending')}
-        {tab('all')}
-        {signingProvider ? tab('myprojects') : null}
+        <Tab type="trending" />
+        <Tab type="all" />
+
+        {signingProvider ? <Tab type="myprojects" /> : null}
       </Space>
     </div>
   )

--- a/src/components/Projects/TrendingProjectCard.tsx
+++ b/src/components/Projects/TrendingProjectCard.tsx
@@ -12,6 +12,8 @@ import { CSSProperties, useContext, useMemo } from 'react'
 import { formattedNum, formatWad } from 'utils/formatNumber'
 import { getTerminalVersion } from 'utils/v1/terminals'
 
+import { Link } from 'react-router-dom'
+
 import { SECONDS_IN_DAY } from 'constants/numbers'
 import { CURRENCY_ETH } from 'constants/currency'
 
@@ -94,14 +96,14 @@ export default function TrendingProjectCard({
   }, [project, trendingWindowDays])
 
   return project ? (
-    <a
+    <Link
       style={{
         borderRadius: radii.lg,
         cursor: 'pointer',
         overflow: 'hidden',
       }}
-      key={project?.handle}
-      href={`/#/p/${project?.handle}`}
+      key={project.handle}
+      to={`/p/${project.handle}`}
     >
       {metadata ? (
         <div style={cardStyle} className="clickable-border">
@@ -206,7 +208,7 @@ export default function TrendingProjectCard({
           {project?.handle} <Loading />
         </div>
       )}
-    </a>
+    </Link>
   ) : (
     <Loading />
   )

--- a/src/components/Projects/TrendingProjects.tsx
+++ b/src/components/Projects/TrendingProjects.tsx
@@ -5,6 +5,7 @@ import Grid from 'components/shared/Grid'
 import Loading from 'components/shared/Loading'
 import { useTrendingProjects } from 'hooks/v1/Projects'
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 import RankingExplanation from './RankingExplanation'
 import TrendingProjectCard from './TrendingProjectCard'
@@ -42,9 +43,9 @@ export default function TrendingProjects({
             </p>
           ) : (
             <Button type="default" style={{ marginBottom: 40, marginTop: 15 }}>
-              <a href="/#/projects/?tab=trending">
+              <Link to="/projects?tab=trending">
                 <Trans>More trending projects</Trans>
-              </a>
+              </Link>
             </Button>
           )}
         </React.Fragment>

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -11,7 +11,7 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import Grid from 'components/shared/Grid'
 import ProjectCard from 'components/shared/ProjectCard'
 
-import { useLocation } from 'react-router-dom'
+import { Link, useHistory, useLocation } from 'react-router-dom'
 
 import { useInfiniteProjectsQuery, useProjectsSearch } from 'hooks/v1/Projects'
 import { V1TerminalVersion } from 'models/v1/terminals'
@@ -32,23 +32,28 @@ const pageSize = 20
 export default function Projects() {
   // Checks URL to see if tab has been set
   const location = useLocation()
+  const history = useHistory()
+
   const params = new URLSearchParams(location.search)
-  let tab: ProjectCategory | undefined
+  let selectedTab: ProjectCategory = 'all'
   // Convert
   switch (params.get('tab')) {
     case 'trending':
-      tab = 'trending'
+      selectedTab = 'trending'
       break
     case 'all':
-      tab = 'all'
+      selectedTab = 'all'
+      break
+    case 'myprojects':
+      selectedTab = 'myprojects'
       break
   }
 
-  const [searchText, setSearchText] = useState<string>()
-  const [trendingWindowDays, setTrendingWindowDays] = useState<7 | 30>(7)
-  const [selectedTab, setSelectedTab] = useState<ProjectCategory>(
-    tab ? tab : 'trending', // Show trending by default
+  const [searchText, setSearchText] = useState<string>(
+    params.get('search') ?? '',
   )
+  const [trendingWindowDays, setTrendingWindowDays] = useState<7 | 30>(7)
+
   const [orderBy, setOrderBy] = useState<OrderByOption>('totalPaid')
   const [includeV1, setIncludeV1] = useState<boolean>(true)
   const [includeV1_1, setIncludeV1_1] = useState<boolean>(true)
@@ -129,11 +134,11 @@ export default function Projects() {
             <Trans>Projects on Juicebox</Trans>
           </h1>
 
-          <a href="/#/create">
+          <Link to="/create">
             <Button>
               <Trans>Create project</Trans>
             </Button>
-          </a>
+          </Link>
         </div>
 
         <div>
@@ -156,9 +161,10 @@ export default function Projects() {
             prefix="@"
             placeholder={t`Search projects by handle`}
             onSearch={val => {
-              setSelectedTab('all')
               setSearchText(val)
+              history.push(`/projects?tab=all${val ? `&search=${val}` : ''}`)
             }}
+            defaultValue={searchText}
             allowClear
           />
         ) : null}
@@ -173,10 +179,7 @@ export default function Projects() {
             maxWidth: '100vw',
           }}
         >
-          <ProjectsTabs
-            selectedTab={selectedTab}
-            setSelectedTab={setSelectedTab}
-          />
+          <ProjectsTabs selectedTab={selectedTab} />
 
           {selectedTab === 'all' && !searchText ? (
             <ProjectsFilterAndSort

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -12,6 +12,8 @@ import { getTerminalVersion } from 'utils/v1/terminals'
 
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 
+import { Link } from 'react-router-dom'
+
 import { CURRENCY_ETH } from 'constants/currency'
 
 import CurrencySymbol from './CurrencySymbol'
@@ -77,14 +79,14 @@ export default function ProjectCard({
   const terminalVersion = getTerminalVersion(_project?.terminal)
 
   return (
-    <a
+    <Link
       style={{
         borderRadius: radii.lg,
         cursor: 'pointer',
         overflow: 'hidden',
       }}
       key={_project?.handle}
-      href={`/#/p/${_project?.handle}`}
+      to={`/p/${_project?.handle}`}
     >
       {metadata ? (
         <div style={cardStyle} className="clickable-border">
@@ -172,6 +174,6 @@ export default function ProjectCard({
           {_project?.handle} <Loading />
         </div>
       )}
-    </a>
+    </Link>
   )
 }

--- a/src/components/shared/ProjectHandle.tsx
+++ b/src/components/shared/ProjectHandle.tsx
@@ -3,6 +3,7 @@ import { BigNumberish } from '@ethersproject/bignumber'
 import { Tooltip } from 'antd'
 import useHandleForProjectId from 'hooks/v1/contractReader/HandleForProjectId'
 import { CSSProperties } from 'react'
+import { Link } from 'react-router-dom'
 
 export default function ProjectHandle({
   projectId,
@@ -18,14 +19,14 @@ export default function ProjectHandle({
   return link ? (
     <Tooltip
       title={
-        <a
+        <Link
           style={{ fontWeight: 400 }}
-          href={`/#/${handle}`}
+          to={`/p/${handle}`}
           target="_blank"
           rel="noopener noreferrer"
         >
           @{handle} <LinkOutlined />
-        </a>
+        </Link>
       }
     >
       <span style={{ cursor: 'default', ...style }}>@{handle}</span>


### PR DESCRIPTION
## What does this PR do and why?

⚠️ This branch targets [trending-projects-flattened](https://github.com/jbx-protocol/juice-interface/tree/trending-projects-flattened) https://github.com/jbx-protocol/juice-interface/pull/460

- Make the URL query params the single source of truth for tab selection
- persist user's projects search query to the URL

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
