### PR TITLE
Add ability to config custom pinata gateway

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -5,5 +5,6 @@ REACT_APP_SUBGRAPH_URL= # URL of Juicebox subgraph from thegraph.com
 
 REACT_APP_PINATA_PINNER_KEY= # Pinata API key
 REACT_APP_PINATA_PINNER_SECRET= # Pinata API secret
+REACT_APP_PINATA_GATEWAY_HOSTNAME= # Pinata gateway e.g. 'gateway.pinata.cloud'
 
 REACT_APP_BLOCKNATIVE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Next, copy the following fields into your `.env` file:
   `REACT_APP_INFURA_ID` variable.
 - **Endpoint**. This is the Ethereum network that will be used for testing. If
   you don't know which endpoint to use, select **mainnet**. In the `.env` file,
-  copy the network name (e.g. 'mainnet', not the url) into the `REACT_APP_INFURA_NETWORK` variable.
+  copy the network name (e.g. 'mainnet', not the url) into the
+  `REACT_APP_INFURA_NETWORK` variable.
 
 #### Piñata
 
@@ -77,11 +78,12 @@ Take the following steps to set up Piñata for local development:
 1. Create a Piñata API key
    ([learn more](https://docs.pinata.cloud/#your-api-keys)).
    - Enable the **Admin** toggle in the **Admin** field.
-1. Copy the following fields into your `.env` file
+1. Copy the following fields into your `.env` file:
    - **API Key**. In the `.env` file, copy the **API Key** into the
      `REACT_APP_PINATA_PINNER_KEY` variable.
    - **API Secret**. In the `.env` file, copy the **API Secret** into the
      `REACT_APP_PINATA_PINNER_SECRET` variable.
+1. Set `IPFS_GATEWAY_HOSTNAME` to `gateway.pinata.cloud` in your `.env` file.
 
 #### Blocknative
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Take the following steps to set up Piñata for local development:
      `REACT_APP_PINATA_PINNER_KEY` variable.
    - **API Secret**. In the `.env` file, copy the **API Secret** into the
      `REACT_APP_PINATA_PINNER_SECRET` variable.
-1. Set `IPFS_GATEWAY_HOSTNAME` to `gateway.pinata.cloud` in your `.env` file.
 
 #### Blocknative
 

--- a/src/constants/ipfs.ts
+++ b/src/constants/ipfs.ts
@@ -1,0 +1,4 @@
+const JBX_PINATA_GATEWAY = 'jbx.mypinata.cloud'
+
+export const IPFS_GATEWAY_HOSTNAME =
+  process.env.REACT_APP_PINATA_GATEWAY_HOSTNAME || JBX_PINATA_GATEWAY

--- a/src/constants/ipfs.ts
+++ b/src/constants/ipfs.ts
@@ -1,4 +1,4 @@
-const JBX_PINATA_GATEWAY = 'jbx.mypinata.cloud'
+const DEFAULT_PINATA_GATEWAY = 'gateway.pinata.cloud'
 
 export const IPFS_GATEWAY_HOSTNAME =
-  process.env.REACT_APP_PINATA_GATEWAY_HOSTNAME || JBX_PINATA_GATEWAY
+  process.env.REACT_APP_PINATA_GATEWAY_HOSTNAME || DEFAULT_PINATA_GATEWAY

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -2,6 +2,8 @@ import { notification } from 'antd'
 import Axios, { AxiosResponse } from 'axios'
 import { ProjectMetadataV3 } from 'models/project-metadata'
 
+import { IPFS_GATEWAY_HOSTNAME } from 'constants/ipfs'
+
 const pinata_api_key = process.env.REACT_APP_PINATA_PINNER_KEY
 const pinata_secret_api_key = process.env.REACT_APP_PINATA_PINNER_SECRET
 
@@ -161,7 +163,7 @@ export const metadataNameForHandle = (handle: string) =>
   `juicebox-@${handle}-metadata`
 
 export const ipfsCidUrl = (hash: string) =>
-  'https://jbx.mypinata.cloud/ipfs/' + hash
+  `https://${IPFS_GATEWAY_HOSTNAME}/ipfs/${hash}`
 
 export const cidFromUrl = (url: string | undefined) => url?.split('/').pop()
 


### PR DESCRIPTION
## What does this PR do and why?

If a dev isn't using the private `jbx` pinata credentials, any IPFS data they upload won't be available at the currently hard-coded `jbx.mypinata.cloud` gateway.

This PR lets devs set a `REACT_APP_PINATA_GATEWAY_HOSTNAME` in their `.env`.

## Infra updates

Fleek has been updated on `rinkeby` and `mainnet` to specify `REACT_APP_PINATA_GATEWAY_HOSTNAME=jbx.mypinata.cloud`

Fleek:
<img width="473" alt="Screen Shot 2022-02-25 at 7 41 54 am" src="https://user-images.githubusercontent.com/94939382/155616314-e414b498-0f01-4f19-9c77-efbb7d97b338.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
