### PR TITLE
Change redeem ETH button text

### DIFF
--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -91,6 +91,12 @@ export default function Rewards() {
 
   const tokensLabel = tokenSymbol ? tokenSymbol + ' ' + t`ERC20` : t`Tokens`
 
+  const redeemButtonText = `Redeem ${tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })} for ETH`
+
   return (
     <div>
       <Space direction="vertical" size="large">
@@ -214,7 +220,7 @@ export default function Rewards() {
         <Space direction="vertical" style={{ width: '100%' }}>
           {overflow?.gt(0) ? (
             <Button onClick={() => setRedeemModalVisible(true)} block>
-              <Trans>Return my ETH</Trans>
+              <Trans>{redeemButtonText}</Trans>
             </Button>
           ) : (
             <React.Fragment>
@@ -222,7 +228,7 @@ export default function Rewards() {
                 title={t`Cannot redeem tokens for ETH because this project has no overflow.`}
               >
                 <Button disabled block>
-                  <Trans>Return my ETH</Trans>
+                  <Trans>{redeemButtonText}</Trans>
                 </Button>
               </Tooltip>
               <Button onClick={() => setRedeemModalVisible(true)} block>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1425,11 +1425,6 @@ msgstr "Restrict payments and printing tokens."
 msgid "Restricted actions"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr ""
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2291,6 +2286,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# payment} other {# payments}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr "{redeemButtonText}"
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1430,11 +1430,6 @@ msgstr "Restringir pagos y emisión de tokens."
 msgid "Restricted actions"
 msgstr "Acciones restringidas"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "Retorna mi ETH"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2296,6 +2291,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pago} other {# pagos}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1430,11 +1430,6 @@ msgstr "Restringir pagamentos e impressão de tokens."
 msgid "Restricted actions"
 msgstr "Ações restritas"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "Devolver meu ETH"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2296,6 +2291,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pagamento} other {# pagamentos}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1430,11 +1430,6 @@ msgstr "Ограничить платежи и печать токенов."
 msgid "Restricted actions"
 msgstr "Ограниченные действия"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "Вернуть ЕТН"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2295,6 +2290,11 @@ msgstr "{название}"
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1430,11 +1430,6 @@ msgstr "Ödemeleri ve token basımını kısıtlayın."
 msgid "Restricted actions"
 msgstr "Kısıtlanmış eylemler"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "ETH'mi iade et"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2295,6 +2290,11 @@ msgstr ""
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1430,11 +1430,6 @@ msgstr "限制付款以及铸造代币。"
 msgid "Restricted actions"
 msgstr "受限操作"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "退回我的 ETH"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2295,6 +2290,11 @@ msgstr "{label}"
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx


### PR DESCRIPTION
## What does this PR do and why?

'Return my ETH' -> 'Redeem <Tokens> for ETH'

## Screenshots or screen recordings

<img width="561" alt="Screen Shot 2022-03-09 at 1 12 28 pm" src="https://user-images.githubusercontent.com/96150256/157366081-90d29c22-d338-4a0e-8748-e93e784dc96c.png">


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
