### PR TITLE
Render rich pay disclosure in pay confirmation modal

### DIFF
--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
@@ -19,6 +19,7 @@ import { usePayV1ProjectTx } from 'hooks/v1/transactor/PayV1ProjectTx'
 
 import V1ProjectRiskNotice from './V1ProjectRiskNotice'
 import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
+import Paragraph from 'components/shared/Paragraph'
 
 export default function V1ConfirmPayOwnerModal({
   visible,
@@ -115,7 +116,7 @@ export default function V1ConfirmPayOwnerModal({
             <h4>
               <Trans>Notice from {metadata.name}:</Trans>
             </h4>
-            <p>{metadata.payDisclosure}</p>
+            <Paragraph description={metadata.payDisclosure} />
           </div>
         )}
 

--- a/src/components/v2/V2Project/V2ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v2/V2Project/V2ConfirmPayOwnerModal/index.tsx
@@ -27,6 +27,7 @@ import * as constants from '@ethersproject/constants'
 import { weightedRate } from 'utils/math'
 
 import V2ProjectRiskNotice from './V2ProjectRiskNotice'
+import Paragraph from 'components/shared/Paragraph'
 
 export default function V2ConfirmPayOwnerModal({
   visible,
@@ -140,7 +141,7 @@ export default function V2ConfirmPayOwnerModal({
             <h4>
               <Trans>Notice from {projectMetadata.name}:</Trans>
             </h4>
-            <p>{projectMetadata.payDisclosure}</p>
+            <Paragraph description={projectMetadata.payDisclosure} />
           </div>
         )}
 


### PR DESCRIPTION
#651 

## What does this PR do and why?

Uses the `<Paragraph />` component to render rich pay disclosure in the pay confirmation modal.

## Screenshots or screen recordings

<img width="682" alt="image" src="https://user-images.githubusercontent.com/79433522/158677276-badef5ed-4933-46fb-aaa9-cf098287fc4f.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
