### PR TITLE
Abstract funding cycle details card into own component

### DIFF
--- a/src/components/shared/Project/FundingCycleDetailsCard.tsx
+++ b/src/components/shared/Project/FundingCycleDetailsCard.tsx
@@ -1,0 +1,110 @@
+import { ExclamationCircleOutlined } from '@ant-design/icons'
+import { t, Trans } from '@lingui/macro'
+import { Collapse, Tooltip } from 'antd'
+import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+import { ThemeContext } from 'contexts/themeContext'
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext } from 'react'
+import { detailedTimeString } from 'utils/formatTime'
+
+const COLLAPSE_PANEL_KEY = 'funding-cycle-details'
+const daySeconds = 60 * 60 * 24
+
+export default function FundingCycleDetailsCard({
+  fundingCycleNumber,
+  fundingCycleStartTime,
+  fundingCycleDuration,
+  fundingCycleRiskCount,
+  isFundingCycleRecurring,
+  fundingCycleDetails,
+  showDetail,
+}: {
+  fundingCycleNumber: BigNumber
+  fundingCycleStartTime: BigNumber
+  fundingCycleDuration: BigNumber
+  fundingCycleRiskCount: number
+  fundingCycleDetails: JSX.Element
+  isFundingCycleRecurring: boolean
+  showDetail?: boolean
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const endTimeMilliseconds = fundingCycleStartTime
+    .add(fundingCycleDuration.mul(daySeconds))
+    .mul(1000)
+
+  let headerText = ''
+  if (isFundingCycleRecurring && fundingCycleDuration.gt(0)) {
+    headerText = t`${detailedTimeString(
+      endTimeMilliseconds,
+    )} until #${fundingCycleNumber.add(1).toString()}`
+  } else if (fundingCycleDuration.gt(0)) {
+    headerText = t`${detailedTimeString(endTimeMilliseconds)} left`
+  }
+
+  return (
+    <div>
+      <Collapse
+        style={{
+          background: 'transparent',
+          border: 'none',
+        }}
+        className="minimal"
+        defaultActiveKey={showDetail ? COLLAPSE_PANEL_KEY : undefined}
+      >
+        <CollapsePanel
+          key={COLLAPSE_PANEL_KEY}
+          style={{ border: 'none' }}
+          header={
+            <div
+              style={{
+                display: 'flex',
+                width: '100%',
+                justifyContent: 'space-between',
+                cursor: 'pointer',
+              }}
+            >
+              <div>
+                <span>
+                  {fundingCycleDuration.gt(0) ? (
+                    <Trans>Cycle #{fundingCycleNumber.toString()}</Trans>
+                  ) : (
+                    <Trans>Details</Trans>
+                  )}
+                </span>
+
+                {fundingCycleRiskCount > 0 && (
+                  <span
+                    style={{ marginLeft: 10, color: colors.text.secondary }}
+                  >
+                    <Tooltip
+                      title={
+                        <Trans>
+                          Some funding cycle properties may indicate risk for
+                          project contributors.
+                        </Trans>
+                      }
+                    >
+                      <ExclamationCircleOutlined style={{ marginRight: 2 }} />
+                      {fundingCycleRiskCount}
+                    </Tooltip>
+                  </span>
+                )}
+              </div>
+
+              {headerText.length > 0 && (
+                <span style={{ color: colors.text.secondary, marginLeft: 10 }}>
+                  {headerText}
+                </span>
+              )}
+            </div>
+          }
+        >
+          {fundingCycleDetails}
+        </CollapsePanel>
+      </Collapse>
+    </div>
+  )
+}

--- a/src/components/shared/Project/FundingCycleSection.tsx
+++ b/src/components/shared/Project/FundingCycleSection.tsx
@@ -1,0 +1,83 @@
+import { Space } from 'antd'
+import { Trans } from '@lingui/macro'
+import { ThemeContext } from 'contexts/themeContext'
+
+import { useContext, useState } from 'react'
+
+import SectionHeader from 'components/v1/V1Project/SectionHeader'
+
+type TabType = {
+  key: string
+  label: string | JSX.Element
+  content: JSX.Element
+}
+
+export default function FundingCycleSection({
+  tabs,
+  canReconfigure,
+  reconfigureButton,
+}: {
+  tabs: TabType[]
+  canReconfigure?: boolean
+  reconfigureButton: JSX.Element
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const [selectedTabKey, setSelectedTabKey] = useState<string>(tabs[0]?.key)
+
+  const currentTabContent = tabs.find(
+    tab => tab.key === selectedTabKey,
+  )?.content
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between',
+        }}
+      >
+        <SectionHeader
+          text={<Trans>Funding cycle</Trans>}
+          tip={
+            <Trans>
+              A project's lifetime is defined in funding cycles. If a funding
+              target is set, the project can withdraw no more than the target
+              for the duration of the cycle.
+            </Trans>
+          }
+          style={{
+            marginBottom: 10,
+          }}
+        />
+
+        {(canReconfigure && reconfigureButton) ?? null}
+      </div>
+
+      <Space style={{ fontSize: '.8rem', marginBottom: 12 }} size="middle">
+        {tabs.map(tab => (
+          <div
+            key={tab.key}
+            style={{
+              textTransform: 'uppercase',
+              cursor: 'pointer',
+              ...(tab.key === selectedTabKey
+                ? { color: colors.text.secondary, fontWeight: 600 }
+                : { color: colors.text.tertiary, fontWeight: 500 }),
+            }}
+            className="hover-text-secondary"
+            role="button"
+            onClick={() => setSelectedTabKey(tab.key)}
+          >
+            {tab.label}
+          </div>
+        ))}
+      </Space>
+
+      {currentTabContent && <div>{currentTabContent}</div>}
+    </div>
+  )
+}

