### PR TITLE
Remove newlines from translated strings

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -16,12 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Extract translations
-        run: 'yarn i18n:extract'
-
       - name: Download from Crowdin
         uses: crowdin/github-action@1.4.4
         env:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
-yarn i18n:extract

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,17 +72,33 @@ Juicebox supports the following web browsers:
 ## Translations
 
 Juicebox uses [Crowdin](https://crowdin.com/project/juicebox-interface) for
-managing translations. This workflow uploads new strings for translation to the
+managing translations. A GitHub workflow uploads new strings for translation to the
 Crowdin project whenever code using the lingui translation macros is merged into
 main.
 
 Every day, translations are synced back down from Crowdin to a pull request to
 `main`. We then merge these PR's into `main` manually.
 
-If you are a developer, please mark any new text that you add in the interface
-for translation with the lingui [macros](https://lingui.js.org/ref/macro.html)
-(`` t`Example text`  `` or `<Trans>Text</Trans>`). Feel free to edit any
-existing text that hasn't yet been marked for translations.
+### Marking strings for translation
+
+Any strings that are added or modified in the source code should be marked for
+translation. Use the `t` macro or the `Trans` component from the `@lingui/macro`
+library. [Learn more](https://lingui.js.org/ref/macro.html).
+
+```js
+const myString = t`Example text`
+```
+
+```html
+<Trans>Example text</Trans>
+```
+
+**You must extract strings in PRs**. If your PR adds or modifies translated
+strings, run the following command to generate new `.po` files:
+
+```bash
+yarn i18n:extract
+```
 
 ### Contributing translations
 

--- a/src/components/FundingCycle/FundingCyclePreview.tsx
+++ b/src/components/FundingCycle/FundingCyclePreview.tsx
@@ -75,8 +75,7 @@ export default function FundingCyclePreview({
                     style={{ marginLeft: 10, color: colors.text.secondary }}
                   >
                     <Tooltip
-                      title={t`Some funding cycle properties may indicate risk
-                    for project contributors.`}
+                      title={t`Some funding cycle properties may indicate risk for project contributors.`}
                     >
                       <ExclamationCircleOutlined style={{ marginRight: 2 }} />
                       {fundingCycleRiskCount(fundingCycle)}

--- a/src/components/Project/Rewards/IssueTickets.tsx
+++ b/src/components/Project/Rewards/IssueTickets.tsx
@@ -29,8 +29,7 @@ export default function IssueTickets() {
           <Trans>Issue ERC-20 token</Trans>
         </Button>
         <TooltipIcon
-          tip={t`Issue an ERC-20 to be used as this project's token. Once
-          issued, anyone can claim their existing token balance in the new token.`}
+          tip={t`Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token.`}
         />
       </Space>
 

--- a/src/components/Project/Rewards/index.tsx
+++ b/src/components/Project/Rewards/index.tsx
@@ -97,10 +97,7 @@ export default function Rewards() {
           title={
             <SectionHeader
               text={tokensLabel}
-              tip={t`${tokensLabel}
-                  are distributed to anyone who pays this project. If the project 
-                  has set a funding target, tokens can be redeemed for a portion 
-                  of the project's overflow whether or not they have been claimed yet.`}
+              tip={t`${tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet.`}
             />
           }
           valueRender={() => (

--- a/src/components/shared/modals/ReservedTokenReceiverModal.tsx
+++ b/src/components/shared/modals/ReservedTokenReceiverModal.tsx
@@ -42,13 +42,11 @@ export default function ReservedTokenReceiverModal({
     const realTokenAllocation = (reservedRate ?? 0) * percentOfReserved
     const realTokenAllocationPercent = (realTokenAllocation / 100).toFixed(2)
     const extra =
-      t`The percent this individual receives of the overall ${reservedRate}% 
-      reserved token allocation` +
+      t`The percent this individual receives of the overall ${reservedRate}% reserved token allocation` +
       `${
         realTokenAllocation
           ? ' ' +
-            t`(${realTokenAllocationPercent}%
-          of all newly minted tokens).`
+            t`(${realTokenAllocationPercent}% of all newly minted tokens).`
           : '.'
       }`
     return extra

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -22,12 +22,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr ""
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
-msgstr ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
+msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
+msgstr "({realTokenAllocationPercent}% of all newly minted tokens)."
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
@@ -794,12 +790,8 @@ msgid "Issue ERC-20 token"
 msgstr "Issue ERC-20 token"
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
-msgstr ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
+msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
+msgstr "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 
 #: src/components/Project/Rewards/IssueTickets.tsx
 msgid "Issue an ERC-20 token for this project. Once issued, anyone can claim their existing token balance in the new token."
@@ -1361,12 +1353,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Since you have not set a funding duration, changes to these settings will be applied immediately."
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
-msgstr ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
+msgid "Some funding cycle properties may indicate risk for project contributors."
+msgstr "Some funding cycle properties may indicate risk for project contributors."
 
 #: src/components/Create/ConfirmDeployProject.tsx
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -1455,12 +1443,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr ""
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
-msgstr ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
+msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
+msgstr "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -2032,13 +2016,5 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr ""
 
 #: src/components/Project/Rewards/index.tsx
-msgid ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
-msgstr ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
+msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
+msgstr "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -27,10 +27,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(Opcional) Añadir una nota en este pago de forma on-chain"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
-msgstr ""
+msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
+msgstr "({realTokenAllocationPercent}% de todos los tokens recién acuñados)."
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
@@ -797,10 +795,8 @@ msgid "Issue ERC-20 token"
 msgstr "Emitir token ERC-20"
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
-msgstr ""
+msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
+msgstr "Emite un ERC-20 para que sea usado como token de este proyecto. Una vez emitido, cualquiera puede reclamar su balance existente de tokens como el nuevo token."
 
 #: src/components/Project/Rewards/IssueTickets.tsx
 msgid "Issue an ERC-20 token for this project. Once issued, anyone can claim their existing token balance in the new token."
@@ -1362,10 +1358,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Como no has establecido una duración de financiamiento, los cambios a estos ajustes serán aplicados de inmediato."
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
-msgstr ""
+msgid "Some funding cycle properties may indicate risk for project contributors."
+msgstr "Algunas propiedades de los ciclos de financiamiento pueden indicar riesgo para los contribuyentes de proyectos."
 
 #: src/components/Create/ConfirmDeployProject.tsx
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -1454,10 +1448,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "El futuro será liderado por creadores y las comunidades serán los dueños."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
-msgstr ""
+msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
+msgstr "El porcentaje que recibe esta persona del {reservedRate}% general de la asignación de tokens reservados"
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -2029,9 +2021,5 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Tipo de cambio de {tokenSymbol}/ETH en {exchangeName}."
 
 #: src/components/Project/Rewards/index.tsx
-msgid ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
-msgstr ""
+msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
+msgstr "{tokensLabel} son distribuidos a cualquiera que pague este proyecto. Si el proyecto tiene un objetivo de financiamiento, los tokens pueden ser canjeados por una porción del excedente del proyecto, hayan sido estos reclamados o no."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -27,10 +27,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(Opcional) Adicionar uma nota a esse pagamento em cadeia"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
-msgstr ""
+msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
+msgstr "({realTokenAllocationPercent}% de todos os tokens recentemente criados)."
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
@@ -797,9 +795,7 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
+msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
@@ -1362,10 +1358,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Como você não colocou uma duração de financiamento, as mudanças para essas configurações serão aplicadas imediatamente."
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
-msgstr ""
+msgid "Some funding cycle properties may indicate risk for project contributors."
+msgstr "Algumas propriedades do ciclo de financiamento podem indicar risco para os contribuidores do projeto."
 
 #: src/components/Create/ConfirmDeployProject.tsx
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -1454,10 +1448,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "O futuro será liderado pelos criadores, e pertencente às comunidades."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
-msgstr ""
+msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
+msgstr "O percentual que esse individuo recebe do todo de {reservedRate}% de token alocados como reservados"
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -2029,9 +2021,5 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{tokenSymbol}/ETH taxa de câmbio em {exchangeName}."
 
 #: src/components/Project/Rewards/index.tsx
-msgid ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
-msgstr ""
+msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
+msgstr "{tokensLabel} são distribuídos para qualquer pessoa que pague este projeto. Se o projeto já definiu o objetivo de financiamento, os tokens podem ser resgatados por uma porção de overflow do projeto caso eles tenham ou não sido reivindicados ainda."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -27,9 +27,7 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(Необязательно) Добавить примечание к этому платежу в цепочке"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
+msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr ""
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -797,9 +795,7 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
+msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
@@ -1362,9 +1358,7 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr ""
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
+msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr ""
 
 #: src/components/Create/ConfirmDeployProject.tsx
@@ -1454,9 +1448,7 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "Будущее будет возглавляться создателями и принадлежать сообществам."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
+msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr ""
 
 #: src/constants/fundingWarningText.ts
@@ -2029,9 +2021,5 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Обменный курс {tokenSymbol}/ETH на {exchangeName}."
 
 #: src/components/Project/Rewards/index.tsx
-msgid ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
+msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -27,9 +27,7 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "(İsteğe bağlı) Bu ödemeye zincir üstü bir not ekleyin"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
+msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr ""
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -797,9 +795,7 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
+msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
@@ -1362,10 +1358,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr ""
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
-msgstr ""
+msgid "Some funding cycle properties may indicate risk for project contributors."
+msgstr "Bazı finansman döngüsü özellikleri projeye katkıda bulunanlar için risk oluşturabilir."
 
 #: src/components/Create/ConfirmDeployProject.tsx
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -1454,9 +1448,7 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "Gelecek, içerik üreticileri tarafından yönetilecek ve topluluklara ait olacak."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
+msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr ""
 
 #: src/constants/fundingWarningText.ts
@@ -2029,9 +2021,5 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{exchangeName} üzerinde {tokenSymbol}/ETH kuru."
 
 #: src/components/Project/Rewards/index.tsx
-msgid ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
+msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -27,10 +27,8 @@ msgid "(Optional) Add a note to this payment on-chain"
 msgstr "（可选的）在此链上付款中添加备注"
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"({realTokenAllocationPercent}%\n"
-"of all newly minted tokens)."
-msgstr ""
+msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
+msgstr "（{realTokenAllocationPercent}% 新铸造的代币）。"
 
 #: src/components/Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
@@ -797,9 +795,7 @@ msgid "Issue ERC-20 token"
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
-msgid ""
-"Issue an ERC-20 to be used as this project's token. Once\n"
-"issued, anyone can claim their existing token balance in the new token."
+msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr ""
 
 #: src/components/Project/Rewards/IssueTickets.tsx
@@ -971,9 +967,7 @@ msgstr "未设定"
 
 #: src/components/Landing/index.tsx
 msgid "Note: Juicebox is new, unaudited, and not guaranteed to work perfectly. Before spending money, do your own research: <0>ask questions</0>, <1>check out the code</1>, and understand the risks!"
-msgstr ""
-"注意： Juicebox是一个全新的协议，它未经审计且不保证能完美工作。\n"
-" 在花钱之前请先做好您自己的研究：提出疑问，核查代码以及了解所涉及的风险！"
+msgstr "注意： Juicebox是一个全新的协议，它未经审计且不保证能完美工作。在花钱之前请先做好您自己的研究：提出疑问，核查代码以及了解所涉及的风险！"
 
 #: src/components/Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Notice from {0}:"
@@ -1364,10 +1358,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr ""
 
 #: src/components/FundingCycle/FundingCyclePreview.tsx
-msgid ""
-"Some funding cycle properties may indicate risk\n"
-"for project contributors."
-msgstr ""
+msgid "Some funding cycle properties may indicate risk for project contributors."
+msgstr "一些筹款周期的配置可能会给项目贡献者们造成一些风险。"
 
 #: src/components/Create/ConfirmDeployProject.tsx
 #: src/components/Project/modals/ReconfigureFCModal.tsx
@@ -1456,10 +1448,8 @@ msgid "The future will be led by creators, and owned by communities."
 msgstr "创造者将引领未来, 而社区会拥有未来."
 
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
-msgid ""
-"The percent this individual receives of the overall {reservedRate}% \n"
-"reserved token allocation"
-msgstr ""
+msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
+msgstr "这个地址会收到保留代币中的 {reservedRate}%"
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -2031,9 +2021,5 @@ msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "在 {exchangeName} 的兑换率为 {tokenSymbol}/ETH"
 
 #: src/components/Project/Rewards/index.tsx
-msgid ""
-"{tokensLabel}\n"
-"are distributed to anyone who pays this project. If the project \n"
-"has set a funding target, tokens can be redeemed for a portion \n"
-"of the project's overflow whether or not they have been claimed yet."
+msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""


### PR DESCRIPTION
## What does this PR do and why?

- Removes `\n` from strings marked for translation. This causing issues in lingui's extract script; results varied between local and github action.
- Removes lingui script from crowdin download
- Removes the pre-commit hook

Unfortunately, we can't test whether this works as we need to first _upload_ these new strings to crowdin so that the _download_ script will download these new strings. I will test as soon as it hits `main` - note that there shouldn't be any adverse affects on production.

This action demonstrates that the crowdin action itself _already does_ extraction in its script:
https://github.com/jbx-protocol/juice-interface/runs/5172363112?check_suite_focus=true
```
DOWNLOAD TRANSLATIONS
✔️  Fetching project info
✔️  Building ZIP archive with the latest translations
✔️  Building translation (100%)
✔️  Downloading translations
✔️  Extracting archive
✔️  Extracted: 'src/locales/es/messages.po'
✔️  Extracted: 'src/locales/fr/messages.po'
✔️  Extracted: 'src/locales/hi/messages.po'
✔️  Extracted: 'src/locales/ja/messages.po'
✔️  Extracted: 'src/locales/pt/messages.po'
✔️  Extracted: 'src/locales/ru/messages.po'
✔️  Extracted: 'src/locales/tr/messages.po'
✔️  Extracted: 'src/locales/zh/messages.po'
```

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
