### PR TITLE
Add CI test runner with Github Actions

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   run-yarn-tests:
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false
     name: Run yarn tests
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
 
-  # manual trigger from Github UI - Action tab 
+  # manual trigger from Github UI - Action tab
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add-test-runner-github-action
 
   # manual trigger from Github UI - Action tab
   workflow_dispatch:

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - [review_requested, ready_for_review]
   push:
     branches:
       - main

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - [review_requested, ready_for_review]
   push:
     branches:
       - main
@@ -15,6 +13,7 @@ on:
 
 jobs:
   run-yarn-tests:
+    if: github.event.pull_request.draft == true
     name: Run yarn tests
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -1,11 +1,14 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
 
-  # manual trigger from Github UI - Action tab
+  # manual trigger from Github UI - Action tab 
   workflow_dispatch:
 
 jobs:
@@ -16,13 +19,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Install with yarn
-        uses: borales/actions-yarn@v2.3.0
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
-          cmd: install # will run `yarn install` command
-
-      - name: Test with yarn
-        uses: borales/actions-yarn@v2.3.0
+          node-version: 14
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore cached yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
         with:
-          cmd: test # will run `yarn test` command
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Restore cached node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+          key: ${{ runner.os }}-${{ steps.nvm.outputs.NVMRC }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.nvm.outputs.NVMRC }}-nodemodules-
+      - name: Install JS dependencies
+        if: |
+          steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
+          steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --prefer-offline
+      - name: Tests with yarn
+        run: yarn test

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - add-test-runner-github-action
+
+  # manual trigger from Github UI - Action tab
+  workflow_dispatch:
+
+jobs:
+  run-yarn-tests:
+    name: Run yarn tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install with yarn
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: install # will run `yarn install` command
+
+      - name: Test with yarn
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: test # will run `yarn test` command

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -27,9 +27,11 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(Opcional) Añadir una nota en este pago de forma on-chain"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "({realTokenAllocationPercent}%\n"
+msgid ""
+"({realTokenAllocationPercent}%\n"
 "of all newly minted tokens)."
-msgstr "({realTokenAllocationPercent}%\n"
+msgstr ""
+"({realTokenAllocationPercent}%\n"
 "de todos los tokens recién acuñados)."
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -797,7 +799,8 @@ msgid "Issue ERC-20 token"
 msgstr "Emitir token ERC-20"
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid "Issue an ERC-20 to be used as this project's token. Once\n"
+msgid ""
+"Issue an ERC-20 to be used as this project's token. Once\n"
 "issued, anyone can claim their existing token balance in the new token."
 msgstr "Emite un ERC-20 para que sea usado como token de este proyecto. Una vez emitido, cualquiera puede reclamar su balance existente de tokens como el nuevo token."
 
@@ -1361,7 +1364,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Como no has establecido una duración de financiamiento, los cambios a estos ajustes serán aplicados de inmediato."
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid "Some funding cycle properties may indicate risk\n"
+msgid ""
+"Some funding cycle properties may indicate risk\n"
 "for project contributors."
 msgstr "Algunas propiedades de los ciclos de financiamiento pueden indicar riesgo para los contribuyentes de proyectos."
 
@@ -1452,9 +1456,11 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "El futuro será liderado por creadores y las comunidades serán los dueños."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "The percent this individual receives of the overall {reservedRate}% \n"
+msgid ""
+"The percent this individual receives of the overall {reservedRate}% \n"
 "reserved token allocation"
-msgstr "El porcentaje que recibe esta persona del {reservedRate}% general\n"
+msgstr ""
+"El porcentaje que recibe esta persona del {reservedRate}% general\n"
 "de la asignación de tokens reservados"
 
 #: src/constants/fundingWarningText.ts
@@ -2027,11 +2033,12 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Tipo de cambio de {tokenSymbol}/ETH en {exchangeName}."
 
 #: src/components/Project/Rewards/index.tsx
-msgid "{tokensLabel}\n"
+msgid ""
+"{tokensLabel}\n"
 "are distributed to anyone who pays this project. If the project \n"
 "has set a funding target, tokens can be redeemed for a portion \n"
 "of the project's overflow whether or not they have been claimed yet."
-msgstr "{tokensLabel}\n"
+msgstr ""
+"{tokensLabel}\n"
 "son distribuidos a cualquiera que pague este proyecto. Si el proyecto tiene un objetivo de financiamiento, los tokens pueden ser canjeados por una porción del excedente del proyecto,\n"
 "hayan sido estos reclamados o no."
-

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -27,7 +27,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(Opcional) Adicionar uma nota a esse pagamento em cadeia"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "({realTokenAllocationPercent}%\n"
+msgid ""
+"({realTokenAllocationPercent}%\n"
 "of all newly minted tokens)."
 msgstr "({realTokenAllocationPercent}% de todos os tokens recentemente criados)."
 
@@ -796,7 +797,8 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid "Issue an ERC-20 to be used as this project's token. Once\n"
+msgid ""
+"Issue an ERC-20 to be used as this project's token. Once\n"
 "issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
@@ -1360,7 +1362,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Como você não colocou uma duração de financiamento, as mudanças para essas configurações serão aplicadas imediatamente."
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid "Some funding cycle properties may indicate risk\n"
+msgid ""
+"Some funding cycle properties may indicate risk\n"
 "for project contributors."
 msgstr "Algumas propriedades do ciclo de financiamento podem indicar risco para os contribuidores do projeto."
 
@@ -1451,7 +1454,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "O futuro será liderado pelos criadores, e pertencente às comunidades."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "The percent this individual receives of the overall {reservedRate}% \n"
+msgid ""
+"The percent this individual receives of the overall {reservedRate}% \n"
 "reserved token allocation"
 msgstr "O percentual que esse individuo recebe do todo de {reservedRate}% de token alocados como reservados"
 
@@ -2025,10 +2029,11 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{tokenSymbol}/ETH taxa de câmbio em {exchangeName}."
 
 #: src/components/Project/Rewards/index.tsx
-msgid "{tokensLabel}\n"
+msgid ""
+"{tokensLabel}\n"
 "are distributed to anyone who pays this project. If the project \n"
 "has set a funding target, tokens can be redeemed for a portion \n"
 "of the project's overflow whether or not they have been claimed yet."
-msgstr "{tokensLabel}\n"
+msgstr ""
+"{tokensLabel}\n"
 "são distribuídos para qualquer pessoa que pague este projeto. Se o projeto já definiu o objetivo de financiamento, os tokens podem ser resgatados por uma porção de overflow do projeto caso eles tenham ou não sido reivindicados ainda."
-

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -27,7 +27,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(Необязательно) Добавить примечание к этому платежу в цепочке"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "({realTokenAllocationPercent}%\n"
+msgid ""
+"({realTokenAllocationPercent}%\n"
 "of all newly minted tokens)."
 msgstr ""
 
@@ -796,7 +797,8 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid "Issue an ERC-20 to be used as this project's token. Once\n"
+msgid ""
+"Issue an ERC-20 to be used as this project's token. Once\n"
 "issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
@@ -1360,7 +1362,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr ""
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid "Some funding cycle properties may indicate risk\n"
+msgid ""
+"Some funding cycle properties may indicate risk\n"
 "for project contributors."
 msgstr ""
 
@@ -1451,7 +1454,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "Будущее будет возглавляться создателями и принадлежать сообществам."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "The percent this individual receives of the overall {reservedRate}% \n"
+msgid ""
+"The percent this individual receives of the overall {reservedRate}% \n"
 "reserved token allocation"
 msgstr ""
 
@@ -2025,9 +2029,9 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Обменный курс {tokenSymbol}/ETH на {exchangeName}."
 
 #: src/components/Project/Rewards/index.tsx
-msgid "{tokensLabel}\n"
+msgid ""
+"{tokensLabel}\n"
 "are distributed to anyone who pays this project. If the project \n"
 "has set a funding target, tokens can be redeemed for a portion \n"
 "of the project's overflow whether or not they have been claimed yet."
 msgstr ""
-

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -27,7 +27,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(İsteğe bağlı) Bu ödemeye zincir üstü bir not ekleyin"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "({realTokenAllocationPercent}%\n"
+msgid ""
+"({realTokenAllocationPercent}%\n"
 "of all newly minted tokens)."
 msgstr ""
 
@@ -796,7 +797,8 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid "Issue an ERC-20 to be used as this project's token. Once\n"
+msgid ""
+"Issue an ERC-20 to be used as this project's token. Once\n"
 "issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
@@ -1360,7 +1362,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr ""
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid "Some funding cycle properties may indicate risk\n"
+msgid ""
+"Some funding cycle properties may indicate risk\n"
 "for project contributors."
 msgstr "Bazı finansman döngüsü özellikleri projeye katkıda bulunanlar için risk oluşturabilir."
 
@@ -1451,7 +1454,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "Gelecek, içerik üreticileri tarafından yönetilecek ve topluluklara ait olacak."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "The percent this individual receives of the overall {reservedRate}% \n"
+msgid ""
+"The percent this individual receives of the overall {reservedRate}% \n"
 "reserved token allocation"
 msgstr ""
 
@@ -2025,9 +2029,9 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{exchangeName} üzerinde {tokenSymbol}/ETH kuru."
 
 #: src/components/Project/Rewards/index.tsx
-msgid "{tokensLabel}\n"
+msgid ""
+"{tokensLabel}\n"
 "are distributed to anyone who pays this project. If the project \n"
 "has set a funding target, tokens can be redeemed for a portion \n"
 "of the project's overflow whether or not they have been claimed yet."
 msgstr ""
-

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -27,9 +27,11 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "（可选的）在此链上付款中添加备注"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "({realTokenAllocationPercent}%\n"
+msgid ""
+"({realTokenAllocationPercent}%\n"
 "of all newly minted tokens)."
-msgstr "（{realTokenAllocationPercent}%\n"
+msgstr ""
+"（{realTokenAllocationPercent}%\n"
 "新铸造的代币）。"
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -797,7 +799,8 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid "Issue an ERC-20 to be used as this project's token. Once\n"
+msgid ""
+"Issue an ERC-20 to be used as this project's token. Once\n"
 "issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
@@ -970,7 +973,8 @@ msgstr "未设定"
 
 #: src/components/Landing/index.tsx
 msgid "Note: Juicebox is new, unaudited, and not guaranteed to work perfectly. Before spending money, do your own research: <0>ask questions</0>, <1>check out the code</1>, and understand the risks!"
-msgstr "注意： Juicebox是一个全新的协议，它未经审计且不保证能完美工作。\n"
+msgstr ""
+"注意： Juicebox是一个全新的协议，它未经审计且不保证能完美工作。\n"
 " 在花钱之前请先做好您自己的研究：提出疑问，核查代码以及了解所涉及的风险！"
 
 #: src/components/Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -1362,7 +1366,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr ""
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid "Some funding cycle properties may indicate risk\n"
+msgid ""
+"Some funding cycle properties may indicate risk\n"
 "for project contributors."
 msgstr "一些筹款周期的配置可能会给项目贡献者们造成一些风险。"
 
@@ -1453,7 +1458,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "创造者将引领未来, 而社区会拥有未来."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid "The percent this individual receives of the overall {reservedRate}% \n"
+msgid ""
+"The percent this individual receives of the overall {reservedRate}% \n"
 "reserved token allocation"
 msgstr "这个地址会收到保留代币中的 {reservedRate}%"
 
@@ -2027,9 +2033,9 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "在 {exchangeName} 的兑换率为 {tokenSymbol}/ETH"
 
 #: src/components/Project/Rewards/index.tsx
-msgid "{tokensLabel}\n"
+msgid ""
+"{tokensLabel}\n"
 "are distributed to anyone who pays this project. If the project \n"
 "has set a funding target, tokens can be redeemed for a portion \n"
 "of the project's overflow whether or not they have been claimed yet."
 msgstr ""
-


### PR DESCRIPTION
## What does this PR do and why?

This PR closes #512 by adding a Github Actions workflow that runs `yarn install` (with caching) and `yarn test` on commits and PRs to `main` to our CI pipeline.

## Screenshots or screen recordings

[This](https://github.com/seanmc9/juice-interface/runs/5142469887?check_suite_focus=true) is an example of a successful run.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