--- a/src/components/v1/FundingCycle/CurrentFundingCycle.tsx
+++ b/src/components/v1/FundingCycle/CurrentFundingCycle.tsx
@@ -1,6 +1,5 @@
 import { CardSection } from 'components/shared/CardSection'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
-import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 
 import FundingCyclePreview from './FundingCyclePreview'
@@ -14,10 +13,6 @@ export default function CurrentFundingCycle({
 }) {
   const { projectId, currentFC, currentPayoutMods, currentTicketMods } =
     useContext(V1ProjectContext)
-
-  const {
-    theme: { colors },
-  } = useContext(ThemeContext)
 
   if (!projectId) return null
 
@@ -38,17 +33,6 @@ export default function CurrentFundingCycle({
           ticketMods={currentTicketMods}
         />
       </CardSection>
-      <div
-        style={{
-          position: 'absolute',
-          zIndex: -1,
-          left: 10,
-          right: -10,
-          top: 10,
-          bottom: 0,
-          background: colors.background.l1,
-        }}
-      ></div>
     </div>
   )
 }

--- a/src/components/v1/FundingCycle/FundingCyclePreview.tsx
+++ b/src/components/v1/FundingCycle/FundingCyclePreview.tsx
@@ -1,11 +1,6 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
-import { Collapse, Tooltip } from 'antd'
-import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
-import { ThemeContext } from 'contexts/themeContext'
+import FundingCycleDetailsCard from 'components/shared/Project/FundingCycleDetailsCard'
 import { V1FundingCycle } from 'models/v1/fundingCycle'
-import { useContext } from 'react'
-import { detailedTimeString } from 'utils/formatTime'
+
 import { fundingCycleRiskCount, isRecurring } from 'utils/v1/fundingCycle'
 
 import FundingCycleDetails from './FundingCycleDetails'
@@ -17,83 +12,17 @@ export default function FundingCyclePreview({
   fundingCycle: V1FundingCycle | undefined
   showDetail?: boolean
 }) {
-  const {
-    theme: { colors },
-  } = useContext(ThemeContext)
-
   if (!fundingCycle) return null
 
-  const secsPerDay = 60 * 60 * 24
-
-  const endTime = fundingCycle.start
-    .add(fundingCycle.duration.mul(secsPerDay))
-    .mul(1000)
-
-  let headerText = ''
-  if (isRecurring(fundingCycle) && fundingCycle.duration.gt(0)) {
-    headerText = t`${detailedTimeString(endTime)} until #${fundingCycle.number
-      .add(1)
-      .toString()}`
-  } else if (fundingCycle.duration.gt(0)) {
-    headerText = t`${detailedTimeString(endTime)} left`
-  }
-
   return (
-    <div>
-      <Collapse
-        style={{
-          background: 'transparent',
-          border: 'none',
-        }}
-        className="minimal"
-        defaultActiveKey={showDetail ? '0' : undefined}
-      >
-        <CollapsePanel
-          key={'0'}
-          style={{ border: 'none' }}
-          header={
-            <div
-              style={{
-                display: 'flex',
-                width: '100%',
-                justifyContent: 'space-between',
-                cursor: 'pointer',
-              }}
-            >
-              <span>
-                {fundingCycle.duration.gt(0) ? (
-                  <span>
-                    <Trans>Cycle #{fundingCycle.number.toString()}</Trans>
-                  </span>
-                ) : (
-                  <span>
-                    <Trans>Details</Trans>
-                  </span>
-                )}
-                {fundingCycleRiskCount(fundingCycle) > 0 && (
-                  <span
-                    style={{ marginLeft: 10, color: colors.text.secondary }}
-                  >
-                    <Tooltip
-                      title={t`Some funding cycle properties may indicate risk for project contributors.`}
-                    >
-                      <ExclamationCircleOutlined style={{ marginRight: 2 }} />
-                      {fundingCycleRiskCount(fundingCycle)}
-                    </Tooltip>
-                  </span>
-                )}
-              </span>
-              <span style={{ color: colors.text.secondary }}>
-                {headerText.length > 0 && (
-                  <span style={{ marginLeft: 10 }}>{headerText}</span>
-                )}
-              </span>
-            </div>
-          }
-        >
-          <FundingCycleDetails fundingCycle={fundingCycle} />
-        </CollapsePanel>
-      </Collapse>
-    </div>
+    <FundingCycleDetailsCard
+      fundingCycleDetails={<FundingCycleDetails fundingCycle={fundingCycle} />}
+      fundingCycleDuration={fundingCycle.duration}
+      fundingCycleNumber={fundingCycle.number}
+      fundingCycleStartTime={fundingCycle.start}
+      isFundingCycleRecurring={isRecurring(fundingCycle)}
+      fundingCycleRiskCount={fundingCycleRiskCount(fundingCycle)}
+      showDetail={showDetail}
+    />
   )
 }

--- a/src/components/v1/V1Project/FundingCycles/index.tsx
+++ b/src/components/v1/V1Project/FundingCycles/index.tsx
@@ -1,5 +1,5 @@
-import { Space, Tooltip } from 'antd'
-import { t } from '@lingui/macro'
+import { Tooltip } from 'antd'
+import { t, Trans } from '@lingui/macro'
 import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { CardSection } from 'components/shared/CardSection'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
@@ -8,32 +8,27 @@ import {
   OperatorPermission,
   useHasPermission,
 } from 'hooks/v1/contractReader/HasPermission'
-import { useContext, useState } from 'react'
+import { useContext } from 'react'
 
 import { fundingCycleRiskCount } from 'utils/v1/fundingCycle'
 import { V1FundingCycle } from 'models/v1/fundingCycle'
 import CurrentFundingCycle from 'components/v1/FundingCycle/CurrentFundingCycle'
 import QueuedFundingCycle from 'components/v1/FundingCycle/QueuedFundingCycle'
 
-import FundingHistory from './FundingHistory'
-import SectionHeader from '../SectionHeader'
-import ReconfigureFundingModalTrigger from './ReconfigureFundingModalTrigger'
+import FundingCycleSection from 'components/shared/Project/FundingCycleSection'
 
-type TabOption = 'current' | 'upcoming' | 'history'
+import FundingHistory from './FundingHistory'
+import ReconfigureFundingModalTrigger from './ReconfigureFundingModalTrigger'
 
 export default function FundingCycles({
   showCurrentDetail,
 }: {
   showCurrentDetail?: boolean
 }) {
-  const [selectedTab, setSelectedTab] = useState<TabOption>('current')
-  const [hoverTab, setHoverTab] = useState<TabOption>()
-
-  const { projectId, currentFC, queuedFC } = useContext(V1ProjectContext)
-
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+  const { projectId, currentFC, queuedFC } = useContext(V1ProjectContext)
 
   const tabText = ({
     text,
@@ -42,9 +37,19 @@ export default function FundingCycles({
     text: string
     fundingCycle: V1FundingCycle | undefined
   }) => {
-    return fundingCycle && fundingCycleRiskCount(fundingCycle) ? (
+    const hasRisks = fundingCycle && fundingCycleRiskCount(fundingCycle)
+    if (!hasRisks) {
+      return text
+    }
+
+    return (
       <Tooltip
-        title={t`This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project.`}
+        title={
+          <Trans>
+            This funding cycle may pose risks to contributors. Check the funding
+            cycle details before paying this project.
+          </Trans>
+        }
       >
         <span>
           {text}
@@ -56,93 +61,41 @@ export default function FundingCycles({
           />
         </span>
       </Tooltip>
-    ) : (
-      text
     )
   }
 
-  const tab = (option: TabOption) => {
-    let text: string | JSX.Element
-    switch (option) {
-      case 'current':
-        text = tabText({ text: t`Current`, fundingCycle: currentFC })
-        break
-      case 'upcoming':
-        text = tabText({ text: t`Upcoming`, fundingCycle: queuedFC })
-        break
-      case 'history':
-        text = t`History`
-        break
-    }
-    return (
-      <div
-        style={{
-          textTransform: 'uppercase',
-          cursor: 'pointer',
-          ...(option === selectedTab
-            ? { color: colors.text.secondary, fontWeight: 600 }
-            : { color: colors.text.tertiary, fontWeight: 500 }),
-          ...(option === hoverTab ? { color: colors.text.secondary } : {}),
-        }}
-        onClick={() => setSelectedTab(option)}
-        onMouseEnter={() => setHoverTab(option)}
-        onMouseLeave={() => setHoverTab(undefined)}
-      >
-        {text}
-      </div>
-    )
-  }
-
-  let tabContent: JSX.Element
-
-  switch (selectedTab) {
-    case 'current':
-      tabContent = <CurrentFundingCycle showCurrentDetail={showCurrentDetail} />
-      break
-    case 'upcoming':
-      tabContent = <QueuedFundingCycle />
-      break
-    case 'history':
-      tabContent = (
+  const tabs = [
+    {
+      key: 'current',
+      label: tabText({ text: t`Current`, fundingCycle: currentFC }),
+      content: <CurrentFundingCycle showCurrentDetail={showCurrentDetail} />,
+    },
+    {
+      key: 'upcoming',
+      label: tabText({ text: t`Upcoming`, fundingCycle: queuedFC }),
+      content: <QueuedFundingCycle />,
+    },
+    {
+      key: 'history',
+      label: <Trans>History</Trans>,
+      content: (
         <CardSection>
           <FundingHistory startId={currentFC?.basedOn} />
         </CardSection>
-      )
-      break
-  }
+      ),
+    },
+  ]
 
   const canReconfigure = useHasPermission(OperatorPermission.Configure)
 
   if (!projectId) return null
-
   return (
-    <div>
-      <div
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          justifyContent: 'space-between',
-        }}
-      >
-        <SectionHeader
-          text={t`Funding cycle`}
-          tip={t`A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle.`}
-          style={{
-            marginBottom: 10,
-          }}
-        />
-        {canReconfigure && (
-          <ReconfigureFundingModalTrigger
-            fundingDuration={currentFC?.duration}
-          />
-        )}
-      </div>
-      <Space style={{ fontSize: '.8rem', marginBottom: 12 }} size="middle">
-        {tab('current')}
-        {currentFC?.duration.gt(0) ? tab('upcoming') : null}
-        {tab('history')}
-      </Space>
-      <div>{tabContent}</div>
-    </div>
+    <FundingCycleSection
+      tabs={tabs}
+      canReconfigure={canReconfigure}
+      reconfigureButton={
+        <ReconfigureFundingModalTrigger fundingDuration={currentFC?.duration} />
+      }
+    />
   )
 }

--- a/src/components/v1/V1Project/SectionHeader.tsx
+++ b/src/components/v1/V1Project/SectionHeader.tsx
@@ -10,8 +10,8 @@ export default function SectionHeader({
   tip,
   style,
 }: {
-  text: string | undefined
-  tip?: string
+  text: string | JSX.Element | undefined
+  tip?: string | JSX.Element
   style?: CSSProperties
 }) {
   const {

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -205,7 +205,7 @@ msgstr ""
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
+#: src/components/shared/Project/FundingCycleSection.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Custom token beneficiary"
 msgstr "Custom token beneficiary"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgstr "Deposit 1 wei to @{handle}"
 msgid "Design your project"
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr ""
 
@@ -788,9 +788,9 @@ msgstr "Funding Distribution"
 msgid "Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr ""
 
+#: src/components/shared/Project/FundingCycleSection.tsx
 #: src/components/shared/forms/BudgetForm.tsx
 #: src/components/v1/V1Create/index.tsx
-#: src/components/v1/V1Project/FundingCycles/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Funding cycle"
 msgstr ""
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Since you have not set a funding duration, changes to these settings will be applied immediately."
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr "Some funding cycle properties may indicate risk for project contributors."
 
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "{0} holders"
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} left"
 msgstr ""
 
@@ -2353,9 +2353,9 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} until #{1}"
-msgstr ""
+msgstr "{0} until #{1}"
 
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "{0} will go to the project owner: <0/>"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -210,7 +210,7 @@ msgstr "Un proyecto puede elegir reservar un porcentaje de tokens para sí mismo
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un proyecto puede reservar un porcentaje de tokens acuñados de cada pago que reciba. Los tokens reservados pueden ser distribuidos de acorde a la asignación que está debajo en cualquier momento."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
+#: src/components/shared/Project/FundingCycleSection.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "El tiempo de vida de un proyecto se define en ciclos de financiación. Si se establece un objetivo de financiación, el proyecto no podrá retirar más de ese objetivo durante la duración del ciclo."
 
@@ -560,7 +560,7 @@ msgstr "Estrategia personalizada"
 msgid "Custom token beneficiary"
 msgstr "Beneficiario de token personalizado"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Ciclo #{0}"
 
@@ -596,7 +596,7 @@ msgstr "Deposita 1 wei a @{handle}"
 msgid "Design your project"
 msgstr "Diseña tu proyecto"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Detalles"
 
@@ -793,9 +793,9 @@ msgstr "Distribución de fondos"
 msgid "Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "El financiamiento puede ser reconfigurado en cualquier momento. Las reconfiguraciones empiezan un nuevo ciclo de financiamiento."
 
+#: src/components/shared/Project/FundingCycleSection.tsx
 #: src/components/shared/forms/BudgetForm.tsx
 #: src/components/v1/V1Create/index.tsx
-#: src/components/v1/V1Project/FundingCycles/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Funding cycle"
 msgstr "Ciclo de financiamiento"
@@ -1665,7 +1665,7 @@ msgstr "¿Deberías de usar Juicebox?"
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Como no has establecido una duración de financiamiento, los cambios a estos ajustes serán aplicados de inmediato."
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr "Algunas propiedades de los ciclos de financiamiento pueden indicar riesgo para los contribuyentes de proyectos."
 
@@ -2338,7 +2338,7 @@ msgstr "{0} para ti"
 msgid "{0} holders"
 msgstr "{0} holders"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} left"
 msgstr "{0} restantes"
 
@@ -2358,9 +2358,9 @@ msgstr "{0} staked"
 msgid "{0} total"
 msgstr "{0} en total"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} until #{1}"
-msgstr "{0} hasta #{1}"
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "{0} will go to the project owner: <0/>"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -210,7 +210,7 @@ msgstr "Um projeto pode escolher reservar uma porcentagem de tokens para si mesm
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Um projeto pode reservar uma porcentagem de tokens gerados por cada pagamento recebido. Tokens reservados podem ser distribuídos a qualquer momento conforme a alocação abaixo."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
+#: src/components/shared/Project/FundingCycleSection.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "O tempo de vida de um projeto é definido em ciclos de financiamento. Se for definida uma meta de financiamento, o projeto não poderá retirar mais do que a meta para a duração do ciclo."
 
@@ -560,7 +560,7 @@ msgstr "Estratégia personalizada"
 msgid "Custom token beneficiary"
 msgstr "Titular de token personalizado"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Ciclo #{0}"
 
@@ -596,7 +596,7 @@ msgstr "Deposite 1 Wei para @{handle}"
 msgid "Design your project"
 msgstr "Crie seu projeto"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Detalhes"
 
@@ -793,9 +793,9 @@ msgstr "Distribuição de financiamento"
 msgid "Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "O financiamento pode ser reconfigurado a qualquer momento. As reconfigurações iniciarão um novo ciclo de financiamento."
 
+#: src/components/shared/Project/FundingCycleSection.tsx
 #: src/components/shared/forms/BudgetForm.tsx
 #: src/components/v1/V1Create/index.tsx
-#: src/components/v1/V1Project/FundingCycles/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Funding cycle"
 msgstr "Ciclo de financiamento"
@@ -1665,7 +1665,7 @@ msgstr "Você deveria usar o Juicebox?"
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Como você não colocou uma duração de financiamento, as mudanças para essas configurações serão aplicadas imediatamente."
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr "Algumas propriedades do ciclo de financiamento podem indicar risco para os contribuidores do projeto."
 
@@ -2338,7 +2338,7 @@ msgstr "{0} para você"
 msgid "{0} holders"
 msgstr "{0} titulares"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} left"
 msgstr "{0} restante"
 
@@ -2358,9 +2358,9 @@ msgstr "{0} staked"
 msgid "{0} total"
 msgstr "{0} total"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} until #{1}"
