### PR TITLE
Project creation fixes

### DIFF
--- a/src/components/shared/Paragraph.tsx
+++ b/src/components/shared/Paragraph.tsx
@@ -12,12 +12,15 @@ export default function Paragraph({
   characterLimit?: number
 }) {
   const CHARACTER_LIMIT_EXCEEDED =
-    characterLimit && description.length > characterLimit
+    (characterLimit && description.length > characterLimit) ||
+    description.split('\n').length > 1
+
   const [expanded, setExpanded] = useState<boolean>(false)
   const toggleExpanded = () => setExpanded(!expanded)
 
+  // truncate the first line of the description
   const shortDescription = useMemo(
-    () => `${description.slice(0, characterLimit).trim()}...`,
+    () => `${description.split('\n')[0].slice(0, characterLimit).trim()}...`,
     [description, characterLimit],
   )
 

--- a/src/components/shared/RichNote.tsx
+++ b/src/components/shared/RichNote.tsx
@@ -36,7 +36,7 @@ export default function RichNote({
 
   if (!note) return null
 
-  const _note =
+  const sanitizedNote =
     mediaLink &&
     (contentType === 'image/jpeg' ||
       contentType === 'image/jpg' ||
@@ -55,13 +55,13 @@ export default function RichNote({
           paddingRight: '0.5rem',
         }}
         dangerouslySetInnerHTML={{
-          __html: Autolinker.link(_note, {
+          __html: Autolinker.link(sanitizedNote, {
             sanitizeHtml: true,
             truncate: {
               length: 30,
               location: 'smart',
             },
-          }),
+          }).replaceAll('\n', '<br>'),
         }}
       ></span>
 

--- a/src/components/v1/V1Create/index.tsx
+++ b/src/components/v1/V1Create/index.tsx
@@ -62,6 +62,8 @@ import RestrictedActionsForm, {
   RestrictedActionsFormFields,
 } from 'components/shared/forms/RestrictedActionsForm'
 
+import { toDateSeconds } from 'utils/formatDate'
+
 import ConfirmDeployProject from './ConfirmDeployProject'
 
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
@@ -205,6 +207,11 @@ export default function V1Create() {
   ) => {
     dispatch(editingProjectActions.setTarget(target))
     dispatch(editingProjectActions.setDuration(duration))
+    dispatch(
+      editingProjectActions.setFundingCycleStart(
+        `${toDateSeconds(new Date())}`,
+      ),
+    )
     dispatch(editingProjectActions.setCurrency(currency))
 
     if (!duration) {

--- a/src/redux/slices/editingProject.ts
+++ b/src/redux/slices/editingProject.ts
@@ -14,6 +14,7 @@ import {
   SerializedV1FundingCycle,
   serializeV1FundingCycle,
 } from 'utils/v1/serializers'
+import { toDateSeconds } from 'utils/formatDate'
 
 interface EditingProjectInfo {
   metadata: ProjectMetadataV4
@@ -57,7 +58,7 @@ export const defaultProjectState: EditingProjectState = {
     basedOn: BigNumber.from(0),
     target: constants.MaxUint256,
     currency: BigNumber.from(1),
-    start: BigNumber.from(Math.floor(new Date().valueOf() / 1000)),
+    start: BigNumber.from(toDateSeconds(new Date())),
     duration: BigNumber.from(0),
     tapped: BigNumber.from(0),
     weight: constants.WeiPerEther.mul(1000000), // 1e24
@@ -136,6 +137,9 @@ export const editingProjectSlice = createSlice({
     },
     setDuration: (state, action: PayloadAction<string>) => {
       state.fundingCycle.duration = action.payload
+    },
+    setFundingCycleStart: (state, action: PayloadAction<string>) => {
+      state.fundingCycle.start = action.payload
     },
     setReserved: (state, action: PayloadAction<string>) => {
       state.fundingCycle.reserved = action.payload

--- a/src/utils/formatDate.tsx
+++ b/src/utils/formatDate.tsx
@@ -15,3 +15,12 @@ export function formatHistoricalDate(dateMillis: BigNumberish) {
     </Tooltip>
   )
 }
+
+/**
+ * Convert a date to Epoch time in seconds.
+ * @param date
+ * @returns Epoch time in seconds
+ */
+export const toDateSeconds = (date: Date) => {
+  return Math.floor(date.valueOf() / 1000)
+}


### PR DESCRIPTION
## What does this PR do and why?

- if FC start date in project creation is cached, it's never updated. This PR ensures it's reset to the current time whenever funding duration changes.
- adds support for newline characters in project description. fixes https://github.com/jbx-protocol/juice-interface/issues/645

## Screenshots or screen recordings

https://user-images.githubusercontent.com/94939382/158300662-baf45be6-58b5-4cb4-87d3-cd346fce4c1a.mp4


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
