### PR TITLE
New manage tokens modal

### DIFF
--- a/src/components/shared/RichButton.tsx
+++ b/src/components/shared/RichButton.tsx
@@ -1,4 +1,4 @@
-import { RightOutlined } from '@ant-design/icons'
+import { CaretRightFilled } from '@ant-design/icons'
 import { ThemeContext } from 'contexts/themeContext'
 import { ComponentPropsWithoutRef, CSSProperties, useContext } from 'react'
 
@@ -62,7 +62,7 @@ export default function RichButton({
           padding: 5,
         }}
       >
-        <RightOutlined
+        <CaretRightFilled
           style={{
             color: disabled
               ? colors.text.disabled

--- a/src/components/shared/RichButton.tsx
+++ b/src/components/shared/RichButton.tsx
@@ -1,0 +1,75 @@
+import { RightOutlined } from '@ant-design/icons'
+import { ThemeContext } from 'contexts/themeContext'
+import { CSSProperties, useContext } from 'react'
+
+export default function RichButton({
+  title,
+  description,
+  onClick,
+  disabled,
+}: {
+  title: JSX.Element | string
+  description: JSX.Element | string
+  onClick?: React.MouseEventHandler<HTMLDivElement>
+  disabled?: boolean
+}) {
+  const { colors, radii } = useContext(ThemeContext).theme
+
+  const cardStyles: CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    borderRadius: radii.md,
+    cursor: 'pointer',
+    border:
+      '1px solid ' +
+      (disabled ? colors.stroke.disabled : colors.stroke.action.primary),
+    background: colors.background.l0,
+  }
+
+  return (
+    <div
+      className="clickable-border"
+      style={cardStyles}
+      role="button"
+      onClick={e => {
+        if (disabled) return
+        onClick?.(e)
+      }}
+    >
+      <div style={{ padding: '1rem 0 1rem 1rem' }}>
+        <h4
+          style={{
+            color: disabled ? colors.text.disabled : colors.text.action.primary,
+          }}
+        >
+          {title}
+        </h4>
+        <p
+          style={{
+            color: disabled ? colors.text.disabled : colors.text.primary,
+            margin: 0,
+            fontSize: 12,
+          }}
+        >
+          {description}
+        </p>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 5,
+        }}
+      >
+        <RightOutlined
+          style={{
+            color: disabled
+              ? colors.text.disabled
+              : colors.stroke.action.primary,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/shared/RichButton.tsx
+++ b/src/components/shared/RichButton.tsx
@@ -1,25 +1,24 @@
 import { RightOutlined } from '@ant-design/icons'
 import { ThemeContext } from 'contexts/themeContext'
-import { CSSProperties, useContext } from 'react'
+import { ComponentPropsWithoutRef, CSSProperties, useContext } from 'react'
 
 export default function RichButton({
-  title,
+  heading,
   description,
-  onClick,
   disabled,
+  ...props
 }: {
-  title: JSX.Element | string
+  heading: JSX.Element | string
   description: JSX.Element | string
-  onClick?: React.MouseEventHandler<HTMLDivElement>
   disabled?: boolean
-}) {
+} & ComponentPropsWithoutRef<'div'>) {
   const { colors, radii } = useContext(ThemeContext).theme
 
   const cardStyles: CSSProperties = {
     display: 'flex',
     justifyContent: 'space-between',
     borderRadius: radii.md,
-    cursor: 'pointer',
+    cursor: disabled ? 'not-allowed' : 'pointer',
     border:
       '1px solid ' +
       (disabled ? colors.stroke.disabled : colors.stroke.action.primary),
@@ -30,10 +29,11 @@ export default function RichButton({
     <div
       className="clickable-border"
       style={cardStyles}
-      role="button"
+      {...props}
       onClick={e => {
         if (disabled) return
-        onClick?.(e)
+
+        props?.onClick?.(e)
       }}
     >
       <div style={{ padding: '1rem 0 1rem 1rem' }}>
@@ -42,7 +42,7 @@ export default function RichButton({
             color: disabled ? colors.text.disabled : colors.text.action.primary,
           }}
         >
-          {title}
+          {heading}
         </h4>
         <p
           style={{

--- a/src/components/v1/V1Create/index.tsx
+++ b/src/components/v1/V1Create/index.tsx
@@ -375,6 +375,7 @@ export default function V1Create() {
                 borderStyle: 'solid',
                 borderWidth: `1px 1px 1px ${active ? '10px' : '1px'}`,
               }}
+              role="button"
               onClick={() => {
                 if (currentStep !== undefined) return
                 setCurrentStep(i)

--- a/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+++ b/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
@@ -1,5 +1,6 @@
 import { t, Trans } from '@lingui/macro'
 import { Modal, Space, Tooltip } from 'antd'
+import ExternalLink from 'components/shared/ExternalLink'
 import RichButton from 'components/shared/RichButton'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import useCanPrintPreminedTokens from 'hooks/v1/contractReader/CanPrintPreminedTokens'
@@ -15,20 +16,34 @@ import ConfirmUnstakeTokensModal from '../modals/ConfirmUnstakeTokensModal'
 import PrintPreminedModal from '../modals/PrintPreminedModal'
 import RedeemModal from '../modals/RedeemModal'
 
+const BURN_DEFINITION_LINK =
+  'https://www.investopedia.com/tech/cryptocurrency-burning-can-it-manage-inflation/'
+
+const BurnTokensHelp = () => {
+  return (
+    <Trans>
+      <ExternalLink href={BURN_DEFINITION_LINK}>Learn more</ExternalLink> about
+      burning tokens.
+    </Trans>
+  )
+}
+
 const RedeemButtonTooltip = ({
   buttonDisabled,
   children,
 }: PropsWithChildren<{
   buttonDisabled: boolean
 }>) => {
-  if (!buttonDisabled) return <>{children}</>
-
   return (
     <Tooltip
       title={
-        <Trans>
-          Cannot redeem tokens for ETH because this project has no overflow.
-        </Trans>
+        buttonDisabled ? (
+          <Trans>
+            Cannot redeem tokens for ETH because this project has no overflow.
+          </Trans>
+        ) : (
+          <BurnTokensHelp />
+        )
       }
       placement="right"
     >
@@ -90,7 +105,10 @@ export default function ManageTokensModal({
             <RichButton
               heading={<Trans>Redeem {tokensLabel} for ETH</Trans>}
               description={
-                <Trans>Burn your {tokensLabel} in exchange for ETH.</Trans>
+                <Trans>
+                  Redeem your {tokensLabel} for a portion of the project's
+                  overflow. Any {tokensLabel} you redeem will be burned.
+                </Trans>
               }
               onClick={() => setRedeemModalVisible(true)}
               disabled={redeemDisabled}
@@ -98,16 +116,18 @@ export default function ManageTokensModal({
           </RedeemButtonTooltip>
 
           {redeemDisabled && (
-            <RichButton
-              heading={<Trans>Burn {tokensLabel}</Trans>}
-              description={
-                <Trans>
-                  Burn your {tokensLabel}. You won't receive ETH because this
-                  project has no overflow.
-                </Trans>
-              }
-              onClick={() => setRedeemModalVisible(true)}
-            />
+            <Tooltip title={<BurnTokensHelp />} placement="right">
+              <RichButton
+                heading={<Trans>Burn {tokensLabel}</Trans>}
+                description={
+                  <Trans>
+                    Burn your {tokensLabel}. You won't receive ETH in return
+                    because this project has no overflow.
+                  </Trans>
+                }
+                onClick={() => setRedeemModalVisible(true)}
+              />
+            </Tooltip>
           )}
 
           <RichButton

--- a/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+++ b/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
@@ -1,0 +1,152 @@
+import { t, Trans } from '@lingui/macro'
+import { Button, Modal, Space, Tooltip } from 'antd'
+import RichButton from 'components/shared/RichButton'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import useCanPrintPreminedTokens from 'hooks/v1/contractReader/CanPrintPreminedTokens'
+import {
+  OperatorPermission,
+  useHasPermission,
+} from 'hooks/v1/contractReader/HasPermission'
+import { V1FundingCycleMetadata } from 'models/v1/fundingCycle'
+import { useContext, useState } from 'react'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
+
+import ConfirmUnstakeTokensModal from '../modals/ConfirmUnstakeTokensModal'
+import PrintPreminedModal from '../modals/PrintPreminedModal'
+import RedeemModal from '../modals/RedeemModal'
+
+export default function ManageTokensModal({
+  metadata,
+  onCancel,
+  visible,
+}: {
+  metadata?: V1FundingCycleMetadata
+  onCancel?: VoidFunction
+  visible?: boolean
+}) {
+  const { projectId, tokenSymbol, overflow } = useContext(V1ProjectContext)
+
+  const [redeemModalVisible, setRedeemModalVisible] = useState<boolean>(false)
+  const [unstakeModalVisible, setUnstakeModalVisible] = useState<boolean>()
+  const [mintModalVisible, setMintModalVisible] = useState<boolean>()
+
+  const canPrintPreminedV1Tickets = useCanPrintPreminedTokens()
+  const hasPrintPreminePermission = useHasPermission(
+    OperatorPermission.PrintTickets,
+  )
+
+  const mintingTokensIsAllowed =
+    metadata &&
+    (metadata.version === 0
+      ? canPrintPreminedV1Tickets
+      : metadata.ticketPrintingIsAllowed)
+
+  const tokensLabelLowercase = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: true,
+    plural: true,
+  })
+
+  const redeemDisabled = !Boolean(overflow?.gt(0))
+
+  return (
+    <>
+      <Modal
+        title={t`Manage ${tokenSymbolText({
+          tokenSymbol: tokenSymbol,
+          capitalize: false,
+          plural: true,
+          includeTokenWord: true,
+        })}`}
+        visible={visible}
+        onCancel={onCancel}
+        okButtonProps={{ hidden: true }}
+        centered
+      >
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <RichButton
+            heading={<Trans>Redeem {tokensLabelLowercase} for ETH</Trans>}
+            description={
+              <Trans>
+                Burn your {tokensLabelLowercase} in exchange for ETH.
+              </Trans>
+            }
+            onClick={() => setRedeemModalVisible(true)}
+            disabled={redeemDisabled}
+          />
+
+          {redeemDisabled && (
+            <RichButton
+              heading={<Trans>Burn {tokensLabelLowercase}</Trans>}
+              description={
+                <Trans>
+                  Burn your {tokensLabelLowercase}. You won't receive ETH
+                  because this project has no overflow.
+                </Trans>
+              }
+              onClick={() => setRedeemModalVisible(true)}
+            />
+          )}
+
+          <RichButton
+            heading={<Trans>Claim {tokensLabelLowercase} as ERC20</Trans>}
+            description={
+              <Trans>
+                Move your {tokensLabelLowercase} from the Juicebox contract to
+                your wallet.
+              </Trans>
+            }
+            onClick={() => setUnstakeModalVisible(true)}
+          />
+
+          {!hasPrintPreminePermission && projectId?.gt(0) && (
+            <div style={{ marginTop: '1rem' }}>
+              <h3>Privileged actions</h3>
+              <Tooltip
+                title={
+                  <Trans>
+                    Token minting is only available for V1.1 projects. Token
+                    minting can be enabled or disabled by reconfiguring the
+                    project's funding cycle.
+                  </Trans>
+                }
+                placement="right"
+              >
+                <RichButton
+                  heading={<Trans>Mint {tokensLabelLowercase}</Trans>}
+                  description={
+                    <Trans>
+                      Mint new {tokensLabelLowercase} into an account. Only a
+                      project's owner, a designated operator, or one of its
+                      terminal's delegates can mint its tokens.
+                    </Trans>
+                  }
+                  onClick={() => setMintModalVisible(true)}
+                  disabled={!mintingTokensIsAllowed}
+                />
+              </Tooltip>
+            </div>
+          )}
+        </Space>
+      </Modal>
+
+      <RedeemModal
+        visible={redeemModalVisible}
+        onOk={() => {
+          setRedeemModalVisible(false)
+        }}
+        onCancel={() => {
+          setRedeemModalVisible(false)
+        }}
+      />
+      <ConfirmUnstakeTokensModal
+        visible={unstakeModalVisible}
+        onCancel={() => setUnstakeModalVisible(false)}
+      />
+      <PrintPreminedModal
+        visible={mintModalVisible}
+        onCancel={() => setMintModalVisible(false)}
+      />
+    </>
+  )
+}

--- a/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+++ b/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
@@ -41,9 +41,9 @@ export default function ManageTokensModal({
       ? canPrintPreminedV1Tickets
       : metadata.ticketPrintingIsAllowed)
 
-  const tokensLabelLowercase = tokenSymbolText({
+  const tokensLabel = tokenSymbolText({
     tokenSymbol: tokenSymbol,
-    capitalize: true,
+    capitalize: false,
     plural: true,
   })
 
@@ -65,11 +65,9 @@ export default function ManageTokensModal({
       >
         <Space direction="vertical" style={{ width: '100%' }}>
           <RichButton
-            heading={<Trans>Redeem {tokensLabelLowercase} for ETH</Trans>}
+            heading={<Trans>Redeem {tokensLabel} for ETH</Trans>}
             description={
-              <Trans>
-                Burn your {tokensLabelLowercase} in exchange for ETH.
-              </Trans>
+              <Trans>Burn your {tokensLabel} in exchange for ETH.</Trans>
             }
             onClick={() => setRedeemModalVisible(true)}
             disabled={redeemDisabled}
@@ -77,11 +75,11 @@ export default function ManageTokensModal({
 
           {redeemDisabled && (
             <RichButton
-              heading={<Trans>Burn {tokensLabelLowercase}</Trans>}
+              heading={<Trans>Burn {tokensLabel}</Trans>}
               description={
                 <Trans>
-                  Burn your {tokensLabelLowercase}. You won't receive ETH
-                  because this project has no overflow.
+                  Burn your {tokensLabel}. You won't receive ETH because this
+                  project has no overflow.
                 </Trans>
               }
               onClick={() => setRedeemModalVisible(true)}
@@ -89,43 +87,40 @@ export default function ManageTokensModal({
           )}
 
           <RichButton
-            heading={<Trans>Claim {tokensLabelLowercase} as ERC20</Trans>}
+            heading={<Trans>Claim {tokensLabel} as ERC20</Trans>}
             description={
               <Trans>
-                Move your {tokensLabelLowercase} from the Juicebox contract to
-                your wallet.
+                Move your {tokensLabel} from the Juicebox contract to your
+                wallet.
               </Trans>
             }
             onClick={() => setUnstakeModalVisible(true)}
           />
 
-          {!hasPrintPreminePermission && projectId?.gt(0) && (
-            <div style={{ marginTop: '1rem' }}>
-              <h3>Privileged actions</h3>
-              <Tooltip
-                title={
+          {hasPrintPreminePermission && projectId?.gt(0) && (
+            <Tooltip
+              title={
+                <Trans>
+                  Token minting is only available for V1.1 projects. Token
+                  minting can be enabled or disabled by reconfiguring the
+                  project's funding cycle.
+                </Trans>
+              }
+              placement="right"
+            >
+              <RichButton
+                heading={<Trans>Mint {tokensLabel}</Trans>}
+                description={
                   <Trans>
-                    Token minting is only available for V1.1 projects. Token
-                    minting can be enabled or disabled by reconfiguring the
-                    project's funding cycle.
+                    Mint new {tokensLabel} into an account. Only a project's
+                    owner, a designated operator, or one of its terminal's
+                    delegates can mint its tokens.
                   </Trans>
                 }
-                placement="right"
-              >
-                <RichButton
-                  heading={<Trans>Mint {tokensLabelLowercase}</Trans>}
-                  description={
-                    <Trans>
-                      Mint new {tokensLabelLowercase} into an account. Only a
-                      project's owner, a designated operator, or one of its
-                      terminal's delegates can mint its tokens.
-                    </Trans>
-                  }
-                  onClick={() => setMintModalVisible(true)}
-                  disabled={!mintingTokensIsAllowed}
-                />
-              </Tooltip>
-            </div>
+                onClick={() => setMintModalVisible(true)}
+                disabled={!mintingTokensIsAllowed}
+              />
+            </Tooltip>
           )}
         </Space>
       </Modal>

--- a/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+++ b/src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Button, Modal, Space, Tooltip } from 'antd'
+import { Modal, Space, Tooltip } from 'antd'
 import RichButton from 'components/shared/RichButton'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import useCanPrintPreminedTokens from 'hooks/v1/contractReader/CanPrintPreminedTokens'
@@ -8,12 +8,34 @@ import {
   useHasPermission,
 } from 'hooks/v1/contractReader/HasPermission'
 import { V1FundingCycleMetadata } from 'models/v1/fundingCycle'
-import { useContext, useState } from 'react'
+import { PropsWithChildren, useContext, useState } from 'react'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import ConfirmUnstakeTokensModal from '../modals/ConfirmUnstakeTokensModal'
 import PrintPreminedModal from '../modals/PrintPreminedModal'
 import RedeemModal from '../modals/RedeemModal'
+
+const RedeemButtonTooltip = ({
+  buttonDisabled,
+  children,
+}: PropsWithChildren<{
+  buttonDisabled: boolean
+}>) => {
+  if (!buttonDisabled) return <>{children}</>
+
+  return (
+    <Tooltip
+      title={
+        <Trans>
+          Cannot redeem tokens for ETH because this project has no overflow.
+        </Trans>
+      }
+      placement="right"
+    >
+      {children}
+    </Tooltip>
+  )
+}
 
 export default function ManageTokensModal({
   metadata,
@@ -64,14 +86,16 @@ export default function ManageTokensModal({
         centered
       >
         <Space direction="vertical" style={{ width: '100%' }}>
-          <RichButton
-            heading={<Trans>Redeem {tokensLabel} for ETH</Trans>}
-            description={
-              <Trans>Burn your {tokensLabel} in exchange for ETH.</Trans>
-            }
-            onClick={() => setRedeemModalVisible(true)}
-            disabled={redeemDisabled}
-          />
+          <RedeemButtonTooltip buttonDisabled={redeemDisabled}>
+            <RichButton
+              heading={<Trans>Redeem {tokensLabel} for ETH</Trans>}
+              description={
+                <Trans>Burn your {tokensLabel} in exchange for ETH.</Trans>
+              }
+              onClick={() => setRedeemModalVisible(true)}
+              disabled={redeemDisabled}
+            />
+          </RedeemButtonTooltip>
 
           {redeemDisabled && (
             <RichButton

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -91,6 +91,12 @@ export default function Rewards() {
 
   const tokensLabel = tokenSymbol ? tokenSymbol + ' ' + t`ERC20` : t`Tokens`
 
+  const redeemButtonText = `Redeem ${tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })} for ETH`
+
   return (
     <div>
       <Space direction="vertical" size="large">
@@ -214,7 +220,7 @@ export default function Rewards() {
         <Space direction="vertical" style={{ width: '100%' }}>
           {overflow?.gt(0) ? (
             <Button onClick={() => setRedeemModalVisible(true)} block>
-              <Trans>Return my ETH</Trans>
+              <Trans>{redeemButtonText}</Trans>
             </Button>
           ) : (
             <React.Fragment>
@@ -222,7 +228,7 @@ export default function Rewards() {
                 title={t`Cannot redeem tokens for ETH because this project has no overflow.`}
               >
                 <Button disabled block>
-                  <Trans>Return my ETH</Trans>
+                  <Trans>{redeemButtonText}</Trans>
                 </Button>
               </Tooltip>
               <Button onClick={() => setRedeemModalVisible(true)} block>

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -70,7 +70,7 @@ export default function Rewards() {
     width: 128,
   }
 
-  const tokensLabelUppercase = tokenSymbolText({
+  const tokensLabel = tokenSymbolText({
     tokenSymbol: tokenSymbol,
     capitalize: true,
     plural: true,
@@ -82,8 +82,8 @@ export default function Rewards() {
         <Statistic
           title={
             <SectionHeader
-              text={tokensLabelUppercase}
-              tip={t`${tokensLabelUppercase} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet.`}
+              text={tokensLabel}
+              tip={t`${tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet.`}
             />
           }
           valueRender={() => (

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -1,15 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
-import { Button, Descriptions, Modal, Space, Statistic, Tooltip } from 'antd'
-import ConfirmUnstakeTokensModal from 'components/v1/V1Project/modals/ConfirmUnstakeTokensModal'
-import ParticipantsModal from 'components/v1/V1Project/modals/ParticipantsModal'
-import RedeemModal from 'components/v1/V1Project/modals/RedeemModal'
+import { Button, Descriptions, Space, Statistic } from 'antd'
+
 import FormattedAddress from 'components/shared/FormattedAddress'
 import { NetworkContext } from 'contexts/networkContext'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import * as constants from '@ethersproject/constants'
-import useCanPrintPreminedTokens from 'hooks/v1/contractReader/CanPrintPreminedTokens'
 import useERC20BalanceOf from 'hooks/v1/contractReader/ERC20BalanceOf'
 import {
   OperatorPermission,
@@ -19,41 +16,34 @@ import useReservedTokensOfProject from 'hooks/v1/contractReader/ReservedTokensOf
 import useTotalBalanceOf from 'hooks/v1/contractReader/TotalBalanceOf'
 import useTotalSupplyOfProjectToken from 'hooks/v1/contractReader/TotalSupplyOfProjectToken'
 import useUnclaimedBalanceOfUser from 'hooks/v1/contractReader/UnclaimedBalanceOfUser'
-import React, { CSSProperties, useContext, useState } from 'react'
+import { CSSProperties, useContext, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/v1/fundingCycle'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
-import PrintPreminedModal from '../modals/PrintPreminedModal'
 import IssueTickets from './IssueTickets'
 import SectionHeader from '../SectionHeader'
+import ManageTokensModal from './ManageTokensModal'
+import ParticipantsModal from '../modals/ParticipantsModal'
 
 export default function Rewards() {
   const [manageTokensModalVisible, setManageTokensModalVisible] =
     useState<boolean>()
-  const [unstakeModalVisible, setUnstakeModalVisible] = useState<boolean>()
-  const [mintModalVisible, setMintModalVisible] = useState<boolean>()
   const [participantsModalVisible, setParticipantsModalVisible] =
     useState<boolean>(false)
-  const { userAddress } = useContext(NetworkContext)
 
+  const { userAddress } = useContext(NetworkContext)
   const {
     projectId,
     tokenAddress,
     tokenSymbol,
     isPreviewMode,
     currentFC,
-    overflow,
     terminal,
   } = useContext(V1ProjectContext)
-
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-
-  const [redeemModalVisible, setRedeemModalVisible] = useState<boolean>(false)
-
-  const canPrintPreminedV1Tickets = useCanPrintPreminedTokens()
 
   const claimedBalance = useERC20BalanceOf(tokenAddress, userAddress)
   const unclaimedBalance = useUnclaimedBalanceOfUser()
@@ -75,27 +65,16 @@ export default function Rewards() {
     : false
 
   const hasIssueTicketsPermission = useHasPermission(OperatorPermission.Issue)
-  const hasPrintPreminePermission = useHasPermission(
-    OperatorPermission.PrintTickets,
-  )
-
-  const mintingTokensIsAllowed =
-    metadata &&
-    (metadata.version === 0
-      ? canPrintPreminedV1Tickets
-      : metadata.ticketPrintingIsAllowed)
 
   const labelStyle: CSSProperties = {
     width: 128,
   }
 
-  const tokensLabel = tokenSymbol ? tokenSymbol + ' ' + t`ERC20` : t`Tokens`
-
-  const redeemButtonText = `Redeem ${tokenSymbolText({
+  const tokensLabelUppercase = tokenSymbolText({
     tokenSymbol: tokenSymbol,
-    capitalize: false,
+    capitalize: true,
     plural: true,
-  })} for ETH`
+  })
 
   return (
     <div>
@@ -103,8 +82,8 @@ export default function Rewards() {
         <Statistic
           title={
             <SectionHeader
-              text={tokensLabel}
-              tip={t`${tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet.`}
+              text={tokensLabelUppercase}
+              tip={t`${tokensLabelUppercase} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet.`}
             />
           }
           valueRender={() => (
@@ -205,77 +184,13 @@ export default function Rewards() {
         )}
       </Space>
 
-      <Modal
-        title={t`Manage ${tokenSymbolText({
-          tokenSymbol: tokenSymbol,
-          capitalize: false,
-          plural: true,
-          includeTokenWord: true,
-        })}`}
+      <ManageTokensModal
         visible={manageTokensModalVisible}
         onCancel={() => setManageTokensModalVisible(false)}
-        okButtonProps={{ hidden: true }}
-        centered
-      >
-        <Space direction="vertical" style={{ width: '100%' }}>
-          {overflow?.gt(0) ? (
-            <Button onClick={() => setRedeemModalVisible(true)} block>
-              <Trans>{redeemButtonText}</Trans>
-            </Button>
-          ) : (
-            <React.Fragment>
-              <Tooltip
-                title={t`Cannot redeem tokens for ETH because this project has no overflow.`}
-              >
-                <Button disabled block>
-                  <Trans>{redeemButtonText}</Trans>
-                </Button>
-              </Tooltip>
-              <Button onClick={() => setRedeemModalVisible(true)} block>
-                <Trans>Burn tokens</Trans>
-              </Button>
-            </React.Fragment>
-          )}
-          <Button onClick={() => setUnstakeModalVisible(true)} block>
-            <Trans>Claim {tokenSymbol || t`tokens`} as ERC20</Trans>
-          </Button>
-          {hasPrintPreminePermission && projectId?.gt(0) && (
-            <Tooltip
-              title={t`Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner.`}
-            >
-              <Button
-                disabled={!mintingTokensIsAllowed}
-                onClick={() => setMintModalVisible(true)}
-                block
-              >
-                <Trans>
-                  Mint {tokenSymbol ? tokenSymbol + ' ' : ''}tokens{' '}
-                </Trans>
-              </Button>
-            </Tooltip>
-          )}
-        </Space>
-      </Modal>
-      <RedeemModal
-        visible={redeemModalVisible}
-        onOk={() => {
-          setRedeemModalVisible(false)
-        }}
-        onCancel={() => {
-          setRedeemModalVisible(false)
-        }}
-      />
-      <ConfirmUnstakeTokensModal
-        visible={unstakeModalVisible}
-        onCancel={() => setUnstakeModalVisible(false)}
       />
       <ParticipantsModal
         visible={participantsModalVisible}
         onCancel={() => setParticipantsModalVisible(false)}
-      />
-      <PrintPreminedModal
-        visible={mintModalVisible}
-        onCancel={() => setMintModalVisible(false)}
       />
     </div>
   )

--- a/src/components/v1/V1Project/modals/ParticipantsModal.tsx
+++ b/src/components/v1/V1Project/modals/ParticipantsModal.tsx
@@ -66,6 +66,7 @@ export default function ParticipantsModal({
         'lastPaidTimestamp',
         'balance',
         'stakedBalance',
+        'id',
       ],
       first: pageSize,
       skip: pageNumber * pageSize,

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1451,11 +1451,6 @@ msgstr "Restrict payments and printing tokens."
 msgid "Restricted actions"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr ""
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2315,6 +2310,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# payment} other {# payments}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr "{redeemButtonText}"
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -122,6 +122,10 @@ msgstr "<0>Discount rate disabled when funding cycle duration has not been set.<
 msgid "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "<0>Learn more</0> about burning tokens."
+msgstr "<0>Learn more</0> about burning tokens."
+
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr ""
@@ -405,12 +409,8 @@ msgid "Burn project tokens"
 msgstr "Burn project tokens"
 
 #: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel} in exchange for ETH."
-msgstr "Burn your {tokensLabel} in exchange for ETH."
-
-#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
-msgstr "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
+msgstr "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -1387,6 +1387,10 @@ msgstr "Recurring target"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Redeem"
 msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
+msgstr "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -404,13 +404,21 @@ msgstr ""
 msgid "Burn project tokens"
 msgstr "Burn project tokens"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Burn tokens"
-msgstr "Burn tokens"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel} in exchange for ETH."
+msgstr "Burn your {tokensLabel} in exchange for ETH."
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgstr "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Burn {0} {tokensTextShort}"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn {tokensLabel}"
+msgstr "Burn {tokensLabel}"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
@@ -432,7 +440,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Cannot redeem tokens for ETH because this project has no overflow."
 
@@ -452,9 +460,9 @@ msgstr "Check this to mint this project's ERC20 tokens to your wallet. Leave unc
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Claim {0} as ERC20"
-msgstr ""
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Claim {tokensLabel} as ERC20"
+msgstr "Claim {tokensLabel} as ERC20"
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC20 tokens and mint them to your wallet."
@@ -660,10 +668,6 @@ msgstr "Due to their public nature, any exploits to the contracts may have irrev
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
 msgid "Duration"
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "ERC20"
 msgstr ""
 
 #: src/components/Landing/index.tsx
@@ -1005,7 +1009,7 @@ msgstr "MAX"
 msgid "Manage"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Manage {0}"
 msgstr "Manage {0}"
 
@@ -1018,6 +1022,10 @@ msgstr "Memo"
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrate to Juicebox V1.1"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+msgstr "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+
 #: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Mint project tokens on demand"
@@ -1026,17 +1034,17 @@ msgstr "Mint project tokens on demand"
 msgid "Mint tokens to a custom address."
 msgstr "Mint tokens to a custom address."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Mint {0}tokens"
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner."
-msgstr ""
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint {tokensLabel}"
+msgstr "Mint {tokensLabel}"
 
 #: src/components/Projects/TrendingProjects.tsx
 msgid "More trending projects"
 msgstr "More trending projects"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
+msgstr "Move your {tokensLabel} from the Juicebox contract to your wallet."
 
 #: src/components/v1/V1Create/ConfirmDeployProject.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -1383,6 +1391,10 @@ msgstr ""
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Redeem {0} {tokensTextShort} for ETH"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem {tokensLabel} for ETH"
+msgstr "Redeem {tokensLabel} for ETH"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
@@ -1803,6 +1815,10 @@ msgstr ""
 msgid "Token minting"
 msgstr ""
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgstr "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+
 #: src/components/v1/V1Project/Rewards/IssueTickets.tsx
 msgid "Token name"
 msgstr "Token name"
@@ -1816,7 +1832,6 @@ msgid "Token symbol"
 msgstr "Token symbol"
 
 #: src/components/shared/Mod.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr ""
@@ -2183,7 +2198,6 @@ msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr ""
@@ -2310,11 +2324,6 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# payment} other {# payments}}"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "{redeemButtonText}"
-msgstr "{redeemButtonText}"
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -409,13 +409,21 @@ msgstr "Construido para:"
 msgid "Burn project tokens"
 msgstr "Quemar tokens del proyecto"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Burn tokens"
-msgstr "Quemar tokens"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel} in exchange for ETH."
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Quemar {0} {tokensTextShort}"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn {tokensLabel}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
@@ -437,9 +445,9 @@ msgstr "¿Puedo eliminar un proyecto?"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
-msgstr "No se pueden canjear tokens por ETH porque este proyecto no tiene excedente."
+msgstr ""
 
 #: src/components/v1/V1Create/index.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
@@ -457,9 +465,9 @@ msgstr "Marca aquí para acuñar tokens ERC-20 de este proyecto a tu billetera. 
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
 msgstr "Marca aquí para acuñar un {tokenSymbol} ERC20 a tu billetera. Deja sin marcar para tener tu balance de tokens rastreado por Juicebox, ahorrando gas en esta transacción. Siempre podrás reclamar tus tokens ERC20 después."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Claim {0} as ERC20"
-msgstr "Reclama {0} como ERC20"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Claim {tokensLabel} as ERC20"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC20 tokens and mint them to your wallet."
@@ -666,10 +674,6 @@ msgstr "Debido a su naturaleza pública, cualquier explotación a los contratos 
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
 msgid "Duration"
 msgstr "Duración"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "ERC20"
-msgstr "ERC20"
 
 #: src/components/Landing/index.tsx
 msgid "ERC20 community tokens"
@@ -1010,7 +1014,7 @@ msgstr "MÁXIMO"
 msgid "Manage"
 msgstr "Administra"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Manage {0}"
 msgstr "Gestionar {0}"
 
@@ -1023,6 +1027,10 @@ msgstr "Memo"
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrar a Juicebox V1.1"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+msgstr ""
+
 #: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Crea tokens del proyecto a demanda"
@@ -1031,17 +1039,17 @@ msgstr "Crea tokens del proyecto a demanda"
 msgid "Mint tokens to a custom address."
 msgstr "Acuña tokens a una dirección personalizada."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Mint {0}tokens"
-msgstr "Acuña {0}tokens"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner."
-msgstr "Acuñar tokens puede ser activado o desactivado reconfigurando un ciclo de financiación del proyecto v1.1. Los tokens solo pueden acuñarse por el dueño del proyecto."
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint {tokensLabel}"
+msgstr ""
 
 #: src/components/Projects/TrendingProjects.tsx
 msgid "More trending projects"
 msgstr "Más proyectos en tendencia"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
+msgstr ""
 
 #: src/components/v1/V1Create/ConfirmDeployProject.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -1388,6 +1396,10 @@ msgstr "Canjear"
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Canjear {0} {tokensTextShort} por ETH"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem {tokensLabel} for ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
@@ -1808,6 +1820,10 @@ msgstr "Dirección del token: <0/>"
 msgid "Token minting"
 msgstr "Acuñación del token"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/IssueTickets.tsx
 msgid "Token name"
 msgstr "Nombre del token"
@@ -1821,7 +1837,6 @@ msgid "Token symbol"
 msgstr "Símbolo del token"
 
 #: src/components/shared/Mod.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
@@ -2188,7 +2203,6 @@ msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
@@ -2315,11 +2329,6 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pago} other {# pagos}}"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "{redeemButtonText}"
-msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -127,6 +127,10 @@ msgstr "<0>Tasa de descuento deshabilitada cuando la duración del ciclo de fina
 msgid "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "<0>Learn more</0> about burning tokens."
+msgstr ""
+
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>Aprende más</0> acerca de la duración del ciclo de financiación."
@@ -410,11 +414,7 @@ msgid "Burn project tokens"
 msgstr "Quemar tokens del proyecto"
 
 #: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel} in exchange for ETH."
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1392,6 +1392,10 @@ msgstr "Objetivo recurrente"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Redeem"
 msgstr "Canjear"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1456,11 +1456,6 @@ msgstr "Restringir pagos y emisión de tokens."
 msgid "Restricted actions"
 msgstr "Acciones restringidas"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "Retorna mi ETH"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2320,6 +2315,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pago} other {# pagos}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -127,6 +127,10 @@ msgstr "<0>A taxa de desconto desativada enquanto a duração do ciclo de financ
 msgid "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr "<0>Os contratos Juicebox</0> não são auditados e podem estar vulneráveis para bugs, erros ou hackers. Todos os fundos movidos através do Juicebox podem ser perdidos ou roubados. O JuiceboxDAO e Peel não são responsáveis por qualquer perda de projetos ou seus apoiadores."
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "<0>Learn more</0> about burning tokens."
+msgstr ""
+
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>Saiba mais</0> sobre a duração do ciclo de financiamento."
@@ -410,11 +414,7 @@ msgid "Burn project tokens"
 msgstr "Queimar os tokens do projeto"
 
 #: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel} in exchange for ETH."
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1392,6 +1392,10 @@ msgstr "Objetivo recorrente"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Redeem"
 msgstr "Resgatar"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1456,11 +1456,6 @@ msgstr "Restringir pagamentos e impressão de tokens."
 msgid "Restricted actions"
 msgstr "Ações restritas"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "Devolver meu ETH"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2320,6 +2315,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pagamento} other {# pagamentos}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -409,13 +409,21 @@ msgstr "Construído para:"
 msgid "Burn project tokens"
 msgstr "Queimar os tokens do projeto"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Burn tokens"
-msgstr "Queimar tokens"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel} in exchange for ETH."
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Queimar {0} {tokensTextShort}"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn {tokensLabel}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
@@ -437,9 +445,9 @@ msgstr "Posso excluir um projeto?"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
-msgstr "Não é possível reivindicar tokens por ETH, porque este projeto não tem overflow."
+msgstr ""
 
 #: src/components/v1/V1Create/index.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
@@ -457,9 +465,9 @@ msgstr "Verifique isto para inserir ERC20 tokens do projeto em sua carteira. Dei
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
 msgstr "Verifique isso para inserir {tokenSymbol} ERC20 em sua carteira. Deixe desmarcado para que seu saldo de tokens seja acompanhado pelo Juicebok, economizando gás em sua transação. Você poderá reivindicar sempre seus tokens ERC20 mais tarde."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Claim {0} as ERC20"
-msgstr "Reivindicar {0} como ERC20"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Claim {tokensLabel} as ERC20"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC20 tokens and mint them to your wallet."
@@ -666,10 +674,6 @@ msgstr "Devido à sua natureza pública, qualquer vulnerabilidade dos contratos 
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
 msgid "Duration"
 msgstr "Duração"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "ERC20"
-msgstr "ERC20"
 
 #: src/components/Landing/index.tsx
 msgid "ERC20 community tokens"
@@ -1010,7 +1014,7 @@ msgstr "MÁX"
 msgid "Manage"
 msgstr "Administrar"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Manage {0}"
 msgstr "Administre {0}"
 
@@ -1023,6 +1027,10 @@ msgstr "Memo"
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrar para Juicebox V1.1"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+msgstr ""
+
 #: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Crie tokens do projeto sob demanda"
@@ -1031,17 +1039,17 @@ msgstr "Crie tokens do projeto sob demanda"
 msgid "Mint tokens to a custom address."
 msgstr "Crie tokens para um endereço personalizado."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Mint {0}tokens"
-msgstr "Cunhar {0}tokens"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner."
-msgstr "Cunhar tokens pode ser habilitado ou desabilitado reconfigurando um ciclo de financiamento do projeto v1.1. Os tokens podem apenas ser produzidos pelo proprietário do projeto."
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint {tokensLabel}"
+msgstr ""
 
 #: src/components/Projects/TrendingProjects.tsx
 msgid "More trending projects"
 msgstr "Mais projetos populares"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
+msgstr ""
 
 #: src/components/v1/V1Create/ConfirmDeployProject.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -1388,6 +1396,10 @@ msgstr "Resgatar"
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Resgatar {0} {tokensTextShort} por ETH"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem {tokensLabel} for ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
@@ -1808,6 +1820,10 @@ msgstr "Endereço de token: <0/>"
 msgid "Token minting"
 msgstr "Criação de tokens"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/IssueTickets.tsx
 msgid "Token name"
 msgstr "O nome do token"
@@ -1821,7 +1837,6 @@ msgid "Token symbol"
 msgstr "O símbolo do token"
 
 #: src/components/shared/Mod.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
@@ -2188,7 +2203,6 @@ msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
@@ -2315,11 +2329,6 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pagamento} other {# pagamentos}}"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "{redeemButtonText}"
-msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -409,13 +409,21 @@ msgstr "Создан для:"
 msgid "Burn project tokens"
 msgstr "Сжечь токены проекта"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Burn tokens"
-msgstr "Сжечь жетоны"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel} in exchange for ETH."
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Сжечь {0} {tokensTextShort}"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn {tokensLabel}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
@@ -437,9 +445,9 @@ msgstr "Могу ли я удалить проект?"
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
-msgstr "Невозможно обменять токены на ETH, так как в этом проекте нет переполнения."
+msgstr ""
 
 #: src/components/v1/V1Create/index.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
@@ -457,9 +465,9 @@ msgstr ""
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
 msgstr "Проверьте это, чтобы минтить {tokenSymbol} ERC20 к вашему кошельку. Оставьте неотмеченным, чтобы ваш баланс токена отслеживался Juicebox, экономя газ на этой транзакции. Вы всегда можете запросить ваши ERC20 позже."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Claim {0} as ERC20"
-msgstr "Получить {0} как ERC20"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Claim {tokensLabel} as ERC20"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC20 tokens and mint them to your wallet."
@@ -666,10 +674,6 @@ msgstr "В связи с публичным характером, любые э�
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
 msgid "Duration"
 msgstr "Продолжительность"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "ERC20"
-msgstr "ERC20"
 
 #: src/components/Landing/index.tsx
 msgid "ERC20 community tokens"
@@ -1010,7 +1014,7 @@ msgstr "Максимум"
 msgid "Manage"
 msgstr "Управление"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Manage {0}"
 msgstr "Управлять {0}"
 
@@ -1023,6 +1027,10 @@ msgstr "Мемо"
 msgid "Migrate to Juicebox V1.1"
 msgstr "Перейти на Juicebox V1.1"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+msgstr ""
+
 #: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Создание токенов проекта по требованию"
@@ -1031,17 +1039,17 @@ msgstr "Создание токенов проекта по требованию
 msgid "Mint tokens to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Mint {0}tokens"
-msgstr "Создать {0}токенов"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner."
-msgstr "Создание или минтинг токенов может быть включен или отключен путем перенастройки цикла финансирования v1.1 проекта. Токены могут быть добыты только владельцем проекта."
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint {tokensLabel}"
+msgstr ""
 
 #: src/components/Projects/TrendingProjects.tsx
 msgid "More trending projects"
 msgstr "Другие актуальные проекты"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
+msgstr ""
 
 #: src/components/v1/V1Create/ConfirmDeployProject.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -1388,6 +1396,10 @@ msgstr "Обменять"
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Обменять {0} {tokensTextShort} за ETH"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem {tokensLabel} for ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
@@ -1808,6 +1820,10 @@ msgstr "Адрес токена: <0/>"
 msgid "Token minting"
 msgstr "Производство токенов"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/IssueTickets.tsx
 msgid "Token name"
 msgstr "Название токена"
@@ -1821,7 +1837,6 @@ msgid "Token symbol"
 msgstr "Символ токена"
 
 #: src/components/shared/Mod.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Жетоны"
@@ -2188,7 +2203,6 @@ msgstr "токен"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "токены"
@@ -2314,11 +2328,6 @@ msgstr "{название}"
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -127,6 +127,10 @@ msgstr "<0> Ставка скидки отключена, если продол�
 msgid "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "<0>Learn more</0> about burning tokens."
+msgstr ""
+
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>Подробнее</0> о продолжительности цикла финансирования."
@@ -410,11 +414,7 @@ msgid "Burn project tokens"
 msgstr "Сжечь токены проекта"
 
 #: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel} in exchange for ETH."
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1392,6 +1392,10 @@ msgstr "Повторяющаяся цель"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Redeem"
 msgstr "Обменять"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1456,11 +1456,6 @@ msgstr "Ограничить платежи и печать токенов."
 msgid "Restricted actions"
 msgstr "Ограниченные действия"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "Вернуть ЕТН"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2319,6 +2314,11 @@ msgstr "{название}"
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1456,11 +1456,6 @@ msgstr "Ödemeleri ve token basımını kısıtlayın."
 msgid "Restricted actions"
 msgstr "Kısıtlanmış eylemler"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "ETH'mi iade et"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2320,6 +2315,11 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# ödeme} other {# ödeme}}"
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
+msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -127,6 +127,10 @@ msgstr ""
 msgid "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "<0>Learn more</0> about burning tokens."
+msgstr ""
+
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "Finansman döngü süresi hakkında <0>daha fazla bilgi edinin</0>."
@@ -410,11 +414,7 @@ msgid "Burn project tokens"
 msgstr "Proje token'larını yakın"
 
 #: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel} in exchange for ETH."
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1392,6 +1392,10 @@ msgstr ""
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Redeem"
 msgstr "Talep edin"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -409,13 +409,21 @@ msgstr "Şunlar için üretildi:"
 msgid "Burn project tokens"
 msgstr "Proje token'larını yakın"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Burn tokens"
-msgstr "Token'ları yak"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel} in exchange for ETH."
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "{0} adet {tokensTextShort} token'ını yak"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn {tokensLabel}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
@@ -437,9 +445,9 @@ msgstr "Bir projeyi silebilir miyim?"
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
-msgstr "Bu projede taşma bulunmadığından ETH için token talep edilemez."
+msgstr ""
 
 #: src/components/v1/V1Create/index.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
@@ -457,9 +465,9 @@ msgstr ""
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
 msgstr "Cüzdanınıza {tokenSymbol} ERC20 basmak için burayı işaretleyin. Token bakiyenizin Juicebox tarafından takip edilmesini sağlamak için işaretlemeden bırakın ve bu işlemde gazdan tasarruf edin. ERC20 token'larınızı daha sonra her zaman talep edebilirsiniz."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Claim {0} as ERC20"
-msgstr "{0} talebini ERC20 olarak al"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Claim {tokensLabel} as ERC20"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC20 tokens and mint them to your wallet."
@@ -666,10 +674,6 @@ msgstr ""
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
 msgid "Duration"
 msgstr "Süre"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "ERC20"
-msgstr "ERC20"
 
 #: src/components/Landing/index.tsx
 msgid "ERC20 community tokens"
@@ -1010,7 +1014,7 @@ msgstr "MAKS"
 msgid "Manage"
 msgstr "Yönet"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Manage {0}"
 msgstr ""
 
@@ -1023,6 +1027,10 @@ msgstr "Not"
 msgid "Migrate to Juicebox V1.1"
 msgstr "Juicebox V1.1'e geçiş yapın"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+msgstr ""
+
 #: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr ""
@@ -1031,17 +1039,17 @@ msgstr ""
 msgid "Mint tokens to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Mint {0}tokens"
-msgstr "{0}token'ı bas"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner."
-msgstr "Token basımı bir v1.1 projesinin finansman döngüsü yeniden yapılandırılarak etkinleştirilebilir veya devre dışı bırakılabilir. Token'lar yalnızca proje sahibi tarafından basılabilir."
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint {tokensLabel}"
+msgstr ""
 
 #: src/components/Projects/TrendingProjects.tsx
 msgid "More trending projects"
 msgstr "Daha fazla ilgi gören proje"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
+msgstr ""
 
 #: src/components/v1/V1Create/ConfirmDeployProject.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -1387,6 +1395,10 @@ msgstr "Talep edin"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem {tokensLabel} for ETH"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1808,6 +1820,10 @@ msgstr "Token adresi: <0/>"
 msgid "Token minting"
 msgstr "Token basımı"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/IssueTickets.tsx
 msgid "Token name"
 msgstr "Token adı"
@@ -1821,7 +1837,6 @@ msgid "Token symbol"
 msgstr "Token sembolü"
 
 #: src/components/shared/Mod.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Token'lar"
@@ -2188,7 +2203,6 @@ msgstr "token"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr ""
@@ -2315,11 +2329,6 @@ msgstr "{label}"
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# ödeme} other {# ödeme}}"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "{redeemButtonText}"
-msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1456,11 +1456,6 @@ msgstr "限制付款以及铸造代币。"
 msgid "Restricted actions"
 msgstr "受限操作"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Return my ETH"
-msgstr "退回我的 ETH"
-
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/DeployProjectButton.tsx
 msgid "Review & Deploy"
@@ -2319,6 +2314,11 @@ msgstr "{label}"
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/index.tsx
+msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -409,13 +409,21 @@ msgstr "服务的对象:"
 msgid "Burn project tokens"
 msgstr "燃烧项目代币"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Burn tokens"
-msgstr "燃烧代币"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel} in exchange for ETH."
+msgstr ""
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "燃烧 {0} {tokensTextShort}"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Burn {tokensLabel}"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
@@ -437,9 +445,9 @@ msgstr "我可以删除一个项目吗？"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
-msgstr "这个项目的筹款没有溢出，无法用代币赎回 ETH"
+msgstr ""
 
 #: src/components/v1/V1Create/index.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
@@ -457,9 +465,9 @@ msgstr ""
 msgid "Check this to mint {tokenSymbol} ERC20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC20 tokens later."
 msgstr "勾选此项来以 ERC20 形式铸造 {tokenSymbol} 并领取到你的钱包。不勾选的话，你的代币余额会交给 Juicebox 去记录，这次交易就可以省下一些 gas。你之后随时都可以再来领取你的 ERC20 代币。"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Claim {0} as ERC20"
-msgstr "Claim {0} as ERC20"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Claim {tokensLabel} as ERC20"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC20 tokens and mint them to your wallet."
@@ -666,10 +674,6 @@ msgstr "由于其公共性质，任何对合约的恶意利用都可能产生不
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
 msgid "Duration"
 msgstr "持续时间"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "ERC20"
-msgstr "ERC20"
 
 #: src/components/Landing/index.tsx
 msgid "ERC20 community tokens"
@@ -1010,7 +1014,7 @@ msgstr "最大值"
 msgid "Manage"
 msgstr "管理代币"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
 msgid "Manage {0}"
 msgstr "管理 {0}"
 
@@ -1023,6 +1027,10 @@ msgstr "留言"
 msgid "Migrate to Juicebox V1.1"
 msgstr "迁移至 Juicebox V1.1"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
+msgstr ""
+
 #: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "按需铸造项目代币"
@@ -1031,17 +1039,17 @@ msgstr "按需铸造项目代币"
 msgid "Mint tokens to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Mint {0}tokens"
-msgstr "铸造 {0} 代币"
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "Minting tokens can be enabled or disabled by reconfiguring a v1.1 project's funding cycle. Tokens can only be minted by the project owner."
-msgstr "可通过重新配置 v 1.1项目的融资周期来启用或禁止代币铸造的功能。代币只能由项目的所有者来铸造。"
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Mint {tokensLabel}"
+msgstr ""
 
 #: src/components/Projects/TrendingProjects.tsx
 msgid "More trending projects"
 msgstr "更多热门项目"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
+msgstr ""
 
 #: src/components/v1/V1Create/ConfirmDeployProject.tsx
 #: src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -1388,6 +1396,10 @@ msgstr "赎回"
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "燃烧 {0} {tokensTextShort} 来赎回 ETH"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem {tokensLabel} for ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
@@ -1808,6 +1820,10 @@ msgstr "代币地址：<0/>"
 msgid "Token minting"
 msgstr "代币铸造"
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/IssueTickets.tsx
 msgid "Token name"
 msgstr "代币名称"
@@ -1821,7 +1837,6 @@ msgid "Token symbol"
 msgstr "代币符号"
 
 #: src/components/shared/Mod.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "代币"
@@ -2188,7 +2203,6 @@ msgstr "代币"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
 #: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "代币"
@@ -2314,11 +2328,6 @@ msgstr "{label}"
 
 #: src/components/Projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/V1Project/Rewards/index.tsx
-msgid "{redeemButtonText}"
 msgstr ""
 
 #: src/components/shared/AMMPrices/TokenAMMPriceRow.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -127,6 +127,10 @@ msgstr ""
 msgid "<0>Juicebox contracts</0> are unaudited, and may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "<0>Learn more</0> about burning tokens."
+msgstr ""
+
 #: src/components/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>进一步了解</0> 筹款周期持续时间。"
@@ -410,11 +414,7 @@ msgid "Burn project tokens"
 msgstr "燃烧项目代币"
 
 #: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel} in exchange for ETH."
-msgstr ""
-
-#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
-msgid "Burn your {tokensLabel}. You won't receive ETH because this project has no overflow."
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -1392,6 +1392,10 @@ msgstr ""
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Redeem"
 msgstr "赎回"
+
+#: src/components/v1/V1Project/Rewards/ManageTokensModal.tsx
+msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"


### PR DESCRIPTION
## What does this PR do and why?

Attempts to address user confusion with `Manage Tokens` modal by adding short descriptions to buttons.

## Screenshots or screen recordings

| state | img |
| --- | --- |
| Has print ticket permission, `canPrintPreminedTickets` is false | <img width="541" alt="Screen Shot 2022-03-13 at 8 20 26 pm" src="https://user-images.githubusercontent.com/94939382/158054085-7de36345-59b9-40ab-a87e-7bd1ffb06f30.png"> |
| Has print ticket permission, `canPrintPreminedTickets` is false | <img width="536" alt="Screen Shot 2022-03-13 at 8 22 35 pm" src="https://user-images.githubusercontent.com/94939382/158054133-19f8050b-84ce-4999-b16b-071995813d0e.png"> | 
| Doesn't have print ticket permission | <img width="535" alt="Screen Shot 2022-03-13 at 8 23 36 pm" src="https://user-images.githubusercontent.com/94939382/158054163-249f023e-c639-4455-9652-4883dfe5ad22.png"> |
| Project has no overflow (can't "redeem" any ETH) | <img width="541" alt="Screen Shot 2022-03-13 at 8 30 40 pm" src="https://user-images.githubusercontent.com/94939382/158054391-eaae994a-9e3a-4527-902d-ce7eb5d09348.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