-msgstr "{0} até #{1}"
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "{0} will go to the project owner: <0/>"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -210,7 +210,7 @@ msgstr "Проект может зарезервировать для себя �
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Проект может резервировать процент выпущенных токенов с каждого платежа, который он получает. Зарезервированные токены могут быть распределены в соответствии с приведенным ниже распределением в любое время."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
+#: src/components/shared/Project/FundingCycleSection.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "Срок действия проекта определен в циклах финансирования. Если установлен целевой показатель финансирования, проект может вывести не более целевого показателя на период действия цикла."
 
@@ -560,7 +560,7 @@ msgstr "Индивидуальная стратегия"
 msgid "Custom token beneficiary"
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Цикл #{0}"
 
@@ -596,7 +596,7 @@ msgstr "Депозит 1 wei на @{handle}"
 msgid "Design your project"
 msgstr "Создай свой проект"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Подробности"
 
@@ -793,9 +793,9 @@ msgstr "Распределение финансирования"
 msgid "Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr " финансирование можно изменить в любой момент, что приведет к началу нового цикла финансирования."
 
+#: src/components/shared/Project/FundingCycleSection.tsx
 #: src/components/shared/forms/BudgetForm.tsx
 #: src/components/v1/V1Create/index.tsx
-#: src/components/v1/V1Project/FundingCycles/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Funding cycle"
 msgstr "Цикл финансирования"
