### PR TITLE
Make "Claim token as ERC-20" btn a primary btn

### DIFF
--- a/src/components/Project/Rewards/index.tsx
+++ b/src/components/Project/Rewards/index.tsx
@@ -227,7 +227,11 @@ export default function Rewards() {
               </Button>
             </React.Fragment>
           )}
-          <Button onClick={() => setUnstakeModalVisible(true)} block>
+          <Button
+            type="primary"
+            onClick={() => setUnstakeModalVisible(true)}
+            block
+          >
             <Trans>Claim {tokenSymbol || t`tokens`} as ERC20</Trans>
           </Button>
           {hasPrintPreminePermission && projectId?.gt(0) && (


### PR DESCRIPTION
## What does this PR do and why?

Make "Claim token as ERC-20" btn (in "Manage") modal a primary btn to differentiate from "Burn tokens"

## Screenshots or screen recordings

<img width="638" alt="Screen Shot 2022-02-10 at 8 24 08 pm" src="https://user-images.githubusercontent.com/96150256/153388456-ced1346a-1c53-4ec2-93cf-72cf91756dd5.png">

<img width="622" alt="Screen Shot 2022-02-10 at 8 25 37 pm" src="https://user-images.githubusercontent.com/96150256/153388427-53dd8df2-f1c3-405a-b9e0-b72af31527cd.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
