### PR TITLE
[docs] update documentation with the graph subgraph setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,10 @@ using a GraphQL API.
 
 Take the following steps to set up Juicebox's subgraph for local development:
 
-1. Go to the
-   [Juicebox subgraph](https://thegraph.com/explorer/subgraph?id=FVmuv3TndQDNd2BWARV8Y27yuKKukryKXPzvAS5E7htC&view=Overview)
-   on [The Graph](https://thegraph.com).
-1. Click the query button.
-1. Click the `copy query URL` button from the slide-out information panel.
-1. Copy the query URL into the `REACT_APP_SUBGRAPH_URL` variable of the `.env`
-   file.
+1. Go to
+   [Peel's discord server dev channel](https://discord.com/channels/939317843059679252/939705688563810304)
+   and inquire about mainnet and rinkeby subgraph URLs.
+1. Copy the URL into the `REACT_APP_SUBGRAPH_URL` variable of the `.env` file.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ Take the following steps to set up Blocknative for local development:
 1. Copy the API key into the `REACT_APP_BLOCKNATIVE_API_KEY` variable of the
    `.env` file.
 
+#### The Graph
+
+Juicebox uses [The Graph](https://thegraph.com) to query the Ethereum network
+using a GraphQL API.
+
+Take the following steps to set up Juicebox's subgraph for local development:
+
+1. Go to the
+   [Juicebox subgraph](https://thegraph.com/explorer/subgraph?id=FVmuv3TndQDNd2BWARV8Y27yuKKukryKXPzvAS5E7htC&view=Overview)
+   on [The Graph](https://thegraph.com).
+1. Click the query button.
+1. Click the `copy query URL` button from the slide-out information panel.
+1. Copy the query URL into the `REACT_APP_SUBGRAPH_URL` variable of the `.env`
+   file.
+
 ### Usage
 
 1. Start the app.


### PR DESCRIPTION
## What does this PR do and why?

I went through the documentation to get the project working locally on my machine. I assumed we would also want to document the subgraph setup too.

Adds setup up steps for Juicebox subgraph initial step up.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.

 I tried looking at the approval guidelines, but a don't have access to the docs
 
<img height="400" src="https://user-images.githubusercontent.com/2502947/159102295-cd6acba6-d30d-46d2-8ca3-3bd630459a6d.jpg" />
 
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