@@ -1665,7 +1665,7 @@ msgstr "Следует ли вам заниматься Juicebox?"
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Поскольку вы не установили срок финансирования, изменения в этих настройках будут применены немедленно."
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr "Некоторые свойства цикла финансирования могут указывать на риск для участников проекта."
 
@@ -2338,7 +2338,7 @@ msgstr "{0} для вас"
 msgid "{0} holders"
 msgstr "{0} держатели"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} left"
 msgstr "осталось {0}"
 
@@ -2358,9 +2358,9 @@ msgstr "{0} размещено"
 msgid "{0} total"
 msgstr "{0} всего"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} until #{1}"
-msgstr "{0} до #{1}"
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "{0} will go to the project owner: <0/>"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -210,7 +210,7 @@ msgstr "Bir proje, kendisi için tokenlerin bir yüzdesini ayırmayı seçebilir
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Bir proje, aldığı her ödemeden basılan token'ların belirli bir yüzdesini ayırabilir. Ayrılan token'lar, herhangi bir zamanda aşağıdaki tahsise göre dağıtılabilir."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
+#: src/components/shared/Project/FundingCycleSection.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "Bir projenin ömrü, finansman döngülerinde tanımlanır. Bir finansman hedefi belirlenirse proje döngü süresince hedeften fazlasını çekemez."
 
