### PR TITLE
[POC] Types + graph query utils for V2 projects

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,7 @@ import V1Create from 'components/v1/V1Create'
 import Projects from 'components/Projects'
 import V2UserProvider from 'providers/v2/UserProvider'
 import Loading from 'components/shared/Loading'
+import V2Projects from 'components/v2/V2Projects'
 
 const V2Create = lazy(() => import('components/v2/V2Create'))
 const V2Dashboard = lazy(() => import('components/v2/V2Dashboard'))
@@ -35,6 +36,11 @@ export default function Router() {
         </Route>
         <Route path="/p/:handle">
           <V1Dashboard />
+        </Route>
+        <Route path="/v2/projects">
+          <Suspense fallback={<Loading />}>
+            <V2Projects />
+          </Suspense>
         </Route>
         <Route path="/v2/create">
           <Suspense fallback={<Loading />}>

--- a/src/components/v2/V2Projects/ProjectCard.tsx
+++ b/src/components/v2/V2Projects/ProjectCard.tsx
@@ -1,0 +1,41 @@
+import axios from 'axios'
+import FormattedAddress from 'components/shared/FormattedAddress'
+import { ProjectVx } from 'models/subgraph-entities/project'
+import { useEffect, useState } from 'react'
+import { formatHistoricalDate } from 'utils/formatDate'
+import { ipfsCidUrl } from 'utils/ipfs'
+
+export default function ProjectCard({ project }: { project: ProjectVx }) {
+  const [metadata, setMetadata] = useState()
+
+  useEffect(() => {
+    axios.get(ipfsCidUrl(project.metadataUri)).then(res => {
+      setMetadata(res.data)
+    })
+  }, [project])
+
+  return (
+    <div>
+      <a
+        href={ipfsCidUrl(project.metadataUri)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        #{project.projectId}
+      </a>{' '}
+      - <FormattedAddress address={project.creator} /> -{' '}
+      {formatHistoricalDate(project.createdAt * 1000)}
+      {metadata && (
+        <div>
+          {Object.entries(metadata).map(([key, val]) =>
+            val ? (
+              <div>
+                {key}: {JSON.stringify(val)}
+              </div>
+            ) : null,
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/v2/V2Projects/index.tsx
+++ b/src/components/v2/V2Projects/index.tsx
@@ -1,0 +1,33 @@
+import Loading from 'components/shared/Loading'
+import { layouts } from 'constants/styles/layouts'
+import { useProjectsVxQuery } from 'hooks/v1/Projects'
+import { ProjectVx } from 'models/subgraph-entities/project'
+
+import ProjectCard from './ProjectCard'
+
+export default function V2Projects() {
+  const { data: projects, isLoading } = useProjectsVxQuery({
+    orderBy: 'createdAt',
+    orderDirection: 'desc',
+    pageSize: 1000,
+    cv: 2,
+  })
+
+  return (
+    <div style={layouts.maxWidth}>
+      <h1>V2 Projects</h1>
+
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <div>
+          {projects?.map(project => (
+            <div style={{ marginBottom: 20 }}>
+              <ProjectCard project={project as ProjectVx} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/v1/Projects.ts
+++ b/src/hooks/v1/Projects.ts
@@ -6,6 +6,7 @@ import { ProjectState } from 'models/project-visibility'
 import {
   parseTrendingProjectJson,
   Project,
+  ProjectVx,
   TrendingProject,
   TrendingProjectJson,
 } from 'models/subgraph-entities/project'
@@ -27,15 +28,24 @@ import useSubgraphQuery, { useInfiniteSubgraphQuery } from '../SubgraphQuery'
 interface ProjectsOptions {
   pageNumber?: number
   projectId?: BigNumber
-  handle?: string
-  uri?: string
   orderBy?: 'createdAt' | 'currentBalance' | 'totalPaid'
   orderDirection?: 'asc' | 'desc'
   pageSize?: number
   state?: ProjectState
   keys?: (keyof Project)[]
   terminalVersion?: V1TerminalVersion
-  searchText?: string
+}
+
+interface ProjectsVxOptions {
+  pageNumber?: number
+  projectId?: number
+  orderBy?: 'createdAt' | 'currentBalance' | 'totalPaid'
+  orderDirection?: 'asc' | 'desc'
+  pageSize?: number
+  state?: ProjectState
+  keys?: (keyof ProjectVx)[]
+  terminalVersion?: V1TerminalVersion
+  cv?: ProjectVx['cv']
 }
 
 const staleTime = 60 * 1000 // 60 seconds
@@ -64,20 +74,20 @@ const queryOpts = (
 
   if (terminalAddress) {
     where.push({
-      key: 'terminal' as const,
+      key: 'terminal',
       value: terminalAddress,
     })
   }
 
   if (opts.state === 'archived') {
     where.push({
-      key: 'id' as const,
+      key: 'id',
       value: archivedProjectIds,
       operator: 'in',
     })
   } else if (opts.projectId) {
     where.push({
-      key: 'id' as const,
+      key: 'id',
       value: opts.projectId.toString(),
     })
   }
@@ -85,6 +95,65 @@ const queryOpts = (
   return {
     entity: 'project',
     keys: opts.keys ?? keys,
+    orderDirection: opts.orderDirection ?? 'desc',
+    orderBy: opts.orderBy ?? 'totalPaid',
+    pageSize: opts.pageSize,
+    where,
+  }
+}
+
+const queryOptsVx = (
+  opts: ProjectsVxOptions,
+): Partial<
+  | GraphQueryOpts<'projectVx', EntityKeys<'projectVx'>>
+  | InfiniteGraphQueryOpts<'projectVx', EntityKeys<'projectVx'>>
+> => {
+  const where: WhereConfig<'projectVx'>[] = []
+
+  const terminalAddress = getTerminalAddress(opts.terminalVersion)
+
+  if (terminalAddress) {
+    where.push({
+      key: 'terminal',
+      value: terminalAddress,
+    })
+  }
+
+  if (opts.cv) {
+    where.push({
+      key: 'cv',
+      value: opts.cv,
+    })
+  }
+
+  if (opts.state === 'archived') {
+    where.push({
+      key: 'id',
+      value: archivedProjectIds,
+      operator: 'in',
+    })
+  } else if (opts.projectId) {
+    where.push({
+      key: 'projectId',
+      value: opts.projectId.toString(),
+    })
+  }
+
+  return {
+    entity: 'projectVx',
+    keys: opts.keys ?? [
+      'id',
+      'projectId',
+      'handle',
+      'creator',
+      'createdAt',
+      'metadataUri',
+      'metadataDomain',
+      'currentBalance',
+      'totalPaid',
+      'totalRedeemed',
+      'terminal',
+    ],
     orderDirection: opts.orderDirection ?? 'desc',
     orderBy: opts.orderBy ?? 'totalPaid',
     pageSize: opts.pageSize,
@@ -367,5 +436,25 @@ export function useInfiniteProjectsQuery(opts: ProjectsOptions) {
   return useInfiniteSubgraphQuery(
     queryOpts(opts) as InfiniteGraphQueryOpts<'project', EntityKeys<'project'>>,
     { staleTime },
+  )
+}
+
+export function useProjectsVxQuery(opts: ProjectsVxOptions) {
+  return useSubgraphQuery(
+    {
+      ...(queryOptsVx(opts) as GraphQueryOpts<
+        'projectVx',
+        EntityKeys<'projectVx'>
+      >),
+      first: opts.pageSize,
+      skip:
+        opts.pageNumber && opts.pageSize
+          ? opts.pageNumber * opts.pageSize
+          : undefined,
+      url: 'https://api.studio.thegraph.com/query/2231/juicebox-dev-rinkeby/0.1.8',
+    },
+    {
+      staleTime,
+    },
   )
 }

--- a/src/models/subgraph-entities/project.ts
+++ b/src/models/subgraph-entities/project.ts
@@ -148,6 +148,7 @@ export const parseTrendingProjectJson = (
 
 type BaseProjectVx = {
   id: string
+  projectId: number
   creator: string
   createdAt: number
   totalPaid: BigNumber
@@ -165,7 +166,6 @@ type BaseProjectVx = {
 }
 
 export type ProjectV1 = {
-  projectId: number
   cv: 1 // contracts version
   terminal: string
   metadataUri: string
@@ -174,7 +174,6 @@ export type ProjectV1 = {
 } & BaseProjectVx
 
 export type ProjectV2 = {
-  projectId: number
   cv: 2 // contracts version
   terminal: null
   metadataUri: string

--- a/src/models/subgraph-entities/project.ts
+++ b/src/models/subgraph-entities/project.ts
@@ -145,3 +145,102 @@ export const parseTrendingProjectJson = (
   trendingScore: BigNumber.from(project.trendingScore),
   trendingVolume: BigNumber.from(project.trendingVolume),
 })
+
+type BaseProjectVx = {
+  id: string
+  creator: string
+  createdAt: number
+  totalPaid: BigNumber
+  totalRedeemed: BigNumber
+  currentBalance: BigNumber
+  participants: Partial<Participant>[]
+  payEvents: Partial<PayEvent>[]
+  printPremineEvents: Partial<PrintPremineEvent>[]
+  tapEvents: Partial<TapEvent>[]
+  redeemEvents: Partial<RedeemEvent>[]
+  printReservesEvents: Partial<PrintReservesEvent>[]
+  distributeToPayoutModEvents: Partial<DistributeToPayoutModEvent>[]
+  distributeToTicketModEvents: Partial<DistributeToTicketModEvent>[]
+  deployedERC20Events: Partial<DeployedERC20Event>[]
+}
+
+export type ProjectV1 = {
+  projectId: number
+  cv: 1 // contracts version
+  terminal: string
+  metadataUri: string
+  metadataDomain: null
+  handle: string
+} & BaseProjectVx
+
+export type ProjectV2 = {
+  projectId: number
+  cv: 2 // contracts version
+  terminal: null
+  metadataUri: string
+  metadataDomain: number
+  handle: null
+} & BaseProjectVx
+
+export type ProjectVx = ProjectV1 | ProjectV2 // Separate entity used for testing
+
+export type ProjectVxJson = Partial<
+  Record<
+    Exclude<
+      keyof ProjectVx,
+      | 'cv'
+      | 'projectId'
+      | 'metadataDomain'
+      | 'participants'
+      | 'printPremineEvents'
+      | 'payEvents'
+      | 'tapEvents'
+      | 'redeemEvents'
+      | 'printReservesEvents'
+      | 'deployedERC20Events'
+      | 'distributeToPayoutModEvents'
+      | 'distributeToTicketModEvents'
+    >,
+    string
+  > & {
+    participants: ParticipantJson[]
+    printPremineEvents: PrintPremineEventJson[]
+    payEvents: PayEventJson[]
+    tapEvents: TapEventJson[]
+    redeemEvents: RedeemEventJson[]
+    printReservesEvents: PrintReservesEventJson[]
+    deployedERC20Events: DeployedERC20EventJson[]
+    distributeToPayoutModEvents: DistributeToPayoutModEventJson[]
+    distributeToTicketModEvents: DistributeToTicketModEventJson[]
+  }
+>
+
+export const parseProjectVxJson = (
+  project: ProjectVxJson,
+): Partial<ProjectVx> => ({
+  ...project,
+  createdAt: project.createdAt ? parseInt(project.createdAt) : undefined,
+  currentBalance: project.currentBalance
+    ? BigNumber.from(project.currentBalance)
+    : undefined,
+  totalPaid: project.totalPaid ? BigNumber.from(project.totalPaid) : undefined,
+  totalRedeemed: project.totalRedeemed
+    ? BigNumber.from(project.totalRedeemed)
+    : undefined,
+  participants: project.participants?.map(parseParticipantJson) ?? undefined,
+  printPremineEvents:
+    project.printPremineEvents?.map(parsePrintPremineEventJson) ?? undefined,
+  payEvents: project.payEvents?.map(parsePayEventJson) ?? undefined,
+  tapEvents: project.tapEvents?.map(parseTapEventJson) ?? undefined,
+  redeemEvents: project.redeemEvents?.map(parseRedeemEventJson) ?? undefined,
+  printReservesEvents:
+    project.printReservesEvents?.map(parsePrintReservesEventJson) ?? undefined,
+  deployedERC20Events:
+    project.deployedERC20Events?.map(parseDeployedERC20EventJson) ?? undefined,
+  distributeToPayoutModEvents:
+    project.distributeToPayoutModEvents?.map(parseDistributeToPayoutModEvent) ??
+    undefined,
+  distributeToTicketModEvents:
+    project.distributeToTicketModEvents?.map(parseDistributeToTicketModEvent) ??
+    undefined,
+})


### PR DESCRIPTION
## What does this PR do and why?

- Adds temporary `ProjectVx` subgraph entity and utils for querying versioned projects on experimental subgraph. Uses hard-coded rinkeby subgraph URL for query
- POC V2Projects page
- Light fixes/cleanup to graph query structure

## Screenshots or screen recordings

<img width="844" alt="image" src="https://user-images.githubusercontent.com/79433522/156828979-10f98eb9-6f55-4c75-b2ce-ec2063473a04.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
