### PR TITLE
Add basic skeleton loaders to v2 project

### DIFF
--- a/src/components/shared/Project/SpendingStats.tsx
+++ b/src/components/shared/Project/SpendingStats.tsx
@@ -22,8 +22,8 @@ export default function SpendingStats({
   hasFundingTarget,
 }: {
   currency: CurrencyName | undefined
-  targetAmount: BigNumber | undefined
-  distributedAmount: BigNumber | undefined
+  targetAmount: BigNumber
+  distributedAmount: BigNumber
   projectBalanceInCurrency: BigNumber | undefined
   ownerAddress: string | undefined
   feePercentage: string | undefined
@@ -32,8 +32,6 @@ export default function SpendingStats({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-
-  if (!targetAmount || !distributedAmount) return <span>Loading...</span>
 
   const untapped = targetAmount.sub(distributedAmount)
 

--- a/src/components/shared/Project/StatLine.tsx
+++ b/src/components/shared/Project/StatLine.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { CSSProperties, useContext } from 'react'
 
@@ -8,11 +9,13 @@ export default function StatLine({
   statLabelTip,
   statValue,
   style = {},
+  loading = false,
 }: {
   statLabel: JSX.Element
   statLabelTip: JSX.Element
   statValue: JSX.Element
   style?: CSSProperties
+  loading?: boolean
 }) {
   const {
     theme: { colors },
@@ -39,13 +42,23 @@ export default function StatLine({
         <TooltipLabel label={statLabel} tip={statLabelTip} />
       </div>
 
-      <div
-        style={{
-          marginLeft: 10,
-        }}
-      >
-        {statValue}
-      </div>
+      {loading ? (
+        <div style={{ width: 60, height: 16 }}>
+          <Skeleton
+            paragraph={{ rows: 1, width: '100%' }}
+            title={false}
+            active
+          />
+        </div>
+      ) : (
+        <div
+          style={{
+            marginLeft: 10,
+          }}
+        >
+          {statValue}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/v2/V2Project/TreasuryStats.tsx
+++ b/src/components/v2/V2Project/TreasuryStats.tsx
@@ -77,21 +77,22 @@ export default function TreasuryStats() {
           </div>
         }
         style={{ marginBottom: spacing }}
+        loading={!Boolean(balanceInDistributionLimitCurrency)}
       />
 
-      {distributionLimit?.gt(0) ? (
-        <StatLine
-          statLabel={<Trans>Distributed</Trans>}
-          statLabelTip={
-            <Trans>
-              The amount that has been distributed from the Juicebox balance in
-              this funding cycle, out of the current funding target. No more
-              than the funding target can be distributed in a single funding
-              cycle—any remaining ETH in Juicebox is overflow, until the next
-              cycle begins.
-            </Trans>
-          }
-          statValue={
+      <StatLine
+        loading={!Boolean(distributionLimit)}
+        statLabel={<Trans>Distributed</Trans>}
+        statLabelTip={
+          <Trans>
+            The amount that has been distributed from the Juicebox balance in
+            this funding cycle, out of the current funding target. No more than
+            the funding target can be distributed in a single funding cycle—any
+            remaining ETH in Juicebox is overflow, until the next cycle begins.
+          </Trans>
+        }
+        statValue={
+          distributionLimit?.gt(0) ? (
             <div
               style={{
                 ...secondaryTextStyle,
@@ -101,27 +102,27 @@ export default function TreasuryStats() {
               {formatCurrencyAmount(usedDistributionLimit)} /{' '}
               {formatCurrencyAmount(distributionLimit)}
             </div>
-          }
-        />
-      ) : (
-        <div
-          style={{
-            ...secondaryTextStyle,
-            textAlign: 'right',
-          }}
-        >
-          <TooltipLabel
-            tip={
-              <Trans>
-                The target for this funding cycle is 0, meaning all funds in
-                Juicebox are currently considered overflow. Overflow can be
-                redeemed by token holders, but not distributed.
-              </Trans>
-            }
-            label={<Trans>100% overflow</Trans>}
-          />
-        </div>
-      )}
+          ) : (
+            <div
+              style={{
+                ...secondaryTextStyle,
+                textAlign: 'right',
+              }}
+            >
+              <TooltipLabel
+                tip={
+                  <Trans>
+                    The target for this funding cycle is 0, meaning all funds in
+                    Juicebox are currently considered overflow. Overflow can be
+                    redeemed by token holders, but not distributed.
+                  </Trans>
+                }
+                label={<Trans>100% overflow</Trans>}
+              />
+            </div>
+          )
+        }
+      />
     </>
   )
 }

--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { Button, Space } from 'antd'
+import { Button, Skeleton, Space } from 'antd'
 import { CardSection } from 'components/shared/CardSection'
 import TooltipLabel from 'components/shared/TooltipLabel'
 import SpendingStats from 'components/shared/Project/SpendingStats'
@@ -34,7 +34,9 @@ export default function PayoutSplitsCard() {
     <CardSection>
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          {ETHPaymentTerminalFee ? (
+          {ETHPaymentTerminalFee &&
+          distributionLimit &&
+          usedDistributionLimit ? (
             <SpendingStats
               hasFundingTarget={distributionLimit?.gt(0)}
               currency={V2CurrencyName(
@@ -46,7 +48,14 @@ export default function PayoutSplitsCard() {
               feePercentage={formatFee(ETHPaymentTerminalFee)} // TODO
               ownerAddress={projectOwnerAddress}
             />
-          ) : null}
+          ) : (
+            <Skeleton
+              active
+              title={false}
+              paragraph={{ rows: 2, width: ['60%', '60%'] }}
+            />
+          )}
+
           <Button
             type="ghost"
             size="small"

--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -49,6 +49,7 @@ export default function V2Project() {
         <Col md={12} xs={24}>
           {/* TODO volume chart */}
           {/* TODO token section */}
+          <br />
           <V2FundingCycleSection />
         </Col>
       </Row>

--- a/src/styles/antd-overrides/index.scss
+++ b/src/styles/antd-overrides/index.scss
@@ -25,3 +25,4 @@
 @import 'tooltip.scss';
 @import 'dropdown.scss';
 @import 'menu.scss';
+@import 'skeleton.scss';

--- a/src/styles/antd-overrides/skeleton.scss
+++ b/src/styles/antd-overrides/skeleton.scss
@@ -1,0 +1,3 @@
+.ant-skeleton-content .ant-skeleton-paragraph {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## What does this PR do and why?

Basic skeleton loaders for:
- Treasury stats
- funding distribution stats

## Screenshots or screen recordings

| loading | done |
| --- | --- |
| <img width="1043" alt="Screen Shot 2022-04-01 at 1 44 30 pm" src="https://user-images.githubusercontent.com/94939382/161188360-bee9f985-bce5-4592-8c3f-2b06191e1146.png"> | <img width="1219" alt="Screen Shot 2022-04-01 at 1 44 42 pm" src="https://user-images.githubusercontent.com/94939382/161188391-391af1ae-2e6b-41bd-b6b4-fe860b915f6e.png"> | 

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