@@ -560,7 +560,7 @@ msgstr "Özel strateji"
 msgid "Custom token beneficiary"
 msgstr ""
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Döngü #{0}"
 
@@ -596,7 +596,7 @@ msgstr "@{handle} hesabına 1 wei yatırın"
 msgid "Design your project"
 msgstr "Projenizi tasarlayın"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Detaylar"
 
@@ -793,9 +793,9 @@ msgstr "Finansman Dağılımı"
 msgid "Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "Finansman herhangi bir zamanda yeniden yapılandırılabilir. Yeniden yapılandırmalar yeni bir finansman döngüsü başlatacaktır."
 
+#: src/components/shared/Project/FundingCycleSection.tsx
 #: src/components/shared/forms/BudgetForm.tsx
 #: src/components/v1/V1Create/index.tsx
-#: src/components/v1/V1Project/FundingCycles/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Funding cycle"
 msgstr "Finansman döngüsü"
@@ -1665,7 +1665,7 @@ msgstr "Juicebox’a katılmalı mısın?"
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Bir finansman süresi belirlemediğiniz için bu ayarlarda yapılan değişiklikler hemen uygulanacaktır."
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr ""
 
@@ -2338,7 +2338,7 @@ msgstr "Size ait {0}"
 msgid "{0} holders"
 msgstr "{0} sahipleri"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} left"
 msgstr "{0} kaldı"
 
