### PR TITLE
No explicit any

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "extends": ["react-app", "react-app/jest", "prettier"],
   "parser": "@typescript-eslint/parser",
   "rules": {
+    "@typescript-eslint/no-explicit-any": "error",
     "react-hooks/exhaustive-deps": "error",
     "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-unused-vars": "error",

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,5 @@ changes._
 
 ## Acceptance checklist
 
-- [ ] I have evaluated the
-      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
-      for this PR.
-- [ ] I have tested this PR in
-      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
+- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
+- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).

--- a/src/components/Projects/ProjectsFilterAndSort.tsx
+++ b/src/components/Projects/ProjectsFilterAndSort.tsx
@@ -29,7 +29,7 @@ export default function ProjectsFilterAndSort({
   showArchived: boolean
   setShowArchived: CheckboxOnChange
   orderBy: OrderByOption
-  setOrderBy: any
+  setOrderBy: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }) {
   const {
     theme: { colors },

--- a/src/components/shared/ProjectCard.tsx
+++ b/src/components/shared/ProjectCard.tsx
@@ -57,7 +57,7 @@ export default function ProjectCard({
   ).data
 
   // Must use any to convert (ProjectCardProject | bigNumber) to ProjectCardProject
-  const projectObj: any = project
+  const projectObj: any = project // eslint-disable-line @typescript-eslint/no-explicit-any
   let _project: ProjectCardProject
 
   // If we were given projectId (BN) and therefore projectQuery returned something,

--- a/src/components/shared/formItems/ProjectBondingCurveRate.tsx
+++ b/src/components/shared/formItems/ProjectBondingCurveRate.tsx
@@ -138,7 +138,7 @@ export default function ProjectBondingCurveRate({
   toggleDisabled?: (checked: boolean) => void
 } & FormItemExt) {
   const { colors } = useContext(ThemeContext).theme
-  const [calculator, setCalculator] = useState<any>()
+  const [calculator, setCalculator] = useState<any>() // eslint-disable-line @typescript-eslint/no-explicit-any
 
   const bondingCurveId = 'bonding-curve'
   const baseCurveId = 'base-curve'

--- a/src/components/shared/formItems/ProjectPayoutMods.tsx
+++ b/src/components/shared/formItems/ProjectPayoutMods.tsx
@@ -498,7 +498,7 @@ export default function ProjectPayoutMods({
                 extra: t`The address that should receive the tokens minted from paying this project.`,
                 rules: [
                   {
-                    validator: (rule: any, value: any) => {
+                    validator: () => {
                       const address = form.getFieldValue('beneficiary')
                       if (!address || !isAddress(address))
                         return Promise.reject('Address is required')

--- a/src/components/shared/inputs/ImageUploader.tsx
+++ b/src/components/shared/inputs/ImageUploader.tsx
@@ -16,7 +16,7 @@ export default function ImageUploader({
   text,
 }: {
   initialUrl?: string
-  metadata?: Record<string | number, any>
+  metadata?: Record<string | number, any> // eslint-disable-line @typescript-eslint/no-explicit-any
   onSuccess?: (url?: string) => void
   maxSize?: number // KB
   text?: string

--- a/src/hooks/JuiceTheme.ts
+++ b/src/hooks/JuiceTheme.ts
@@ -6,7 +6,7 @@ import { juiceTheme } from 'constants/theme'
 import { ThemeOption } from 'constants/theme/theme-option'
 
 const flattenNestedObject = (
-  nestedObj: Record<string, any>,
+  nestedObj: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
   prefix?: string,
 ): Record<string, string> =>
   Object.keys(nestedObj).reduce((acc, key) => {

--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -26,7 +26,7 @@ export type TransactorOptions = {
 export type Transactor = (
   contract: Contract,
   functionName: string,
-  args: any[],
+  args: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
   options?: TransactorOptions,
 ) => Promise<boolean>
 
@@ -64,7 +64,7 @@ export function useTransactor({
     async (
       contract: Contract,
       functionName: string,
-      args: any[],
+      args: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
       options?: TransactorOptions,
     ) => {
       if (!onSelectWallet) return false

--- a/src/hooks/v1/contractReader/ContractReader.ts
+++ b/src/hooks/v1/contractReader/ContractReader.ts
@@ -27,7 +27,7 @@ export default function useContractReader<V>({
   functionName?: string
   args?: unknown[] | null
   updateOn?: ContractUpdateOn
-  formatter?: (val?: any) => V | undefined
+  formatter?: (val?: any) => V | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
   callback?: (val?: V) => void
   valueDidChange?: (oldVal?: V, newVal?: V) => boolean
 }): V | undefined {
@@ -36,15 +36,15 @@ export default function useContractReader<V>({
   const { contracts } = useContext(V1UserContext)
 
   const _formatter = useCallback(
-    (val: any) => (formatter ? formatter(val) : val),
+    (val: any) => (formatter ? formatter(val) : val), // eslint-disable-line @typescript-eslint/no-explicit-any
     [formatter],
   )
   const _callback = useCallback(
-    (val: any) => (callback ? callback(val) : val),
+    (val: any) => (callback ? callback(val) : val), // eslint-disable-line @typescript-eslint/no-explicit-any
     [callback],
   )
   const _valueDidChange = useCallback(
-    (a?: any, b?: any) => (valueDidChange ? valueDidChange(a, b) : a !== b),
+    (a?: any, b?: any) => (valueDidChange ? valueDidChange(a, b) : a !== b), // eslint-disable-line @typescript-eslint/no-explicit-any
     [valueDidChange],
   )
 
@@ -96,7 +96,7 @@ export default function useContractReader<V>({
 
     getValue()
 
-    const listener = (x: any) => getValue()
+    const listener = (x: any) => getValue() // eslint-disable-line @typescript-eslint/no-explicit-any
 
     let subscriptions: {
       contract: Contract

--- a/src/hooks/v1/transactor/PrintTokensTx.ts
+++ b/src/hooks/v1/transactor/PrintTokensTx.ts
@@ -25,7 +25,7 @@ export function usePrintTokensTx(): TransactorInstance<{
 
     let terminalContract: Contract
     let functionName: string
-    let args: any[]
+    let args: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
 
     switch (terminal.version) {
       case '1':

--- a/src/hooks/v2/contractReader/V2ContractReader.ts
+++ b/src/hooks/v2/contractReader/V2ContractReader.ts
@@ -27,7 +27,7 @@ export default function useV2ContractReader<V>({
   functionName?: string
   args?: unknown[] | null
   updateOn?: ContractUpdateOn
-  formatter?: (val?: any) => V | undefined
+  formatter?: (val?: any) => V | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
   callback?: (val?: V) => void
   valueDidChange?: (oldVal?: V, newVal?: V) => boolean
 }): { data: V | undefined; loading: boolean } {
@@ -37,15 +37,15 @@ export default function useV2ContractReader<V>({
   const { contracts } = useContext(V2UserContext)
 
   const _formatter = useCallback(
-    (val: any) => (formatter ? formatter(val) : val),
+    (val: any) => (formatter ? formatter(val) : val), // eslint-disable-line @typescript-eslint/no-explicit-any
     [formatter],
   )
   const _callback = useCallback(
-    (val: any) => (callback ? callback(val) : val),
+    (val: any) => (callback ? callback(val) : val), // eslint-disable-line @typescript-eslint/no-explicit-any
     [callback],
   )
   const _valueDidChange = useCallback(
-    (a?: any, b?: any) => (valueDidChange ? valueDidChange(a, b) : a !== b),
+    (a?: any, b?: any) => (valueDidChange ? valueDidChange(a, b) : a !== b), // eslint-disable-line @typescript-eslint/no-explicit-any
     [valueDidChange],
   )
 
@@ -102,7 +102,7 @@ export default function useV2ContractReader<V>({
 
     getValue()
 
-    const listener = (x: any) => getValue()
+    const listener = (x: any) => getValue() // eslint-disable-line @typescript-eslint/no-explicit-any
 
     let subscriptions: {
       contract: Contract

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -95,7 +95,7 @@ export const uploadProjectMetadata = (
     pinataMetadata: {
       keyvalues: {
         tag: IPFS_TAGS.METADATA,
-      } as any,
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       name: handle
         ? metadataNameForHandle(handle)
         : 'juicebox-project-metadata.json',
@@ -110,7 +110,7 @@ export const uploadIpfsJsonCache = <T extends IpfsCacheName>(
     pinataMetadata: {
       keyvalues: {
         tag: IPFS_TAGS[tag],
-      } as any,
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       name: IPFS_TAGS[tag] + '.json',
     },
   })


### PR DESCRIPTION
## What does this PR do and why?

- Bans `any` type via eslint
- ignore existing uses of `any` in the codebase - we can iteratively fix these when we come across them where it makes sense to.
- Sometimes we _do_ need `any` - that's cool too.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [x] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [-] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
