### PR TITLE
Append newline to generated translation files

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lint:fix": "yarn lint --fix",
     "lint-staged": "lint-staged",
     "prepare": "husky install",
-    "i18n:extract": "lingui extract --clean",
+    "i18n:extract": "./scripts/extract-translations.sh",
     "i18n:compile": "lingui compile",
     "i18n:lint": "./scripts/lint-translations.sh",
     "postinstall": "yarn i18n:compile",

--- a/scripts/extract-translations.sh
+++ b/scripts/extract-translations.sh
@@ -1,0 +1,11 @@
+lingui extract --clean
+
+
+# Append newline to every file,
+# to match the behavior of the Crowdin GitHub
+# action script.
+LOCALE_CHANGED_FILES=$(git diff --name-only src/locales)
+for FILE in $LOCALE_CHANGED_FILES
+do
+	echo "" >> $FILE
+done


### PR DESCRIPTION
The extraction script used in the Crowdin GitHub action behaves differently to lingui.
It appends an extra newline to files. So, lingui tries to remove these extra newlines, which breaks the linter.

This commit adds a script to add a newline to every translation file.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