@@ -2358,7 +2358,7 @@ msgstr "stake edilen {0}"
 msgid "{0} total"
 msgstr "Toplam {0}"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} until #{1}"
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -210,7 +210,7 @@ msgstr "项目可以选择为自己保留一定比例的代币。这些代币不
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "项目每收到一笔付款都会铸造代币，其中某个百分比的代币会保留在项目内。保留代币可随时按以下分配方案进行分发。"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
+#: src/components/shared/Project/FundingCycleSection.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "一个项目的寿命是以筹款周期来定义的。如果设定了筹款目标，那么在周期内，项目的提款不能超过目标。"
 
@@ -560,7 +560,7 @@ msgstr "自定义策略"
 msgid "Custom token beneficiary"
 msgstr "自定义代币受益人"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "周期 #{0}"
 
@@ -596,7 +596,7 @@ msgstr "存入 1 wei 给 @{handle}"
 msgid "Design your project"
 msgstr "设计你的项目"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "详情"
 
@@ -793,9 +793,9 @@ msgstr "资金分发"
 msgid "Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "可以随时更改筹款配置。更改配置将重新开始一个筹款周期。"
 
+#: src/components/shared/Project/FundingCycleSection.tsx
 #: src/components/shared/forms/BudgetForm.tsx
 #: src/components/v1/V1Create/index.tsx
