### PR TITLE
Fix default FC weight

### DIFF
--- a/src/redux/slices/editingProject.ts
+++ b/src/redux/slices/editingProject.ts
@@ -59,7 +59,7 @@ export const defaultProjectState: EditingProjectState = {
     start: BigNumber.from(Math.floor(new Date().valueOf() / 1000)),
     duration: BigNumber.from(0),
     tapped: BigNumber.from(0),
-    weight: constants.WeiPerEther, // 1e24
+    weight: constants.WeiPerEther.mul(1000000), // 1e24
     fee: BigNumber.from(0),
     reserved: parsePerbicent(0),
     bondingCurveRate: defaultBondingCurveRate,


### PR DESCRIPTION
## What does this PR do and why?

Fixes #548

Previously this was `BigNumber.from('1000000000000000000000000')`, which is equiv to `WeiPerEth*10^6`.

## Screenshots or screen recordings

Screenshot demonstrates fix.

<img width="754" alt="Screen Shot 2022-02-14 at 9 20 41 pm" src="https://user-images.githubusercontent.com/94939382/153859226-e895922c-e186-4b28-b595-5d42375dddf5.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
