### PR TITLE
Fix funding target input field in create flow

### DIFF
--- a/src/components/shared/formItems/ProjectTarget.tsx
+++ b/src/components/shared/formItems/ProjectTarget.tsx
@@ -3,6 +3,8 @@ import { V1CurrencyOption } from 'models/v1/currencyOption'
 
 import { BigNumber } from '@ethersproject/bignumber'
 
+import { Trans } from '@lingui/macro'
+
 import BudgetTargetInput from '../inputs/BudgetTargetInput'
 import { FormItemExt } from './formItemExt'
 
@@ -29,8 +31,14 @@ export default function ProjectTarget({
 } & FormItemExt) {
   return (
     <Form.Item
-      extra="The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
-      label={hideLabel ? undefined : 'Funding target'}
+      extra={
+        <Trans>
+          The maximum amount of funds that can be distributed from this project
+          in one funding cycle. Funds will be withdrawn in ETH no matter the
+          currency you choose.
+        </Trans>
+      }
+      label={hideLabel ? undefined : <Trans>Funding target</Trans>}
       {...formItemProps}
     >
       <BudgetTargetInput

--- a/src/components/shared/formItems/formHelpers.tsx
+++ b/src/components/shared/formItems/formHelpers.tsx
@@ -73,12 +73,12 @@ export const targetToTargetSubFeeFormatted = (
 export const targetSubFeeToTargetFormatted = (
   targetSubFee: string,
   fee: BigNumber | undefined,
-) => {
+): string => {
   if (targetSubFee === fromWad(constants.MaxUint256)) {
     return fromWad(constants.MaxUint256)
   }
-  const newTarget = amountAddFee(parseWad(targetSubFee ?? '0'), fee)
-  return fromWad(newTarget)
+  const newTarget = amountAddFee(targetSubFee ?? '0', fee)
+  return newTarget ?? '0'
 }
 
 // Returns amount from a given percentage of the

--- a/src/components/shared/inputs/BudgetTargetInput.tsx
+++ b/src/components/shared/inputs/BudgetTargetInput.tsx
@@ -5,8 +5,11 @@ import { CSSProperties, useContext, useEffect, useState } from 'react'
 import { V1CurrencyName } from 'utils/v1/currency'
 import { perbicentToPercent } from 'utils/formatNumber'
 
+import { Trans } from '@lingui/macro'
+
 import InputAccessoryButton from '../InputAccessoryButton'
 import FormattedNumberInput from './FormattedNumberInput'
+import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
 
 export default function BudgetTargetInput({
   currency,
@@ -47,17 +50,18 @@ export default function BudgetTargetInput({
 
   if (_currency === undefined) return null
 
-  function CurrencySwitch() {
+  const CurrencySwitch = () => {
     if (onCurrencyChange)
       return (
         <InputAccessoryButton
           onClick={() => {
-            const newCurrency = _currency === 1 ? 0 : 1
+            const newCurrency =
+              _currency === V1_CURRENCY_USD ? V1_CURRENCY_ETH : V1_CURRENCY_USD
             setCurrency(newCurrency)
             onCurrencyChange(newCurrency)
           }}
           content={V1CurrencyName(_currency)}
-          withArrow={true}
+          withArrow
           placement="suffix"
         />
       )
@@ -91,7 +95,9 @@ export default function BudgetTargetInput({
               }
             />
           </div>
-          <div>after {perbicentToPercent(fee?.toString())}% JBX fee</div>
+          <div>
+            <Trans>after {perbicentToPercent(fee?.toString())}% JBX fee</Trans>
+          </div>
         </div>
       )}
     </div>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -791,6 +791,7 @@ msgstr "Funding cycles can be reconfigured moments before a new cycle begins, wi
 msgid "Funding distribution"
 msgstr "Funding distribution"
 
+#: src/components/shared/formItems/ProjectTarget.tsx
 #: src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
 msgid "Funding target"
 msgstr "Funding target"
@@ -1732,6 +1733,10 @@ msgstr "The funds available to withdraw for this funding cycle after the {0}% JB
 msgid "The future will be led by creators, and owned by communities."
 msgstr ""
 
+#: src/components/shared/formItems/ProjectTarget.tsx
+msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+msgstr "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -2173,6 +2178,7 @@ msgstr ""
 msgid "Your project's website."
 msgstr ""
 
+#: src/components/shared/inputs/BudgetTargetInput.tsx
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr ""

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -796,6 +796,7 @@ msgstr "Los ciclos de financiamiento pueden ser reconfigurados momentos antes de
 msgid "Funding distribution"
 msgstr "Distribución de fondos"
 
+#: src/components/shared/formItems/ProjectTarget.tsx
 #: src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
 msgid "Funding target"
 msgstr "Objetivo de financiamiento"
@@ -1737,6 +1738,10 @@ msgstr "Los fondos disponibles para retirar para este ciclo de financiación des
 msgid "The future will be led by creators, and owned by communities."
 msgstr "El futuro será liderado por creadores y las comunidades serán los dueños."
 
+#: src/components/shared/formItems/ProjectTarget.tsx
+msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "El porcentaje que recibe esta persona del {reservedRate}% general de la asignación de tokens reservados"
@@ -2178,6 +2183,7 @@ msgstr "El objetivo y duración de tu ciclo de financiamiento."
 msgid "Your project's website."
 msgstr "El sitio web de tu proyecto."
 
+#: src/components/shared/inputs/BudgetTargetInput.tsx
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "{0}% después de la comisión de JBX"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -796,6 +796,7 @@ msgstr "Ciclos de financiamento podem ser reconfigurados momentos antes de um no
 msgid "Funding distribution"
 msgstr "Distribuição de fundos"
 
+#: src/components/shared/formItems/ProjectTarget.tsx
 #: src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
 msgid "Funding target"
 msgstr "Objetivo de financiamento"
@@ -1737,6 +1738,10 @@ msgstr "Os fundos disponíveis para saque para este ciclo de financiamento após
 msgid "The future will be led by creators, and owned by communities."
 msgstr "O futuro será liderado pelos criadores, e pertencente às comunidades."
 
+#: src/components/shared/formItems/ProjectTarget.tsx
+msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "O percentual que esse individuo recebe do todo de {reservedRate}% de token alocados como reservados"
@@ -2178,6 +2183,7 @@ msgstr "Objetivo e duração do ciclo de financiamento do seu projeto."
 msgid "Your project's website."
 msgstr "Site do seu projeto."
 
+#: src/components/shared/inputs/BudgetTargetInput.tsx
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "depois da taxa de {0}% de JBX"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -796,6 +796,7 @@ msgstr "Циклы финансирования можно изменить за
 msgid "Funding distribution"
 msgstr "Распределение финансирования"
 
+#: src/components/shared/formItems/ProjectTarget.tsx
 #: src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
 msgid "Funding target"
 msgstr "Цель финансирования"
@@ -1737,6 +1738,10 @@ msgstr "Средства, доступные для вывода в течени
 msgid "The future will be led by creators, and owned by communities."
 msgstr "Будущее будет возглавляться создателями и принадлежать сообществам."
 
+#: src/components/shared/formItems/ProjectTarget.tsx
+msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "Процент, который получает это лицо от общего количества {reservedRate}%зарезервированное распределение токенов"
@@ -2178,6 +2183,7 @@ msgstr "Цель и продолжительность цикла финанси
 msgid "Your project's website."
 msgstr "Сайт вашего проекта."
 
+#: src/components/shared/inputs/BudgetTargetInput.tsx
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "после  {0}% комиссии JBX"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -796,6 +796,7 @@ msgstr "Finansman döngüleri, katkı sahiplerini bilgilendirmeden, yeni bir dö
 msgid "Funding distribution"
 msgstr "Finansman dağılımı"
 
+#: src/components/shared/formItems/ProjectTarget.tsx
 #: src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
 msgid "Funding target"
 msgstr ""
@@ -1737,6 +1738,10 @@ msgstr ""
 msgid "The future will be led by creators, and owned by communities."
 msgstr "Gelecek, içerik üreticileri tarafından yönetilecek ve topluluklara ait olacak."
 
+#: src/components/shared/formItems/ProjectTarget.tsx
+msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr ""
@@ -2178,6 +2183,7 @@ msgstr "Projenizin finansman döngüsü hedefi ve süresi."
 msgid "Your project's website."
 msgstr "Projenizin web sitesi."
 
+#: src/components/shared/inputs/BudgetTargetInput.tsx
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "%{0} JBX ücretinden sonra"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -796,6 +796,7 @@ msgstr "新的筹款周期开始前即可重新配置筹款周期参数，无须
 msgid "Funding distribution"
 msgstr "资金分发"
 
+#: src/components/shared/formItems/ProjectTarget.tsx
 #: src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
 msgid "Funding target"
 msgstr "筹款目标"
@@ -1737,6 +1738,10 @@ msgstr "在减去 {0} 的 JBX 费用后，当前筹款周期可提取的资金�
 msgid "The future will be led by creators, and owned by communities."
 msgstr "创造者将引领未来, 而社区会拥有未来."
 
+#: src/components/shared/formItems/ProjectTarget.tsx
+msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
+msgstr ""
+
 #: src/components/shared/modals/ReservedTokenReceiverModal.tsx
 msgid "The percent this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "这个地址会收到保留代币中的 {reservedRate}%"
@@ -2178,6 +2183,7 @@ msgstr "项目筹款周期的目标与持续时间。"
 msgid "Your project's website."
 msgstr "你项目的网站。"
 
+#: src/components/shared/inputs/BudgetTargetInput.tsx
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "计算 {0}% JBX 费用之后"

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -89,7 +89,16 @@ export const amountSubFee = (amount?: BigNumber, feePercent?: BigNumber) => {
   return amount.sub(feeForAmount(amount, feePercent) ?? 0)
 }
 
-export const amountAddFee = (amount?: BigNumber, feePercent?: BigNumber) => {
-  if (!feePercent || !amount) return
-  return amount.add(amount.mul(100).div(feePercent.mul(200)))
+/**
+ * new amount = old amount / (1 - fee)
+ */
+export const amountAddFee = (amount?: string, feePerbicent?: BigNumber) => {
+  if (!feePerbicent || !amount) return
+
+  const inverseFeePerbicent = percentToPerbicent(100).sub(feePerbicent)
+  const amountPerbicent = BigNumber.from(amount).mul(percentToPerbicent(100))
+  // new amount is in regular decimal units
+  const newAmount = amountPerbicent.div(inverseFeePerbicent)
+
+  return newAmount.toString()
 }


### PR DESCRIPTION
## What does this PR do and why?

Fixes calculation for calculating the target given a fee and a `targetSubFee` amount.

## Screenshots or screen recordings

<img width="601" alt="Screen Shot 2022-03-23 at 10 57 24 am" src="https://user-images.githubusercontent.com/94939382/159598406-f37334a1-e5e8-487a-8afd-5b595997c8e2.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](../CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](../CONTRIBUTING.md#browser-support).
