### PR TITLE
[chore] update pull request template to absolute links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,8 @@ changes._
 
 ## Acceptance checklist
 
-- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
-- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
+- [ ] I have evaluated the
+      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
+      for this PR.
+- [ ] I have tested this PR in
+      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).


### PR DESCRIPTION
## What does this PR do and why?
Did a quick google search and it looks like relative paths are broken in GitHub Pull Request templates: https://github.com/github/markup/issues/576. This PR updates relative paths to absolute paths in the pull request template for the project.

After this PR is merged, contributors will be able to click the Acceptance checklist links and be taken to the docs and not a 404 page.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
