### PR TITLE
Improve currency context typing

### DIFF
--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -1,5 +1,4 @@
 import RichNote from 'components/shared/RichNote'
-import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import Loading from 'components/shared/Loading'
 import ProjectHandle from 'components/shared/ProjectHandle'
@@ -8,9 +7,8 @@ import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
-import { formatWad } from 'utils/formatNumber'
 
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
+import ETHAmount from 'components/shared/ETHAmount'
 
 export default function Payments() {
   const {
@@ -74,8 +72,7 @@ export default function Payments() {
                 }}
               >
                 <span style={{ fontSize: '1rem', fontWeight: 500 }}>
-                  <CurrencySymbol currency={V1_CURRENCY_ETH} />
-                  {formatWad(e.amount, { precision: 4 })}
+                  <ETHAmount amount={e.amount} precision={4} />
                 </span>
                 <span>
                   <FormattedAddress address={e.beneficiary} />

--- a/src/components/Navbar/Balance.tsx
+++ b/src/components/Navbar/Balance.tsx
@@ -5,8 +5,6 @@ import { useEthBalanceQuery } from 'hooks/EthBalance'
 import { useContext } from 'react'
 import { formatWad } from 'utils/formatNumber'
 
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
-
 import CurrencySymbol from '../shared/CurrencySymbol'
 
 export default function Balance({
@@ -30,7 +28,7 @@ export default function Balance({
         color: colors.text.tertiary,
       }}
     >
-      <CurrencySymbol currency={V1_CURRENCY_ETH} />
+      <CurrencySymbol currency="ETH" />
       {formatWad(balance, { precision: 4 }) ?? '--'}
       {showEthPrice && (
         <div style={{ color: colors.text.tertiary }}>

--- a/src/components/Navbar/EthPrice.tsx
+++ b/src/components/Navbar/EthPrice.tsx
@@ -1,16 +1,15 @@
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 
 import { useEtherPrice } from 'hooks/v1/EtherPrice'
-import { V1CurrencyName } from 'utils/v1/currency'
 
-import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
+import { CURRENCY_METADATA } from 'constants/currency'
 
 export default function EthPrice() {
   const price = useEtherPrice()
   return (
     <div>
-      <CurrencySymbol currency={V1_CURRENCY_USD} />
-      {price?.toFixed(2)}/{V1CurrencyName(V1_CURRENCY_ETH)}
+      <CurrencySymbol currency="USD" />
+      {price?.toFixed(2)}/{CURRENCY_METADATA.ETH.name}
     </div>
   )
 }

--- a/src/components/shared/CurrencySymbol.tsx
+++ b/src/components/shared/CurrencySymbol.tsx
@@ -1,22 +1,26 @@
-import { V1CurrencyOption } from 'models/v1/currencyOption'
-import { CSSProperties } from 'react'
-import { V1CurrencyStyle, V1CurrencySymbol } from 'utils/v1/currency'
+import { CurrencyContext } from 'contexts/currencyContext'
+import { CSSProperties, useContext } from 'react'
+
+import { CurrencyOption } from 'models/currencyOption'
 
 export default function CurrencySymbol({
   currency,
   style,
 }: {
-  currency: V1CurrencyOption
+  currency: CurrencyOption
   style?: CSSProperties
 }) {
+  const { currencyMetadata } = useContext(CurrencyContext)
+  const metadata = currencyMetadata[currency]
+
   return (
     <span
       style={{
         ...style,
-        ...V1CurrencyStyle(currency),
+        ...metadata.style,
       }}
     >
-      {V1CurrencySymbol(currency)}
+      {metadata.symbol}
     </span>
   )
 }

--- a/src/components/shared/CurrencySymbol.tsx
+++ b/src/components/shared/CurrencySymbol.tsx
@@ -1,17 +1,17 @@
-import { CurrencyContext } from 'contexts/currencyContext'
-import { CSSProperties, useContext } from 'react'
+import { CSSProperties } from 'react'
 
-import { CurrencyOption } from 'models/currencyOption'
+import { CurrencyName, CURRENCY_METADATA } from 'constants/currency'
 
 export default function CurrencySymbol({
   currency,
   style,
 }: {
-  currency: CurrencyOption
+  currency?: CurrencyName
   style?: CSSProperties
 }) {
-  const { currencyMetadata } = useContext(CurrencyContext)
-  const metadata = currencyMetadata[currency]
+  if (!currency) return null
+
+  const metadata = CURRENCY_METADATA[currency]
 
   return (
     <span

--- a/src/components/shared/ETHAmount.tsx
+++ b/src/components/shared/ETHAmount.tsx
@@ -6,8 +6,6 @@ import { betweenZeroAndOne } from 'utils/bigNumbers'
 
 import CurrencySymbol from './CurrencySymbol'
 
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
-
 import ETHToUSD from './ETHToUSD'
 
 // Eth amount which displays the equiv USD amount in a tooltip on hover
@@ -35,10 +33,11 @@ export default function ETHAmount({
   if (amount) {
     return (
       <Tooltip title={<ETHToUSD ethAmount={amount} />}>
-        <CurrencySymbol currency={V1_CURRENCY_ETH} />
+        <CurrencySymbol currency="ETH" />
         {formattedETHAmount}
       </Tooltip>
     )
   }
+
   return null
 }

--- a/src/components/shared/ETHToUSD.tsx
+++ b/src/components/shared/ETHToUSD.tsx
@@ -14,7 +14,7 @@ export default function ETHToUSD({
   ethAmount: BigNumber | string
 }) {
   const converter = useCurrencyConverter()
-  const usdAmount = converter.wadToCurrency(ethAmount, 1, 0)
+  const usdAmount = converter.wadToCurrency(ethAmount, 'USD', 'ETH')
   const usdAmountFormatted = formatWad(usdAmount, {
     precision: 2,
     padEnd: true,

--- a/src/components/shared/ETHToUSD.tsx
+++ b/src/components/shared/ETHToUSD.tsx
@@ -3,8 +3,6 @@ import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { formatWad } from 'utils/formatNumber'
 import { LoadingOutlined } from '@ant-design/icons'
 
-import { V1_CURRENCY_USD } from 'constants/v1/currency'
-
 import CurrencySymbol from './CurrencySymbol'
 
 // Takes an ETH amount and returns equiv in USD
@@ -22,7 +20,7 @@ export default function ETHToUSD({
   if (usdAmount?.gt(0)) {
     return (
       <span>
-        <CurrencySymbol currency={V1_CURRENCY_USD} />
+        <CurrencySymbol currency="USD" />
         {usdAmountFormatted}
       </span>
     )

--- a/src/components/shared/PayoutModsList.tsx
+++ b/src/components/shared/PayoutModsList.tsx
@@ -20,6 +20,8 @@ import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 import { formatWad, permyriadToPercent, fromWad } from 'utils/formatNumber'
 import { amountSubFee } from 'utils/math'
 
+import { V1CurrencyName } from 'utils/v1/currency'
+
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
 import ProjectPayoutMods from './formItems/ProjectPayoutMods'
 
@@ -46,6 +48,10 @@ export default function PayoutModsList({
   const [editingMods, setEditingMods] = useState<PayoutMod[]>()
   const { owner } = useContext(V1ProjectContext)
   const setPayoutModsTx = useSetPayoutModsTx()
+
+  const fundingCycleCurrency = V1CurrencyName(
+    fundingCycle?.currency.toNumber() as V1CurrencyOption,
+  )
 
   const { editableMods, lockedMods } = useMemo(() => {
     const now = new Date().valueOf() / 1000
@@ -111,11 +117,7 @@ export default function PayoutModsList({
                         <>
                           {' '}
                           (
-                          <CurrencySymbol
-                            currency={
-                              fundingCycle.currency.toNumber() as V1CurrencyOption
-                            }
-                          />
+                          <CurrencySymbol currency={fundingCycleCurrency} />
                           {formatWad(baseTotal?.mul(mod.percent).div(10000), {
                             precision: fundingCycle.currency.eq(V1_CURRENCY_ETH)
                               ? 4
@@ -142,11 +144,7 @@ export default function PayoutModsList({
                 <>
                   {' '}
                   (
-                  <CurrencySymbol
-                    currency={
-                      fundingCycle.currency.toNumber() as V1CurrencyOption
-                    }
-                  />
+                  <CurrencySymbol currency={fundingCycleCurrency} />
                   {formatWad(baseTotal?.mul(ownerPercent).div(10000), {
                     precision: fundingCycle.currency.eq(V1_CURRENCY_ETH)
                       ? 4

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -5,7 +5,7 @@ import * as constants from '@ethersproject/constants'
 import { ThemeContext } from 'contexts/themeContext'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import { Project } from 'models/subgraph-entities/project'
-import React, { CSSProperties, useContext } from 'react'
+import { CSSProperties, useContext } from 'react'
 import { formatDate } from 'utils/formatDate'
 
 import { getTerminalVersion } from 'utils/v1/terminals'

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -80,6 +80,7 @@ export default function ProjectPayoutMods({
   const [settingHandle, setSettingHandle] = useState<string>()
 
   const { owner } = useContext(V1ProjectContext)
+  const currencyName = V1CurrencyName(currency)
 
   useContractReader<BigNumber>({
     contract: V1ContractName.Projects,
@@ -240,7 +241,7 @@ export default function ProjectPayoutMods({
                       <span>{permyriadToPercent(mod.percent)}%</span>
                       {parseWad(target).lt(constants.MaxUint256) && (
                         <span>
-                          <CurrencySymbol currency={currency} />
+                          <CurrencySymbol currency={currencyName} />
                           {formatWad(
                             amountSubFee(parseWad(target), fee)
                               ?.mul(mod.percent)
@@ -293,11 +294,11 @@ export default function ProjectPayoutMods({
       colors.icon.disabled,
       radii.md,
       target,
-      currency,
       fee,
       form,
       editingPercent,
       onModsChanged,
+      currencyName,
     ],
   )
 
@@ -526,7 +527,8 @@ export default function ProjectPayoutMods({
                 isPercentBeingRounded() &&
                 !(form.getFieldValue('percent') > 100) ? (
                   <div>
-                    Will be rounded to <CurrencySymbol currency={currency} />
+                    Will be rounded to{' '}
+                    <CurrencySymbol currency={currencyName} />
                     {roundedDownAmount()}
                   </div>
                 ) : null

--- a/src/components/shared/forms/BudgetForm.tsx
+++ b/src/components/shared/forms/BudgetForm.tsx
@@ -19,7 +19,7 @@ import { hasFundingTarget, isRecurring } from 'utils/v1/fundingCycle'
 import { helpPagePath } from 'utils/helpPageHelper'
 
 import ExternalLink from '../ExternalLink'
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
+import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
 
 const DEFAULT_TARGET_AFTER_FEE = '10000'
 
@@ -131,7 +131,7 @@ export default function BudgetForm({
                 setTarget(
                   targetSubFeeToTargetFormatted(targetSubFee, terminalFee),
                 )
-                setCurrency(1)
+                setCurrency(V1_CURRENCY_USD)
                 setShowFundingFields(checked)
               }}
             />

--- a/src/components/shared/inputs/Pay/PayInputGroup.tsx
+++ b/src/components/shared/inputs/Pay/PayInputGroup.tsx
@@ -33,16 +33,14 @@ export default function PayInputGroup({
 }) {
   const {
     currencyMetadata,
-    currencies: { currencyUSD, currencyETH },
+    currencies: { USD, ETH },
   } = useContext(CurrencyContext)
 
   const [payAmount, setPayAmount] = useState<string>('0')
-  const [payInCurrency, setPayInCurrency] =
-    useState<CurrencyOption>(currencyETH)
+  const [payInCurrency, setPayInCurrency] = useState<CurrencyOption>(ETH)
 
   const togglePayInCurrency = () => {
-    const newPayInCurrency =
-      payInCurrency === currencyETH ? currencyUSD : currencyETH
+    const newPayInCurrency = payInCurrency === ETH ? USD : ETH
     setPayInCurrency(newPayInCurrency)
   }
 
@@ -64,13 +62,13 @@ export default function PayInputGroup({
           accessory={
             <InputAccessoryButton
               withArrow={true}
-              content={currencyMetadata[payInCurrency ?? currencyETH].name}
+              content={currencyMetadata[payInCurrency ?? ETH].name}
               onClick={togglePayInCurrency}
             />
           }
         />
         <PayInputSubText
-          payInCurrency={payInCurrency ?? currencyETH}
+          payInCurrency={payInCurrency ?? ETH}
           amount={payAmount}
           reservedRate={reservedRate}
           weight={weight}

--- a/src/components/shared/inputs/Pay/PayInputSubText.tsx
+++ b/src/components/shared/inputs/Pay/PayInputSubText.tsx
@@ -49,10 +49,10 @@ export default function PayInputSubText({
 
   const {
     currencyMetadata,
-    currencies: { currencyETH },
+    currencies: { ETH },
   } = useContext(CurrencyContext)
 
-  const weiPayAmt = useWeiConverter({
+  const weiPayAmt = useWeiConverter<CurrencyOption>({
     currency: payInCurrency,
     amount: amount,
   })
@@ -81,9 +81,8 @@ export default function PayInputSubText({
     }
 
     const receivedTickets = formatReceivedTickets(
-      (payInCurrency === currencyETH
-        ? parseEther('1')
-        : converter.usdToWei('1')) ?? BigNumber.from(0),
+      (payInCurrency === ETH ? parseEther('1') : converter.usdToWei('1')) ??
+        BigNumber.from(0),
     )
 
     const tokenReceiveText = tokenSymbolText({
@@ -99,7 +98,7 @@ export default function PayInputSubText({
     weiPayAmt,
     weight,
     currencyMetadata,
-    currencyETH,
+    ETH,
     reservedRate,
     tokenSymbol,
     weightingFn,

--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -24,6 +24,8 @@ import {
 import { weightedRate } from 'utils/math'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
+import { V1CurrencyName } from 'utils/v1/currency'
+
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
 
 import TooltipLabel from '../../shared/TooltipLabel'
@@ -90,9 +92,9 @@ export default function FundingCycleDetails({
             {hasFundingTarget(fundingCycle) ? (
               <>
                 <CurrencySymbol
-                  currency={
-                    fundingCycle.currency.toNumber() as V1CurrencyOption
-                  }
+                  currency={V1CurrencyName(
+                    fundingCycle.currency.toNumber() as V1CurrencyOption,
+                  )}
                 />
                 {formatWad(fundingCycle.target)}
               </>

--- a/src/components/v1/FundingCycle/Spending.tsx
+++ b/src/components/v1/FundingCycle/Spending.tsx
@@ -14,6 +14,8 @@ import { CSSProperties, useContext, useState } from 'react'
 import { formatWad, perbicentToPercent } from 'utils/formatNumber'
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 
+import { V1CurrencyName } from 'utils/v1/currency'
+
 import PayoutModsList from '../../shared/PayoutModsList'
 
 export default function Spending({
@@ -31,6 +33,10 @@ export default function Spending({
   const [withdrawModalVisible, setWithdrawModalVisible] = useState<boolean>()
 
   if (!currentFC) return null
+
+  const currentFCCurrency = V1CurrencyName(
+    currentFC.currency.toNumber() as V1CurrencyOption,
+  )
 
   const untapped = currentFC.target.sub(currentFC.tapped)
 
@@ -63,9 +69,7 @@ export default function Spending({
                   fontWeight: 500,
                 }}
               >
-                <CurrencySymbol
-                  currency={currentFC.currency.toNumber() as V1CurrencyOption}
-                />
+                <CurrencySymbol currency={currentFCCurrency} />
                 {formatWad(withdrawable, { precision: 4 }) || '0'}{' '}
               </span>
               <TooltipLabel
@@ -88,9 +92,7 @@ export default function Spending({
           <div style={{ ...smallHeaderStyle, color: colors.text.tertiary }}>
             <div>
               <Trans>
-                <CurrencySymbol
-                  currency={currentFC.currency.toNumber() as V1CurrencyOption}
-                />
+                <CurrencySymbol currency={currentFCCurrency} />
                 {formatWad(currentFC.tapped, { precision: 4 }) || '0'}
                 {hasFundingTarget(currentFC) ? (
                   <span>/{formatWad(currentFC.target, { precision: 4 })} </span>

--- a/src/components/v1/FundingCycle/modals/WithdrawModal.tsx
+++ b/src/components/v1/FundingCycle/modals/WithdrawModal.tsx
@@ -23,7 +23,7 @@ import {
 } from 'utils/formatNumber'
 import { amountSubFee, feeForAmount } from 'utils/math'
 
-import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
+import { V1_CURRENCY_USD } from 'constants/v1/currency'
 
 export default function WithdrawModal({
   visible,
@@ -41,6 +41,7 @@ export default function WithdrawModal({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+
   const tapProjectTx = useTapProjectTx()
 
   const converter = useCurrencyConverter()
@@ -58,6 +59,9 @@ export default function WithdrawModal({
 
   if (!currentFC) return null
 
+  const currentFCCurrency = V1CurrencyName(
+    currentFC.currency.toNumber() as V1CurrencyOption,
+  )
   const untapped = currentFC.target.sub(currentFC.tapped)
 
   const withdrawable = balanceInCurrency?.gt(untapped)
@@ -111,9 +115,7 @@ export default function WithdrawModal({
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
             <Trans>Total funds:</Trans>{' '}
             <div>
-              <CurrencySymbol
-                currency={currentFC.currency.toNumber() as V1CurrencyOption}
-              />
+              <CurrencySymbol currency={currentFCCurrency} />
               {formatWad(withdrawable, { precision: 4 })}
             </div>
           </div>
@@ -122,10 +124,7 @@ export default function WithdrawModal({
               <Trans>JBX Fee ({perbicentToPercent(currentFC.fee)}%):</Trans>
             </div>
             <div>
-              -{' '}
-              <CurrencySymbol
-                currency={currentFC.currency.toNumber() as V1CurrencyOption}
-              />
+              - <CurrencySymbol currency={currentFCCurrency} />
               {formatWad(feeForAmount(withdrawable, currentFC.fee) ?? 0, {
                 precision: 4,
               })}
@@ -142,9 +141,7 @@ export default function WithdrawModal({
               <Trans>Available after fee:</Trans>
             </div>
             <div>
-              <CurrencySymbol
-                currency={currentFC.currency.toNumber() as V1CurrencyOption}
-              />
+              <CurrencySymbol currency={currentFCCurrency} />
               {formatWad(amountSubFee(withdrawable, currentFC.fee) ?? 0, {
                 precision: 4,
               })}
@@ -183,7 +180,7 @@ export default function WithdrawModal({
 
           <div style={{ color: colors.text.primary, marginBottom: 10 }}>
             <span style={{ fontWeight: 500 }}>
-              <CurrencySymbol currency={V1_CURRENCY_ETH} />
+              <CurrencySymbol currency="ETH" />
               {formatWad(
                 amountSubFee(
                   currentFC.currency.eq(V1_CURRENCY_USD)
@@ -215,7 +212,7 @@ export default function WithdrawModal({
           </div>
         ) : (
           <p>
-            <CurrencySymbol currency={V1_CURRENCY_ETH} />
+            <CurrencySymbol currency="ETH" />
             <Trans>
               {formatWad(
                 amountSubFee(

--- a/src/components/v1/V1Create/ConfirmDeployProject.tsx
+++ b/src/components/v1/V1Create/ConfirmDeployProject.tsx
@@ -31,18 +31,25 @@ import {
 import { amountSubFee } from 'utils/math'
 import { orEmpty } from 'utils/orEmpty'
 
+import { V1CurrencyName } from 'utils/v1/currency'
+
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
 
 export default function ConfirmDeployProject() {
   const editingFC = useEditingV1FundingCycleSelector()
   const editingProject = useAppSelector(state => state.editingProject.info)
   const { terminal } = useContext(V1ProjectContext)
+
   const { payoutMods, ticketMods } = useAppSelector(
     state => state.editingProject,
   )
   const terminalFee = useTerminalFee(terminal?.version)
 
   const isMobile = useMobile()
+
+  const editingFCCurrency = V1CurrencyName(
+    editingFC?.currency.toNumber() as V1CurrencyOption,
+  )
 
   const rowGutter: [Gutter, Gutter] = [25, 20]
 
@@ -158,20 +165,12 @@ export default function ConfirmDeployProject() {
                   </span>
                 ) : (
                   <span>
-                    <CurrencySymbol
-                      currency={
-                        editingFC?.currency.toNumber() as V1CurrencyOption
-                      }
-                    />
+                    <CurrencySymbol currency={editingFCCurrency} />
                     {formatWad(editingFC?.target)}{' '}
                     {editingFC.fee?.gt(0) && (
                       <span style={{ fontSize: '0.8rem' }}>
                         (
-                        <CurrencySymbol
-                          currency={
-                            editingFC?.currency.toNumber() as V1CurrencyOption
-                          }
-                        />
+                        <CurrencySymbol currency={editingFCCurrency} />
                         <Trans>
                           {formatWad(
                             amountSubFee(editingFC.target, terminalFee),

--- a/src/components/v1/V1Dashboard/index.tsx
+++ b/src/components/v1/V1Dashboard/index.tsx
@@ -5,7 +5,6 @@ import {
   V1ProjectContext,
   V1ProjectContextType,
 } from 'contexts/v1/projectContext'
-import { CurrencyContext } from 'contexts/currencyContext'
 
 import useBalanceOfProject from 'hooks/v1/contractReader/BalanceOfProject'
 import useCurrentFundingCycleOfProject from 'hooks/v1/contractReader/CurrentFundingCycleOfProject'
@@ -24,7 +23,7 @@ import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import { useProjectsQuery } from 'hooks/v1/Projects'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 import { getTerminalName, getTerminalVersion } from 'utils/v1/terminals'
 import useTerminalOfProject from 'hooks/v1/contractReader/TerminalOfProject'
@@ -33,6 +32,10 @@ import FeedbackPromptModal from 'components/v1/V1Project/modals/FeedbackPromptMo
 import { Button } from 'antd'
 import ScrollToTopButton from 'components/shared/ScrollToTopButton'
 
+import V1CurrencyProvider from 'providers/v1/V1CurrencyProvider'
+
+import { V1CurrencyName } from 'utils/v1/currency'
+
 import { padding } from 'constants/styles/padding'
 import { layouts } from 'constants/styles/layouts'
 import { projectTypes } from 'constants/v1/projectTypes'
@@ -40,7 +43,6 @@ import { archivedProjectIds } from 'constants/v1/archivedProjects'
 
 import Loading from '../../shared/Loading'
 import V1Project from '../V1Project'
-import { V1_CURRENCY_CONTEXT } from 'constants/v1/currency'
 
 export default function V1Dashboard() {
   const { handle }: { handle?: string } = useParams()
@@ -82,17 +84,15 @@ export default function V1Dashboard() {
   const tokenSymbol = useSymbolOfERC20(tokenAddress)
   const balance = useBalanceOfProject(projectId, terminalName)
   const converter = useCurrencyConverter()
-  const { currencyMetadata } = useContext(CurrencyContext)
   const balanceInCurrency = useMemo(
     () =>
       balance &&
       converter.wadToCurrency(
         balance,
-        currencyMetadata[currentFC?.currency.toNumber() as V1CurrencyOption]
-          .name,
+        V1CurrencyName(currentFC?.currency.toNumber() as V1CurrencyOption),
         'ETH',
       ),
-    [balance, converter, currentFC, currencyMetadata],
+    [balance, converter, currentFC],
   )
   const overflow = useOverflowOfProject(projectId, terminalName)
   const uri = useUriOfProject(projectId)
@@ -237,7 +237,7 @@ export default function V1Dashboard() {
 
   return (
     <V1ProjectContext.Provider value={project}>
-      <CurrencyContext.Provider value={V1_CURRENCY_CONTEXT}>
+      <V1CurrencyProvider>
         <div style={layouts.maxWidth}>
           <V1Project />
           <div style={{ textAlign: 'center', padding: 20 }}>
@@ -252,7 +252,7 @@ export default function V1Dashboard() {
             userAddress={owner}
           />
         </div>
-      </CurrencyContext.Provider>
+      </V1CurrencyProvider>
     </V1ProjectContext.Provider>
   )
 }

--- a/src/components/v1/V1Dashboard/index.tsx
+++ b/src/components/v1/V1Dashboard/index.tsx
@@ -24,7 +24,7 @@ import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import { useProjectsQuery } from 'hooks/v1/Projects'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
-import { useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 import { getTerminalName, getTerminalVersion } from 'utils/v1/terminals'
 import useTerminalOfProject from 'hooks/v1/contractReader/TerminalOfProject'
@@ -82,15 +82,17 @@ export default function V1Dashboard() {
   const tokenSymbol = useSymbolOfERC20(tokenAddress)
   const balance = useBalanceOfProject(projectId, terminalName)
   const converter = useCurrencyConverter()
+  const { currencyMetadata } = useContext(CurrencyContext)
   const balanceInCurrency = useMemo(
     () =>
       balance &&
       converter.wadToCurrency(
         balance,
-        currentFC?.currency.toNumber() as V1CurrencyOption,
-        0,
+        currencyMetadata[currentFC?.currency.toNumber() as V1CurrencyOption]
+          .name,
+        'ETH',
       ),
-    [balance, converter, currentFC],
+    [balance, converter, currentFC, currencyMetadata],
   )
   const overflow = useOverflowOfProject(projectId, terminalName)
   const uri = useUriOfProject(projectId)

--- a/src/components/v1/V1Project/BalanceTimeline.tsx
+++ b/src/components/v1/V1Project/BalanceTimeline.tsx
@@ -30,7 +30,6 @@ import { querySubgraph } from 'utils/graph'
 import { readProvider } from 'constants/readProvider'
 
 import SectionHeader from './SectionHeader'
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
 
 const now = moment.now() - 5 * 60 * 1000 // 5 min ago
 
@@ -490,7 +489,7 @@ export default function BalanceTimeline({ height }: { height: number }) {
                     </div>
                     {payload[0].payload.tapped ? (
                       <div>
-                        -<CurrencySymbol currency={V1_CURRENCY_ETH} />
+                        -<CurrencySymbol currency="ETH" />
                         {payload[0].payload.tapped}
                         <div
                           style={{
@@ -504,7 +503,7 @@ export default function BalanceTimeline({ height }: { height: number }) {
                       </div>
                     ) : (
                       <div>
-                        <CurrencySymbol currency={V1_CURRENCY_ETH} />
+                        <CurrencySymbol currency="ETH" />
                         {payload[0].payload.value}
                       </div>
                     )}

--- a/src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
+++ b/src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
@@ -18,6 +18,7 @@ import { formatWad } from 'utils/formatNumber'
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 
 import FundingCycleDetails from 'components/v1/FundingCycle/FundingCycleDetails'
+import { V1CurrencyName } from 'utils/v1/currency'
 
 export default function FundingHistory({
   startId,
@@ -90,7 +91,9 @@ export default function FundingHistory({
 
               <div style={{ fontSize: '.8rem', marginLeft: 10 }}>
                 <CurrencySymbol
-                  currency={cycle.currency.toNumber() as V1CurrencyOption}
+                  currency={V1CurrencyName(
+                    cycle.currency.toNumber() as V1CurrencyOption,
+                  )}
                 />
                 {hasFundingTarget(cycle) ? (
                   <>

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -18,11 +18,11 @@ import { CSSProperties, useContext, useMemo, useState } from 'react'
 import { formatWad, fracDiv, fromWad } from 'utils/formatNumber'
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 
-import { CurrencyContext } from 'contexts/currencyContext'
+import { V1CurrencyName } from 'utils/v1/currency'
 
 import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
 import { readNetwork } from 'constants/networks'
-import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
+import { V1_CURRENCY_USD } from 'constants/v1/currency'
 
 import BalancesModal from './modals/BalancesModal'
 
@@ -31,6 +31,7 @@ export default function Paid() {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+
   const {
     projectId,
     currentFC,
@@ -40,14 +41,13 @@ export default function Paid() {
     earned,
     overflow,
   } = useContext(V1ProjectContext)
-  const { currencyMetadata } = useContext(CurrencyContext)
 
   const converter = useCurrencyConverter()
   const { data: ownerBalance } = useEthBalanceQuery(owner)
 
   const overflowInCurrency = converter.wadToCurrency(
     overflow ?? 0,
-    currencyMetadata[currentFC?.currency.toNumber() as V1CurrencyOption].name,
+    V1CurrencyName(currentFC?.currency.toNumber() as V1CurrencyOption),
     'ETH',
   )
 
@@ -92,7 +92,7 @@ export default function Paid() {
             <Tooltip
               title={
                 <span>
-                  <CurrencySymbol currency={V1_CURRENCY_ETH} />
+                  <CurrencySymbol currency="ETH" />
                   {formatWad(converter.usdToWei(fromWad(amt)), {
                     precision: 2,
                     padEnd: true,
@@ -100,13 +100,13 @@ export default function Paid() {
                 </span>
               }
             >
-              <CurrencySymbol currency={V1_CURRENCY_USD} />
+              <CurrencySymbol currency="USD" />
               {formatWad(amt, { precision: 2, padEnd: true })}
             </Tooltip>
           </span>
         ) : (
           <span>
-            <CurrencySymbol currency={V1_CURRENCY_ETH} />
+            <CurrencySymbol currency="ETH" />
             {formatWad(amt, { precision: 2, padEnd: true })}
           </span>
         )}
@@ -136,7 +136,7 @@ export default function Paid() {
         <span style={primaryTextStyle}>
           {isConstitutionDAO && (
             <span style={secondaryTextStyle}>
-              <CurrencySymbol currency={V1_CURRENCY_USD} />
+              <CurrencySymbol currency="USD" />
               {formatWad(converter.wadToCurrency(earned, 'USD', 'ETH'), {
                 precision: 2,
                 padEnd: true,

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -18,6 +18,8 @@ import { CSSProperties, useContext, useMemo, useState } from 'react'
 import { formatWad, fracDiv, fromWad } from 'utils/formatNumber'
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 
+import { CurrencyContext } from 'contexts/currencyContext'
+
 import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
 import { readNetwork } from 'constants/networks'
 import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
@@ -29,7 +31,6 @@ export default function Paid() {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-
   const {
     projectId,
     currentFC,
@@ -39,15 +40,16 @@ export default function Paid() {
     earned,
     overflow,
   } = useContext(V1ProjectContext)
+  const { currencyMetadata } = useContext(CurrencyContext)
 
   const converter = useCurrencyConverter()
+  const { data: ownerBalance } = useEthBalanceQuery(owner)
+
   const overflowInCurrency = converter.wadToCurrency(
     overflow ?? 0,
-    currentFC?.currency.toNumber() as V1CurrencyOption,
-    0,
+    currencyMetadata[currentFC?.currency.toNumber() as V1CurrencyOption].name,
+    'ETH',
   )
-
-  const { data: ownerBalance } = useEthBalanceQuery(owner)
 
   const percentPaid = useMemo(
     () =>
@@ -135,7 +137,7 @@ export default function Paid() {
           {isConstitutionDAO && (
             <span style={secondaryTextStyle}>
               <CurrencySymbol currency={V1_CURRENCY_USD} />
-              {formatWad(converter.wadToCurrency(earned, 1, 0), {
+              {formatWad(converter.wadToCurrency(earned, 'USD', 'ETH'), {
                 precision: 2,
                 padEnd: true,
               })}{' '}

--- a/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
@@ -10,8 +10,6 @@ import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
-
 import ActivityTabContent from './ActivityTabContent'
 import { contentLineHeight, smallHeaderStyle } from './styles'
 
@@ -119,7 +117,7 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
               </div>
 
               <div style={{ color: colors.text.secondary }}>
-                <CurrencySymbol currency={V1_CURRENCY_ETH} />
+                <CurrencySymbol currency="ETH" />
                 {formatWad(e.returnAmount, { precision: 4 })} overflow received
               </div>
             </div>

--- a/src/components/v1/V1Project/ProjectActivity/TapEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/TapEventElem.tsx
@@ -10,8 +10,6 @@ import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 
-import { V1_CURRENCY_ETH } from 'constants/v1/currency'
-
 import { smallHeaderStyle } from '../styles'
 
 export default function TapEventElem({
@@ -112,7 +110,7 @@ export default function TapEventElem({
             </div>
 
             <div style={{ color: colors.text.secondary }}>
-              <CurrencySymbol currency={V1_CURRENCY_ETH} />
+              <CurrencySymbol currency="ETH" />
               {formatWad(e.modCut, { precision: 4 })}
             </div>
           </div>
@@ -140,7 +138,7 @@ export default function TapEventElem({
                   : { fontWeight: 500 }
               }
             >
-              <CurrencySymbol currency={V1_CURRENCY_ETH} />
+              <CurrencySymbol currency="ETH" />
               {formatWad(tapEvent.beneficiaryTransferAmount, { precision: 4 })}
             </div>
           </div>
@@ -155,7 +153,7 @@ export default function TapEventElem({
             textAlign: 'right',
           }}
         >
-          <CurrencySymbol currency={V1_CURRENCY_ETH} />
+          <CurrencySymbol currency="ETH" />
           {formatWad(tapEvent.netTransferAmount, { precision: 4 })}
         </div>
       ) : null}

--- a/src/components/v1/V1Project/V1PayButton.tsx
+++ b/src/components/v1/V1Project/V1PayButton.tsx
@@ -10,6 +10,8 @@ import useWeiConverter from 'hooks/WeiConverter'
 import PayWarningModal from 'components/shared/PayWarningModal'
 import { CurrencyOption } from 'models/currencyOption'
 
+import { V1CurrencyOption } from 'models/v1/currencyOption'
+
 import { readNetwork } from 'constants/networks'
 import { disablePayOverrides } from 'constants/v1/overrides'
 import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
@@ -22,7 +24,7 @@ export default function V1PayButton({
   payInCurrency,
 }: {
   payAmount: string
-  payInCurrency: CurrencyOption
+  payInCurrency: CurrencyOption // TODO make the V1CurrencyOption
 }) {
   const { projectId, currentFC, metadata, isArchived, terminal } =
     useContext(V1ProjectContext)
@@ -31,8 +33,8 @@ export default function V1PayButton({
   const [payWarningModalVisible, setPayWarningModalVisible] =
     useState<boolean>(false)
 
-  const weiPayAmt = useWeiConverter({
-    currency: payInCurrency,
+  const weiPayAmt = useWeiConverter<V1CurrencyOption>({
+    currency: payInCurrency as V1CurrencyOption,
     amount: payAmount,
   })
 

--- a/src/components/v1/V1Project/V1PayButton.tsx
+++ b/src/components/v1/V1Project/V1PayButton.tsx
@@ -15,7 +15,7 @@ import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { readNetwork } from 'constants/networks'
 import { disablePayOverrides } from 'constants/v1/overrides'
 import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
-import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
+import { V1_CURRENCY_USD } from 'constants/v1/currency'
 
 import V1ConfirmPayOwnerModal from './modals/V1ConfirmPayOwnerModal'
 
@@ -112,7 +112,7 @@ export default function V1PayButton({
       {payInCurrency === V1_CURRENCY_USD && (
         <div style={{ fontSize: '.7rem' }}>
           <Trans>
-            Paid as <CurrencySymbol currency={V1_CURRENCY_ETH} />
+            Paid as <CurrencySymbol currency="ETH" />
           </Trans>
           {formatWad(weiPayAmt) || '0'}
         </div>

--- a/src/components/v1/V1Project/modals/ParticipantsModal.tsx
+++ b/src/components/v1/V1Project/modals/ParticipantsModal.tsx
@@ -198,7 +198,7 @@ export default function ParticipantsModal({
                   <FormattedAddress address={p.wallet} />
                 </div>
                 <div style={smallHeaderStyle}>
-                  <CurrencySymbol currency={0} />
+                  <CurrencySymbol currency="ETH" />
                   <Trans>
                     {formatWad(p.totalPaid, { precision: 6 })} contributed
                   </Trans>

--- a/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
@@ -45,6 +45,8 @@ import { amountSubFee } from 'utils/math'
 import { serializeV1FundingCycle } from 'utils/v1/serializers'
 import { drawerWidth } from 'utils/drawerWidth'
 
+import { V1CurrencyName } from 'utils/v1/currency'
+
 import { getBallotStrategyByAddress } from 'constants/ballotStrategies/getBallotStrategiesByAddress'
 
 import BudgetForm from '../../../shared/forms/BudgetForm'
@@ -99,6 +101,7 @@ export default function ReconfigureFCModal({
     queuedTicketMods,
     currentTicketMods,
   } = useContext(V1ProjectContext)
+
   const editingFC = useEditingV1FundingCycleSelector()
   const terminalFee = useTerminalFee(terminal?.version)
   const configureProjectTx = useConfigureProjectTx()
@@ -110,6 +113,10 @@ export default function ReconfigureFCModal({
 
   const fcMetadata: V1FundingCycleMetadata | undefined =
     decodeFundingCycleMetadata(currentFC?.metadata)
+
+  const editingFCCurrency = V1CurrencyName(
+    editingFC.currency.toNumber() as V1CurrencyOption,
+  )
 
   const resetRestrictedActionsForm = () => {
     if (fcMetadata?.version === 1) {
@@ -402,21 +409,13 @@ export default function ReconfigureFCModal({
                 title={t`Amount`}
                 valueRender={() => (
                   <span>
-                    <CurrencySymbol
-                      currency={
-                        editingFC.currency.toNumber() as V1CurrencyOption
-                      }
-                    />
+                    <CurrencySymbol currency={editingFCCurrency} />
                     {formatWad(editingFC.target)}{' '}
                     <span style={{ fontSize: '0.8rem' }}>
                       (
                       {terminalFee?.gt(0) ? (
                         <span>
-                          <CurrencySymbol
-                            currency={
-                              editingFC.currency.toNumber() as V1CurrencyOption
-                            }
-                          />
+                          <CurrencySymbol currency={editingFCCurrency} />
                           <Trans>
                             {formatWad(
                               amountSubFee(editingFC.target, terminalFee),

--- a/src/components/v1/V1Project/modals/RedeemModal.tsx
+++ b/src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -18,7 +18,7 @@ import { formattedNum, formatWad, fromWad, parseWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/v1/fundingCycle'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
-import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
+import { V1_CURRENCY_USD } from 'constants/v1/currency'
 
 // This double as the 'Redeem' and 'Burn' modal depending on if project has overflow
 export default function RedeemModal({
@@ -174,7 +174,7 @@ export default function RedeemModal({
             <Trans>
               Currently worth:{' '}
               <span>
-                <CurrencySymbol currency={V1_CURRENCY_ETH} />
+                <CurrencySymbol currency="ETH" />
                 {formatWad(maxClaimable, { precision: 4 })}
               </span>
             </Trans>

--- a/src/components/v2/V2Create/DeployProjectModal/PayoutSplitsList.tsx
+++ b/src/components/v2/V2Create/DeployProjectModal/PayoutSplitsList.tsx
@@ -5,10 +5,9 @@ import { Split } from 'models/v2/splits'
 import { formatWad, permyriadToPercent, parseWad } from 'utils/formatNumber'
 import { SerializedV2FundAccessConstraint } from 'utils/v2/serializers'
 import { hasFundingTarget } from 'utils/v2/fundingCycle'
-import { toV1Currency } from 'utils/v1/currency'
 import { toMod } from 'utils/v2/splits'
 
-import { V2_CURRENCY_ETH } from 'utils/v2/currency'
+import { V2CurrencyName, V2_CURRENCY_ETH } from 'utils/v2/currency'
 
 function SplitItem({
   split,
@@ -29,7 +28,7 @@ function SplitItem({
         <>
           {' '}
           (
-          <CurrencySymbol currency={toV1Currency(distributionCurrency)} />
+          <CurrencySymbol currency={V2CurrencyName(distributionCurrency)} />
           {formatWad(
             parseWad(fundAccessConstraint?.distributionLimit)
               ?.mul(split.percent)

--- a/src/components/v2/V2Create/DeployProjectModal/index.tsx
+++ b/src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -19,7 +19,8 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import { V2CurrencyOption } from 'models/v2/currencyOption'
 import { formattedNum, formatWad, parseWad } from 'utils/formatNumber'
 import { amountSubFee } from 'utils/math'
-import { toV1Currency } from 'utils/v1/currency'
+
+import { V2CurrencyName } from 'utils/v2/currency'
 
 import PayoutSplitsList from './PayoutSplitsList'
 
@@ -57,7 +58,7 @@ export default function ConfirmDeployV2ProjectModal({
 
   const rowGutter: [Gutter, Gutter] = [25, 20]
 
-  const fundingCurrency = toV1Currency(
+  const fundingCurrency = V2CurrencyName(
     parseInt(
       fundAccessConstraint?.distributionLimitCurrency ?? '1',
     ) as V2CurrencyOption,

--- a/src/components/v2/V2Create/index.tsx
+++ b/src/components/v2/V2Create/index.tsx
@@ -6,7 +6,8 @@ import V2UserProvider from 'providers/v2/UserProvider'
 
 import { t, Trans } from '@lingui/macro'
 import { ThemeContext } from 'contexts/themeContext'
-import { CurrencyContext } from 'contexts/currencyContext'
+
+import V2CurrencyProvider from 'providers/v2/V2CurrencyProvider'
 
 import { readNetwork } from 'constants/networks'
 import V2WarningBanner from './V2WarningBanner'
@@ -16,8 +17,6 @@ import FundingTabContent from './tabs/FundingTab/FundingTabContent'
 import TokenTabContent from './tabs/TokenTab/TokenTabContent'
 import RulesTabContent from './tabs/RulesTab/RulesTabContent'
 import { TabContentProps } from './models'
-
-import { V2_CURRENCY_CONTEXT } from 'constants/v2/currency'
 
 const { TabPane } = Tabs
 
@@ -56,7 +55,7 @@ export default function V2Create() {
 
   return (
     <V2UserProvider>
-      <CurrencyContext.Provider value={V2_CURRENCY_CONTEXT}>
+      <V2CurrencyProvider>
         {isRinkeby ? <V2WarningBanner /> : null}
         <div style={{ margin: '4rem', marginBottom: 0 }}>
           {!isRinkeby && (
@@ -100,7 +99,7 @@ export default function V2Create() {
             </div>
           )}
         </div>
-      </CurrencyContext.Provider>
+      </V2CurrencyProvider>
     </V2UserProvider>
   )
 }

--- a/src/components/v2/V2Project/V2PayButton.tsx
+++ b/src/components/v2/V2Project/V2PayButton.tsx
@@ -11,6 +11,10 @@ import { V2_CURRENCY_ETH, V2_CURRENCY_USD } from 'utils/v2/currency'
 import PayWarningModal from 'components/shared/PayWarningModal'
 import useWeiConverter from 'hooks/WeiConverter'
 
+import { CurrencyOption } from 'models/currencyOption'
+
+import { V2CurrencyOption } from 'models/v2/currencyOption'
+
 import V2ConfirmPayOwnerModal from './V2ConfirmPayOwnerModal'
 
 export default function V2PayButton({
@@ -18,7 +22,7 @@ export default function V2PayButton({
   payInCurrency,
 }: {
   payAmount: string
-  payInCurrency: number
+  payInCurrency: CurrencyOption // TODO make the V2CurrencyOption
 }) {
   const { fundingCycle, projectMetadata } = useContext(V2ProjectContext)
   // if (!projectMetadata || !fundingCycle) return null
@@ -27,8 +31,8 @@ export default function V2PayButton({
   const [payWarningModalVisible, setPayWarningModalVisible] =
     useState<boolean>(false)
 
-  const weiPayAmt = useWeiConverter({
-    currency: payInCurrency,
+  const weiPayAmt = useWeiConverter<V2CurrencyOption>({
+    currency: payInCurrency as V2CurrencyOption,
     amount: payAmount,
   })
 

--- a/src/components/v2/V2Project/V2PayButton.tsx
+++ b/src/components/v2/V2Project/V2PayButton.tsx
@@ -7,7 +7,7 @@ import { formatWad, fromWad } from 'utils/formatNumber'
 import { decodeFundingCycleMetadata } from 'utils/v1/fundingCycle'
 
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2_CURRENCY_ETH, V2_CURRENCY_USD } from 'utils/v2/currency'
+import { V2_CURRENCY_USD } from 'utils/v2/currency'
 import PayWarningModal from 'components/shared/PayWarningModal'
 import useWeiConverter from 'hooks/WeiConverter'
 
@@ -63,7 +63,7 @@ export default function V2PayButton({
       {payInCurrency === V2_CURRENCY_USD && (
         <div style={{ fontSize: '.7rem' }}>
           <Trans>
-            Paid as <CurrencySymbol currency={V2_CURRENCY_ETH} />
+            Paid as <CurrencySymbol currency="ETH" />
           </Trans>
           {formatWad(weiPayAmt) || '0'}
         </div>

--- a/src/constants/v1/currency.ts
+++ b/src/constants/v1/currency.ts
@@ -17,5 +17,5 @@ export const V1_CURRENCY_METADATA: Record<V1CurrencyOption, CurrencyMetadata> =
 
 export const V1_CURRENCY_CONTEXT = {
   currencyMetadata: V1_CURRENCY_METADATA,
-  currencies: { currencyETH: V1_CURRENCY_ETH, currencyUSD: V1_CURRENCY_USD },
+  currencies: { ETH: V1_CURRENCY_ETH, USD: V1_CURRENCY_USD },
 }

--- a/src/constants/v2/currency.ts
+++ b/src/constants/v2/currency.ts
@@ -6,5 +6,5 @@ import {
 
 export const V2_CURRENCY_CONTEXT = {
   currencyMetadata: V2_CURRENCY_METADATA,
-  currencies: { currencyETH: V2_CURRENCY_ETH, currencyUSD: V2_CURRENCY_USD },
+  currencies: { ETH: V2_CURRENCY_ETH, USD: V2_CURRENCY_USD },
 }

--- a/src/contexts/currencyContext.ts
+++ b/src/contexts/currencyContext.ts
@@ -7,18 +7,18 @@ import {
 
 import { CurrencyOption } from 'models/currencyOption'
 
-import { CurrencyMetadata } from 'constants/currency'
+import { CurrencyMetadata, CurrencyName } from 'constants/currency'
 
 // TODO make this CurrencyOption instead of number
 export type CurrencyMetadataType = Record<number, CurrencyMetadata>
 
 export type CurrencyContextType = {
   currencyMetadata: CurrencyMetadataType
-  currencies: Record<string, CurrencyOption>
+  currencies: Record<CurrencyName, CurrencyOption>
 }
 
 // Defaults to V2
 export const CurrencyContext = createContext<CurrencyContextType>({
   currencyMetadata: V2_CURRENCY_METADATA,
-  currencies: { currencyETH: V2_CURRENCY_ETH, currencyUSD: V2_CURRENCY_USD },
+  currencies: { ETH: V2_CURRENCY_ETH, USD: V2_CURRENCY_USD },
 })

--- a/src/hooks/WeiConverter.ts
+++ b/src/hooks/WeiConverter.ts
@@ -3,20 +3,21 @@ import { parseEther } from 'ethers/lib/utils'
 
 import { useContext } from 'react'
 import { CurrencyContext } from 'contexts/currencyContext'
+import { CurrencyOption } from 'models/currencyOption'
 
 // Converts an amount (ETH or USD) to WEIw
-export default function useWeiConverter({
+export default function useWeiConverter<C extends CurrencyOption>({
   currency,
   amount,
 }: {
-  currency?: number
+  currency?: C
   amount?: string
 }) {
   const converter = useCurrencyConverter()
   const {
-    currencies: { currencyUSD },
+    currencies: { USD },
   } = useContext(CurrencyContext)
-  if (currency === currencyUSD) {
+  if (currency === USD) {
     return converter.usdToWei(amount)
   }
 

--- a/src/providers/v1/V1CurrencyProvider.tsx
+++ b/src/providers/v1/V1CurrencyProvider.tsx
@@ -1,0 +1,15 @@
+import { CurrencyContext } from 'contexts/currencyContext'
+
+import { PropsWithChildren } from 'react'
+
+import { V1_CURRENCY_CONTEXT } from 'constants/v1/currency'
+
+export default function V1CurrencyProvider({
+  children,
+}: PropsWithChildren<{}>) {
+  return (
+    <CurrencyContext.Provider value={V1_CURRENCY_CONTEXT}>
+      {children}
+    </CurrencyContext.Provider>
+  )
+}

--- a/src/providers/v2/V2CurrencyProvider.tsx
+++ b/src/providers/v2/V2CurrencyProvider.tsx
@@ -1,0 +1,15 @@
+import { CurrencyContext } from 'contexts/currencyContext'
+
+import { PropsWithChildren } from 'react'
+
+import { V2_CURRENCY_CONTEXT } from 'constants/v2/currency'
+
+export default function V2CurrencyProvider({
+  children,
+}: PropsWithChildren<{}>) {
+  return (
+    <CurrencyContext.Provider value={V2_CURRENCY_CONTEXT}>
+      {children}
+    </CurrencyContext.Provider>
+  )
+}

--- a/src/redux/slices/editingProject.ts
+++ b/src/redux/slices/editingProject.ts
@@ -16,6 +16,8 @@ import {
 } from 'utils/v1/serializers'
 import { toDateSeconds } from 'utils/formatDate'
 
+import { V1_CURRENCY_USD } from 'constants/v1/currency'
+
 interface EditingProjectInfo {
   metadata: ProjectMetadataV4
   handle: string
@@ -57,7 +59,7 @@ export const defaultProjectState: EditingProjectState = {
     number: BigNumber.from(1),
     basedOn: BigNumber.from(0),
     target: constants.MaxUint256,
-    currency: BigNumber.from(1),
+    currency: BigNumber.from(V1_CURRENCY_USD),
     start: BigNumber.from(toDateSeconds(new Date())),
     duration: BigNumber.from(0),
     tapped: BigNumber.from(0),

--- a/src/utils/formatCurrency.ts
+++ b/src/utils/formatCurrency.ts
@@ -1,7 +1,7 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
-import { V1CurrencyOption } from 'models/v1/currencyOption'
 
 import { parseWad } from './formatNumber'
+import { CurrencyName } from 'constants/currency'
 
 export class CurrencyUtils {
   // Define non-fractional conversion units
@@ -53,13 +53,14 @@ export class CurrencyUtils {
 
   wadToCurrency = (
     amount: BigNumberish | undefined,
-    targetCurrency: V1CurrencyOption | undefined,
-    sourceCurrency: V1CurrencyOption | undefined,
+    targetCurrency: CurrencyName | undefined,
+    sourceCurrency: CurrencyName | undefined,
   ) => {
     if (targetCurrency === undefined || sourceCurrency === undefined) return
     if (targetCurrency === sourceCurrency) return BigNumber.from(amount)
-    if (targetCurrency === 1) return parseWad(this.weiToUsd(amount)?.toString())
-    if (targetCurrency === 0 && this.usdPerEth !== undefined)
+    if (targetCurrency === 'USD')
+      return parseWad(this.weiToUsd(amount)?.toString())
+    if (targetCurrency === 'ETH' && this.usdPerEth !== undefined)
       return BigNumber.from(amount)
         .div(this.usdPerEth * 100)
         .mul(100)


### PR DESCRIPTION
## What does this PR do and why?

- Updates `wadToCurrency` function to accept a currency name (`'ETH'` or `'USD'`) instead of the ID (0 or 1). This is to enable us to use it in V2.
- Updates `CurrencySymbol` component to accept a currency name (`'ETH'` or `'USD'`) instead of the ID (0 or 1). Similarly, for easier V2 use (and IMO just nicer).
- Improves typing of `CurrencyContext`, partially resolving https://github.com/jbx-protocol/juice-interface/issues/643. Specifically we use `CurrencyName`s in the `currencies` object in the context.

## Screenshots or screen recordings

No user facing changes.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
