### PR TITLE
[WIP] Add paused indicator on trending projects and checkbox to show them

### DIFF
--- a/src/components/Projects/PausedIndiciator.tsx
+++ b/src/components/Projects/PausedIndiciator.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { Tooltip } from 'antd'
+import { t } from '@lingui/macro'
+import { V1TerminalVersion } from 'models/v1/terminals'
+import { BigNumber } from 'ethers'
+import { getTerminalName } from 'utils/v1/terminals'
+import { paymentsPaused } from 'utils/paymentsPaused'
+import { PauseCircleOutlined } from '@ant-design/icons'
+
+import useCurrentFundingCycleOfProject from 'hooks/v1/contractReader/CurrentFundingCycleOfProject'
+
+export default function PausedIndicator({
+  projectId,
+  terminalVersion,
+}: {
+  projectId?: BigNumber
+  terminalVersion?: V1TerminalVersion
+}) {
+  console.log('rendering paused indicator')
+  const terminalName = getTerminalName({
+    version: terminalVersion,
+  })
+  // Gets the current FC so we can get projectPaymentsPaused
+  const currentFC = useCurrentFundingCycleOfProject(projectId, terminalName)
+  const projectPaymentsPaused = paymentsPaused(
+    projectId,
+    currentFC,
+    terminalVersion,
+  )
+
+  if (projectPaymentsPaused) {
+    return (
+      <React.Fragment>
+        <Tooltip title={t`Payments are paused`}>
+          <PauseCircleOutlined />
+        </Tooltip>
+      </React.Fragment>
+    )
+  }
+  return null
+}

--- a/src/components/Projects/TrendingProjectCard.tsx
+++ b/src/components/Projects/TrendingProjectCard.tsx
@@ -16,16 +16,19 @@ import { Link } from 'react-router-dom'
 
 import { SECONDS_IN_DAY } from 'constants/numbers'
 import { CURRENCY_ETH } from 'constants/currency'
