### PR TITLE
[BUG] Make large "Total supply" amount wrap properly

### DIFF
--- a/src/components/Dashboard/Rewards.tsx
+++ b/src/components/Dashboard/Rewards.tsx
@@ -123,6 +123,8 @@ export default function Rewards() {
                       justifyContent: 'space-between',
                       alignItems: 'baseline',
                       width: '100%',
+                      gap: 5,
+                      flexWrap: 'wrap',
                     }}
                   >
                     {formatWad(totalSupply, { precision: 0 })}
@@ -144,6 +146,7 @@ export default function Rewards() {
                     style={{
                       display: 'flex',
                       flexWrap: 'wrap',
+                      gap: 5,
                       justifyContent: 'space-between',
                       width: '100%',
                     }}


### PR DESCRIPTION
## What does this PR do and why?

Fix this issue which I noticed on my own mobile with AssangeDAO.

Problem:

<img width="484" alt="Screen Shot 2022-02-07 at 8 11 27 pm" src="https://user-images.githubusercontent.com/96150256/152769831-b6302847-8127-4a78-b4a1-cacea2613ec2.png">

Fix:

https://user-images.githubusercontent.com/96150256/152769696-d7c5cdc7-d570-4add-b92f-130dea4935ca.mp4



## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
