### PR TITLE
[chore] update caniuse

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6930,14 +6930,9 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001259:
-  version "1.0.30001259"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz#ae21691d3da9c4be6144403ac40f71d9f6efd790"
-  integrity sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==
-
-caniuse-lite@^1.0.30001317:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001259, caniuse-lite@^1.0.30001317:
   version "1.0.30001319"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz#eb4da4eb3ecdd409f7ba1907820061d56096e88f"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz"
   integrity sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==
 
 capture-exit@^2.0.0:


### PR DESCRIPTION
## What does this PR do and why?

After running the project, a warning was shown to run `npx browserslist@latest --update-db`, which seemed like a normal housekeeping task after reading the documentation: https://github.com/browserslist/browserslist#browsers-data-updating. 



Target browser changes:
```
- and_chr 93
+ and_chr 99
- and_ff 92
+ and_ff 96
- chrome 92
- chrome 91
- chrome 90
- chrome 87
- chrome 85
+ chrome 98
+ chrome 97
+ chrome 96
+ chrome 93
+ chrome 79
- edge 92
+ edge 98
+ edge 97
- firefox 91
- firefox 90
+ firefox 97
+ firefox 96
- ios_saf 14.5-14.7
+ ios_saf 15.2-15.3
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 12.2-12.5
- opera 78
- opera 77
+ opera 83
+ opera 82
+ safari 15.2-15.3
+ safari 15.1
- samsung 14.0
+ samsung 16.0
```





## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md) for this PR.
- [x] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