+import PausedIndicator from './PausedIndiciator'
 
 export default function TrendingProjectCard({
   project,
   size,
   rank,
+  showPausedState,
   trendingWindowDays,
 }: {
   project: TrendingProject
   size?: 'sm' | 'lg'
   rank: number
+  showPausedState?: boolean
   trendingWindowDays: number
 }) {
   const {
@@ -136,7 +139,13 @@ export default function TrendingProjectCard({
                 fontSize: size === 'sm' ? 16 : 21,
               }}
             >
-              {metadata.name}
+              {metadata.name}{' '}
+              {showPausedState ? (
+                <PausedIndicator
+                  projectId={project.id}
+                  terminalVersion={terminalVersion}
+                />
+              ) : null}
             </h2>
 
             {size === 'sm' ? null : (

--- a/src/components/Projects/TrendingProjects.tsx
+++ b/src/components/Projects/TrendingProjects.tsx
@@ -13,10 +13,12 @@ import TrendingProjectCard from './TrendingProjectCard'
 export default function TrendingProjects({
   isHomePage,
   count, // number of trending project cards to show
+  showPausedState,
   trendingWindowDays,
 }: {
   isHomePage?: boolean
   count: number
+  showPausedState?: boolean
   trendingWindowDays: number
 }) {
   const { data: projects, isLoading } = useTrendingProjects(
@@ -36,6 +38,7 @@ export default function TrendingProjects({
                 rank={i + 1}
                 key={i}
                 trendingWindowDays={trendingWindowDays}
+                showPausedState={showPausedState}
               />
             ))}
           </Grid>

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -25,6 +25,7 @@ import ProjectsTabs from './ProjectsTabs'
 import HoldingsProjects from './HoldingsProjects'
 import ProjectsFilterAndSort from './ProjectsFilterAndSort'
 import ArchivedProjectsMessage from './ArchivedProjectsMessage'
+import FilterCheckboxItem from './FilterCheckboxItem'
 
 type OrderByOption = 'createdAt' | 'totalPaid'
 
@@ -71,6 +72,8 @@ export default function Projects() {
   const [includeV1_1, setIncludeV1_1] = useState<boolean>(true)
   const [includeActive, setIncludeActive] = useState<boolean>(true)
   const [includeArchived, setIncludeArchived] = useState<boolean>(false)
+
+  const [showPausedState, setShowPausedState] = useState<boolean>(false)
 
   const loadMoreContainerRef = useRef<HTMLDivElement>(null)
 
@@ -206,6 +209,12 @@ export default function Projects() {
               orderBy={orderBy}
               setOrderBy={setOrderBy}
             />
+          ) : selectedTab === 'trending' && !searchText ? (
+            <FilterCheckboxItem
+              label={t`Show paused state`}
+              checked={showPausedState}
+              onChange={() => setShowPausedState(!showPausedState)}
+            />
           ) : null}
         </div>
         <ArchivedProjectsMessage
@@ -266,7 +275,11 @@ export default function Projects() {
         </div>
       ) : selectedTab === 'trending' ? (
         <div style={{ paddingBottom: 50 }}>
-          <TrendingProjects count={12} trendingWindowDays={7} />
+          <TrendingProjects
+            count={12}
+            trendingWindowDays={7}
+            showPausedState={showPausedState}
+          />
         </div>
       ) : null}
       <FeedbackFormLink />

--- a/src/utils/paymentsPaused.ts
+++ b/src/utils/paymentsPaused.ts
@@ -1,0 +1,47 @@
+import { BigNumber } from 'ethers'
+import { FundingCycle } from 'models/funding-cycle'
+import { FundingCycleMetadata } from 'models/funding-cycle-metadata'
+import { V1TerminalVersion } from 'models/v1/terminals'
+
+import { readNetwork } from 'constants/networks'
+import { disablePayOverrides } from 'constants/v1/overrides'
+
+import { decodeFundingCycleMetadata } from './fundingCycle'
+import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
+
+// v1 projects who still use 100% RR to disable pay
+export const isV1AndMaxRR = (
+  version?: V1TerminalVersion,
+  reservedRate?: number,
+) => version === '1' && reservedRate === 200
+
+// Edge case for MoonDAO, upgraded to v1.1 but can't use payIsPaused for now
+export const isMoonAndMaxRR = (
+  projectId?: BigNumber,
+  fcMetadata?: FundingCycleMetadata,
+) => projectId?.eq(V1_PROJECT_IDS.MOON_DAO) && fcMetadata?.reservedRate === 200
+
+// Gets any case where a project's payments are paused
+export const paymentsPaused = (
+  projectId?: BigNumber,
+  currentFC?: FundingCycle,
+  terminalVersion?: V1TerminalVersion | undefined,
+) => {
+  const overridePayDisabled = Boolean(
+    projectId &&
+      disablePayOverrides[readNetwork.name]?.has(projectId.toNumber()),
+  )
+
+  const fcMetadata: FundingCycleMetadata | undefined =
+    decodeFundingCycleMetadata(currentFC?.metadata)
+
+  fcMetadata?.payIsPaused ||
+    isV1AndMaxRR(terminalVersion, fcMetadata?.reservedRate)
+  return (
+    fcMetadata?.payIsPaused || // v1.1 only
+    overridePayDisabled ||
+    isV1AndMaxRR(terminalVersion, fcMetadata?.reservedRate) || // v1 projects who still use 100% RR to disable pay
+    currentFC?.configured.eq(0) || // Edge case, see sequoiacapitaldao
+    isMoonAndMaxRR(projectId, fcMetadata) // Edge case for MoonDAO
+  )
+}


### PR DESCRIPTION
## What does this PR do and why?

- Adds check box on trending projects to show paused indicator on cards
- Extracts all paymentsPaused logic into `utils` file

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/153337476-48d8112f-6dfe-4616-a761-cc3d92d8019c.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
