### PR TITLE
Make util functions to replace `tokenSymbol ?? "token"` all over the codebase

### DIFF
--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -13,7 +13,7 @@ import { V1FundingCycle } from 'models/v1/fundingCycle'
 import { TicketMod } from 'models/mods'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 import { formatWad, fromPermyriad } from 'utils/formatNumber'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 export default function TicketModsList({
   total,
@@ -89,7 +89,7 @@ export default function TicketModsList({
                     (total
                       ? ` (${formatWad(total?.mul(mod.percent).div(10000), {
                           precision: 0,
-                        })} ${pluralTokenShort(tokenSymbol)})`
+                        })} ${tokenSymbolText(tokenSymbol, false, true)})`
                       : '')
                   }
                 />
@@ -106,7 +106,7 @@ export default function TicketModsList({
               {total
                 ? ` (${formatWad(total?.mul(ownerPercent).div(10000), {
                     precision: 0,
-                  })} ${pluralTokenShort(tokenSymbol)})`
+                  })} ${tokenSymbolText(tokenSymbol, false, true)})`
                 : ''}
             </span>
           }

--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -13,6 +13,7 @@ import { V1FundingCycle } from 'models/v1/fundingCycle'
 import { TicketMod } from 'models/mods'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 import { formatWad, fromPermyriad } from 'utils/formatNumber'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 export default function TicketModsList({
   total,
@@ -88,7 +89,7 @@ export default function TicketModsList({
                     (total
                       ? ` (${formatWad(total?.mul(mod.percent).div(10000), {
                           precision: 0,
-                        })} ${tokenSymbol ?? ' tokens'})`
+                        })} ${pluralTokenShort(tokenSymbol)})`
                       : '')
                   }
                 />
@@ -105,7 +106,7 @@ export default function TicketModsList({
               {total
                 ? ` (${formatWad(total?.mul(ownerPercent).div(10000), {
                     precision: 0,
-                  })} ${tokenSymbol ?? ' tokens'})`
+                  })} ${pluralTokenShort(tokenSymbol)})`
                 : ''}
             </span>
           }

--- a/src/components/shared/TicketModsList.tsx
+++ b/src/components/shared/TicketModsList.tsx
@@ -89,7 +89,11 @@ export default function TicketModsList({
                     (total
                       ? ` (${formatWad(total?.mul(mod.percent).div(10000), {
                           precision: 0,
-                        })} ${tokenSymbolText(tokenSymbol, false, true)})`
+                        })} ${tokenSymbolText({
+                          tokenSymbol: tokenSymbol,
+                          capitalize: false,
+                          plural: true,
+                        })})`
                       : '')
                   }
                 />
@@ -106,7 +110,11 @@ export default function TicketModsList({
               {total
                 ? ` (${formatWad(total?.mul(ownerPercent).div(10000), {
                     precision: 0,
-                  })} ${tokenSymbolText(tokenSymbol, false, true)})`
+                  })} ${tokenSymbolText({
+                    tokenSymbol: tokenSymbol,
+                    capitalize: false,
+                    plural: true,
+                  })})`
                 : ''}
             </span>
           }

--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -153,9 +153,7 @@ export default function FundingCycleDetails({
                 capitalize: false,
                 plural: true,
               })}`}
-              tip={t`Whenever someone pays your project, this percentage of tokens will be reserved and the 
-              rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other 
-              wallet addresses by the owner. Once tokens are reserved, anyone can "mint" them, which distributes them to their intended receivers.`}
+              tip={t`Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can "mint" them, which distributes them to their intended receivers.`}
             />
           }
         >
@@ -176,9 +174,7 @@ export default function FundingCycleDetails({
                 tokenSymbol: tokenSymbol,
                 capitalize: false,
                 plural: true,
-              })} received per ETH 
-              paid to the treasury. This can change over time according to the discount rate 
-              and reserved tokens amount of future funding cycles.`}
+              })} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles.`}
             />
           }
           span={2}

--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -148,7 +148,11 @@ export default function FundingCycleDetails({
         <Descriptions.Item
           label={
             <TooltipLabel
-              label={t`Reserved ${tokenSymbolText(tokenSymbol, false, true)}`}
+              label={t`Reserved ${tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })}`}
               tip={t`Whenever someone pays your project, this percentage of tokens will be reserved and the 
               rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other 
               wallet addresses by the owner. Once tokens are reserved, anyone can "mint" them, which distributes them to their intended receivers.`}
@@ -168,11 +172,11 @@ export default function FundingCycleDetails({
           label={
             <TooltipLabel
               label={t`Issue rate`}
-              tip={t`${tokenSymbolText(
-                tokenSymbol,
-                false,
-                true,
-              )} received per ETH 
+              tip={t`${tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })} received per ETH 
               paid to the treasury. This can change over time according to the discount rate 
               and reserved tokens amount of future funding cycles.`}
             />
@@ -190,7 +194,14 @@ export default function FundingCycleDetails({
                 },
               )} reserved)`
             : ''}{' '}
-          <Trans>{tokenSymbolText(tokenSymbol, false, true)}/ETH</Trans>
+          <Trans>
+            {tokenSymbolText({
+              tokenSymbol: tokenSymbol,
+              capitalize: false,
+              plural: true,
+            })}
+            /ETH
+          </Trans>
         </Descriptions.Item>
 
         <Descriptions.Item

--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -18,7 +18,7 @@ import {
   isRecurring,
 } from 'utils/fundingCycle'
 import { weightedRate } from 'utils/math'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
 
@@ -148,7 +148,7 @@ export default function FundingCycleDetails({
         <Descriptions.Item
           label={
             <TooltipLabel
-              label={t`Reserved ${pluralTokenShort(tokenSymbol)}`}
+              label={t`Reserved ${tokenSymbolText(tokenSymbol, false, true)}`}
               tip={t`Whenever someone pays your project, this percentage of tokens will be reserved and the 
               rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other 
               wallet addresses by the owner. Once tokens are reserved, anyone can "mint" them, which distributes them to their intended receivers.`}
@@ -168,7 +168,11 @@ export default function FundingCycleDetails({
           label={
             <TooltipLabel
               label={t`Issue rate`}
-              tip={t`${pluralTokenShort(tokenSymbol, true)} received per ETH 
+              tip={t`${tokenSymbolText(
+                tokenSymbol,
+                false,
+                true,
+              )} received per ETH 
               paid to the treasury. This can change over time according to the discount rate 
               and reserved tokens amount of future funding cycles.`}
             />
@@ -186,23 +190,8 @@ export default function FundingCycleDetails({
                 },
               )} reserved)`
             : ''}{' '}
-          <Trans>{pluralTokenShort(tokenSymbol)}/ETH</Trans>
+          <Trans>{tokenSymbolText(tokenSymbol, false, true)}/ETH</Trans>
         </Descriptions.Item>
-
-        {/* <Descriptions.Item
-          span={2}
-          label={
-            <TooltipLabel
-              label={t`Redeem rate`}
-              tip={t`The amount of ${pluralTokenLong(tokenSymbol)} that must be redeemed in exchange for one ETH of overflow. This can change over time according to the bonding curve of future funding cycles.`}
-            />
-          }
-        >
-          {redeemRate && redeemRate?.gt(0)
-            ? formattedNum(parseWad(1).div(redeemRate))
-            : '--'}{' '}
-          {pluralTokenShort(tokenSymbol)}/ETH
-        </Descriptions.Item> */}
 
         <Descriptions.Item
           span={2}

--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -18,6 +18,7 @@ import {
   isRecurring,
 } from 'utils/fundingCycle'
 import { weightedRate } from 'utils/math'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
 
@@ -147,8 +148,10 @@ export default function FundingCycleDetails({
         <Descriptions.Item
           label={
             <TooltipLabel
-              label={t`Reserved ${tokenSymbol ?? 'tokens'}`}
-              tip={t`Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can "mint" them, which distributes them to their intended receivers.`}
+              label={t`Reserved ${pluralTokenShort(tokenSymbol)}`}
+              tip={t`Whenever someone pays your project, this percentage of tokens will be reserved and the 
+              rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other 
+              wallet addresses by the owner. Once tokens are reserved, anyone can "mint" them, which distributes them to their intended receivers.`}
             />
           }
         >
@@ -165,9 +168,9 @@ export default function FundingCycleDetails({
           label={
             <TooltipLabel
               label={t`Issue rate`}
-              tip={t`${
-                tokenSymbol ?? 'Tokens'
-              } received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles.`}
+              tip={t`${pluralTokenShort(tokenSymbol, true)} received per ETH 
+              paid to the treasury. This can change over time according to the discount rate 
+              and reserved tokens amount of future funding cycles.`}
             />
           }
           span={2}
@@ -183,24 +186,22 @@ export default function FundingCycleDetails({
                 },
               )} reserved)`
             : ''}{' '}
