### PR TITLE
Translations lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push
+
+jobs:
+  lint-translations:
+    name: Lint source code for missing translations.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint translations
+        run: 'yarn i18n:lint'

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prepare": "husky install",
     "i18n:extract": "lingui extract --clean",
     "i18n:compile": "lingui compile",
+    "i18n:lint": "./scripts/lint-translations.sh",
     "postinstall": "yarn i18n:compile",
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js'"
   },

--- a/scripts/lint-translations.sh
+++ b/scripts/lint-translations.sh
@@ -1,0 +1,16 @@
+# extract new strings
+yarn i18n:extract
+
+# get all translation files that were updated
+# from `yarn i18n:extract`
+LOCALE_CHANGED_FILES=$(git diff --name-only src/locales)
+
+# Bail if there were changes to translation files
+# that weren't included in the commit.
+if ! [ -z "$LOCALE_CHANGED_FILES" ]; then
+  echo "🍎 Translation source files are out of date. Run 'yarn i18n:extract' locally and commit changes to the following files:\n$LOCALE_CHANGED_FILES."
+  exit 1
+else
+  echo "🍏 Translation source files are up to date."
+  exit 0
+fi


### PR DESCRIPTION
## What does this PR do and why?

Adds translation linting to CI. PRs will be un-mergable if translation source files aren't up to date.

Fixes https://github.com/jbx-protocol/juice-interface/issues/473

## Example

Example of a failed GitHub action. https://github.com/jbx-protocol/juice-interface/runs/5117826457?check_suite_focus=true
The action was run on this commit: https://github.com/jbx-protocol/juice-interface/commit/441662b5ca61ca4a9400310bb0d592d007c17405
