### PR TITLE
Page archived projects using project ids in subgraph query

### DIFF
--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -43,7 +43,6 @@ export default function Landing() {
 
   const { data: previewProjects } = useProjectsQuery({
     pageSize: 4,
-    states: { active: true, archived: false },
   })
 
   const smallHeader = (text: string) => (

--- a/src/components/Projects/ProjectsFilterAndSort.tsx
+++ b/src/components/Projects/ProjectsFilterAndSort.tsx
@@ -17,10 +17,8 @@ export default function ProjectsFilterAndSort({
   setIncludeV1,
   includeV1_1,
   setIncludeV1_1,
-  includeActive,
-  setIncludeActive,
-  includeArchived,
-  setIncludeArchived,
+  showArchived,
+  setShowArchived,
   orderBy,
   setOrderBy,
 }: {
@@ -28,10 +26,8 @@ export default function ProjectsFilterAndSort({
   setIncludeV1: CheckboxOnChange
   includeV1_1: boolean
   setIncludeV1_1: CheckboxOnChange
-  includeActive: boolean
-  setIncludeActive: CheckboxOnChange
-  includeArchived: boolean
-  setIncludeArchived: CheckboxOnChange
+  showArchived: boolean
+  setShowArchived: CheckboxOnChange
   orderBy: OrderByOption
   setOrderBy: any
 }) {
@@ -47,13 +43,6 @@ export default function ProjectsFilterAndSort({
     marginTop: 0,
     marginBottom: 0,
     marginRight: 15,
-  }
-
-  // If includeArchived is true, we set active back to true
-  // to avoid both being unselected
-  const toggleArchived = () => {
-    setIncludeActive(includeArchived)
-    setIncludeArchived(!includeArchived)
   }
 
   // Close collapse when clicking anywhere in the window except the collapse items
@@ -112,8 +101,8 @@ export default function ProjectsFilterAndSort({
             />
             <FilterCheckboxItem
               label={t`Archived`}
-              checked={includeArchived}
-              onChange={toggleArchived}
+              checked={showArchived}
+              onChange={setShowArchived}
             />
           </div>
         </CollapsePanel>

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -5,7 +5,7 @@ import Search from 'antd/lib/input/Search'
 import FeedbackFormLink from 'components/shared/FeedbackFormLink'
 import Loading from 'components/shared/Loading'
 
-import { ProjectCategory, ProjectStateFilter } from 'models/project-visibility'
+import { ProjectCategory } from 'models/project-visibility'
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import Grid from 'components/shared/Grid'
@@ -69,19 +69,13 @@ export default function Projects() {
   const [orderBy, setOrderBy] = useState<OrderByOption>('totalPaid')
   const [includeV1, setIncludeV1] = useState<boolean>(true)
   const [includeV1_1, setIncludeV1_1] = useState<boolean>(true)
-  const [includeActive, setIncludeActive] = useState<boolean>(true)
-  const [includeArchived, setIncludeArchived] = useState<boolean>(false)
+  const [showArchived, setShowArchived] = useState<boolean>(false)
 
   const loadMoreContainerRef = useRef<HTMLDivElement>(null)
 
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-
-  const includedStates: ProjectStateFilter = {
-    active: includeActive,
-    archived: includeArchived,
-  }
 
   const terminalVersion: V1TerminalVersion | undefined = useMemo(() => {
     if (includeV1 && !includeV1_1) return '1'
@@ -98,7 +92,7 @@ export default function Projects() {
     orderBy,
     pageSize,
     orderDirection: 'desc',
-    states: includedStates,
+    state: showArchived ? 'archived' : 'active',
     terminalVersion,
   })
 
@@ -129,8 +123,6 @@ export default function Projects() {
   const concatenatedPages = searchText?.length
     ? searchPages
     : pages?.pages?.reduce((prev, group) => [...prev, ...group], [])
-
-  const filterOnlyArchived = !includeActive && includeArchived
 
   return (
     <div style={{ ...layouts.maxWidth }}>
@@ -166,20 +158,18 @@ export default function Projects() {
           </p>
         </div>
 
-        {!filterOnlyArchived ? (
-          <Search
-            autoFocus
-            style={{ flex: 1, marginBottom: 20, marginRight: 20 }}
-            prefix="@"
-            placeholder={t`Search projects by handle`}
-            onSearch={val => {
-              setSearchText(val)
-              history.push(`/projects?tab=all${val ? `&search=${val}` : ''}`)
-            }}
-            defaultValue={searchText}
-            allowClear
-          />
-        ) : null}
+        <Search
+          autoFocus
+          style={{ flex: 1, marginBottom: 20, marginRight: 20 }}
+          prefix="@"
+          placeholder={t`Search projects by handle`}
+          onSearch={val => {
+            setSearchText(val)
+            history.push(`/projects?tab=all${val ? `&search=${val}` : ''}`)
+          }}
+          defaultValue={searchText}
+          allowClear
+        />
 
         <div
           hidden={!!searchText}
@@ -199,17 +189,15 @@ export default function Projects() {
               setIncludeV1={setIncludeV1}
               includeV1_1={includeV1_1}
               setIncludeV1_1={setIncludeV1_1}
-              includeActive={includeActive}
-              setIncludeActive={setIncludeActive}
-              includeArchived={includeArchived}
-              setIncludeArchived={setIncludeArchived}
+              showArchived={showArchived}
+              setShowArchived={setShowArchived}
               orderBy={orderBy}
               setOrderBy={setOrderBy}
             />
           ) : null}
         </div>
         <ArchivedProjectsMessage
-          hidden={!filterOnlyArchived || selectedTab !== 'all'}
+          hidden={!showArchived || selectedTab !== 'all'}
         />
       </div>
 

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -19,6 +19,7 @@ import { CURRENCY_ETH } from 'constants/currency'
 import CurrencySymbol from './CurrencySymbol'
 import Loading from './Loading'
 import ProjectLogo from './ProjectLogo'
+import { archivedProjectIds } from '../../constants/v1/archivedProjects'
 
 type ProjectCardProject = Pick<
   Project,
@@ -36,6 +37,7 @@ export default function ProjectCard({
 
   const cardStyle: CSSProperties = {
     display: 'flex',
+    position: 'relative',
     alignItems: 'center',
     whiteSpace: 'pre',
     overflow: 'hidden',
@@ -77,6 +79,8 @@ export default function ProjectCard({
       : 0
 
   const terminalVersion = getTerminalVersion(_project?.terminal)
+
+  const isArchived = archivedProjectIds.includes(_project.id.toNumber())
 
   return (
     <Link
@@ -161,6 +165,23 @@ export default function ProjectCard({
               </Tooltip>
             )}
           </div>
+
+          {isArchived && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                padding: '2px 4px',
+                background: colors.background.l1,
+                fontSize: '0.7rem',
+                color: colors.text.tertiary,
+                fontWeight: 500,
+              }}
+            >
+              ARCHIVED
+            </div>
+          )}
         </div>
       ) : (
         <div

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2032,4 +2032,3 @@ msgstr "Tipo de cambio de {tokenSymbol}/ETH en {exchangeName}."
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} son distribuidos a cualquiera que pague este proyecto. Si el proyecto tiene un objetivo de financiamiento, los tokens pueden ser canjeados por una porción del excedente del proyecto, hayan sido estos reclamados o no."
-

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2032,4 +2032,3 @@ msgstr "{tokenSymbol}/ETH taxa de câmbio em {exchangeName}."
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""
-

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2032,4 +2032,3 @@ msgstr "Обменный курс {tokenSymbol}/ETH на {exchangeName}."
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""
-

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2032,4 +2032,3 @@ msgstr "{exchangeName} üzerinde {tokenSymbol}/ETH kuru."
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""
-

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -963,7 +963,8 @@ msgstr "未设定"
 
 #: src/components/Landing/index.tsx
 msgid "Note: Juicebox is new, unaudited, and not guaranteed to work perfectly. Before spending money, do your own research: <0>ask questions</0>, <1>check out the code</1>, and understand the risks!"
-msgstr "注意： Juicebox是一个全新的协议，它未经审计且不保证能完美工作。\n"
+msgstr ""
+"注意： Juicebox是一个全新的协议，它未经审计且不保证能完美工作。\n"
 " 在花钱之前请先做好您自己的研究：提出疑问，核查代码以及了解所涉及的风险！"
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -2033,4 +2034,3 @@ msgstr "在 {exchangeName} 的兑换率为 {tokenSymbol}/ETH"
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} 会被分配给付款的人。如果项目设置了筹款目标，可以燃烧代币来按比例赎回溢出池中的 ETH。"
-

--- a/src/models/project-visibility.ts
+++ b/src/models/project-visibility.ts
@@ -1,3 +1,2 @@
 export type ProjectState = 'active' | 'archived'
-export type ProjectStateFilter = { [key in ProjectState]: boolean }
 export type ProjectCategory = 'all' | 'holdings' | 'trending' //| 'metaverse' | 'defi' | 'nft' | 'web3'

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -83,7 +83,7 @@ export type OrderDirection = 'asc' | 'desc'
 
 export type WhereConfig<E extends EntityKey> = {
   key: EntityKeys<E>
-  value: string | number | boolean | string[]
+  value: string | number | boolean | string[] | number[]
   operator?:
     | 'not'
     | 'gt'


### PR DESCRIPTION
## What does this PR do and why?

Previously archived projects have been paged using a filter _after_ data is returned from the initial subgraph query. This means that if no archived projects were returned in the original query, they won't be shown after the list is filtered.

This PR updates the projects query hooks to query projects by id using `archivedProjectIds`, removing the need for a second-step filter on data that has already been returned from the query.

Note: Since we aren't using the project "states" anywhere to query both archived and active projects at the same time, they've been removed for simplicity. Projects can now only be queried by archived _OR_ active.

UI changes:
- an `archived` tag has been added to project cards
- the Search bar is no longer hidden when archived projects are being queried (running a search query still has the same behavior and ignores any other filters)

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/79433522/154098449-6d6277da-9433-48f2-8bc3-03b0a7e44199.png)
![image](https://user-images.githubusercontent.com/79433522/154098502-d3e57d0a-87d8-452d-bb4d-7a30bc9a4135.png)


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
