### PR TITLE
Add ExternalLink, fix newlines in translations

### DIFF
--- a/src/components/Landing/QAs.tsx
+++ b/src/components/Landing/QAs.tsx
@@ -1,18 +1,14 @@
 import { t, Trans } from '@lingui/macro'
+import ExternalLink from 'components/shared/ExternalLink'
+import { PropsWithChildren } from 'react'
+import { Link } from 'react-router-dom'
 
-export const OverflowVideoLink = ({ text }: { text: string }) => (
-  <a
-    href="https://www.youtube.com/watch?v=9Mq5oDh0aBY&ab_channel=JuiceboxDAO"
-    rel="noreferrer"
-    target="_blank"
-  >
-    {text}
-  </a>
+export const OverflowVideoLink = ({ children }: PropsWithChildren<{}>) => (
+  <ExternalLink href="https://youtu.be/9Mq5oDh0aBY">{children}</ExternalLink>
 )
-const JBDiscordLink = ({ text }: { text: string }) => (
-  <a href="https://discord.gg/6jXrJSyDFf" rel="noreferrer" target="_blank">
-    {text}
-  </a>
+
+const JBDiscordLink = ({ children }: PropsWithChildren<{}>) => (
+  <ExternalLink href="https://discord.gg/6jXrJSyDFf">{children}</ExternalLink>
 )
 
 // t macro function wasn't working when QAs was in the same file
@@ -20,31 +16,33 @@ const JBDiscordLink = ({ text }: { text: string }) => (
 // Saw the suggestion to separate the store and render into 2 files here:
 // https://github.com/lingui/js-lingui/issues/707#issuecomment-657199843
 // Not sure why but this fixed the problem.
-// Take-away: If you're storing a list of t`` strings in a list,
+// Take-away: If you're storing a list of <Trans>` strings in a list,
 // make sure you're not rendering it from the same file.
 export default function QAs() {
   return [
     {
-      q: t`Who funds Juicebox projects?`,
+      q: <Trans>Who funds Juicebox projects?</Trans>,
       a: [
-        t`Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).`,
-        t`For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.`,
+        <Trans>
+          Users fund your project by paying to use your app or service, or as a
+          patron or investor by making a payment directly to your project's
+          smart contract (like on this app).
+        </Trans>,
+        <Trans>
+          For users paying through your app, you should route those funds
+          through the Juicebox smart contracts so they receive tokens in return.
+        </Trans>,
       ],
     },
     {
-      q: t`What does Juicebox cost?`,
+      q: <Trans>What does Juicebox cost?</Trans>,
       a: [
         <Trans>
           Juicebox is an open protocol on Ethereum that is funded using Juicebox
           itself. You can check out the contractualized budget specs{' '}
-          <a
-            href="https://juicebox.money/#/p/juicebox"
-            rel="noreferrer"
-            target="_blank"
-          >
-            {' '}
+          <ExternalLink href="https://juicebox.money/#/p/juicebox">
             here
-          </a>
+          </ExternalLink>
           .
         </Trans>,
         <Trans>
@@ -52,35 +50,35 @@ export default function QAs() {
           withdrawn funds into the JuiceboxDAO treasury. Projects can then use
           their JBX to participate in the governance of JuiceboxDAO and its
           collective treasury, as well as redeem from its growing{' '}
-          <OverflowVideoLink text={t`overflow`} />. The fee is also subject to
-          change via JBX member votes.
+          <OverflowVideoLink>overflow</OverflowVideoLink>. The fee is also
+          subject to change via JBX member votes.
         </Trans>,
       ],
     },
     {
-      q: t`What is overflow?`,
+      q: <Trans>What is overflow?</Trans>,
       a: [
-        t`If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. 
-        If your project earns more than that, the surplus funds are locked in an overflow pool. 
-        Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.`,
+        <Trans>
+          If you know how much your project needs to earn over some period of
+          time to be sustainable, you can set a funding target with that amount.
+          If your project earns more than that, the surplus funds are locked in
+          an overflow pool. Anyone holding your project's tokens can claim a
+          portion of the overflow pool in exchange for redeeming their tokens.
+        </Trans>,
         <Trans>
           For more info, check out this{' '}
-          <OverflowVideoLink text={t`short video`} />.
+          <OverflowVideoLink>short video</OverflowVideoLink>.
         </Trans>,
       ],
     },
     {
-      q: t`What are community tokens?`,
+      q: <Trans>What are community tokens?</Trans>,
       a: [
         <Trans>
           Each project has its own{' '}
-          <a
-            href="https://www.youtube.com/watch?v=cqZhNzZoMh8&ab_channel=SimplyExplained"
-            rel="noreferrer"
-            target="_blank"
-          >
+          <ExternalLink href="https://youtu.be/cqZhNzZoMh8">
             ERC-20 tokens
-          </a>
+          </ExternalLink>
           . Anyone who contributes funds to a project receives that project's
           tokens in return. Token balances will be tracked by the protocol until
           ERC-20 tokens are optionally issued by the project owner.
@@ -88,178 +86,260 @@ export default function QAs() {
       ],
     },
     {
-      q: t`Why should I want to own a project's tokens?`,
+      q: <Trans>Why should I want to own a project's tokens?</Trans>,
       a: [
         <Trans>
           Tokens can be redeemed for a portion of a project's{' '}
-          <OverflowVideoLink text={t`overflow`} />, letting you benefit from its
-          success. After all, you helped it get there. The token may also give
-          you exclusive member-only privledges, and allow you to contribute to
-          the governance of the community.
+          <OverflowVideoLink>overflow</OverflowVideoLink>, letting you benefit
+          from its success. After all, you helped it get there. The token may
+          also give you exclusive member-only privledges, and allow you to
+          contribute to the governance of the community.
         </Trans>,
       ],
     },
     {
-      q: t`What's a discount rate?`,
+      q: <Trans>What's a discount rate?</Trans>,
       a: [
-        t`Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. 
-        The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate 
-        will incentivize supporters to pay your project earlier rather than later.`,
+        <Trans>
+          Projects can be created with an optional discount rate designed to
+          incentivize supporters to contribute earlier rather than later. The
+          amount of tokens rewarded per amount paid to your project will
+          decrease by the discount rate with each new funding cycle. A higher
+          discount rate will incentivize supporters to pay your project earlier
+          rather than later.
+        </Trans>,
       ],
     },
     {
-      q: t`What's a bonding curve?`,
+      q: <Trans>What's a bonding curve?</Trans>,
       a: [
-        t`A bonding curve rewards people who wait longer to redeem your tokens for overflow.`,
-        t`For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.`,
-        t`The rest is left to share between token hodlers.`,
+        <Trans>
+          A bonding curve rewards people who wait longer to redeem your tokens
+          for overflow.
+        </Trans>,
+        <Trans>
+          For example, with a bonding curve of 70%, redeeming 10% of the token
+          supply at any given time will claim around 7% of the total overflow.
+        </Trans>,
+        <Trans>The rest is left to share between token hodlers.</Trans>,
         <Trans>
           For more info, check out this{' '}
-          <a
-            href="https://www.youtube.com/watch?v=dxqc3yMqi5M&ab_channel=JuiceboxDAO"
-            rel="noreferrer"
-            target="_blank"
-          >
+          <ExternalLink href="https://youtu.be/dxqc3yMqi5M">
             short video
-          </a>{' '}
+          </ExternalLink>{' '}
           on bonding curves.
         </Trans>,
       ],
     },
     {
-      q: t`Does a project benefit from its own overflow?`,
+      q: <Trans>Does a project benefit from its own overflow?</Trans>,
       a: [
-        t`A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.`,
-        t`Holding these tokens entitles a project to a portion of its own overflow.`,
+        <Trans>
+          A project can choose to reserve a percentage of tokens for itself.
+          Instead of being distributed to paying users, this percentage of
+          tokens is instead minted for the project.
+        </Trans>,
+        <Trans>
+          Holding these tokens entitles a project to a portion of its own
+          overflow.
+        </Trans>,
       ],
     },
     {
-      q: t`Can I change my project's contract after it's been created?`,
+      q: (
+        <Trans>
+          Can I change my project's contract after it's been created?
+        </Trans>
+      ),
       a: [
-        t`Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain 
-        number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days 
-        before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls.`,
+        <Trans>
+          Project owners can configure a delay period, meaning reconfigurations
+          to an upcoming funding cycle must be submitted a certain number of
+          days before it starts. For example, a 3-day delay period means
+          reconfigurations must be submitted at least 3 days before the next
+          funding cycle starts. This gives token holders time to react to the
+          decision and reduces the chance of rug-pulls.
+        </Trans>,
       ],
     },
     {
-      q: t`Can I delete a project?`,
+      q: <Trans>Can I delete a project?</Trans>,
       a: [
         <Trans>
           It isn't possible to remove a project's data from the blockchain, but
           we can hide it in the app if you'd like to prevent people from seeing
           or interacting with it — just let us know in{' '}
-          <JBDiscordLink text={`Discord`} />. Keep in mind people will still be
-          able to use your project by interacting directly with the contract.
+          <JBDiscordLink>Discord</JBDiscordLink>. Keep in mind people will still
+          be able to use your project by interacting directly with the contract.
         </Trans>,
       ],
     },
     {
-      q: t`Why Ethereum?`,
+      q: <Trans>Why Ethereum?</Trans>,
       a: [
-        t`A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.`,
-        t`Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.`,
-        t`This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.`,
-        t`People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.`,
-        t`Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.`,
+        <Trans>
+          A mechanism like Juicebox where upfront financial commitments should
+          be honored over time is only guaranteed within an ecosystem like
+          Ethereum.
+        </Trans>,
+        <Trans>
+          Ethereum provides a public environment where internet apps like
+          Juicebox can run in a permission-less, trustless, and unstoppable
+          fashion.
+        </Trans>,
+        <Trans>
+          This means that anyone can see the code that they're using, anyone can
+          use the code without asking for permission, and no one can mess with
+          the code or take it down.
+        </Trans>,
+        <Trans>
+          People using Juicebox are interacting with each other through public
+          infrastructure—not a private, profit-seeking corporate service that
+          brokers the exchange.
+        </Trans>,
+        <Trans>
+          Juicebox was built to allow people and projects to get paid for
+          creating public art and infrastructure, as much as or more than they
+          would working towards corporate ends. No more shady business.
+        </Trans>,
       ],
     },
     {
-      q: t`What's going on under the hood?`,
+      q: <Trans>What's going on under the hood?</Trans>,
       a: [
-        t`This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).`,
-        t`Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.`,
-        t`The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.`,
+        <Trans>
+          This website (juicebox.money) connects to the Juicebox protocol's
+          smart contracts, deployed on the Ethereum network. (note: anyone else
+          can make a website that also connects to these same smart contracts.
+          For now, don't trust any site other than this one to access the
+          Juicebox protocol).
+        </Trans>,
+        <Trans>
+          Creating a Juicebox project mints you an NFT (ERC-721) representing
+          ownership over it. Whoever owns this NFT can configure the rules of
+          the game and how payouts are distributed.
+        </Trans>,
+        <Trans>
+          The project's tokens that are minted and distributed as a result of a
+          received payment are ERC-20's. The amount of tokens minted and
+          distributed are proportional to the volume of payments received,
+          weighted by the project's discount rate over time.
+        </Trans>,
       ],
     },
     {
-      q: t`How decentralized is Juicebox?`,
+      q: <Trans>How decentralized is Juicebox?</Trans>,
       a: [
-        t`Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.`,
-        t`The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.`,
+        <Trans>
+          Juicebox is a governance-minimal protocol. There are only a few levers
+          that can be tuned, none of which impose changes for users without
+          their consent. The Juicebox governance smart contract can adjust these
+          levers.
+        </Trans>,
+        <Trans>
+          The Juicebox protocol is governed by a community of JBX token holders
+          who vote on proposals fortnightly.
+        </Trans>,
       ],
     },
     {
-      q: t`What are the risks?`,
+      q: <Trans>What are the risks?</Trans>,
       a: [
-        t`Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.`,
-        t`However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.`,
-        t`Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.`,
+        <Trans>
+          Juicebox has handled tens of thousands of ETH through its protocol,
+          and has so far had 0 security mishaps.
+        </Trans>,
+        <Trans>
+          However, Juicebox is still experimental software. Although the
+          Juicebox contract team have done their part to shape the smart
+          contracts for public use and have tested the code thoroughly, the risk
+          of exploits is never 0%.
+        </Trans>,
+        <Trans>
+          Due to their public nature, any exploits to the contracts may have
+          irreversible consequences, including loss of funds. Please use
+          Juicebox with caution.
+        </Trans>,
       ],
     },
     {
-      q: t`How have the contracts been tested?`,
+      q: <Trans>How have the contracts been tested?</Trans>,
       a: [
-        t`There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.`,
-        t`There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.`,
+        <Trans>
+          There are unit tests written for every condition of every function in
+          the contracts, and integration tests for every workflow that the
+          protocol supports.
+        </Trans>,
+        <Trans>
+          There was also a script written to iteratively run the integration
+          tests using a random input generator, prioritizing edge cases. The
+          code has successfully passed over 1 million test cases through this
+          stress-testing script.
+        </Trans>,
         <Trans>
           The code could always use more eyes and more critique to further the
-          community's confidence. Join our <JBDiscordLink text={`Discord`} />{' '}
-          and check out the code on{' '}
-          <a
-            href="https://github.com/jbx-protocol"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Github
-          </a>{' '}
+          community's confidence. Join our{' '}
+          <JBDiscordLink>Discord</JBDiscordLink> and check out the code on{' '}
+          <ExternalLink href="https://github.com/jbx-protocol">
+            GitHub
+          </ExternalLink>{' '}
           to work with us.
         </Trans>,
       ],
     },
     {
-      q: t`Will it work on L2s?`,
+      q: <Trans>Will it work on L2s?</Trans>,
       a: [
-        t`That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.`,
-        t`The contract team will soon start working on L2 payment terminals for Juicebox projects.`,
+        <Trans>
+          That's the plan, but the core Juicebox contracts will first be
+          deployed to Ethereum Mainnet.
+        </Trans>,
+        <Trans>
+          The contract team will soon start working on L2 payment terminals for
+          Juicebox projects.
+        </Trans>,
       ],
     },
     {
-      q: t`Do I have to make my project open source to use Juicebox as its business model?`,
+      q: (
+        <Trans>
+          Do I have to make my project open source to use Juicebox as its
+          business model?
+        </Trans>
+      ),
       img: {
         src: '/assets/cooler_if_you_did.png',
         alt: t`It'd be a lot cooler if you did`,
       },
     },
     {
-      q: t`Who is Peel?`,
+      q: <Trans>Who is Peel?</Trans>,
       a: [
         <Trans>
-          <a
-            href="https://juicebox.money/#/p/peel"
-            rel="noreferrer"
-            target="_blank"
-          >
+          <Link to="/p/peel" target="_blank">
             Peel
-          </a>{' '}
+          </Link>{' '}
           is the DAO that manages the juicebox.money frontend interface. You can
           reach out to Peel either through the{' '}
-          <a
-            href="https://discord.gg/XvmfY4Hkcz"
-            rel="noreferrer"
-            target="_blank"
-          >
+          <ExternalLink href="https://discord.gg/XvmfY4Hkcz">
             Peel Discord
-          </a>{' '}
-          or <JBDiscordLink text={`Juicebox's Discord`} />.
+          </ExternalLink>{' '}
+          or the <JBDiscordLink>Juicebox Discord</JBDiscordLink>.
         </Trans>,
       ],
     },
     {
-      q: t`How do I create a project?`,
+      q: <Trans>How do I create a project?</Trans>,
       a: [
         <Trans>
           If you're interested in creating a project but still confused on how
           to get started, consider watching this{' '}
-          <a
-            href="https://www.youtube.com/watch?v=R43XqPriS5M&ab_channel=JuiceboxDAO"
-            rel="noreferrer"
-            target="_blank"
-          >
+          <ExternalLink href="https://youtu.be/R43XqPriS5M">
             instructional video
-          </a>
-          . Also feel free to reach out through our{' '}
-          <JBDiscordLink text={`Discord`} /> where our team will be happy to
-          help bring your project idea to life!
+          </ExternalLink>
+          . Also feel free to reach out in the{' '}
+          <JBDiscordLink>Juicebox Discord</JBDiscordLink> where our team will be
+          happy to help bring your project idea to life!
         </Trans>,
       ],
     },

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -14,6 +14,8 @@ import ProjectCard from 'components/shared/ProjectCard'
 
 import { Link } from 'react-router-dom'
 
+import ExternalLink from 'components/shared/ExternalLink'
+
 import { ThemeOption } from 'constants/theme/theme-option'
 
 import Faq from './Faq'
@@ -22,40 +24,52 @@ import Payments from './Payments'
 import TrendingSection from './TrendingSection'
 import { OverflowVideoLink } from './QAs'
 
+const listData = [
+  t`Indie artists, devs, creators`,
+  t`Ethereum protocols and DAOs`,
+  t`Public goods and services`,
+  t`Open source businesses`,
+]
+
+const BigHeader = ({ text }: { text: string }) => (
+  <h1
+    style={{
+      fontSize: '2.4rem',
+      fontWeight: 600,
+      lineHeight: 1.2,
+      margin: 0,
+    }}
+  >
+    {text}
+  </h1>
+)
+
+const SmallHeader = ({ text }: { text: string }) => (
+  <h3 style={{ fontWeight: 600, margin: 0 }}>{text}</h3>
+)
+
+const FourthCol = ({
+  header,
+  children,
+}: React.PropsWithChildren<{ header: string }>) => (
+  <div>
+    <SmallHeader text={header} />
+    <p style={{ marginBottom: 0, marginTop: 5 }}>{children}</p>
+  </div>
+)
+
+function scrollToCreate() {
+  document.getElementById('create')?.scrollIntoView({ behavior: 'smooth' })
+}
+
 export default function Landing() {
   const { theme, forThemeOption } = useContext(ThemeContext)
-
   const colors = theme.colors
-
   const totalMaxWidth = 1080
-
-  const bigHeader = (text: string) => (
-    <h1
-      style={{
-        fontSize: '2.4rem',
-        fontWeight: 600,
-        lineHeight: 1.2,
-        margin: 0,
-      }}
-    >
-      {text}
-    </h1>
-  )
 
   const { data: previewProjects } = useProjectsQuery({
     pageSize: 4,
   })
-
-  const smallHeader = (text: string) => (
-    <h3 style={{ fontWeight: 600, margin: 0 }}>{text}</h3>
-  )
-
-  const listData = [
-    t`Indie artists, devs, creators`,
-    t`Ethereum protocols and DAOs`,
-    t`Public goods and services`,
-    t`Open source businesses`,
-  ]
 
   const section: CSSProperties = {
     paddingLeft: 40,
@@ -68,21 +82,6 @@ export default function Landing() {
     maxWidth: totalMaxWidth,
     margin: '0 auto',
   }
-
-  function scrollToCreate() {
-    document.getElementById('create')?.scrollIntoView({ behavior: 'smooth' })
-  }
-
-  const fourthCol = (header: string, body: (JSX.Element | string)[]) => (
-    <div>
-      {smallHeader(header)}
-      <p style={{ marginBottom: 0, marginTop: 5 }}>
-        {body.map((b, i) => (
-          <span key={i}>{b} </span>
-        ))}
-      </p>
-    </div>
-  )
 
   return (
     <div>
@@ -104,7 +103,9 @@ export default function Landing() {
                   rowGap: 30,
                 }}
               >
-                {bigHeader(t`Community funding for people and projects`)}
+                <BigHeader
+                  text={t`Community funding for people and projects`}
+                />
                 <div
                   style={{
                     fontWeight: 500,
@@ -120,7 +121,7 @@ export default function Landing() {
                   <br />
                   <Trans>
                     Powered by public smart contracts on{' '}
-                    <a
+                    <ExternalLink
                       style={{
                         color: colors.text.primary,
                         fontWeight: 500,
@@ -128,11 +129,9 @@ export default function Landing() {
                           '1px solid ' + colors.stroke.action.primary,
                       }}
                       href="https://ethereum.org/en/what-is-ethereum/"
-                      target="_blank"
-                      rel="noopener noreferrer"
                     >
                       Ethereum
-                    </a>
+                    </ExternalLink>
                     .
                   </Trans>
                 </div>
@@ -216,7 +215,7 @@ export default function Landing() {
         >
           <Row gutter={60}>
             <Col xs={24} md={12} style={{ marginBottom: 100 }}>
-              {smallHeader(t`Projects using Juicebox`)}
+              <SmallHeader text={t`Projects using Juicebox`} />
               <div style={{ marginTop: 20 }}>
                 {previewProjects ? (
                   <Grid list>
@@ -237,7 +236,7 @@ export default function Landing() {
               </div>
             </Col>
             <Col xs={24} md={12} style={{ marginBottom: 100 }}>
-              {smallHeader(t`Latest payments`)}
+              <SmallHeader text={t`Latest payments`} />
               <div style={{ maxHeight: 600, overflow: 'auto' }}>
                 <Payments />
               </div>
@@ -273,45 +272,51 @@ export default function Landing() {
             </Col>
             <Col xs={24} sm={13}>
               <div style={{ display: 'grid', rowGap: 20, marginBottom: 40 }}>
-                {fourthCol(t`Programmable spending`, [
-                  t`Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they.`,
-                ])}
-                {fourthCol(t`ERC20 community tokens`, [
-                  t`When someone pays your project, they'll receive your project's tokens in return. 
-                  Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. 
-                  Leverage your project's token to grant governance rights, community access, or other membership perks.`,
-                ])}
-                {fourthCol(t`Redistributable surplus`, [
+                <FourthCol header={t`Programmable spending`}>
+                  <Trans>
+                    Commit portions of your funds to the people or projects you
+                    want to support, or the contributors you want to pay. When
+                    you get paid, so do they.
+                  </Trans>
+                </FourthCol>
+                <FourthCol header={t`ERC20 community tokens`}>
+                  <Trans>
+                    When someone pays your project, they'll receive your
+                    project's tokens in return. Tokens can be redeemed for a
+                    portion of your project's overflow funds; when you win, your
+                    community wins with you. Leverage your project's token to
+                    grant governance rights, community access, or other
+                    membership perks.
+                  </Trans>
+                </FourthCol>
+                <FourthCol header={t`Redistributable surplus`}>
                   <Trans>
                     Set a funding target to cover predictable expenses. Any
-                    extra funds (<OverflowVideoLink text={t`overflow`} />) can
-                    be claimed by anyone holding your project's tokens alongside
-                    you.
-                  </Trans>,
-                ])}
-                {fourthCol(t`Transparency & accountability`, [
-                  t`Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. 
-                  Your supporters don't have to trust you — even though they already do.`,
-                ])}
+                    extra funds (<OverflowVideoLink>overflow</OverflowVideoLink>
+                    ) can be claimed by anyone holding your project's tokens
+                    alongside you.
+                  </Trans>
+                </FourthCol>
+                <FourthCol header={t`Transparency & accountability`}>
+                  <Trans>
+                    Changes to your project's funding configuration require a
+                    community-approved period to take effect, which acts as a
+                    safeguard against rug pulls. Your supporters don't have to
+                    trust you — even though they already do.
+                  </Trans>
+                </FourthCol>
+
                 <p>
                   <Trans>
                     Note: Juicebox is new, unaudited, and not guaranteed to work
                     perfectly. Before spending money, do your own research:{' '}
-                    <a
-                      href="https://discord.gg/6jXrJSyDFf"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
+                    <ExternalLink href="https://discord.gg/6jXrJSyDFf">
                       ask questions
-                    </a>
+                    </ExternalLink>
                     ,{' '}
-                    <a
-                      href="https://github.com/jbx-protocol/juice-interface"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
+                    <ExternalLink href="https://github.com/jbx-protocol/juice-interface">
                       check out the code
-                    </a>
+                    </ExternalLink>
                     , and understand the risks!
                   </Trans>
                 </p>
@@ -348,7 +353,7 @@ export default function Landing() {
           <Row align="middle" gutter={40}>
             <Col xs={24} md={14}>
               <div style={{ display: 'grid', rowGap: 20 }}>
-                {bigHeader(t`Should you Juicebox?`)}
+                <BigHeader text={t`Should you Juicebox?`} />
                 <div style={{ color: colors.text.over.brand.secondary }}>
                   <p className="ol">
                     <Trans>Almost definitely.</Trans>
@@ -400,7 +405,7 @@ export default function Landing() {
               paddingRight: 20,
             }}
           >
-            {bigHeader(t`FAQs`)}
+            <BigHeader text={t`FAQs`} />
             <Faq />
           </div>
         </div>

--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -1,10 +1,11 @@
 import { t } from '@lingui/macro'
 
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { Collapse, Space } from 'antd'
 import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+import ExternalLink from 'components/shared/ExternalLink'
 
 export function ItemDropdown({
   heading,
@@ -88,15 +89,9 @@ export function DropdownItem({
   onClick?: VoidFunction
 }) {
   return (
-    <a
-      className="nav-dropdown-item"
-      href={route}
-      rel="noreferrer"
-      target="_blank"
-      onClick={onClick}
-    >
+    <ExternalLink className="nav-dropdown-item" href={route} onClick={onClick}>
       {text}
-    </a>
+    </ExternalLink>
   )
 }
 

--- a/src/components/Projects/RankingExplanation.tsx
+++ b/src/components/Projects/RankingExplanation.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import ExternalLink from 'components/shared/ExternalLink'
 
 // Explains how trending projects rankings are calculated
 export default function RankingExplanation({
@@ -12,13 +13,9 @@ export default function RankingExplanation({
     <Trans>
       Rankings based on number of contributions and volume gained in the last{' '}
       {trendingWindow} days.{' '}
-      <a
-        href={trendingRankingExplanationCodeURL}
-        target="_blank"
-        rel="noreferrer"
-      >
+      <ExternalLink href={trendingRankingExplanationCodeURL}>
         See code
-      </a>
+      </ExternalLink>
     </Trans>
   )
 }

--- a/src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
+++ b/src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
@@ -6,6 +6,8 @@ import UniswapLogo from 'components/icons/Uniswap'
 import { CSSProperties } from 'react'
 import { formattedNum } from 'utils/formatNumber'
 
+import ExternalLink from '../ExternalLink'
+
 import TooltipIcon from '../TooltipIcon'
 
 type ExchangeName = 'Uniswap' | 'Sushiswap'
@@ -79,15 +81,10 @@ export default function TokenAMMPriceRow({
             title={t`${tokenSymbol}/ETH exchange rate on ${exchangeName}.`}
             overlayInnerStyle={{ ...fontStyle }}
           >
-            <a
-              href={exchangeLink}
-              rel="noopener noreferrer"
-              target="_blank"
-              style={{ fontWeight: 400 }}
-            >
+            <ExternalLink href={exchangeLink} style={{ fontWeight: 400 }}>
               {`${formattedNum(WETHPrice)} ${tokenSymbol}/ETH`}
               <LinkOutlined style={{ marginLeft: '0.2rem' }} />
-            </a>
+            </ExternalLink>
           </Tooltip>
         ) : (
           <NotAvailableText />

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -31,7 +31,7 @@ export default function EtherscanLink({
 
   if (type === 'tx') {
     return (
-      <Tooltip trigger={['hover', 'click']} title={t`See transaction`}>
+      <Tooltip title={t`See transaction`}>
         <ExternalLink {...linkProps}>
           <LinkOutlined />
         </ExternalLink>
@@ -40,7 +40,7 @@ export default function EtherscanLink({
   }
 
   return (
-    <Tooltip trigger={['hover', 'click']} title={t`Go to Etherscan`}>
+    <Tooltip title={t`Go to Etherscan`}>
       <ExternalLink {...linkProps}>{value}</ExternalLink>
     </Tooltip>
   )

--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -7,56 +7,41 @@ import { NetworkName } from 'models/network-name'
 import { LinkOutlined } from '@ant-design/icons'
 
 import { readNetwork } from 'constants/networks'
+import ExternalLink from './ExternalLink'
 
 export default function EtherscanLink({
   value,
   type,
-  showText,
 }: {
   value: string | undefined
   type: 'tx' | 'address'
-  showText?: boolean
 }) {
   if (!value) return null
 
   let subdomain = ''
-
   if (readNetwork.name !== NetworkName.mainnet) {
     subdomain = readNetwork.name + '.'
   }
 
-  const goToEtherscan = () => {
-    window.open(`https://${subdomain}etherscan.io/${type}/${value}`)
+  const linkProps = {
+    className: 'hover-action',
+    style: { fontWeight: 400 },
+    href: `https://${subdomain}etherscan.io/${type}/${value}`,
   }
 
   if (type === 'tx') {
     return (
       <Tooltip trigger={['hover', 'click']} title={t`See transaction`}>
-        <a
-          className="hover-action"
-          style={{ fontWeight: 400 }}
-          onClick={goToEtherscan}
-          href={`https://${subdomain}etherscan.io/${type}/${value}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <ExternalLink {...linkProps}>
           <LinkOutlined />
-        </a>
+        </ExternalLink>
       </Tooltip>
     )
   }
+
   return (
     <Tooltip trigger={['hover', 'click']} title={t`Go to Etherscan`}>
-      <a
-        className="hover-action"
-        style={{ fontWeight: 400 }}
-        onClick={goToEtherscan}
-        href={`https://${subdomain}etherscan.io/${type}/${value}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {value}
-      </a>
+      <ExternalLink {...linkProps}>{value}</ExternalLink>
     </Tooltip>
   )
 }

--- a/src/components/shared/ExternalLink.tsx
+++ b/src/components/shared/ExternalLink.tsx
@@ -1,0 +1,10 @@
+export default function ExternalLink({
+  children,
+  ...props
+}: React.HTMLProps<HTMLAnchorElement>) {
+  return (
+    <a {...props} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  )
+}

--- a/src/components/shared/FeedbackFormBtn.tsx
+++ b/src/components/shared/FeedbackFormBtn.tsx
@@ -10,6 +10,8 @@ import { useContext } from 'react'
 import { feedbackFormURL } from 'utils/feedbackFormURL'
 import { NetworkContext } from 'contexts/networkContext'
 
+import ExternalLink from './ExternalLink'
+
 export default function FeedbackFormBtn({
   mobile,
   projectHandle,
@@ -32,15 +34,13 @@ export default function FeedbackFormBtn({
     return (
       <div style={{ height: 30 }}>
         <MessageOutlined size={iconSize} />
-        <a
+        <ExternalLink
           style={{ margin: '0 0 2px 12px', fontWeight: 400 }}
           className="quiet"
           href={formUrl}
-          target="_blank"
-          rel="noreferrer"
         >
           <Trans>Give feedback</Trans>
-        </a>
+        </ExternalLink>
       </div>
     )
   }
@@ -48,24 +48,17 @@ export default function FeedbackFormBtn({
   return (
     <Tooltip
       title={
-        <a
-          className="quiet hover-action"
-          href={formUrl}
-          target="_blank"
-          rel="noreferrer"
-        >
+        <ExternalLink className="quiet hover-action" href={formUrl}>
           <Trans>Give feedback</Trans>
-        </a>
+        </ExternalLink>
       }
     >
-      <a
+      <ExternalLink
         className={`feedback-button hide-mobile ${isDarkMode ? 'dark' : ''}`}
         href={formUrl}
-        target="_blank"
-        rel="noreferrer"
       >
         <img src="/assets/stoned_banny.png" alt="Stoned banny" />
-      </a>
+      </ExternalLink>
     </Tooltip>
   )
 }

--- a/src/components/shared/forms/BudgetForm.tsx
+++ b/src/components/shared/forms/BudgetForm.tsx
@@ -18,6 +18,8 @@ import { fromWad, parseWad } from 'utils/formatNumber'
 import { hasFundingTarget, isRecurring } from 'utils/fundingCycle'
 import { helpPagePath } from 'utils/helpPageHelper'
 
+import ExternalLink from '../ExternalLink'
+
 const DEFAULT_TARGET_AFTER_FEE = '10000'
 
 export default function BudgetForm({
@@ -77,13 +79,11 @@ export default function BudgetForm({
           configuration will depend on the kind of project you're starting.
         </Trans>{' '}
         <Trans>
-          <a
+          <ExternalLink
             href={helpPagePath('protocol/learn/topics/funding-cycle')}
-            rel="noopener noreferrer"
-            target="_blank"
           >
             Learn more
-          </a>{' '}
+          </ExternalLink>{' '}
           about funding cycles.
         </Trans>
       </p>
@@ -108,13 +108,11 @@ export default function BudgetForm({
               holders.
             </Trans>{' '}
             <Trans>
-              <a
+              <ExternalLink
                 href={helpPagePath('protocol/learn/topics/overflow')}
-                rel="noopener noreferrer"
-                target="_blank"
               >
                 Learn more
-              </a>{' '}
+              </ExternalLink>{' '}
               about overflow.
             </Trans>
           </p>
@@ -189,13 +187,11 @@ export default function BudgetForm({
               The project's entire balance will be considered overflow.{' '}
             </Trans>
             <Trans>
-              <a
+              <ExternalLink
                 href={helpPagePath('protocol/learn/topics/overflow')}
-                rel="noopener noreferrer"
-                target="_blank"
               >
                 Learn more
-              </a>{' '}
+              </ExternalLink>{' '}
               about overflow.
             </Trans>
           </p>
@@ -215,13 +211,11 @@ export default function BudgetForm({
           <p style={{ color: colors.text.secondary }}>
             <Trans>Set the length of your funding cycles.</Trans>{' '}
             <Trans>
-              <a
+              <ExternalLink
                 href={helpPagePath('protocol/learn/topics/funding-cycle')}
-                rel="noopener noreferrer"
-                target="_blank"
               >
                 Learn more
-              </a>{' '}
+              </ExternalLink>{' '}
               about funding cycle duration.
             </Trans>
           </p>

--- a/src/components/shared/forms/RulesForm.tsx
+++ b/src/components/shared/forms/RulesForm.tsx
@@ -8,6 +8,7 @@ import { constants, utils } from 'ethers'
 import { useContext, useLayoutEffect, useState } from 'react'
 
 import { ballotStrategies } from 'constants/ballotStrategies/ballotStrategies'
+import ExternalLink from '../ExternalLink'
 
 export default function RulesForm({
   initialBallot,
@@ -128,13 +129,9 @@ export default function RulesForm({
                 The address of any smart contract deployed on {signerNetwork}{' '}
                 that implements
               </Trans>{' '}
-              <a
-                href="https://github.com/jbx-protocol/juice-contracts-v1/blob/05828d57e3a27580437fc258fe9041b2401fc044/contracts/FundingCycles.sol"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <ExternalLink href="https://github.com/jbx-protocol/juice-contracts-v1/blob/05828d57e3a27580437fc258fe9041b2401fc044/contracts/FundingCycles.sol">
                 <Trans>this interface</Trans>
-              </a>
+              </ExternalLink>
               .
             </p>
           </div>,

--- a/src/components/shared/inputs/ImageUploader.tsx
+++ b/src/components/shared/inputs/ImageUploader.tsx
@@ -6,6 +6,8 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useContext, useLayoutEffect, useState } from 'react'
 import { ipfsCidUrl, pinFileToIpfs } from 'utils/ipfs'
 
+import ExternalLink from '../ExternalLink'
+
 export default function ImageUploader({
   initialUrl,
   onSuccess,
@@ -104,10 +106,7 @@ export default function ImageUploader({
             }}
           >
             <Trans>
-              Uploaded to:{' '}
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                {url}
-              </a>
+              Uploaded to: <ExternalLink href={url}>{url}</ExternalLink>
             </Trans>
           </span>
         ) : null}

--- a/src/components/v1/V1Project/ProjectHeader.tsx
+++ b/src/components/v1/V1Project/ProjectHeader.tsx
@@ -20,6 +20,8 @@ import {
 } from 'hooks/v1/contractReader/HasPermission'
 import { useContext, useState } from 'react'
 
+import ExternalLink from 'components/shared/ExternalLink'
+
 import Paragraph from '../../shared/Paragraph'
 
 export default function ProjectHeader() {
@@ -208,34 +210,30 @@ export default function ProjectHeader() {
               </span>
             )}
             {metadata?.infoUri && (
-              <a
+              <ExternalLink
                 style={{ fontWeight: 500, marginRight: spacing }}
                 href={linkUrl(metadata.infoUri)}
-                target="_blank"
-                rel="noopener noreferrer"
               >
                 {prettyUrl(metadata.infoUri)}
-              </a>
+              </ExternalLink>
             )}
             {metadata?.twitter && (
-              <a
+              <ExternalLink
                 style={{
                   fontWeight: 500,
                   marginRight: spacing,
                   whiteSpace: 'pre',
                 }}
                 href={'https://twitter.com/' + metadata.twitter}
-                target="_blank"
-                rel="noopener noreferrer"
               >
                 <span style={{ marginRight: 4 }}>
                   <TwitterOutlined />
                 </span>
                 @{prettyUrl(metadata.twitter)}
-              </a>
+              </ExternalLink>
             )}
             {metadata?.discord && (
-              <a
+              <ExternalLink
                 style={{
                   fontWeight: 500,
                   display: 'flex',
@@ -244,14 +242,12 @@ export default function ProjectHeader() {
                   whiteSpace: 'pre',
                 }}
                 href={linkUrl(metadata.discord)}
-                target="_blank"
-                rel="noopener noreferrer"
               >
                 <span style={{ display: 'flex', marginRight: 4 }}>
                   <Discord size={13} />
                 </span>
                 Discord
-              </a>
+              </ExternalLink>
             )}
           </div>
           {metadata?.description && (

--- a/src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
+++ b/src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Button, Modal } from 'antd'
+import ExternalLink from 'components/shared/ExternalLink'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from 'ethers'
 import { useAddToBalanceTx } from 'hooks/v1/transactor/AddToBalanceTx'
@@ -82,13 +83,9 @@ export default function MigrateV1Pt1Modal({
         </li>
       </ul>
       <p>
-        <a
-          href="https://juicebox.notion.site/Migration-plan-1a05f62d80284cb1b8df2a3b53da341a"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <ExternalLink href="https://juicebox.notion.site/Migration-plan-1a05f62d80284cb1b8df2a3b53da341a">
           <Trans>Documentation on v1.1 contracts</Trans>
-        </a>
+        </ExternalLink>
       </p>
 
       {needsBalance && (

--- a/src/components/v1/V1Project/modals/PayWarningModal.tsx
+++ b/src/components/v1/V1Project/modals/PayWarningModal.tsx
@@ -1,5 +1,6 @@
 import { Modal } from 'antd'
 import { t, Trans } from '@lingui/macro'
+import ExternalLink from 'components/shared/ExternalLink'
 
 export default function PayWarningModal({
   visible,
@@ -23,13 +24,9 @@ export default function PayWarningModal({
         <Trans>Heads up</Trans>
       </h2>
       <p style={{ fontWeight: 500 }}>
-        <a
-          href="https://github.com/jbx-protocol/juice-contracts"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <ExternalLink href="https://github.com/jbx-protocol/juice-contracts">
           <Trans>Juicebox contracts</Trans>
-        </a>{' '}
+        </ExternalLink>{' '}
         <Trans>
           are unaudited, and may be vulnerable to bugs or hacks. All funds moved
           through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -111,8 +111,8 @@ msgid "<0>Notice:</0> These balances will not reflect transfers of claimed token
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
-msgstr "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
+msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
+msgstr "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 
 #: src/components/Landing/TrendingSection.tsx
 msgid "<0>Trending projects</0><1><2/></1>"
@@ -374,12 +374,8 @@ msgid "Changes to these attributes can be made at any time and will be applied t
 msgstr "Changes to these attributes can be made at any time and will be applied to your project immediately."
 
 #: src/components/Landing/index.tsx
-msgid ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
-msgstr ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
+msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
+msgstr "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
@@ -647,12 +643,12 @@ msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supp
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0/>."
-msgstr "For more info, check out this <0/>."
-
-#: src/components/Landing/QAs.tsx
 msgid "For more info, check out this <0>short video</0> on bonding curves."
 msgstr "For more info, check out this <0>short video</0> on bonding curves."
+
+#: src/components/Landing/QAs.tsx
+msgid "For more info, check out this <0>short video</0>."
+msgstr "For more info, check out this <0>short video</0>."
 
 #: src/components/Landing/QAs.tsx
 msgid "For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return."
@@ -788,18 +784,12 @@ msgid "If you have a project you'd like to archive, let the Juicebox team know i
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
-msgstr ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgstr "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
 
 #: src/components/Landing/QAs.tsx
-msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
-msgstr "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
+msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
+msgstr "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
@@ -846,8 +836,8 @@ msgid "Issue token"
 msgstr "Issue token"
 
 #: src/components/Landing/QAs.tsx
-msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
-msgstr "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgstr "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 
 #: src/components/Landing/QAs.tsx
 msgid "It'd be a lot cooler if you did"
@@ -1175,32 +1165,20 @@ msgid "Project owner balance"
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
-msgstr ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgstr "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "Projects"
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
-msgstr "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
+msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
+msgstr "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
-msgstr ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
+msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
+msgstr "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 
 #: src/components/Projects/index.tsx
 msgid "Projects on Juicebox"
@@ -1413,8 +1391,8 @@ msgid "Set a funding cycle target"
 msgstr ""
 
 #: src/components/Landing/index.tsx
-msgid "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
-msgstr "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
+msgid "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
+msgstr "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
@@ -1516,8 +1494,8 @@ msgid "The balance of this project in the Juicebox contract."
 msgstr "The balance of this project in the Juicebox contract."
 
 #: src/components/Landing/QAs.tsx
-msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
-msgstr "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
+msgstr "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
 
 #: src/components/Landing/QAs.tsx
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
@@ -1666,8 +1644,8 @@ msgid "Tokens are earned by anyone who pays your project, and can be redeemed fo
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
-msgstr "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgstr "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
@@ -1820,14 +1798,8 @@ msgid "What's going on under the hood?"
 msgstr ""
 
 #: src/components/Landing/index.tsx
-msgid ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
-msgstr ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgstr "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
@@ -1975,12 +1947,6 @@ msgstr "matching \"{searchText}\""
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/index.tsx
-msgid "overflow"
-msgstr "overflow"
-
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "project"
@@ -1994,10 +1960,6 @@ msgstr "project owner"
 #: src/components/Projects/index.tsx
 msgid "projects"
 msgstr "projects"
-
-#: src/components/Landing/QAs.tsx
-msgid "short video"
-msgstr "short video"
 
 #: src/components/shared/forms/RulesForm.tsx
 msgid "this interface"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -116,7 +116,7 @@ msgid "<0>Notice:</0> These balances will not reflect transfers of claimed token
 msgstr "<0>Aviso:</0> Estos balances no reflejarán las transferencias de tokens reclamados porque Juicebox aún no ha indexado el token ERC-20 {tokenSymbol}."
 
 #: src/components/Landing/QAs.tsx
-msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
+msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr ""
 
 #: src/components/Landing/TrendingSection.tsx
@@ -379,9 +379,7 @@ msgid "Changes to these attributes can be made at any time and will be applied t
 msgstr "Se pueden hacer cambios a estos atributos en cualquier momento y serán aplicados a tu proyecto inmediatamente."
 
 #: src/components/Landing/index.tsx
-msgid ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
+msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -402,7 +400,7 @@ msgstr "Cerrar"
 
 #: src/components/Landing/index.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
-msgstr "Asigna porciones de tus fondos para la gente o proyectos que quieres apoyar, o a los colaboradores a los que les quieres pagar. Cuando te pagan, también a ellos."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Community funding for people and projects"
@@ -650,11 +648,11 @@ msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supp
 msgstr "Por ejemplo, con una curva de adhesión de 70%, canjear 10% del suministro de tokens en cualquier momento te daría alrededor de 7% del total del excedente."
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0/>."
+msgid "For more info, check out this <0>short video</0> on bonding curves."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0>short video</0> on bonding curves."
+msgid "For more info, check out this <0>short video</0>."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -791,14 +789,11 @@ msgid "If you have a project you'd like to archive, let the Juicebox team know i
 msgstr "Si tienes un proyecto que quieras archivar, hazlo saber al equipo de Juicebox en Discord."
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
+msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
@@ -846,7 +841,7 @@ msgid "Issue token"
 msgstr "Emitir token"
 
 #: src/components/Landing/QAs.tsx
-msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1175,10 +1170,7 @@ msgid "Project owner balance"
 msgstr "Saldo del dueño del proyecto"
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1186,14 +1178,11 @@ msgid "Projects"
 msgstr "Proyectos"
 
 #: src/components/Landing/QAs.tsx
-msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
+msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
+msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr ""
 
 #: src/components/Projects/index.tsx
@@ -1407,7 +1396,7 @@ msgid "Set a funding cycle target"
 msgstr "Establece una meta-objetivo del ciclo de financiamiento"
 
 #: src/components/Landing/index.tsx
-msgid "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
+msgid "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
 #: src/components/shared/forms/BudgetForm.tsx
@@ -1510,7 +1499,7 @@ msgid "The balance of this project in the Juicebox contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1660,7 +1649,7 @@ msgid "Tokens are earned by anyone who pays your project, and can be redeemed fo
 msgstr "Los tokens son obtenidos por alguien que paga tu proyecto, y pueden ser canjeados por excedente si tu proyecto tiene un objetivo de financiamiento establecido."
 
 #: src/components/Landing/QAs.tsx
-msgid "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1814,10 +1803,7 @@ msgid "What's going on under the hood?"
 msgstr "¿Qué está sucediendo detrás de escena?"
 
 #: src/components/Landing/index.tsx
-msgid ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -1966,12 +1952,6 @@ msgstr "coincidencia \"{searchText}\""
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "o <0><1> compra el {tokenText} en el exchange <2/></1></0>"
 
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/index.tsx
-msgid "overflow"
-msgstr ""
-
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "project"
@@ -1985,10 +1965,6 @@ msgstr "dueño del proyecto"
 #: src/components/Projects/index.tsx
 msgid "projects"
 msgstr "proyectos"
-
-#: src/components/Landing/QAs.tsx
-msgid "short video"
-msgstr ""
 
 #: src/components/shared/forms/RulesForm.tsx
 msgid "this interface"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -116,7 +116,7 @@ msgid "<0>Notice:</0> These balances will not reflect transfers of claimed token
 msgstr "<0>Aviso:</0> Esses saldos não irão refletir as transferências de tokens solicitados, porque o token {tokenSymbol} ERC-20 ainda não foi indexado pelo Juicebox."
 
 #: src/components/Landing/QAs.tsx
-msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
+msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr ""
 
 #: src/components/Landing/TrendingSection.tsx
@@ -379,9 +379,7 @@ msgid "Changes to these attributes can be made at any time and will be applied t
 msgstr "As mudanças para esses atribuitos podem ser feitas a qualquer momento e irão ser aplicadas ao seu projeto imediatamente."
 
 #: src/components/Landing/index.tsx
-msgid ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
+msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -650,11 +648,11 @@ msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supp
 msgstr "Por exemplo, com uma curva de ligação de 70%, ao resgatar 10% do suprimento dos tokens a qualquer momento, irá reivindicar cerca de 7% do total de overflow."
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0/>."
+msgid "For more info, check out this <0>short video</0> on bonding curves."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0>short video</0> on bonding curves."
+msgid "For more info, check out this <0>short video</0>."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -791,14 +789,11 @@ msgid "If you have a project you'd like to archive, let the Juicebox team know i
 msgstr "Se você tem um projeto que gostaria de arquivar, avise a equipe do Juicebox pelo Discord."
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
+msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
@@ -846,7 +841,7 @@ msgid "Issue token"
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1175,10 +1170,7 @@ msgid "Project owner balance"
 msgstr "Saldo do proprietário deste projeto"
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1186,14 +1178,11 @@ msgid "Projects"
 msgstr "Projetos"
 
 #: src/components/Landing/QAs.tsx
-msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
+msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
+msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr ""
 
 #: src/components/Projects/index.tsx
@@ -1407,7 +1396,7 @@ msgid "Set a funding cycle target"
 msgstr "Defina o objetivo de um ciclo de financiamento"
 
 #: src/components/Landing/index.tsx
-msgid "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
+msgid "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
 #: src/components/shared/forms/BudgetForm.tsx
@@ -1510,7 +1499,7 @@ msgid "The balance of this project in the Juicebox contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1660,7 +1649,7 @@ msgid "Tokens are earned by anyone who pays your project, and can be redeemed fo
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1814,10 +1803,7 @@ msgid "What's going on under the hood?"
 msgstr "Como funciona o Juicebox?"
 
 #: src/components/Landing/index.tsx
-msgid ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -1966,12 +1952,6 @@ msgstr "coincidindo \"{searchText}\""
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "ou <0><1> compre {tokenText} em troca<2/></1></0>"
 
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/index.tsx
-msgid "overflow"
-msgstr ""
-
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "project"
@@ -1985,10 +1965,6 @@ msgstr "proprietário do projeto"
 #: src/components/Projects/index.tsx
 msgid "projects"
 msgstr "projetos"
-
-#: src/components/Landing/QAs.tsx
-msgid "short video"
-msgstr ""
 
 #: src/components/shared/forms/RulesForm.tsx
 msgid "this interface"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -116,7 +116,7 @@ msgid "<0>Notice:</0> These balances will not reflect transfers of claimed token
 msgstr "<0>Внимание:</0> Эти балансы не будут отражать переводы выбранных токенов, поскольку токен ERC-20 {tokenSymbol} еще не был проиндексирован Juicebox."
 
 #: src/components/Landing/QAs.tsx
-msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
+msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr ""
 
 #: src/components/Landing/TrendingSection.tsx
@@ -379,9 +379,7 @@ msgid "Changes to these attributes can be made at any time and will be applied t
 msgstr ""
 
 #: src/components/Landing/index.tsx
-msgid ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
+msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -650,11 +648,11 @@ msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supp
 msgstr "Например: с кривой связи 70%, погашение 10% количества токенов в любой момент времени потребует около 7% от общего переполнения."
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0/>."
+msgid "For more info, check out this <0>short video</0> on bonding curves."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0>short video</0> on bonding curves."
+msgid "For more info, check out this <0>short video</0>."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -791,14 +789,11 @@ msgid "If you have a project you'd like to archive, let the Juicebox team know i
 msgstr "Если у вас есть проект, который вы хотели бы архивировать, сообщите команде Juicebox об этом в Discord."
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
+msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
@@ -846,7 +841,7 @@ msgid "Issue token"
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1175,10 +1170,7 @@ msgid "Project owner balance"
 msgstr "Баланс владельца проекта"
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1186,14 +1178,11 @@ msgid "Projects"
 msgstr "Проекты"
 
 #: src/components/Landing/QAs.tsx
-msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
+msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
+msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr ""
 
 #: src/components/Projects/index.tsx
@@ -1407,7 +1396,7 @@ msgid "Set a funding cycle target"
 msgstr "Установите продолжительность цикла финансирования"
 
 #: src/components/Landing/index.tsx
-msgid "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
+msgid "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
 #: src/components/shared/forms/BudgetForm.tsx
@@ -1510,7 +1499,7 @@ msgid "The balance of this project in the Juicebox contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1660,7 +1649,7 @@ msgid "Tokens are earned by anyone who pays your project, and can be redeemed fo
 msgstr "Токены зарабатываются любым, кто оплачивает ваш проект, и могут быть обменены на реальные деньги которые находятся в излишке, если ваш проект установил цель финансирования."
 
 #: src/components/Landing/QAs.tsx
-msgid "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1814,10 +1803,7 @@ msgid "What's going on under the hood?"
 msgstr "Что творится под капотом?"
 
 #: src/components/Landing/index.tsx
-msgid ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -1966,12 +1952,6 @@ msgstr ""
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "или <0><1>купить {tokenText} на бирже <2/></1></0>"
 
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/index.tsx
-msgid "overflow"
-msgstr ""
-
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "project"
@@ -1984,10 +1964,6 @@ msgstr ""
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "projects"
-msgstr ""
-
-#: src/components/Landing/QAs.tsx
-msgid "short video"
 msgstr ""
 
 #: src/components/shared/forms/RulesForm.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -116,7 +116,7 @@ msgid "<0>Notice:</0> These balances will not reflect transfers of claimed token
 msgstr "<0>Uyarı:</0> {tokenSymbol} ERC-20 token'ı henüz Juicebox tarafından dizine eklenmediğinden, bu bakiyeler talep edilen token'ların transferlerini yansıtmaz."
 
 #: src/components/Landing/QAs.tsx
-msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
+msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr ""
 
 #: src/components/Landing/TrendingSection.tsx
@@ -379,9 +379,7 @@ msgid "Changes to these attributes can be made at any time and will be applied t
 msgstr "Bu özellikler üzerinde herhangi bir zamanda değişiklik yapılabilir ve projenize hemen uygulanacaktır."
 
 #: src/components/Landing/index.tsx
-msgid ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
+msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -402,7 +400,7 @@ msgstr "Kapat"
 
 #: src/components/Landing/index.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
-msgstr "Gelirinizin bir kısmını, desteklemek istediğiniz kişilere veya projelere veya ödeme yapmak istediğiniz katkıda bulunanlara gitmesi için taahhüt edin. Siz ödeme aldığınızda, onlar da alsın."
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Community funding for people and projects"
@@ -650,11 +648,11 @@ msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supp
 msgstr "Örnek olarak, %70'lik bir bağlanma eğrisi ile herhangi bir zamanda token arzının %10'u talep edildiğinde, toplam taşmanın yaklaşık %7'sine denk düşecektir."
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0/>."
+msgid "For more info, check out this <0>short video</0> on bonding curves."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0>short video</0> on bonding curves."
+msgid "For more info, check out this <0>short video</0>."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -791,14 +789,11 @@ msgid "If you have a project you'd like to archive, let the Juicebox team know i
 msgstr "Arşivlemek istediğiniz bir proje varsa Discord'da Juicebox ekibine bildirin."
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
+msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
@@ -846,7 +841,7 @@ msgid "Issue token"
 msgstr "Token çıkar"
 
 #: src/components/Landing/QAs.tsx
-msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1175,10 +1170,7 @@ msgid "Project owner balance"
 msgstr "Proje sahibi bakiyesi"
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1186,14 +1178,11 @@ msgid "Projects"
 msgstr "Projeler"
 
 #: src/components/Landing/QAs.tsx
-msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
+msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
+msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr ""
 
 #: src/components/Projects/index.tsx
@@ -1407,7 +1396,7 @@ msgid "Set a funding cycle target"
 msgstr "Bir finansman döngüsü hedefi belirleyin"
 
 #: src/components/Landing/index.tsx
-msgid "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
+msgid "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
 #: src/components/shared/forms/BudgetForm.tsx
@@ -1510,7 +1499,7 @@ msgid "The balance of this project in the Juicebox contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1660,7 +1649,7 @@ msgid "Tokens are earned by anyone who pays your project, and can be redeemed fo
 msgstr "Token'lar, projenize ödeme yapan herkes tarafından kazanılır ve projenizde bir finansman hedefi belirlendiyse taşma için kullanılabilir."
 
 #: src/components/Landing/QAs.tsx
-msgid "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1814,10 +1803,7 @@ msgid "What's going on under the hood?"
 msgstr "Kaputun altında neler oluyor?"
 
 #: src/components/Landing/index.tsx
-msgid ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -1966,12 +1952,6 @@ msgstr ""
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr ""
 
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/index.tsx
-msgid "overflow"
-msgstr ""
-
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "project"
@@ -1985,10 +1965,6 @@ msgstr ""
 #: src/components/Projects/index.tsx
 msgid "projects"
 msgstr "projeler"
-
-#: src/components/Landing/QAs.tsx
-msgid "short video"
-msgstr ""
 
 #: src/components/shared/forms/RulesForm.tsx
 msgid "this interface"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -116,7 +116,7 @@ msgid "<0>Notice:</0> These balances will not reflect transfers of claimed token
 msgstr "<0>注意：</0> 因为 {tokenSymbol} ERC-20 代币还没被 Juicebox 索引，目前还不会根据已领取代币的转移操作来更新这些余额。"
 
 #: src/components/Landing/QAs.tsx
-msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or <2/>."
+msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr ""
 
 #: src/components/Landing/TrendingSection.tsx
@@ -379,9 +379,7 @@ msgid "Changes to these attributes can be made at any time and will be applied t
 msgstr "可以随时修改这些属性，并立即应用于你的项目。"
 
 #: src/components/Landing/index.tsx
-msgid ""
-"Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. \n"
-"Your supporters don't have to trust you — even though they already do."
+msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmPayOwnerModal/index.tsx
@@ -402,7 +400,7 @@ msgstr "关闭"
 
 #: src/components/Landing/index.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
-msgstr "提前设定把您资金的一部分自动分拨给您想要支持的人或项目，或者您需要支付的贡献者。您获得收入的同时，他们也会收到相应款项。"
+msgstr ""
 
 #: src/components/Landing/index.tsx
 msgid "Community funding for people and projects"
@@ -650,11 +648,11 @@ msgid "For example, with a bonding curve of 70%, redeeming 10% of the token supp
 msgstr "例如：在 70% 的联合曲线配置下，任意时间赎回 10% 的代币供应将能从总溢出中领取到 7% 左右。"
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0/>."
+msgid "For more info, check out this <0>short video</0> on bonding curves."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "For more info, check out this <0>short video</0> on bonding curves."
+msgid "For more info, check out this <0>short video</0>."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -791,14 +789,11 @@ msgid "If you have a project you'd like to archive, let the Juicebox team know i
 msgstr "如果你想存档一个项目，可以在在 Discord 上告知 Juicebox 团队。"
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. \n"
-"If your project earns more than that, the surplus funds are locked in an overflow pool. \n"
-"Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
+msgid "If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out through our <1/> where our team will be happy to help bring your project idea to life!"
+msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
@@ -846,7 +841,7 @@ msgid "Issue token"
 msgstr "发行代币"
 
 #: src/components/Landing/QAs.tsx
-msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0/>. Keep in mind people will still be able to use your project by interacting directly with the contract."
+msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1177,10 +1172,7 @@ msgid "Project owner balance"
 msgstr "项目方余额"
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain \n"
-"number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days \n"
-"before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
+msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1188,14 +1180,11 @@ msgid "Projects"
 msgstr "项目"
 
 #: src/components/Landing/QAs.tsx
-msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0/>. The fee is also subject to change via JBX member votes."
+msgid "Projects building on Juicebox pay a 5% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <0>overflow</0>. The fee is also subject to change via JBX member votes."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid ""
-"Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. \n"
-"The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate \n"
-"will incentivize supporters to pay your project earlier rather than later."
+msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr ""
 
 #: src/components/Projects/index.tsx
@@ -1409,7 +1398,7 @@ msgid "Set a funding cycle target"
 msgstr "设定筹款周期目标"
 
 #: src/components/Landing/index.tsx
-msgid "Set a funding target to cover predictable expenses. Any extra funds (<0/>) can be claimed by anyone holding your project's tokens alongside you."
+msgid "Set a funding target to cover predictable expenses. Any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
 #: src/components/shared/forms/BudgetForm.tsx
@@ -1512,7 +1501,7 @@ msgid "The balance of this project in the Juicebox contract."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
-msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0/> and check out the code on <1>Github</1> to work with us."
+msgid "The code could always use more eyes and more critique to further the community's confidence. Join our <0>Discord</0> and check out the code on <1>GitHub</1> to work with us."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -1662,7 +1651,7 @@ msgid "Tokens are earned by anyone who pays your project, and can be redeemed fo
 msgstr "当有人对你的项目进行支付时，他们会获得项目代币。在项目设定了筹款目标时, 可以通过赎回项目代币来获得溢出资金。"
 
 #: src/components/Landing/QAs.tsx
-msgid "Tokens can be redeemed for a portion of a project's <0/>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
+msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1816,10 +1805,7 @@ msgid "What's going on under the hood?"
 msgstr "里面究竟有什么乾坤？"
 
 #: src/components/Landing/index.tsx
-msgid ""
-"When someone pays your project, they'll receive your project's tokens in return. \n"
-"Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. \n"
-"Leverage your project's token to grant governance rights, community access, or other membership perks."
+msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr ""
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -1968,12 +1954,6 @@ msgstr "满足条件 \"{searchText}\""
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "或是 <0><1>在交易所购买 {tokenText} <2/></1></0>"
 
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/QAs.tsx
-#: src/components/Landing/index.tsx
-msgid "overflow"
-msgstr ""
-
 #: src/components/Projects/HoldingsProjects.tsx
 #: src/components/Projects/index.tsx
 msgid "project"
@@ -1987,10 +1967,6 @@ msgstr "项目拥有者"
 #: src/components/Projects/index.tsx
 msgid "projects"
 msgstr "项目"
-
-#: src/components/Landing/QAs.tsx
-msgid "short video"
-msgstr ""
 
 #: src/components/shared/forms/RulesForm.tsx
 msgid "this interface"


### PR DESCRIPTION
## What does this PR do and why?

The `t` macro in Lingui is the culprit for adding `\n` characters to translations. This PR updates the offending strings to use `Trans`.

Also:
- create an ExternalLink component and use it where possible
- minor clean up here and there

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