-#: src/components/v1/V1Project/FundingCycles/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Funding cycle"
 msgstr "筹款周期"
@@ -1665,7 +1665,7 @@ msgstr "你应该使用Juicebox吗?"
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "鉴于你并未设置筹款持续时间，对这些设置的修改将会立即生效。"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle properties may indicate risk for project contributors."
 msgstr "一些筹款周期的配置可能会给项目贡献者们造成一些风险。"
 
@@ -2338,7 +2338,7 @@ msgstr "给到你的 {0}"
 msgid "{0} holders"
 msgstr "{0} 持有者"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} left"
 msgstr "{0} 剩余"
 
@@ -2358,9 +2358,9 @@ msgstr "{0} 已存入"
 msgid "{0} total"
 msgstr "{0} 总共"
 
-#: src/components/v1/FundingCycle/FundingCyclePreview.tsx
+#: src/components/shared/Project/FundingCycleDetailsCard.tsx
 msgid "{0} until #{1}"
-msgstr "{0} 直到 #{1}"
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/WithdrawModal.tsx
 msgid "{0} will go to the project owner: <0/>"

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,5 @@
+@import './utilities';
+
 body {
   margin: 0;
   background: #131115;

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -1,0 +1,6 @@
+.hover-text-secondary {
+  &:hover {
+    color: var(--text-secondary) !important;
+    transition: 250ms;
+  }
+}


### PR DESCRIPTION
## What does this PR do and why?

Prep PR for https://github.com/jbx-protocol/juice-interface/issues/677.

Abstracts out some of the Funding Cycle UI so we can more easily use it in V2.

## Screenshots or screen recordings

No changes to the UI

| before | after |
| --- | --- |
| <img width="533" alt="Screen Shot 2022-03-24 at 9 14 45 pm" src="https://user-images.githubusercontent.com/94939382/159899755-954cd1e4-552c-4bb9-bfd6-842dec011a47.png"> | <img width="541" alt="Screen Shot 2022-03-24 at 9 06 17 pm" src="https://user-images.githubusercontent.com/94939382/159899456-0f87b7be-a575-41ca-9478-d68e6973fd3c.png"> |
| <img width="531" alt="Screen Shot 2022-03-24 at 9 14 51 pm" src="https://user-images.githubusercontent.com/94939382/159899774-0530bc99-28b2-4058-9905-1a28d3e5278e.png"> | <img width="524" alt="Screen Shot 2022-03-24 at 9 06 26 pm" src="https://user-images.githubusercontent.com/94939382/159899441-3e515f55-09ca-4c9b-9ed1-4c935ef1ca0f.png"> |
| <img width="536" alt="Screen Shot 2022-03-24 at 9 14 59 pm" src="https://user-images.githubusercontent.com/94939382/159899806-8355da17-cc39-4f28-9824-3146976c243b.png"> | <img width="532" alt="Screen Shot 2022-03-24 at 9 06 32 pm" src="https://user-images.githubusercontent.com/94939382/159899422-e9eff20f-d87c-494b-ad29-c734dc8bc028.png"> |

## Acceptance checklist

- [x] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [x] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