-          <Trans>{tokenSymbol ?? 'tokens'}/ETH</Trans>
+          <Trans>{pluralTokenShort(tokenSymbol)}/ETH</Trans>
         </Descriptions.Item>
 
         {/* <Descriptions.Item
           span={2}
           label={
             <TooltipLabel
-              label="Burn rate"
-              tip={`The amount of ${
-                tokenSymbol ? tokenSymbol + ' token' : 'token'
-              } that must be burned in exchange for one ETH of overflow. This can change over time according to the bonding curve of future funding cycles.`}
+              label={t`Redeem rate`}
+              tip={t`The amount of ${pluralTokenLong(tokenSymbol)} that must be redeemed in exchange for one ETH of overflow. This can change over time according to the bonding curve of future funding cycles.`}
             />
           }
         >
           {redeemRate && redeemRate?.gt(0)
             ? formattedNum(parseWad(1).div(redeemRate))
             : '--'}{' '}
-          {tokenSymbol ?? 'tokens'}/ETH
+          {pluralTokenShort(tokenSymbol)}/ETH
         </Descriptions.Item> */}
 
         <Descriptions.Item

--- a/src/components/v1/FundingCycle/ReservedTokens.tsx
+++ b/src/components/v1/FundingCycle/ReservedTokens.tsx
@@ -10,6 +10,7 @@ import { NetworkName } from 'models/network-name'
 import { useContext, useState } from 'react'
 import { formatWad, fromPerbicent } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 import { readNetwork } from 'constants/networks'
 
