### PR TITLE
Add "In Juicebox" number to V2 projects

### DIFF
--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -8,7 +8,7 @@ import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 
-import ETHAmount from 'components/shared/ETHAmount'
+import ETHAmount from 'components/shared/currency/ETHAmount'
 
 export default function Payments() {
   const {

--- a/src/components/Projects/TrendingProjectCard.tsx
+++ b/src/components/Projects/TrendingProjectCard.tsx
@@ -1,6 +1,6 @@
 import Loading from 'components/shared/Loading'
 import ProjectLogo from 'components/shared/ProjectLogo'
-import ETHAmount from 'components/shared/ETHAmount'
+import ETHAmount from 'components/shared/currency/ETHAmount'
 
 import { t, Trans, Plural } from '@lingui/macro'
 

--- a/src/components/shared/Project/StatLine.tsx
+++ b/src/components/shared/Project/StatLine.tsx
@@ -1,0 +1,51 @@
+import { ThemeContext } from 'contexts/themeContext'
+import { CSSProperties, useContext } from 'react'
+
+import TooltipLabel from '../TooltipLabel'
+
+export default function StatLine({
+  statLabel,
+  statLabelTip,
+  statValue,
+  style = {},
+}: {
+  statLabel: JSX.Element
+  statLabelTip: JSX.Element
+  statValue: JSX.Element
+  style?: CSSProperties
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const secondaryTextStyle: CSSProperties = {
+    textTransform: 'uppercase',
+    color: colors.text.tertiary,
+    fontSize: '0.8rem',
+    fontWeight: 500,
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        flexWrap: 'nowrap',
+        ...style,
+      }}
+    >
+      <div style={secondaryTextStyle}>
+        <TooltipLabel label={statLabel} tip={statLabelTip} />
+      </div>
+
+      <div
+        style={{
+          marginLeft: 10,
+        }}
+      >
+        {statValue}
+      </div>
+    </div>
+  )
+}

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -16,7 +16,7 @@ import { Link } from 'react-router-dom'
 
 import Loading from './Loading'
 import ProjectLogo from './ProjectLogo'
-import ETHAmount from './ETHAmount'
+import ETHAmount from './currency/ETHAmount'
 import { archivedProjectIds } from '../../constants/v1/archivedProjects'
 
 type ProjectCardProject = Pick<

--- a/src/components/shared/currency/ETHAmount.tsx
+++ b/src/components/shared/currency/ETHAmount.tsx
@@ -4,11 +4,13 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { formatWad, parseWad } from 'utils/formatNumber'
 import { betweenZeroAndOne } from 'utils/bigNumbers'
 
-import CurrencySymbol from './CurrencySymbol'
+import CurrencySymbol from '../CurrencySymbol'
 
 import ETHToUSD from './ETHToUSD'
 
-// Eth amount which displays the equiv USD amount in a tooltip on hover
+/**
+ * Render a given amount formatted as ETH. Displays USD amount in a tooltip on hover.
+ */
 export default function ETHAmount({
   amount,
   precision,

--- a/src/components/shared/currency/ETHToUSD.tsx
+++ b/src/components/shared/currency/ETHToUSD.tsx
@@ -3,7 +3,7 @@ import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { formatWad } from 'utils/formatNumber'
 import { LoadingOutlined } from '@ant-design/icons'
 
-import CurrencySymbol from './CurrencySymbol'
+import CurrencySymbol from '../CurrencySymbol'
 
 // Takes an ETH amount and returns equiv in USD
 export default function ETHToUSD({
@@ -17,7 +17,8 @@ export default function ETHToUSD({
     precision: 2,
     padEnd: true,
   })
-  if (usdAmount?.gt(0)) {
+
+  if (usdAmount?.gt(0) || usdAmount?.eq(0)) {
     return (
       <span>
         <CurrencySymbol currency="USD" />

--- a/src/components/shared/currency/USDAmount.tsx
+++ b/src/components/shared/currency/USDAmount.tsx
@@ -1,0 +1,58 @@
+import { Tooltip } from 'antd'
+
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatWad, fromWad, parseWad } from 'utils/formatNumber'
+import { betweenZeroAndOne } from 'utils/bigNumbers'
+
+import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
+
+import CurrencySymbol from '../CurrencySymbol'
+
+/**
+ * Render a given amount formatted as USD. Displays ETH amount in a tooltip on hover.
+ */
+export default function USDAmount({
+  amount,
+  precision,
+  padEnd,
+}: {
+  amount?: BigNumber | string
+  precision?: number
+  padEnd?: boolean
+}) {
+  const converter = useCurrencyConverter()
+
+  // Account for being passed a string amount or a BigNumber amount
+  const isBetweenZeroAndOne =
+    (BigNumber.isBigNumber(amount) && betweenZeroAndOne(amount)) ||
+    betweenZeroAndOne(parseWad(amount))
+
+  const precisionAdjusted = isBetweenZeroAndOne ? 2 : precision
+
+  const formattedUSDAmount = formatWad(amount, {
+    precision: precisionAdjusted ?? 0,
+    padEnd: padEnd ?? false,
+  })
+
+  const ETHAmount = converter.usdToWei(fromWad(amount))
+  const formattedETHAmount = formatWad(ETHAmount, {
+    precision: precisionAdjusted ?? 0,
+    padEnd: padEnd ?? false,
+  })
+
+  if (!amount) return null
+
+  return (
+    <Tooltip
+      title={
+        <span>
+          <CurrencySymbol currency="ETH" />
+          {formattedETHAmount}
+        </span>
+      }
+    >
+      <CurrencySymbol currency="USD" />
+      {formattedUSDAmount}
+    </Tooltip>
+  )
+}

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -1,6 +1,6 @@
 import { RightCircleOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
-import { t, Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 import { Progress, Tooltip } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import EtherscanLink from 'components/shared/EtherscanLink'
@@ -19,6 +19,7 @@ import { formatWad, fracDiv, fromWad } from 'utils/formatNumber'
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 
 import { V1CurrencyName } from 'utils/v1/currency'
+import StatLine from 'components/shared/Project/StatLine'
 
 import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
 import { readNetwork } from 'constants/networks'
@@ -84,34 +85,33 @@ export default function Paid() {
   const spacing =
     hasFundingTarget(currentFC) && currentFC.target.gt(0) ? 15 : 10
 
-  const formatCurrencyAmount = (amt: BigNumber | undefined) =>
-    amt ? (
-      <>
-        {currentFC.currency.eq(V1_CURRENCY_USD) ? (
-          <span>
-            <Tooltip
-              title={
-                <span>
-                  <CurrencySymbol currency="ETH" />
-                  {formatWad(converter.usdToWei(fromWad(amt)), {
-                    precision: 2,
-                    padEnd: true,
-                  })}
-                </span>
-              }
-            >
-              <CurrencySymbol currency="USD" />
-              {formatWad(amt, { precision: 2, padEnd: true })}
-            </Tooltip>
-          </span>
-        ) : (
-          <span>
-            <CurrencySymbol currency="ETH" />
-            {formatWad(amt, { precision: 2, padEnd: true })}
-          </span>
-        )}
-      </>
-    ) : null
+  const formatCurrencyAmount = (amt: BigNumber | undefined) => {
+    if (!amt) return null
+
+    return currentFC.currency.eq(V1_CURRENCY_USD) ? (
+      <span>
+        <Tooltip
+          title={
+            <span>
+              <CurrencySymbol currency="ETH" />
+              {formatWad(converter.usdToWei(fromWad(amt)), {
+                precision: 2,
+                padEnd: true,
+              })}
+            </span>
+          }
+        >
+          <CurrencySymbol currency="USD" />
+          {formatWad(amt, { precision: 2, padEnd: true })}
+        </Tooltip>
+      </span>
+    ) : (
+      <span>
+        <CurrencySymbol currency="ETH" />
+        {formatWad(amt, { precision: 2, padEnd: true })}
+      </span>
+    )
+  }
 
   const isConstitutionDAO =
     readNetwork.name === NetworkName.mainnet &&
@@ -119,103 +119,92 @@ export default function Paid() {
 
   return (
     <div>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'baseline',
-          marginBottom: spacing,
-        }}
-      >
-        <span style={secondaryTextStyle}>
-          <TooltipLabel
-            label={t`Volume`}
-            tip={t`The total amount received by this project through Juicebox since it was created.`}
-          />
-        </span>
-        <span style={primaryTextStyle}>
-          {isConstitutionDAO && (
-            <span style={secondaryTextStyle}>
-              <CurrencySymbol currency="USD" />
-              {formatWad(converter.wadToCurrency(earned, 'USD', 'ETH'), {
-                precision: 2,
-                padEnd: true,
-              })}{' '}
+      <StatLine
+        statLabel={<Trans>Volume</Trans>}
+        statLabelTip={
+          <Trans>
+            The total amount received by this project through Juicebox since it
+            was created.
+          </Trans>
+        }
+        statValue={
+          <span style={primaryTextStyle}>
+            {isConstitutionDAO && (
+              <span style={secondaryTextStyle}>
+                <CurrencySymbol currency="USD" />
+                {formatWad(converter.wadToCurrency(earned, 'USD', 'ETH'), {
+                  precision: 2,
+                  padEnd: true,
+                })}{' '}
+              </span>
+            )}
+            <span
+              style={{
+                color: isConstitutionDAO
+                  ? colors.text.brand.primary
+                  : colors.text.primary,
+              }}
+            >
+              <ETHAmount amount={earned} />
             </span>
-          )}
-          <span
+          </span>
+        }
+        style={{ marginBottom: spacing }}
+      />
+
+      <StatLine
+        statLabel={<Trans>In Juicebox</Trans>}
+        statLabelTip={
+          <Trans>The balance of this project in the Juicebox contract.</Trans>
+        }
+        statValue={
+          <div
             style={{
+              ...primaryTextStyle,
               color: isConstitutionDAO
-                ? colors.text.brand.primary
-                : colors.text.primary,
+                ? colors.text.primary
+                : colors.text.brand.primary,
+              marginLeft: 10,
             }}
           >
-            <ETHAmount amount={earned} />
-          </span>
-        </span>
-      </div>
-
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'baseline',
-          flexWrap: 'nowrap',
-        }}
-      >
-        <div style={secondaryTextStyle}>
-          <TooltipLabel
-            label={t`In Juicebox`}
-            tip={t`The balance of this project in the Juicebox contract.`}
-          />
-        </div>
-
-        <div
-          style={{
-            ...primaryTextStyle,
-            color: isConstitutionDAO
-              ? colors.text.primary
-              : colors.text.brand.primary,
-            marginLeft: 10,
-          }}
-        >
-          {currentFC.currency.eq(V1_CURRENCY_USD) ? (
-            <span style={secondaryTextStyle}>
-              <ETHAmount amount={balance} precision={2} padEnd={true} />{' '}
-            </span>
-          ) : (
-            ''
-          )}
-          {formatCurrencyAmount(balanceInCurrency)}
-        </div>
-      </div>
+            {currentFC.currency.eq(V1_CURRENCY_USD) ? (
+              <span style={secondaryTextStyle}>
+                <ETHAmount amount={balance} precision={2} padEnd={true} />{' '}
+              </span>
+            ) : (
+              ''
+            )}
+            {formatCurrencyAmount(balanceInCurrency)}
+          </div>
+        }
+        style={{ marginBottom: spacing }}
+      />
 
       {hasFundingTarget(currentFC) &&
         (currentFC.target.gt(0) ? (
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'baseline',
-            }}
-          >
-            <div style={secondaryTextStyle}>
-              <TooltipLabel
-                label={t`Distributed`}
-                tip={t`The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins.`}
-              />
-            </div>
-
-            <div
-              style={{
-                ...secondaryTextStyle,
-                color: colors.text.primary,
-              }}
-            >
-              {formatCurrencyAmount(currentFC.tapped)} /{' '}
-              {formatCurrencyAmount(currentFC.target)}
-            </div>
-          </div>
+          <StatLine
+            statLabel={<Trans>Distributed</Trans>}
+            statLabelTip={
+              <Trans>
+                The amount that has been distributed from the Juicebox balance
+                in this funding cycle, out of the current funding target. No
+                more than the funding target can be distributed in a single
+                funding cycle—any remaining ETH in Juicebox is overflow, until
+                the next cycle begins.
+              </Trans>
+            }
+            statValue={
+              <div
+                style={{
+                  ...secondaryTextStyle,
+                  color: colors.text.primary,
+                }}
+              >
+                {formatCurrencyAmount(currentFC.tapped)} /{' '}
+                {formatCurrencyAmount(currentFC.target)}
+              </div>
+            }
+          />
         ) : (
           <div
             style={{
@@ -224,8 +213,14 @@ export default function Paid() {
             }}
           >
             <TooltipLabel
-              tip={t`The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed.`}
-              label={t`100% overflow`}
+              tip={
+                <Trans>
+                  The target for this funding cycle is 0, meaning all funds in
+                  Juicebox are currently considered overflow. Overflow can be
+                  redeemed by token holders, but not distributed.
+                </Trans>
+              }
+              label={<Trans>100% overflow</Trans>}
             />
           </div>
         ))}
@@ -272,44 +267,38 @@ export default function Paid() {
           />
         ))}
 
-      <div
+      <StatLine
+        statLabel={<Trans>In wallet</Trans>}
+        statLabelTip={
+          <>
+            <p>
+              <Trans>
+                The balance of the wallet that owns this Juicebox project.
+              </Trans>
+            </p>{' '}
+            <EtherscanLink value={owner} type="address" />
+          </>
+        }
         style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'baseline',
           marginTop: spacing,
         }}
-      >
-        <span style={secondaryTextStyle}>
-          <TooltipLabel
-            label={t`In wallet`}
-            tip={
-              <div>
-                <p>
-                  <Trans>
-                    The balance of the wallet that owns this Juicebox project.
-                  </Trans>
-                </p>{' '}
-                <EtherscanLink value={owner} type="address" />
-              </div>
-            }
-          />
-        </span>
-        <span>
-          <span style={secondaryTextStyle}>
-            <ProjectTokenBalance
-              style={{ display: 'inline-block' }}
-              wallet={owner}
-              projectId={BigNumber.from('0x01')}
-              hideHandle
-            />{' '}
-            +{' '}
+        statValue={
+          <span>
+            <span style={secondaryTextStyle}>
+              <ProjectTokenBalance
+                style={{ display: 'inline-block' }}
+                wallet={owner}
+                projectId={BigNumber.from('0x01')}
+                hideHandle
+              />{' '}
+              +{' '}
+            </span>
+            <span style={primaryTextStyle}>
+              <ETHAmount amount={ownerBalance} precision={2} padEnd={true} />
+            </span>
           </span>
-          <span style={primaryTextStyle}>
-            <ETHAmount amount={ownerBalance} precision={2} padEnd={true} />
-          </span>
-        </span>
-      </div>
+        }
+      />
 
       <div
         style={{

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -177,7 +177,6 @@ export default function Paid() {
             {formatCurrencyAmount(balanceInCurrency)}
           </div>
         }
-        style={{ marginBottom: spacing }}
       />
 
       {hasFundingTarget(currentFC) &&

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -1,12 +1,12 @@
 import { RightCircleOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Trans } from '@lingui/macro'
-import { Progress, Tooltip } from 'antd'
+import { Progress } from 'antd'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
 import EtherscanLink from 'components/shared/EtherscanLink'
 import ProjectTokenBalance from 'components/shared/ProjectTokenBalance'
 import TooltipLabel from 'components/shared/TooltipLabel'
-import ETHAmount from 'components/shared/ETHAmount'
+import ETHAmount from 'components/shared/currency/ETHAmount'
 
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -15,15 +15,17 @@ import { useEthBalanceQuery } from 'hooks/EthBalance'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { NetworkName } from 'models/network-name'
 import { CSSProperties, useContext, useMemo, useState } from 'react'
-import { formatWad, fracDiv, fromWad } from 'utils/formatNumber'
+import { formatWad, fracDiv } from 'utils/formatNumber'
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 
 import { V1CurrencyName } from 'utils/v1/currency'
 import StatLine from 'components/shared/Project/StatLine'
 
+import USDAmount from 'components/shared/currency/USDAmount'
+
 import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
 import { readNetwork } from 'constants/networks'
-import { V1_CURRENCY_USD } from 'constants/v1/currency'
+import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
 
 import BalancesModal from './modals/BalancesModal'
 
@@ -88,29 +90,15 @@ export default function Paid() {
   const formatCurrencyAmount = (amt: BigNumber | undefined) => {
     if (!amt) return null
 
-    return currentFC.currency.eq(V1_CURRENCY_USD) ? (
-      <span>
-        <Tooltip
-          title={
-            <span>
-              <CurrencySymbol currency="ETH" />
-              {formatWad(converter.usdToWei(fromWad(amt)), {
-                precision: 2,
-                padEnd: true,
-              })}
-            </span>
-          }
-        >
-          <CurrencySymbol currency="USD" />
-          {formatWad(amt, { precision: 2, padEnd: true })}
-        </Tooltip>
-      </span>
-    ) : (
-      <span>
-        <CurrencySymbol currency="ETH" />
-        {formatWad(amt, { precision: 2, padEnd: true })}
-      </span>
-    )
+    if (currentFC.currency.eq(V1_CURRENCY_ETH)) {
+      return <ETHAmount amount={amt} precision={2} padEnd />
+    }
+
+    if (currentFC.currency.eq(V1_CURRENCY_USD)) {
+      return <USDAmount amount={amt} precision={2} padEnd />
+    }
+
+    return null
   }
 
   const isConstitutionDAO =

--- a/src/components/v1/V1Project/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/PaymentActivity.tsx
@@ -1,6 +1,6 @@
 import FormattedAddress from 'components/shared/FormattedAddress'
 import EtherscanLink from 'components/shared/EtherscanLink'
-import ETHAmount from 'components/shared/ETHAmount'
+import ETHAmount from 'components/shared/currency/ETHAmount'
 
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'

--- a/src/components/v2/V2Dashboard/index.tsx
+++ b/src/components/v2/V2Dashboard/index.tsx
@@ -1,19 +1,21 @@
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import { useParams } from 'react-router-dom'
 import Loading from 'components/shared/Loading'
 import { BigNumber } from '@ethersproject/bignumber'
 import useProjectMetadataContent from 'hooks/v2/contractReader/ProjectMetadataContent'
 import ScrollToTopButton from 'components/shared/ScrollToTopButton'
-
 import useProjectCurrentFundingCycle from 'hooks/v2/contractReader/ProjectCurrentFundingCycle'
-
 import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
 import useProjectTerminals from 'hooks/v2/contractReader/ProjectTerminals'
 import { useETHPaymentTerminalBalance } from 'hooks/v2/contractReader/ETHPaymentTerminalBalance'
-
 import useProjectToken from 'hooks/v2/contractReader/ProjectToken'
+import { useContext, useMemo } from 'react'
+import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
+import { useDistributionLimitCurrency } from 'hooks/v2/contractReader/DistributionLimitCurrency'
+import { V2CurrencyOption } from 'models/v2/currencyOption'
+import { V2_CURRENCY_ETH } from 'utils/v2/currency'
+import { V2UserContext } from 'contexts/v2/userContext'
 
 import { layouts } from 'constants/styles/layouts'
 
@@ -27,6 +29,7 @@ import {
 export default function V2Dashboard() {
   const { projectId: projectIdParameter }: { projectId?: string } = useParams()
   const projectId = BigNumber.from(projectIdParameter)
+  const { contracts } = useContext(V2UserContext)
 
   const { data: metadataCID, loading: metadataURILoading } =
     useProjectMetadataContent(projectId)
@@ -65,6 +68,28 @@ export default function V2Dashboard() {
     projectId,
   })
 
+  const converter = useCurrencyConverter()
+
+  const { data: distributionLimitCurrency } = useDistributionLimitCurrency({
+    projectId,
+    fundingCycleConfiguration: fundingCycle?.configuration,
+    terminal: contracts?.JBETHPaymentTerminal.address,
+  })
+
+  const balanceInDistributionLimitCurrency = useMemo(
+    () =>
+      ETHBalance &&
+      converter.wadToCurrency(
+        ETHBalance,
+        (distributionLimitCurrency?.toNumber() as V2CurrencyOption) ===
+          V2_CURRENCY_ETH
+          ? 'ETH'
+          : 'USD',
+        'ETH',
+      ),
+    [ETHBalance, converter, distributionLimitCurrency],
+  )
+
   if (metadataLoading || metadataURILoading) return <Loading />
 
   if (projectId?.eq(0) || metadataError || !metadataCID) {
@@ -80,6 +105,8 @@ export default function V2Dashboard() {
     tokenAddress,
     terminals,
     ETHBalance,
+    distributionLimitCurrency,
+    balanceInDistributionLimitCurrency,
   }
 
   return (

--- a/src/components/v2/V2Project/TreasuryStats.tsx
+++ b/src/components/v2/V2Project/TreasuryStats.tsx
@@ -1,0 +1,95 @@
+import { Trans } from '@lingui/macro'
+import { Tooltip } from 'antd'
+import CurrencySymbol from 'components/shared/CurrencySymbol'
+import ETHAmount from 'components/shared/ETHAmount'
+import StatLine from 'components/shared/Project/StatLine'
+import { ThemeContext } from 'contexts/themeContext'
+import { BigNumber } from '@ethersproject/bignumber'
+import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
+import { CSSProperties, useContext } from 'react'
+import { formatWad, fromWad } from 'utils/formatNumber'
+import { V2_CURRENCY_ETH, V2_CURRENCY_USD } from 'utils/v2/currency'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+
+export default function TreasuryStats() {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  const {
+    ETHBalance,
+    balanceInDistributionLimitCurrency,
+    distributionLimitCurrency,
+  } = useContext(V2ProjectContext)
+  const converter = useCurrencyConverter()
+
+  const spacing = 10
+
+  const primaryTextStyle: CSSProperties = {
+    fontWeight: 500,
+    fontSize: '1.1rem',
+    lineHeight: 1,
+  }
+  const secondaryTextStyle: CSSProperties = {
+    textTransform: 'uppercase',
+    color: colors.text.tertiary,
+    fontSize: '0.8rem',
+    fontWeight: 500,
+  }
+
+  const formatCurrencyAmount = (amt: BigNumber | undefined) => {
+    if (!amt) return null
+
+    if (distributionLimitCurrency?.eq(V2_CURRENCY_ETH)) {
+      return <ETHAmount amount={amt} precision={2} padEnd />
+    }
+
+    if (distributionLimitCurrency?.eq(V2_CURRENCY_USD)) {
+      return (
+        <Tooltip
+          title={
+            <span>
+              <CurrencySymbol currency="ETH" />
+              {formatWad(converter.usdToWei(fromWad(amt)), {
+                precision: 2,
+                padEnd: true,
+              })}
+            </span>
+          }
+        >
+          <CurrencySymbol currency="USD" />
+          {formatWad(amt, { precision: 2, padEnd: true })}
+        </Tooltip>
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <StatLine
+      statLabel={<Trans>In Juicebox</Trans>}
+      statLabelTip={
+        <Trans>The balance of this project in the Juicebox contract.</Trans>
+      }
+      statValue={
+        <div
+          style={{
+            ...primaryTextStyle,
+            color: colors.text.brand.primary,
+            marginLeft: 10,
+          }}
+        >
+          {distributionLimitCurrency?.eq(V2_CURRENCY_USD) ? (
+            <span style={secondaryTextStyle}>
+              <ETHAmount amount={ETHBalance} precision={2} padEnd={true} />{' '}
+            </span>
+          ) : (
+            ''
+          )}
+          {formatCurrencyAmount(balanceInDistributionLimitCurrency)}
+        </div>
+      }
+      style={{ marginBottom: spacing }}
+    />
+  )
+}

--- a/src/components/v2/V2Project/TreasuryStats.tsx
+++ b/src/components/v2/V2Project/TreasuryStats.tsx
@@ -1,15 +1,12 @@
 import { Trans } from '@lingui/macro'
-import { Tooltip } from 'antd'
-import CurrencySymbol from 'components/shared/CurrencySymbol'
-import ETHAmount from 'components/shared/ETHAmount'
+import ETHAmount from 'components/shared/currency/ETHAmount'
 import StatLine from 'components/shared/Project/StatLine'
 import { ThemeContext } from 'contexts/themeContext'
 import { BigNumber } from '@ethersproject/bignumber'
-import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { CSSProperties, useContext } from 'react'
-import { formatWad, fromWad } from 'utils/formatNumber'
 import { V2_CURRENCY_ETH, V2_CURRENCY_USD } from 'utils/v2/currency'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
+import USDAmount from 'components/shared/currency/USDAmount'
 
 export default function TreasuryStats() {
   const {
@@ -20,7 +17,6 @@ export default function TreasuryStats() {
     balanceInDistributionLimitCurrency,
     distributionLimitCurrency,
   } = useContext(V2ProjectContext)
-  const converter = useCurrencyConverter()
 
   const spacing = 10
 
@@ -44,22 +40,7 @@ export default function TreasuryStats() {
     }
 
     if (distributionLimitCurrency?.eq(V2_CURRENCY_USD)) {
-      return (
-        <Tooltip
-          title={
-            <span>
-              <CurrencySymbol currency="ETH" />
-              {formatWad(converter.usdToWei(fromWad(amt)), {
-                precision: 2,
-                padEnd: true,
-              })}
-            </span>
-          }
-        >
-          <CurrencySymbol currency="USD" />
-          {formatWad(amt, { precision: 2, padEnd: true })}
-        </Tooltip>
-      )
+      return <USDAmount amount={amt} precision={2} padEnd />
     }
 
     return null

--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -5,12 +5,12 @@ import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useContext } from 'react'
 
 import { permilleToPercent, permyriadToPercent } from 'utils/formatNumber'
-import { fromWad } from 'utils/formatNumber'
 import { decodeV2FundingCycleMetadata } from 'utils/v2/fundingCycle'
 import { weightedAmount } from 'utils/math'
 
 import V2PayButton from './V2PayButton'
 import V2ProjectHeaderActions from '../V2ProjectHeaderActions'
+import TreasuryStats from './TreasuryStats'
 
 export default function V2Project() {
   const {
@@ -19,7 +19,6 @@ export default function V2Project() {
     fundingCycle,
     payoutSplits,
     reserveTokenSplits,
-    ETHBalance,
   } = useContext(V2ProjectContext)
 
   if (!projectId) return null
@@ -53,9 +52,9 @@ export default function V2Project() {
         metadata={projectMetadata}
         actions={<V2ProjectHeaderActions />}
       />
-      <Row>
+      <Row gutter={40}>
         <Col md={12} xs={24}>
-          <h2>In Juicebox: {fromWad(ETHBalance)}</h2>
+          <TreasuryStats />
 
           {fundingCycle && (
             <div>

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -13,6 +13,8 @@ export type V2ProjectContextType = {
   tokenAddress: string | undefined
   terminals: string[] | undefined // array of terminal addresses, 0xABC...
   ETHBalance: BigNumber | undefined
+  distributionLimitCurrency: BigNumber | undefined
+  balanceInDistributionLimitCurrency: BigNumber | undefined
 }
 
 export const V2ProjectContext = createContext<V2ProjectContextType>({
@@ -24,4 +26,6 @@ export const V2ProjectContext = createContext<V2ProjectContextType>({
   tokenAddress: undefined,
   terminals: undefined,
   ETHBalance: undefined,
+  distributionLimitCurrency: undefined,
+  balanceInDistributionLimitCurrency: undefined,
 })

--- a/src/hooks/v2/contractReader/DistributionLimitCurrency.ts
+++ b/src/hooks/v2/contractReader/DistributionLimitCurrency.ts
@@ -1,0 +1,23 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { V2ContractName } from 'models/v2/contracts'
+
+import useV2ContractReader from './V2ContractReader'
+
+export function useDistributionLimitCurrency({
+  projectId,
+  fundingCycleConfiguration,
+  terminal,
+}: {
+  projectId?: BigNumber
+  fundingCycleConfiguration?: BigNumber
+  terminal?: string
+}) {
+  return useV2ContractReader<BigNumber>({
+    contract: V2ContractName.JBController,
+    functionName: 'distributionLimitCurrencyOf',
+    args:
+      projectId && fundingCycleConfiguration && terminal
+        ? [projectId, fundingCycleConfiguration, terminal]
+        : null,
+  })
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -909,6 +909,7 @@ msgstr "If you're unsure if you need to claim, you probably don't."
 
 #: src/components/v1/V1Project/BalanceTimeline.tsx
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "In Juicebox"
 msgstr ""
 
@@ -1711,6 +1712,7 @@ msgid "The balance of the wallet that owns this Juicebox project."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "The balance of this project in the Juicebox contract."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -914,6 +914,7 @@ msgstr "Si dudas de si necesitas reclamar tus tokens, probablemente no deberías
 
 #: src/components/v1/V1Project/BalanceTimeline.tsx
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "In Juicebox"
 msgstr "En Juicebox"
 
@@ -1716,6 +1717,7 @@ msgid "The balance of the wallet that owns this Juicebox project."
 msgstr "El saldo de la wallet que posee este proyecto Juicebox."
 
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "El balance de este proyecto en el contrato de Juicebox."
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -914,6 +914,7 @@ msgstr "Caso tenha dúvidas se precisa reinvidicar seus tokens, você provavelme
 
 #: src/components/v1/V1Project/BalanceTimeline.tsx
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "In Juicebox"
 msgstr "No Juicebox"
 
@@ -1716,6 +1717,7 @@ msgid "The balance of the wallet that owns this Juicebox project."
 msgstr "O saldo da carteira do proprietário desse projeto no Juicebox."
 
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "O saldo deste projeto no contrato do Juicebox."
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -914,6 +914,7 @@ msgstr "Если вы не уверены, нужно ли вам предъяв
 
 #: src/components/v1/V1Project/BalanceTimeline.tsx
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "In Juicebox"
 msgstr "В Juicebox"
 
@@ -1716,6 +1717,7 @@ msgid "The balance of the wallet that owns this Juicebox project."
 msgstr "Баланс кошелька, которому принадлежит этот проект Juicebox."
 
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "Баланс этого проекта в контракте Juicebox."
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -914,6 +914,7 @@ msgstr "Hak talebinde bulunmanız gerekip gerekmediğinden emin değilseniz muht
 
 #: src/components/v1/V1Project/BalanceTimeline.tsx
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "In Juicebox"
 msgstr "Juicebox'da"
 
@@ -1716,6 +1717,7 @@ msgid "The balance of the wallet that owns this Juicebox project."
 msgstr "Bu Juicebox projesinin sahibi olan cüzdanın bakiyesi."
 
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -914,6 +914,7 @@ msgstr "如果你不确定你是否需要领取，那么你或许不需要。"
 
 #: src/components/v1/V1Project/BalanceTimeline.tsx
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "In Juicebox"
 msgstr "项目金库余额"
 
@@ -1716,6 +1717,7 @@ msgid "The balance of the wallet that owns this Juicebox project."
 msgstr "这个 Juicebox 项目拥有者的钱包余额"
 
 #: src/components/v1/V1Project/Paid.tsx
+#: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "该项目在Juicebox合约中的余额。"
 


### PR DESCRIPTION
## What does this PR do and why?

- Adds a `StatLine.tsx` component, and uses the component for treasury stats for V1 projects
- Adds the "in juicebox" number to V2 projects, using the `StatLine` component (resolves https://github.com/jbx-protocol/juice-interface/issues/668)

## Screenshots or screen recordings

### V2 project

<img width="692" alt="Screen Shot 2022-03-20 at 8 37 55 am" src="https://user-images.githubusercontent.com/94939382/159140088-35025383-755b-4d6d-9a55-fa92771fbb73.png">

### V1 projects

Screenshots demonstrate no visual change.

| before | after |
| --- | --- |
| <img width="540" alt="Screen Shot 2022-03-20 at 8 46 59 am" src="https://user-images.githubusercontent.com/94939382/159140325-407014a8-b3d1-4968-be80-164459caf8b1.png"> | <img width="527" alt="Screen Shot 2022-03-20 at 8 45 47 am" src="https://user-images.githubusercontent.com/94939382/159140316-d8e597b2-83a2-437e-a6bb-dda6a8a7a2fa.png"> |
| <img width="533" alt="Screen Shot 2022-03-20 at 8 40 31 am" src="https://user-images.githubusercontent.com/94939382/159140150-93f9efde-24f5-4e89-ac69-30dfe5bb0734.png"> | <img width="531" alt="Screen Shot 2022-03-20 at 8 47 50 am" src="https://user-images.githubusercontent.com/94939382/159140346-640748c4-5007-4760-84b6-0538ef2697ee.png"> |

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