@@ -48,7 +49,7 @@ export default function ReservedTokens({
         <TooltipLabel
           label={
             <h4 style={{ display: 'inline-block' }}>
-              <Trans>Reserved {tokenSymbol ?? t`tokens`}</Trans> (
+              <Trans>Reserved {pluralTokenShort(tokenSymbol)}</Trans> (
               {fromPerbicent(metadata?.reservedRate)}%)
             </h4>
           }

--- a/src/components/v1/FundingCycle/ReservedTokens.tsx
+++ b/src/components/v1/FundingCycle/ReservedTokens.tsx
@@ -10,7 +10,7 @@ import { NetworkName } from 'models/network-name'
 import { useContext, useState } from 'react'
 import { formatWad, fromPerbicent } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { readNetwork } from 'constants/networks'
 
@@ -49,8 +49,10 @@ export default function ReservedTokens({
         <TooltipLabel
           label={
             <h4 style={{ display: 'inline-block' }}>
-              <Trans>Reserved {pluralTokenShort(tokenSymbol)}</Trans> (
-              {fromPerbicent(metadata?.reservedRate)}%)
+              <Trans>
+                Reserved {tokenSymbolText(tokenSymbol, false, true)}
+              </Trans>{' '}
+              ({fromPerbicent(metadata?.reservedRate)}%)
             </h4>
           }
           tip={t`A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time.`}

--- a/src/components/v1/FundingCycle/ReservedTokens.tsx
+++ b/src/components/v1/FundingCycle/ReservedTokens.tsx
@@ -50,7 +50,12 @@ export default function ReservedTokens({
           label={
             <h4 style={{ display: 'inline-block' }}>
               <Trans>
-                Reserved {tokenSymbolText(tokenSymbol, false, true)}
+                Reserved{' '}
+                {tokenSymbolText({
+                  tokenSymbol: tokenSymbol,
+                  capitalize: false,
+                  plural: true,
+                })}
               </Trans>{' '}
               ({fromPerbicent(metadata?.reservedRate)}%)
             </h4>

--- a/src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
+++ b/src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
@@ -46,10 +46,18 @@ export default function DistributeTokensModal({
 
   return (
     <Modal
-      title={`Distribute reserved ${tokenSymbolText(tokenSymbol, false, true)}`}
+      title={`Distribute reserved ${tokenSymbolText({
+        tokenSymbol: tokenSymbol,
+        capitalize: false,
+        plural: true,
+      })}`}
       visible={visible}
       onOk={distribute}
-      okText={`Distribute ${tokenSymbolText(tokenSymbol, false, true)}`}
+      okText={`Distribute ${tokenSymbolText({
+        tokenSymbol: tokenSymbol,
+        capitalize: false,
+        plural: true,
+      })}`}
       confirmLoading={loading}
       onCancel={onCancel}
       okButtonProps={{ disabled: !reservedTokens?.gt(0) }}
@@ -81,8 +89,13 @@ export default function DistributeTokensModal({
         ) : (
           <p>
             <Trans>
-              All {tokenSymbolText(tokenSymbol, false, true)} will go to the
-              project owner:
+              All{' '}
+              {tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })}{' '}
+              will go to the project owner:
             </Trans>{' '}
             <FormattedAddress address={owner} />
           </p>

--- a/src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
+++ b/src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
@@ -8,7 +8,7 @@ import { useDistributeTokensTx } from 'hooks/v1/transactor/DistributeTokensTx'
 import { useContext, useState } from 'react'
 import { formatWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 export default function DistributeTokensModal({
   visible,
@@ -46,10 +46,10 @@ export default function DistributeTokensModal({
 
   return (
     <Modal
-      title={`Distribute reserved ${pluralTokenShort(tokenSymbol)}`}
+      title={`Distribute reserved ${tokenSymbolText(tokenSymbol, false, true)}`}
       visible={visible}
       onOk={distribute}
-      okText={`Distribute ${pluralTokenShort(tokenSymbol)}`}
+      okText={`Distribute ${tokenSymbolText(tokenSymbol, false, true)}`}
       confirmLoading={loading}
       onCancel={onCancel}
       okButtonProps={{ disabled: !reservedTokens?.gt(0) }}
@@ -81,7 +81,8 @@ export default function DistributeTokensModal({
         ) : (
           <p>
             <Trans>
-              All {pluralTokenShort(tokenSymbol)} will go to the project owner:
+              All {tokenSymbolText(tokenSymbol, false, true)} will go to the
+              project owner:
             </Trans>{' '}
             <FormattedAddress address={owner} />
           </p>

--- a/src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
+++ b/src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
@@ -8,6 +8,7 @@ import { useDistributeTokensTx } from 'hooks/v1/transactor/DistributeTokensTx'
 import { useContext, useState } from 'react'
 import { formatWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 export default function DistributeTokensModal({
   visible,
@@ -45,10 +46,10 @@ export default function DistributeTokensModal({
 
   return (
     <Modal
-      title={`Distribute reserved ${tokenSymbol ?? 'tokens'}`}
+      title={`Distribute reserved ${pluralTokenShort(tokenSymbol)}`}
       visible={visible}
       onOk={distribute}
-      okText={`Distribute ${tokenSymbol ?? 'tokens'}`}
+      okText={`Distribute ${pluralTokenShort(tokenSymbol)}`}
       confirmLoading={loading}
       onCancel={onCancel}
       okButtonProps={{ disabled: !reservedTokens?.gt(0) }}
@@ -80,7 +81,7 @@ export default function DistributeTokensModal({
         ) : (
           <p>
             <Trans>
-              All {tokenSymbol ?? 'tokens'} will go to the project owner:
+              All {pluralTokenShort(tokenSymbol)} will go to the project owner:
             </Trans>{' '}
             <FormattedAddress address={owner} />
           </p>

--- a/src/components/v1/V1Project/Pay/PayInputSubText.tsx
+++ b/src/components/v1/V1Project/Pay/PayInputSubText.tsx
@@ -4,7 +4,7 @@ import { parseEther } from 'ethers/lib/utils'
 import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { currencyName } from 'utils/currency'
 import { weightedRate } from 'utils/math'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 import { Trans } from '@lingui/macro'
 import { CurrencyOption } from 'models/currency-option'
 import { useContext, useMemo } from 'react'
@@ -39,7 +39,7 @@ export default function PayInputSubText({
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const tokenText = pluralTokenShort(tokenSymbol)
+  const tokenText = tokenSymbolText(tokenSymbol, false, true)
 
   const receiveText = useMemo(() => {
     const formatReceivedTickets = (wei: BigNumber) => {

--- a/src/components/v1/V1Project/Pay/PayInputSubText.tsx
+++ b/src/components/v1/V1Project/Pay/PayInputSubText.tsx
@@ -4,7 +4,8 @@ import { parseEther } from 'ethers/lib/utils'
 import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { currencyName } from 'utils/currency'
 import { weightedRate } from 'utils/math'
-import { t, Trans } from '@lingui/macro'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { Trans } from '@lingui/macro'
 import { CurrencyOption } from 'models/currency-option'
 import { useContext, useMemo } from 'react'
 
@@ -38,7 +39,7 @@ export default function PayInputSubText({
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const tokenText = tokenSymbol ?? t`tokens`
+  const tokenText = pluralTokenShort(tokenSymbol)
 
   const receiveText = useMemo(() => {
     const formatReceivedTickets = (wei: BigNumber) => {

--- a/src/components/v1/V1Project/Pay/PayInputSubText.tsx
+++ b/src/components/v1/V1Project/Pay/PayInputSubText.tsx
@@ -39,7 +39,11 @@ export default function PayInputSubText({
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const tokenText = tokenSymbolText(tokenSymbol, false, true)
+  const tokenText = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })
 
   const receiveText = useMemo(() => {
     const formatReceivedTickets = (wei: BigNumber) => {

--- a/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
@@ -8,7 +8,7 @@ import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import React, { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { CURRENCY_ETH } from 'constants/currency'
 
@@ -86,7 +86,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                     }}
                   >
                     {formatWad(e.amount, { precision: 0 })}{' '}
-                    {pluralTokenShort(tokenSymbol)}
+                    {tokenSymbolText(tokenSymbol, false, true)}
                   </div>
                 </div>
 

--- a/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
@@ -86,7 +86,11 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                     }}
                   >
                     {formatWad(e.amount, { precision: 0 })}{' '}
-                    {tokenSymbolText(tokenSymbol, false, true)}
+                    {tokenSymbolText({
+                      tokenSymbol: tokenSymbol,
+                      capitalize: false,
+                      plural: true,
+                    })}
                   </div>
                 </div>
 

--- a/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
@@ -8,6 +8,7 @@ import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import React, { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 import { CURRENCY_ETH } from 'constants/currency'
 
@@ -85,7 +86,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                     }}
                   >
                     {formatWad(e.amount, { precision: 0 })}{' '}
-                    {tokenSymbol ?? 'tokens'}
+                    {pluralTokenShort(tokenSymbol)}
                   </div>
                 </div>
 

--- a/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
@@ -67,7 +67,12 @@ export default function ReservesEventElem({
         }}
       >
         <div style={smallHeaderStyle(colors)}>
-          Distributed reserved {tokenSymbolText(tokenSymbol, false, true)}
+          Distributed reserved{' '}
+          {tokenSymbolText({
+            tokenSymbol: tokenSymbol,
+            capitalize: false,
+            plural: true,
+          })}
         </div>
 
         <div style={{ textAlign: 'right' }}>

--- a/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
@@ -8,7 +8,7 @@ import { PrintReservesEvent } from 'models/subgraph-entities/print-reserves-even
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { smallHeaderStyle } from '../styles'
 
@@ -67,7 +67,7 @@ export default function ReservesEventElem({
         }}
       >
         <div style={smallHeaderStyle(colors)}>
-          Distributed reserved {pluralTokenShort(tokenSymbol)}
+          Distributed reserved {tokenSymbolText(tokenSymbol, false, true)}
         </div>
 
         <div style={{ textAlign: 'right' }}>

--- a/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
@@ -8,6 +8,7 @@ import { PrintReservesEvent } from 'models/subgraph-entities/print-reserves-even
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 import { smallHeaderStyle } from '../styles'
 
@@ -66,7 +67,7 @@ export default function ReservesEventElem({
         }}
       >
         <div style={smallHeaderStyle(colors)}>
-          Distributed reserved {tokenSymbol ?? 'tokens'}
+          Distributed reserved {pluralTokenShort(tokenSymbol)}
         </div>
 
         <div style={{ textAlign: 'right' }}>

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -22,7 +22,7 @@ import useUnclaimedBalanceOfUser from 'hooks/v1/contractReader/UnclaimedBalanceO
 import React, { CSSProperties, useContext, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
-import { pluralTokenLong } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import PrintPreminedModal from '../modals/PrintPreminedModal'
 import IssueTickets from './IssueTickets'
@@ -200,7 +200,7 @@ export default function Rewards() {
       </Space>
 
       <Modal
-        title={t`Manage ${pluralTokenLong(tokenSymbol)}`}
+        title={t`Manage ${tokenSymbolText(tokenSymbol, false, true, true)}`}
         visible={manageTokensModalVisible}
         onCancel={() => setManageTokensModalVisible(false)}
         okButtonProps={{ hidden: true }}

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -22,6 +22,7 @@ import useUnclaimedBalanceOfUser from 'hooks/v1/contractReader/UnclaimedBalanceO
 import React, { CSSProperties, useContext, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
+import { pluralTokenLong } from 'utils/tokenSymbolText'
 
 import PrintPreminedModal from '../modals/PrintPreminedModal'
 import IssueTickets from './IssueTickets'
@@ -199,7 +200,7 @@ export default function Rewards() {
       </Space>
 
       <Modal
-        title={t`Manage ${tokenSymbol ? tokenSymbol + ' ' : ''}tokens`}
+        title={t`Manage ${pluralTokenLong(tokenSymbol)}`}
         visible={manageTokensModalVisible}
         onCancel={() => setManageTokensModalVisible(false)}
         okButtonProps={{ hidden: true }}

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -200,7 +200,12 @@ export default function Rewards() {
       </Space>
 
       <Modal
-        title={t`Manage ${tokenSymbolText(tokenSymbol, false, true, true)}`}
+        title={t`Manage ${tokenSymbolText({
+          tokenSymbol: tokenSymbol,
+          capitalize: false,
+          plural: true,
+          includeTokenWord: true,
+        })}`}
         visible={manageTokensModalVisible}
         onCancel={() => setManageTokensModalVisible(false)}
         okButtonProps={{ hidden: true }}

--- a/src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -13,6 +13,7 @@ import { useContext, useState } from 'react'
 import { currencyName } from 'utils/currency'
 import { formattedNum, formatWad } from 'utils/formatNumber'
 import { weightedRate } from 'utils/math'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 import ProjectRiskNotice from './ProjectRiskNotice'
 
@@ -107,7 +108,7 @@ export default function ConfirmPayOwnerModal({
             {currencyName(0)})
           </Descriptions.Item>
           <Descriptions.Item
-            label={t`${tokenSymbol ?? 'Tokens'} for you`}
+            label={t`${pluralTokenShort(tokenSymbol, true)} for you`}
             className="content-right"
           >
             <div>{formatWad(receivedTickets, { precision: 0 })}</div>
@@ -120,7 +121,7 @@ export default function ConfirmPayOwnerModal({
             </div>
           </Descriptions.Item>
           <Descriptions.Item
-            label={t`${tokenSymbol ?? 'Tokens'} reserved`}
+            label={t`${pluralTokenShort(tokenSymbol, true)} reserved`}
             className="content-right"
           >
             {formatWad(ownerTickets, { precision: 0 })}

--- a/src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -108,7 +108,11 @@ export default function ConfirmPayOwnerModal({
             {currencyName(0)})
           </Descriptions.Item>
           <Descriptions.Item
-            label={t`${tokenSymbolText(tokenSymbol, true, true)} for you`}
+            label={t`${tokenSymbolText({
+              tokenSymbol: tokenSymbol,
+              capitalize: true,
+              plural: true,
+            })} for you`}
             className="content-right"
           >
             <div>{formatWad(receivedTickets, { precision: 0 })}</div>
@@ -121,7 +125,11 @@ export default function ConfirmPayOwnerModal({
             </div>
           </Descriptions.Item>
           <Descriptions.Item
-            label={t`${tokenSymbolText(tokenSymbol, true, true)} reserved`}
+            label={t`${tokenSymbolText({
+              tokenSymbol: tokenSymbol,
+              capitalize: true,
+              plural: true,
+            })} reserved`}
             className="content-right"
           >
             {formatWad(ownerTickets, { precision: 0 })}

--- a/src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -13,7 +13,7 @@ import { useContext, useState } from 'react'
 import { currencyName } from 'utils/currency'
 import { formattedNum, formatWad } from 'utils/formatNumber'
 import { weightedRate } from 'utils/math'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import ProjectRiskNotice from './ProjectRiskNotice'
 
@@ -108,7 +108,7 @@ export default function ConfirmPayOwnerModal({
             {currencyName(0)})
           </Descriptions.Item>
           <Descriptions.Item
-            label={t`${pluralTokenShort(tokenSymbol, true)} for you`}
+            label={t`${tokenSymbolText(tokenSymbol, true, true)} for you`}
             className="content-right"
           >
             <div>{formatWad(receivedTickets, { precision: 0 })}</div>
@@ -121,7 +121,7 @@ export default function ConfirmPayOwnerModal({
             </div>
           </Descriptions.Item>
           <Descriptions.Item
-            label={t`${pluralTokenShort(tokenSymbol, true)} reserved`}
+            label={t`${tokenSymbolText(tokenSymbol, true, true)} reserved`}
             className="content-right"
           >
             {formatWad(ownerTickets, { precision: 0 })}

--- a/src/components/v1/V1Project/modals/ParticipantsModal.tsx
+++ b/src/components/v1/V1Project/modals/ParticipantsModal.tsx
@@ -133,7 +133,13 @@ export default function ParticipantsModal({
             value={sortPayerReports}
           >
             <Select.Option value="balance">
-              <Trans>{tokenSymbolText(tokenSymbol, true)} balance</Trans>
+              <Trans>
+                {tokenSymbolText({
+                  tokenSymbol: tokenSymbol,
+                  capitalize: true,
+                })}{' '}
+                balance
+              </Trans>
             </Select.Option>
             <Select.Option value="totalPaid">
               <Trans>Amount paid</Trans>
@@ -205,13 +211,22 @@ export default function ParticipantsModal({
                   }}
                 >
                   {formatWad(p.balance, { precision: 0 })}{' '}
-                  {tokenSymbolText(tokenSymbol, false, true)} (
-                  {formatPercent(p.balance, totalTokenSupply)}%)
+                  {tokenSymbolText({
+                    tokenSymbol: tokenSymbol,
+                    capitalize: false,
+                    plural: true,
+                  })}{' '}
+                  ({formatPercent(p.balance, totalTokenSupply)}%)
                 </div>
                 <div style={smallHeaderStyle}>
                   {formatWad(p.stakedBalance, { precision: 0 })}{' '}
                   <Trans>
-                    {tokenSymbolText(tokenSymbol, false, true)} staked
+                    {tokenSymbolText({
+                      tokenSymbol: tokenSymbol,
+                      capitalize: false,
+                      plural: true,
+                    })}{' '}
+                    staked
                   </Trans>
                 </div>
               </div>
@@ -248,7 +263,10 @@ export default function ParticipantsModal({
     >
       <div>
         <h4>
-          <Trans>{tokenSymbolText(tokenSymbol, true)} holders</Trans>
+          <Trans>
+            {tokenSymbolText({ tokenSymbol: tokenSymbol, capitalize: true })}{' '}
+            holders
+          </Trans>
         </h4>
 
         {tokenAddress && tokenAddress !== constants.AddressZero && (

--- a/src/components/v1/V1Project/modals/ParticipantsModal.tsx
+++ b/src/components/v1/V1Project/modals/ParticipantsModal.tsx
@@ -20,6 +20,7 @@ import { Participant } from 'models/subgraph-entities/participant'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { OrderDirection, querySubgraph } from 'utils/graph'
+import { pluralTokenShort, singleTokenShort } from 'utils/tokenSymbolText'
 
 import { indexedProjectERC20s } from 'constants/v1/indexedProjectERC20s'
 
@@ -132,7 +133,7 @@ export default function ParticipantsModal({
             value={sortPayerReports}
           >
             <Select.Option value="balance">
-              <Trans>{tokenSymbol ?? 'Token'} balance</Trans>
+              <Trans>{singleTokenShort(tokenSymbol, true)} balance</Trans>
             </Select.Option>
             <Select.Option value="totalPaid">
               <Trans>Amount paid</Trans>
@@ -204,12 +205,12 @@ export default function ParticipantsModal({
                   }}
                 >
                   {formatWad(p.balance, { precision: 0 })}{' '}
-                  {tokenSymbol ?? 'tokens'} (
+                  {pluralTokenShort(tokenSymbol)} (
                   {formatPercent(p.balance, totalTokenSupply)}%)
                 </div>
                 <div style={smallHeaderStyle}>
                   {formatWad(p.stakedBalance, { precision: 0 })}{' '}
-                  <Trans>{tokenSymbol ?? 'tokens'} staked</Trans>
+                  <Trans>{pluralTokenShort(tokenSymbol)} staked</Trans>
                 </div>
               </div>
             </div>
@@ -245,7 +246,7 @@ export default function ParticipantsModal({
     >
       <div>
         <h4>
-          <Trans>{tokenSymbol || 'Token'} holders</Trans>
+          <Trans>{singleTokenShort(tokenSymbol, true)} holders</Trans>
         </h4>
 
         {tokenAddress && tokenAddress !== constants.AddressZero && (

--- a/src/components/v1/V1Project/modals/ParticipantsModal.tsx
+++ b/src/components/v1/V1Project/modals/ParticipantsModal.tsx
@@ -20,7 +20,7 @@ import { Participant } from 'models/subgraph-entities/participant'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { OrderDirection, querySubgraph } from 'utils/graph'
-import { pluralTokenShort, singleTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { indexedProjectERC20s } from 'constants/v1/indexedProjectERC20s'
 
@@ -133,7 +133,7 @@ export default function ParticipantsModal({
             value={sortPayerReports}
           >
             <Select.Option value="balance">
-              <Trans>{singleTokenShort(tokenSymbol, true)} balance</Trans>
+              <Trans>{tokenSymbolText(tokenSymbol, true)} balance</Trans>
             </Select.Option>
             <Select.Option value="totalPaid">
               <Trans>Amount paid</Trans>
@@ -205,12 +205,14 @@ export default function ParticipantsModal({
                   }}
                 >
                   {formatWad(p.balance, { precision: 0 })}{' '}
-                  {pluralTokenShort(tokenSymbol)} (
+                  {tokenSymbolText(tokenSymbol, false, true)} (
                   {formatPercent(p.balance, totalTokenSupply)}%)
                 </div>
                 <div style={smallHeaderStyle}>
                   {formatWad(p.stakedBalance, { precision: 0 })}{' '}
-                  <Trans>{pluralTokenShort(tokenSymbol)} staked</Trans>
+                  <Trans>
+                    {tokenSymbolText(tokenSymbol, false, true)} staked
+                  </Trans>
                 </div>
               </div>
             </div>
@@ -246,7 +248,7 @@ export default function ParticipantsModal({
     >
       <div>
         <h4>
-          <Trans>{singleTokenShort(tokenSymbol, true)} holders</Trans>
+          <Trans>{tokenSymbolText(tokenSymbol, true)} holders</Trans>
         </h4>
 
         {tokenAddress && tokenAddress !== constants.AddressZero && (

--- a/src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
@@ -76,7 +76,11 @@ export default function ProjectToolDrawerModal({
     )
   }
 
-  const tokenSymbolShort = tokenSymbolText(tokenSymbol, false, true)
+  const tokenSymbolShort = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })
 
   return (
     <Drawer visible={visible} onClose={onClose} width={600}>

--- a/src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
@@ -11,6 +11,7 @@ import { useSafeTransferFromTx } from 'hooks/v1/transactor/SafeTransferFromTx'
 import { useTransferTokensTx } from 'hooks/v1/transactor/TransferTokensTx'
 import { useContext, useState } from 'react'
 import { formatWad, fromWad, parseWad } from 'utils/formatNumber'
+import { pluralTokenShort } from 'utils/tokenSymbolText'
 
 export default function ProjectToolDrawerModal({
   visible,
@@ -75,7 +76,7 @@ export default function ProjectToolDrawerModal({
     )
   }
 
-  const tokenSymbolText = tokenSymbol || t`tokens`
+  const tokenSymbolShort = pluralTokenShort(tokenSymbol)
 
   return (
     <Drawer visible={visible} onClose={onClose} width={600}>
@@ -121,7 +122,7 @@ export default function ProjectToolDrawerModal({
 
         <section>
           <h3>
-            <Trans>Transfer unclaimed {tokenSymbolText}</Trans>
+            <Trans>Transfer unclaimed {tokenSymbolShort}</Trans>
           </h3>
           <p>
             <Trans>
@@ -168,7 +169,7 @@ export default function ProjectToolDrawerModal({
                 size="small"
                 type="primary"
               >
-                <Trans>Transfer {tokenSymbolText}</Trans>
+                <Trans>Transfer {tokenSymbolShort}</Trans>
               </Button>
             </Form.Item>
           </Form>

--- a/src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
@@ -11,7 +11,7 @@ import { useSafeTransferFromTx } from 'hooks/v1/transactor/SafeTransferFromTx'
 import { useTransferTokensTx } from 'hooks/v1/transactor/TransferTokensTx'
 import { useContext, useState } from 'react'
 import { formatWad, fromWad, parseWad } from 'utils/formatNumber'
-import { pluralTokenShort } from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 export default function ProjectToolDrawerModal({
   visible,
@@ -76,7 +76,7 @@ export default function ProjectToolDrawerModal({
     )
   }
 
-  const tokenSymbolShort = pluralTokenShort(tokenSymbol)
+  const tokenSymbolShort = tokenSymbolText(tokenSymbol, false, true)
 
   return (
     <Drawer visible={visible} onClose={onClose} width={600}>

--- a/src/components/v1/V1Project/modals/RedeemModal.tsx
+++ b/src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -16,6 +16,11 @@ import { useRedeemTokensTx } from 'hooks/v1/transactor/RedeemTokensTx'
 import { CSSProperties, useContext, useState } from 'react'
 import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
+import {
+  pluralTokenLong,
+  pluralTokenShort,
+  singleTokenShort,
+} from 'utils/tokenSymbolText'
 
 import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
 
@@ -88,21 +93,21 @@ export default function RedeemModal({
     alignItems: 'baseline',
   }
 
-  const tokensText = tokenSymbol ? tokenSymbol + ' ' + t`tokens` : t`tokens`
-  const tokensTextShort = tokenSymbol ?? t`tokens`
+  const tokensTextLong = pluralTokenLong(tokenSymbol)
+  const tokensTextShort = pluralTokenShort(tokenSymbol)
 
   let modalTitle: string
   // Defining whole sentence for translations
   if (overflow?.gt(0)) {
-    modalTitle = t`Burn ${tokensText} for ETH`
+    modalTitle = t`Redeem ${tokensTextLong} for ETH`
   } else {
-    modalTitle = t`Burn ${tokensText}`
+    modalTitle = t`Burn ${tokensTextLong}`
   }
 
   let buttonText: string
   // Defining whole sentence for translations
   if (overflow?.gt(0)) {
-    buttonText = t`Burn ${formattedNum(redeemAmount, {
+    buttonText = t`Redeem ${formattedNum(redeemAmount, {
       precision: 2,
     })} ${tokensTextShort} for ETH`
   } else {
@@ -115,9 +120,9 @@ export default function RedeemModal({
 
   const validateRedeemAmount = () => {
     if (redeemBN.eq(0)) {
-      return Promise.reject('Required')
+      return Promise.reject(t`Required`)
     } else if (redeemBN.gt(totalBalance ?? 0)) {
-      return Promise.reject('Balance exceeded')
+      return Promise.reject(t`Balance exceeded`)
     }
     return Promise.resolve()
   }
@@ -154,10 +159,9 @@ export default function RedeemModal({
             </span>
           </p>
           <p style={statsStyle}>
-            {tokenSymbol ?? 'Token'} balance:{' '}
+            {singleTokenShort(tokenSymbol, true)} balance:{' '}
             <span>
-              {formatWad(totalBalance ?? 0, { precision: 0 })}{' '}
-              {tokenSymbol ?? 'tokens'}
+              {formatWad(totalBalance ?? 0, { precision: 0 })} {tokensTextShort}
             </span>
           </p>
           <p style={statsStyle}>

--- a/src/components/v1/V1Project/modals/RedeemModal.tsx
+++ b/src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -89,8 +89,17 @@ export default function RedeemModal({
     alignItems: 'baseline',
   }
 
-  const tokensTextLong = tokenSymbolText(tokenSymbol, false, true, true)
-  const tokensTextShort = tokenSymbolText(tokenSymbol, false, true)
+  const tokensTextLong = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+    includeTokenWord: true,
+  })
+  const tokensTextShort = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })
 
   let modalTitle: string
   // Defining whole sentence for translations
@@ -155,7 +164,8 @@ export default function RedeemModal({
             </span>
           </p>
           <p style={statsStyle}>
-            {tokenSymbolText(tokenSymbol, true)} balance:{' '}
+            {tokenSymbolText({ tokenSymbol: tokenSymbol, capitalize: true })}{' '}
+            balance:{' '}
             <span>
               {formatWad(totalBalance ?? 0, { precision: 0 })} {tokensTextShort}
             </span>

--- a/src/components/v1/V1Project/modals/RedeemModal.tsx
+++ b/src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -16,11 +16,7 @@ import { useRedeemTokensTx } from 'hooks/v1/transactor/RedeemTokensTx'
 import { CSSProperties, useContext, useState } from 'react'
 import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/fundingCycle'
-import {
-  pluralTokenLong,
-  pluralTokenShort,
-  singleTokenShort,
-} from 'utils/tokenSymbolText'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { CURRENCY_ETH, CURRENCY_USD } from 'constants/currency'
 
@@ -93,8 +89,8 @@ export default function RedeemModal({
     alignItems: 'baseline',
   }
 
-  const tokensTextLong = pluralTokenLong(tokenSymbol)
-  const tokensTextShort = pluralTokenShort(tokenSymbol)
+  const tokensTextLong = tokenSymbolText(tokenSymbol, false, true, true)
+  const tokensTextShort = tokenSymbolText(tokenSymbol, false, true)
 
   let modalTitle: string
   // Defining whole sentence for translations
@@ -159,7 +155,7 @@ export default function RedeemModal({
             </span>
           </p>
           <p style={statsStyle}>
-            {singleTokenShort(tokenSymbol, true)} balance:{' '}
+            {tokenSymbolText(tokenSymbol, true)} balance:{' '}
             <span>
               {formatWad(totalBalance ?? 0, { precision: 0 })} {tokensTextShort}
             </span>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1742,17 +1742,8 @@ msgstr "When someone pays your project as a patron or a user of your app, they e
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-msgstr ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-
 #: src/components/shared/formItems/ProjectReserved.tsx
+#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr ""
 
@@ -1954,14 +1945,8 @@ msgid "{0} left"
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
-msgstr ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
+msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
+msgstr "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -297,6 +297,10 @@ msgstr ""
 msgid "Back to top"
 msgstr "Back to top"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Balance exceeded"
+msgstr "Balance exceeded"
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Beneficiary address"
@@ -350,16 +354,8 @@ msgid "Burn {0} {tokensTextShort}"
 msgstr "Burn {0} {tokensTextShort}"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {0} {tokensTextShort} for ETH"
-msgstr "Burn {0} {tokensTextShort} for ETH"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText}"
-msgstr "Burn {tokensText}"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText} for ETH"
-msgstr "Burn {tokensText} for ETH"
+msgid "Burn {tokensTextLong}"
+msgstr "Burn {tokensTextLong}"
 
 #: src/components/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
@@ -884,8 +880,8 @@ msgid "Manage"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Manage {0}tokens"
-msgstr ""
+msgid "Manage {0}"
+msgstr "Manage {0}"
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Memo"
@@ -1197,9 +1193,21 @@ msgstr "Reconfigure upcoming funding"
 msgid "Redeem"
 msgstr ""
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr "Redeem {0} {tokensTextShort} for ETH"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {tokensTextLong} for ETH"
+msgstr "Redeem {tokensTextLong} for ETH"
+
 #: src/components/Landing/index.tsx
 msgid "Redistributable surplus"
 msgstr ""
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Required"
+msgstr "Required"
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "Reserved token allocation (optional)"
@@ -1536,6 +1544,10 @@ msgstr ""
 msgid "To: <0/>"
 msgstr ""
 
+#: src/utils/tokenSymbolText.ts
+msgid "Token"
+msgstr "Token"
+
 #: src/components/v1/V1Project/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr ""
@@ -1560,6 +1572,7 @@ msgstr "Token symbol"
 
 #: src/components/shared/Mod.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr ""
 
@@ -1606,12 +1619,12 @@ msgid "Transfer ownership"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer unclaimed {tokenSymbolText}"
-msgstr "Transfer unclaimed {tokenSymbolText}"
+msgid "Transfer unclaimed {tokenSymbolShort}"
+msgstr "Transfer unclaimed {tokenSymbolShort}"
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer {tokenSymbolText}"
-msgstr "Transfer {tokenSymbolText}"
+msgid "Transfer {tokenSymbolShort}"
+msgstr "Transfer {tokenSymbolShort}"
 
 #: src/components/Landing/index.tsx
 msgid "Transparency & accountability"
@@ -1729,8 +1742,17 @@ msgstr "When someone pays your project as a patron or a user of your app, they e
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr ""
 
-#: src/components/shared/formItems/ProjectReserved.tsx
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
+msgid ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+msgstr ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+
+#: src/components/shared/formItems/ProjectReserved.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr ""
 
@@ -1879,18 +1901,14 @@ msgstr ""
 
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Pay/PayInputSubText.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr ""
 
@@ -1936,8 +1954,14 @@ msgid "{0} left"
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
+msgid ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
 msgstr ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1747,14 +1747,8 @@ msgstr "Cuando alguien paga tu proyecto como patrocinador o un usuario de tu app
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Cuando acuñar tokens es permitido, el dueño de este proyecto tiene permiso de acuñar cualquier número de tokens para cualquier dirección a su discreción. Esto tiene el efecto de diluir a todos los poseedores de tokens actuales, sin incrementar el saldo de la tesorería del proyecto. El dueño del proyecto puede reconfigurar esto junto con todas las demás propiedades del ciclo de financiamiento."
 
-#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-msgstr ""
-
 #: src/components/shared/formItems/ProjectReserved.tsx
+#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Cuando alguien paga tu proyecto, ese porcentaje de tokens será reservado y el resto irá al pagador. Los tokens reservados están reservados por defecto para el dueño del proyecto, pero también pueden ser ubicados en otras direcciones de wallets por el dueño. Una vez que los tokens estén reservados, cualquiera puede \"acuñarlos\" lo que nos distribuye a los receptores esperados."
 
@@ -1956,10 +1950,7 @@ msgid "{0} left"
 msgstr "{0} restantes"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
+msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -302,6 +302,10 @@ msgstr "Disponible:"
 msgid "Back to top"
 msgstr "Regresa arriba"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Balance exceeded"
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Dirección de beneficiario"
@@ -355,16 +359,8 @@ msgid "Burn {0} {tokensTextShort}"
 msgstr "Quemar {0} {tokensTextShort}"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {0} {tokensTextShort} for ETH"
-msgstr "Quemar {0} {tokensTextShort} por ETH"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText}"
-msgstr "Quemar {tokensText}"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText} for ETH"
-msgstr "Quemar {tokensText} por ETH"
+msgid "Burn {tokensTextLong}"
+msgstr ""
 
 #: src/components/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
@@ -889,8 +885,8 @@ msgid "Manage"
 msgstr "Administra"
 
 #: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Manage {0}tokens"
-msgstr "Administra {0}tokens"
+msgid "Manage {0}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Memo"
@@ -1202,9 +1198,21 @@ msgstr "Reconfigurar financiamientos próximos"
 msgid "Redeem"
 msgstr "Canjear"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr ""
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {tokensTextLong} for ETH"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Redistributable surplus"
 msgstr "Excedente redistribuible"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "Reserved token allocation (optional)"
@@ -1541,6 +1549,10 @@ msgstr "Este sitio web (juicebox.money) se conecta a los contratos inteligentes 
 msgid "To: <0/>"
 msgstr "Para: <0/>"
 
+#: src/utils/tokenSymbolText.ts
+msgid "Token"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Dirección del token: <0/>"
@@ -1565,6 +1577,7 @@ msgstr "Símbolo del token"
 
 #: src/components/shared/Mod.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
 
@@ -1611,12 +1624,12 @@ msgid "Transfer ownership"
 msgstr "Transferir propiedad"
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer unclaimed {tokenSymbolText}"
-msgstr "Transferir {tokenSymbolText} no reclamados"
+msgid "Transfer unclaimed {tokenSymbolShort}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer {tokenSymbolText}"
-msgstr "Transferir {tokenSymbolText}"
+msgid "Transfer {tokenSymbolShort}"
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Transparency & accountability"
@@ -1734,8 +1747,14 @@ msgstr "Cuando alguien paga tu proyecto como patrocinador o un usuario de tu app
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Cuando acuñar tokens es permitido, el dueño de este proyecto tiene permiso de acuñar cualquier número de tokens para cualquier dirección a su discreción. Esto tiene el efecto de diluir a todos los poseedores de tokens actuales, sin incrementar el saldo de la tesorería del proyecto. El dueño del proyecto puede reconfigurar esto junto con todas las demás propiedades del ciclo de financiamiento."
 
-#: src/components/shared/formItems/ProjectReserved.tsx
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
+msgid ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+msgstr ""
+
+#: src/components/shared/formItems/ProjectReserved.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Cuando alguien paga tu proyecto, ese porcentaje de tokens será reservado y el resto irá al pagador. Los tokens reservados están reservados por defecto para el dueño del proyecto, pero también pueden ser ubicados en otras direcciones de wallets por el dueño. Una vez que los tokens estén reservados, cualquiera puede \"acuñarlos\" lo que nos distribuye a los receptores esperados."
 
@@ -1884,18 +1903,14 @@ msgstr "esta interfaz"
 
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Pay/PayInputSubText.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
 
@@ -1941,8 +1956,11 @@ msgid "{0} left"
 msgstr "{0} restantes"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
-msgstr "{0} recibido por ETH pagados al tesoro. Esto puede cambiar a través del tiempo de acuerdo con la tasa de descuento y la cantidad de tokens reservados para futuros ciclos de financiamiento."
+msgid ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -302,6 +302,10 @@ msgstr "Disponível:"
 msgid "Back to top"
 msgstr "De volta ao início"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Balance exceeded"
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr ""
@@ -355,16 +359,8 @@ msgid "Burn {0} {tokensTextShort}"
 msgstr "Queimar {0} {tokensTextShort}"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {0} {tokensTextShort} for ETH"
-msgstr "Queimar {0} {tokensTextShort} por ETH"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText}"
-msgstr "Queimar {tokensText}"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText} for ETH"
-msgstr "Queimar {tokensText} do ETH"
+msgid "Burn {tokensTextLong}"
+msgstr ""
 
 #: src/components/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
@@ -889,8 +885,8 @@ msgid "Manage"
 msgstr "Administrar"
 
 #: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Manage {0}tokens"
-msgstr "Administrar {0}tokens"
+msgid "Manage {0}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Memo"
@@ -1202,9 +1198,21 @@ msgstr "Reconfigurar financiamento futuro"
 msgid "Redeem"
 msgstr "Resgatar"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr ""
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {tokensTextLong} for ETH"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Redistributable surplus"
 msgstr "Excedente redistribuível"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "Reserved token allocation (optional)"
@@ -1541,6 +1549,10 @@ msgstr "Este website (juicebox.money) conecta aos contratos inteligentes do prot
 msgid "To: <0/>"
 msgstr "Para: <0/>"
 
+#: src/utils/tokenSymbolText.ts
+msgid "Token"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Endereço de token: <0/>"
@@ -1565,6 +1577,7 @@ msgstr "O símbolo do token"
 
 #: src/components/shared/Mod.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
 
@@ -1611,11 +1624,11 @@ msgid "Transfer ownership"
 msgstr "Transferir propriedade"
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer unclaimed {tokenSymbolText}"
+msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer {tokenSymbolText}"
+msgid "Transfer {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/Landing/index.tsx
@@ -1734,8 +1747,14 @@ msgstr "Quando alguém paga por seu projeto como patrocinador ou como usuário d
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr ""
 
-#: src/components/shared/formItems/ProjectReserved.tsx
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
+msgid ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+msgstr ""
+
+#: src/components/shared/formItems/ProjectReserved.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Quando alguém paga seu projeto, essa porcentagem de tokens será reservada e o resto irá para quem pagou. Os tokens reservados estão reservados por padrão, mas também podem ser alocados em outros endereços de carteiras pelo proprietário. Uma vez que os tokens estão reservados, qualquer um pode \"cria-los\", que, por sua vez, distribuem-nos para seus receptores esperados."
 
@@ -1884,18 +1903,14 @@ msgstr "esta interface"
 
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Pay/PayInputSubText.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
 
@@ -1941,8 +1956,11 @@ msgid "{0} left"
 msgstr "{0} restante"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
-msgstr "{0} recebido por ETH pagos para o tesouro. Isto pode modificar-se através do tempo de acordo com a taxa de desconto e a quantidade de tokens reservados de futuros ciclos de financiamento."
+msgid ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1747,14 +1747,8 @@ msgstr "Quando alguém paga por seu projeto como patrocinador ou como usuário d
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-msgstr ""
-
 #: src/components/shared/formItems/ProjectReserved.tsx
+#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Quando alguém paga seu projeto, essa porcentagem de tokens será reservada e o resto irá para quem pagou. Os tokens reservados estão reservados por padrão, mas também podem ser alocados em outros endereços de carteiras pelo proprietário. Uma vez que os tokens estão reservados, qualquer um pode \"cria-los\", que, por sua vez, distribuem-nos para seus receptores esperados."
 
@@ -1956,10 +1950,7 @@ msgid "{0} left"
 msgstr "{0} restante"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
+msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1747,14 +1747,8 @@ msgstr ""
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Когда допускается обработка токенов, владелец этого проекта имеет разрешение на удаление любого количества токенов на любой адрес по своему усмотрению. Это влечет за собой размытие всех текущих владельцев токенов без увеличения казначейского баланса проекта. Владелец проекта может перенастроить это вместе со всеми остальными свойствами цикла финансирования."
 
-#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-msgstr ""
-
 #: src/components/shared/formItems/ProjectReserved.tsx
+#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Всякий раз, когда кто-то оплачивает ваш проект, этот процент токенов будет зарезервирован, а остальная часть переходит к плательщику. Резервные токены по умолчанию зарезервированы для владельца проекта, но также могут быть выделены владельцем для других адресов кошелька. После того, как токены зарезервированы, любой желающий может их «чеканить», который также рассылает их предполагаемым получателям."
 
@@ -1956,10 +1950,7 @@ msgid "{0} left"
 msgstr "осталось {0}"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
+msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -302,6 +302,10 @@ msgstr "Доступно:"
 msgid "Back to top"
 msgstr "Вернуться наверх"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Balance exceeded"
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr ""
@@ -355,15 +359,7 @@ msgid "Burn {0} {tokensTextShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {0} {tokensTextShort} for ETH"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText}"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText} for ETH"
+msgid "Burn {tokensTextLong}"
 msgstr ""
 
 #: src/components/shared/forms/PayModsForm.tsx
@@ -889,8 +885,8 @@ msgid "Manage"
 msgstr "Управление"
 
 #: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Manage {0}tokens"
-msgstr "Управление {0}токенами"
+msgid "Manage {0}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Memo"
@@ -1202,9 +1198,21 @@ msgstr ""
 msgid "Redeem"
 msgstr "Обменять"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr ""
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {tokensTextLong} for ETH"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Redistributable surplus"
 msgstr "Перераспределяемый излишек"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "Reserved token allocation (optional)"
@@ -1541,6 +1549,10 @@ msgstr "Этот веб-сайт (juicebox.money) подключается к с
 msgid "To: <0/>"
 msgstr "Кому: <0/>"
 
+#: src/utils/tokenSymbolText.ts
+msgid "Token"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Адрес токена: <0/>"
@@ -1565,6 +1577,7 @@ msgstr ""
 
 #: src/components/shared/Mod.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Жетоны"
 
@@ -1611,11 +1624,11 @@ msgid "Transfer ownership"
 msgstr "Передача права собственности"
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer unclaimed {tokenSymbolText}"
+msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer {tokenSymbolText}"
+msgid "Transfer {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/Landing/index.tsx
@@ -1734,8 +1747,14 @@ msgstr ""
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Когда допускается обработка токенов, владелец этого проекта имеет разрешение на удаление любого количества токенов на любой адрес по своему усмотрению. Это влечет за собой размытие всех текущих владельцев токенов без увеличения казначейского баланса проекта. Владелец проекта может перенастроить это вместе со всеми остальными свойствами цикла финансирования."
 
-#: src/components/shared/formItems/ProjectReserved.tsx
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
+msgid ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+msgstr ""
+
+#: src/components/shared/formItems/ProjectReserved.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Всякий раз, когда кто-то оплачивает ваш проект, этот процент токенов будет зарезервирован, а остальная часть переходит к плательщику. Резервные токены по умолчанию зарезервированы для владельца проекта, но также могут быть выделены владельцем для других адресов кошелька. После того, как токены зарезервированы, любой желающий может их «чеканить», который также рассылает их предполагаемым получателям."
 
@@ -1884,18 +1903,14 @@ msgstr "этот интерфейс"
 
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr ""
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Pay/PayInputSubText.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "токены"
 
@@ -1941,8 +1956,11 @@ msgid "{0} left"
 msgstr "осталось {0}"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
-msgstr "{0} получено за ETH выплаченную казну. Это может меняться со временем в зависимости от ставки скидки и зарезервированного количества токенов будущих циклов финансирования."
+msgid ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1747,14 +1747,8 @@ msgstr ""
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Token basımına izin verildiğinde bu projenin sahibi, kararı kendisine ait olmak üzere, herhangi bir adrese, herhangi bir sayıda token basma iznine sahip olacaktır. Bu, projenin hazine bakiyesini artırmadan tüm mevcut token sahiplerinin etkisini azaltabilir. Proje sahibi bunu, finansman döngüsünün diğer tüm özellikleriyle birlikte yapılandırabilir."
 
-#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-msgstr ""
-
 #: src/components/shared/formItems/ProjectReserved.tsx
+#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Birisi projenize ödeme yaptığında bu token yüzdesi ayrılacak ve geri kalanı ödeme yapan kişiye gidecektir. Ayrılmış token'lar, varsayılan olarak proje sahibi için ayrılır ancak proje sahibi tarafından diğer cüzdan adreslerine de tahsis edilebilir. Token'lar ayrıldıktan sonra herkes onları \"basabilir\" ve bu işlem, onları amaçlanan alıcılarına dağıtır."
 
@@ -1956,10 +1950,7 @@ msgid "{0} left"
 msgstr "{0} kaldı"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
+msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -302,6 +302,10 @@ msgstr "Mevcut:"
 msgid "Back to top"
 msgstr "Başa dön"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Balance exceeded"
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr ""
@@ -355,15 +359,7 @@ msgid "Burn {0} {tokensTextShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {0} {tokensTextShort} for ETH"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText}"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText} for ETH"
+msgid "Burn {tokensTextLong}"
 msgstr ""
 
 #: src/components/shared/forms/PayModsForm.tsx
@@ -889,8 +885,8 @@ msgid "Manage"
 msgstr "Yönet"
 
 #: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Manage {0}tokens"
-msgstr "{0}token'larını yönet"
+msgid "Manage {0}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Memo"
@@ -1202,9 +1198,21 @@ msgstr ""
 msgid "Redeem"
 msgstr ""
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr ""
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {tokensTextLong} for ETH"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Redistributable surplus"
 msgstr "Yeniden dağıtılabilir fazlalık"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "Reserved token allocation (optional)"
@@ -1541,6 +1549,10 @@ msgstr "Bu web sitesi (juicebox.money), Juicebox protokolünün Ethereum ağınd
 msgid "To: <0/>"
 msgstr "Kime: <0/>"
 
+#: src/utils/tokenSymbolText.ts
+msgid "Token"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Token adresi: <0/>"
@@ -1565,6 +1577,7 @@ msgstr ""
 
 #: src/components/shared/Mod.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Token'lar"
 
@@ -1611,11 +1624,11 @@ msgid "Transfer ownership"
 msgstr "Mülkiyeti aktar"
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer unclaimed {tokenSymbolText}"
+msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer {tokenSymbolText}"
+msgid "Transfer {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/Landing/index.tsx
@@ -1734,8 +1747,14 @@ msgstr ""
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Token basımına izin verildiğinde bu projenin sahibi, kararı kendisine ait olmak üzere, herhangi bir adrese, herhangi bir sayıda token basma iznine sahip olacaktır. Bu, projenin hazine bakiyesini artırmadan tüm mevcut token sahiplerinin etkisini azaltabilir. Proje sahibi bunu, finansman döngüsünün diğer tüm özellikleriyle birlikte yapılandırabilir."
 
-#: src/components/shared/formItems/ProjectReserved.tsx
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
+msgid ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+msgstr ""
+
+#: src/components/shared/formItems/ProjectReserved.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Birisi projenize ödeme yaptığında bu token yüzdesi ayrılacak ve geri kalanı ödeme yapan kişiye gidecektir. Ayrılmış token'lar, varsayılan olarak proje sahibi için ayrılır ancak proje sahibi tarafından diğer cüzdan adreslerine de tahsis edilebilir. Token'lar ayrıldıktan sonra herkes onları \"basabilir\" ve bu işlem, onları amaçlanan alıcılarına dağıtır."
 
@@ -1884,18 +1903,14 @@ msgstr "bu arayüz"
 
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Pay/PayInputSubText.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr ""
 
@@ -1941,8 +1956,11 @@ msgid "{0} left"
 msgstr "{0} kaldı"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
-msgstr "Hazineye ödenen ETH başına {0} alındı. Bu, yaklaşan finansman döngülerinin indirim oranına ve ayrılmış token miktarına göre zaman içinde değişebilir."
+msgid ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1747,14 +1747,8 @@ msgstr "当有人以赞助人或用户的身份向您的项目付款时，他们
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "当铸造代币功能启用时，该项目方可以铸造任意数量的代币并发送给任意地址。这一操作并不会增加项目金库的余额，所以会稀释所有当前代币持有者的份额。和其他属性一样，也可以在每个筹款周期中重新配置这一项。"
 
-#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
-"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
-"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
-msgstr ""
-
 #: src/components/shared/formItems/ProjectReserved.tsx
+#: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "有人对你的项目付款时，这一比例的代币会被保留, 剩余的代币会发送至付款人。在默认情况下, 保留代币会留给项目拥有者, 但是项目拥有者也可以将保留代币分配给其他钱包地址。保留代币产生后，任何人都可以把它们“铸造”出来，亦即把保留代币分发给预先指定的接收人。"
 
@@ -1956,10 +1950,7 @@ msgid "{0} left"
 msgstr "{0} 剩余"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid ""
-"{0} received per ETH \n"
-"paid to the treasury. This can change over time according to the discount rate \n"
-"and reserved tokens amount of future funding cycles."
+msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -302,6 +302,10 @@ msgstr "可用:"
 msgid "Back to top"
 msgstr "回到顶部"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Balance exceeded"
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "受益人钱包地址"
@@ -355,15 +359,7 @@ msgid "Burn {0} {tokensTextShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {0} {tokensTextShort} for ETH"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText}"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Burn {tokensText} for ETH"
+msgid "Burn {tokensTextLong}"
 msgstr ""
 
 #: src/components/shared/forms/PayModsForm.tsx
@@ -889,8 +885,8 @@ msgid "Manage"
 msgstr "管理代币"
 
 #: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Manage {0}tokens"
-msgstr "管理 {0} 代币"
+msgid "Manage {0}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Memo"
@@ -1202,9 +1198,21 @@ msgstr "重新配置之后的筹款"
 msgid "Redeem"
 msgstr "赎回"
 
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr ""
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redeem {tokensTextLong} for ETH"
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Redistributable surplus"
 msgstr "可分派的盈余"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "Reserved token allocation (optional)"
@@ -1541,6 +1549,10 @@ msgstr "这个网站（juicebox.money）连接到 Juicebox 协议的智能合约
 msgid "To: <0/>"
 msgstr "分配给：<0/>"
 
+#: src/utils/tokenSymbolText.ts
+msgid "Token"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "代币地址：<0/>"
@@ -1565,6 +1577,7 @@ msgstr ""
 
 #: src/components/shared/Mod.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "代币"
 
@@ -1611,11 +1624,11 @@ msgid "Transfer ownership"
 msgstr "所有权转移"
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer unclaimed {tokenSymbolText}"
+msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-msgid "Transfer {tokenSymbolText}"
+msgid "Transfer {tokenSymbolShort}"
 msgstr ""
 
 #: src/components/Landing/index.tsx
@@ -1734,8 +1747,14 @@ msgstr "当有人以赞助人或用户的身份向您的项目付款时，他们
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "当铸造代币功能启用时，该项目方可以铸造任意数量的代币并发送给任意地址。这一操作并不会增加项目金库的余额，所以会稀释所有当前代币持有者的份额。和其他属性一样，也可以在每个筹款周期中重新配置这一项。"
 
-#: src/components/shared/formItems/ProjectReserved.tsx
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
+msgid ""
+"Whenever someone pays your project, this percentage of tokens will be reserved and the \n"
+"rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other \n"
+"wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
+msgstr ""
+
+#: src/components/shared/formItems/ProjectReserved.tsx
 msgid "Whenever someone pays your project, this percentage of tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "有人对你的项目付款时，这一比例的代币会被保留, 剩余的代币会发送至付款人。在默认情况下, 保留代币会留给项目拥有者, 但是项目拥有者也可以将保留代币分配给其他钱包地址。保留代币产生后，任何人都可以把它们“铸造”出来，亦即把保留代币分发给预先指定的接收人。"
 
@@ -1884,18 +1903,14 @@ msgstr "这个界面"
 
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "代币"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Pay/PayInputSubText.tsx
 #: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/modals/ProjectToolDrawerModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
+#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "代币"
 
@@ -1941,8 +1956,11 @@ msgid "{0} left"
 msgstr "{0} 剩余"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
-msgid "{0} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
-msgstr "金库中收到 ETH 付款时对应铸造的 {0} 数量。这个数量会根据之后周期的折扣率和保留率，随着时间而改变。"
+msgid ""
+"{0} received per ETH \n"
+"paid to the treasury. This can change over time according to the discount rate \n"
+"and reserved tokens amount of future funding cycles."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "{0} reserved"

--- a/src/utils/__tests__/tokenSymbolText.test.ts
+++ b/src/utils/__tests__/tokenSymbolText.test.ts
@@ -1,0 +1,30 @@
+import { tokenSymbolText } from '../tokenSymbolText'
+
+describe('tokenSymbolText', () => {
+  it.each`
+    tokenSymbol  | capitalize | plural   | includeTokenWord | result
+    ${'JBX'}     | ${true}    | ${true}  | ${true}          | ${'JBX Tokens'}
+    ${'JBX'}     | ${true}    | ${true}  | ${false}         | ${'JBX'}
+    ${'JBX'}     | ${true}    | ${false} | ${true}          | ${'JBX Token'}
+    ${'JBX'}     | ${true}    | ${false} | ${false}         | ${'JBX'}
+    ${'JBX'}     | ${false}   | ${true}  | ${true}          | ${'JBX tokens'}
+    ${'JBX'}     | ${false}   | ${true}  | ${false}         | ${'JBX'}
+    ${'JBX'}     | ${false}   | ${false} | ${true}          | ${'JBX token'}
+    ${'JBX'}     | ${false}   | ${false} | ${false}         | ${'JBX'}
+    ${undefined} | ${true}    | ${true}  | ${true}          | ${'Tokens'}
+    ${undefined} | ${true}    | ${true}  | ${false}         | ${'Tokens'}
+    ${undefined} | ${true}    | ${false} | ${true}          | ${'Token'}
+    ${undefined} | ${true}    | ${false} | ${false}         | ${'Token'}
+    ${undefined} | ${false}   | ${true}  | ${true}          | ${'tokens'}
+    ${undefined} | ${false}   | ${true}  | ${false}         | ${'tokens'}
+    ${undefined} | ${false}   | ${false} | ${true}          | ${'token'}
+    ${undefined} | ${false}   | ${false} | ${false}         | ${'token'}
+  `(
+    'returns $result when tokenSymbol=$tokenSymbol, capitalize=$capitalize, plural=$plural, $includeTokenWord=includeTokenWord',
+    ({ tokenSymbol, capitalize, plural, includeTokenWord, result }) => {
+      expect(
+        tokenSymbolText({ tokenSymbol, capitalize, plural, includeTokenWord }),
+      ).toBe(result)
+    },
+  )
+})

--- a/src/utils/tokenSymbolText.ts
+++ b/src/utils/tokenSymbolText.ts
@@ -1,36 +1,24 @@
 import { t } from '@lingui/macro'
 
 // Function to return {tokenSymbol} and/or 'tokens', translated and (possibly) capitalized
-export const tokenSymbolText = (
-  tokenSymbol?: string,
-  capitalize?: boolean,
-  plural?: boolean,
-  includeTokenWord?: boolean,
-) => {
-  // e.g. 'JBX' or 'Token'
-  if (!includeTokenWord) {
-    if (!plural) {
-      return capitalize ? tokenSymbol ?? t`Token` : tokenSymbol ?? t`token`
-    } else {
-      return capitalize ? tokenSymbol ?? t`Tokens` : tokenSymbol ?? t`tokens`
-    }
+export const tokenSymbolText = ({
+  tokenSymbol,
+  capitalize,
+  plural,
+  includeTokenWord,
+}: {
+  tokenSymbol?: string
+  capitalize?: boolean
+  plural?: boolean
+  includeTokenWord?: boolean
+}) => {
+  const tokenTextSingular = capitalize ? t`Token` : t`token`
+  const tokenTextPlural = capitalize ? t`Tokens` : t`tokens`
+  const tokenText = plural ? tokenTextPlural : tokenTextSingular
+
+  if (includeTokenWord) {
+    return tokenSymbol ? `${tokenSymbol} ${tokenText}` : tokenText
   }
-  // e.g. 'JBX token'
-  if (!plural) {
-    return capitalize
-      ? tokenSymbol
-        ? tokenSymbol + ' ' + t`token`
-        : t`Token`
-      : tokenSymbol
-      ? tokenSymbol + ' ' + t`token`
-      : t`token`
-  }
-  //e.g. 'JBX tokens'
-  return capitalize
-    ? tokenSymbol
-      ? tokenSymbol + ' ' + t`tokens`
-      : t`Tokens`
-    : tokenSymbol
-    ? tokenSymbol + ' ' + t`tokens`
-    : t`tokens`
+
+  return tokenSymbol ?? tokenText
 }

--- a/src/utils/tokenSymbolText.ts
+++ b/src/utils/tokenSymbolText.ts
@@ -1,27 +1,36 @@
 import { t } from '@lingui/macro'
 
-// Functions to return {tokenSymbol} and/or 'tokens', translated and (possibly) capitalized
-
-export const singleTokenShort = (tokenSymbol?: string, capitalize?: boolean) =>
-  capitalize ? tokenSymbol ?? t`Token` : tokenSymbol ?? t`token`
-
-export const pluralTokenShort = (tokenSymbol?: string, capitalize?: boolean) =>
-  capitalize ? tokenSymbol ?? t`Tokens` : tokenSymbol ?? t`tokens`
-
-export const singleTokenLong = (tokenSymbol?: string, capitalize?: boolean) =>
-  capitalize
-    ? tokenSymbol
+// Function to return {tokenSymbol} and/or 'tokens', translated and (possibly) capitalized
+export const tokenSymbolText = (
+  tokenSymbol?: string,
+  capitalize?: boolean,
+  plural?: boolean,
+  includeTokenWord?: boolean,
+) => {
+  // e.g. 'JBX' or 'Token'
+  if (!includeTokenWord) {
+    if (!plural) {
+      return capitalize ? tokenSymbol ?? t`Token` : tokenSymbol ?? t`token`
+    } else {
+      return capitalize ? tokenSymbol ?? t`Tokens` : tokenSymbol ?? t`tokens`
+    }
+  }
+  // e.g. 'JBX token'
+  if (!plural) {
+    return capitalize
+      ? tokenSymbol
+        ? tokenSymbol + ' ' + t`token`
+        : t`Token`
+      : tokenSymbol
       ? tokenSymbol + ' ' + t`token`
-      : t`Token`
-    : tokenSymbol
-    ? tokenSymbol + ' ' + t`token`
-    : t`token`
-
-export const pluralTokenLong = (tokenSymbol?: string, capitalize?: boolean) =>
-  capitalize
+      : t`token`
+  }
+  //e.g. 'JBX tokens'
+  return capitalize
     ? tokenSymbol
       ? tokenSymbol + ' ' + t`tokens`
       : t`Tokens`
     : tokenSymbol
     ? tokenSymbol + ' ' + t`tokens`
     : t`tokens`
+}

--- a/src/utils/tokenSymbolText.ts
+++ b/src/utils/tokenSymbolText.ts
@@ -1,0 +1,27 @@
+import { t } from '@lingui/macro'
+
+// Functions to return {tokenSymbol} and/or 'tokens', translated and (possibly) capitalized
+
+export const singleTokenShort = (tokenSymbol?: string, capitalize?: boolean) =>
+  capitalize ? tokenSymbol ?? t`Token` : tokenSymbol ?? t`token`
+
+export const pluralTokenShort = (tokenSymbol?: string, capitalize?: boolean) =>
+  capitalize ? tokenSymbol ?? t`Tokens` : tokenSymbol ?? t`tokens`
+
+export const singleTokenLong = (tokenSymbol?: string, capitalize?: boolean) =>
+  capitalize
+    ? tokenSymbol
+      ? tokenSymbol + ' ' + t`token`
+      : t`Token`
+    : tokenSymbol
+    ? tokenSymbol + ' ' + t`token`
+    : t`token`
+
+export const pluralTokenLong = (tokenSymbol?: string, capitalize?: boolean) =>
+  capitalize
+    ? tokenSymbol
+      ? tokenSymbol + ' ' + t`tokens`
+      : t`Tokens`
+    : tokenSymbol
+    ? tokenSymbol + ' ' + t`tokens`
+    : t`tokens`


### PR DESCRIPTION
## What does this PR do and why?

The `tokenSymbol ?? "token"` and its 3 other counterparts weren't being translated properly. I made functions for the 4 different variations in `/utils` and implemented them throughout the codebase. This shouldn't affect anything in the UI, except that a bunch of 'token' and 'tokens' text will now translate properly. 

Apologies for the branch name, initially planned to do the redeem rate slider, then to do these changes and the slider together, but then thought it'd be best to get these changes out in a single PR. 


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
