### PR TITLE
Add V2 reserved tokens card

### DIFF
--- a/src/components/v2/V2Create/DeployProjectButton.tsx
+++ b/src/components/v2/V2Create/DeployProjectButton.tsx
@@ -46,7 +46,7 @@ export default function DeployProjectButton({
 
   const [loadingDeploy, setLoadingDeploy] = useState<boolean>()
 
-  const { projectMetadata, reserveTokenGroupedSplits, payoutGroupedSplits } =
+  const { projectMetadata, reservedTokensGroupedSplits, payoutGroupedSplits } =
     useAppSelector(state => state.editingV2Project)
   const fundingCycleMetadata = useEditingV2FundingCycleMetadataSelector()
   const fundingCycleData = useEditingV2FundingCycleDataSelector()
@@ -75,7 +75,7 @@ export default function DeployProjectButton({
       return
     }
 
-    const groupedSplits = [payoutGroupedSplits, reserveTokenGroupedSplits]
+    const groupedSplits = [payoutGroupedSplits, reservedTokensGroupedSplits]
 
     const didTxExecute = await deployProjectTx(
       {
@@ -116,7 +116,7 @@ export default function DeployProjectButton({
     deployProjectTx,
     projectMetadata,
     payoutGroupedSplits,
-    reserveTokenGroupedSplits,
+    reservedTokensGroupedSplits,
     fundingCycleData,
     fundingCycleMetadata,
     fundAccessConstraints,

--- a/src/components/v2/V2Create/DeployProjectModal/index.tsx
+++ b/src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -293,14 +293,14 @@ export default function ConfirmDeployV2ProjectModal({
 
             {payoutGroupedSplits.splits.length ? (
               <Statistic
-                title={t`Payouts`}
+                title={<Trans>Payouts</Trans>}
                 valueRender={() => (
                   <SplitList
                     splits={payoutGroupedSplits.splits}
-                    distributionLimitCurrency={BigNumber.from(
+                    currency={BigNumber.from(
                       fundAccessConstraint?.distributionLimitCurrency,
                     )}
-                    distributionLimit={amountSubFee(
+                    totalValue={amountSubFee(
                       parseWad(fundAccessConstraint?.distributionLimit),
                       ETHPaymentTerminalFee,
                     )}
@@ -319,10 +319,10 @@ export default function ConfirmDeployV2ProjectModal({
                 valueRender={() => (
                   <SplitList
                     splits={reservedTokensGroupedSplits.splits}
-                    distributionLimitCurrency={BigNumber.from(
+                    currency={BigNumber.from(
                       fundAccessConstraint?.distributionLimitCurrency,
                     )}
-                    distributionLimit={amountSubFee(
+                    totalValue={amountSubFee(
                       parseWad(fundAccessConstraint?.distributionLimit),
                       ETHPaymentTerminalFee,
                     )}

--- a/src/components/v2/V2Create/DeployProjectModal/index.tsx
+++ b/src/components/v2/V2Create/DeployProjectModal/index.tsx
@@ -44,7 +44,7 @@ export default function ConfirmDeployV2ProjectModal({
     fundingCycleData,
     fundingCycleMetadata,
     payoutGroupedSplits,
-    reserveTokenGroupedSplits,
+    reservedTokensGroupedSplits,
     projectMetadata,
   } = useAppSelector(state => state.editingV2Project)
 
@@ -313,12 +313,12 @@ export default function ConfirmDeployV2ProjectModal({
 
             {fundingCycleMetadata.reservedRate &&
             fundingCycleMetadata.reservedRate !== '0' &&
-            reserveTokenGroupedSplits.splits.length ? (
+            reservedTokensGroupedSplits.splits.length ? (
               <Statistic
                 title={t`Reserved token allocations`}
                 valueRender={() => (
                   <SplitList
-                    splits={reserveTokenGroupedSplits.splits}
+                    splits={reservedTokensGroupedSplits.splits}
                     distributionLimitCurrency={BigNumber.from(
                       fundAccessConstraint?.distributionLimitCurrency,
                     )}

--- a/src/components/v2/V2Create/tabs/TokenTab/ReservedTokensFormItem.tsx
+++ b/src/components/v2/V2Create/tabs/TokenTab/ReservedTokensFormItem.tsx
@@ -10,16 +10,16 @@ export default function ReservedTokensFormItem({
   name,
   hideLabel,
   value,
-  reserveTokenSplits,
-  onReserveTokenSplitsChange,
+  reservedTokensSplits,
+  onReservedTokensSplitsChange,
   style = {},
   onChange,
   disabled,
   toggleDisabled,
 }: {
   value: number | undefined
-  reserveTokenSplits: Split[]
-  onReserveTokenSplitsChange: (splits: Split[]) => void
+  reservedTokensSplits: Split[]
+  onReservedTokensSplitsChange: (splits: Split[]) => void
   style?: CSSProperties
   onChange: (val?: number) => void
   disabled?: boolean
@@ -45,10 +45,10 @@ export default function ReservedTokensFormItem({
 
       {!disabled ? (
         <FormItems.ProjectTicketMods
-          mods={reserveTokenSplits.map(split => toMod(split))}
+          mods={reservedTokensSplits.map(split => toMod(split))}
           onModsChanged={mods => {
             const splits = mods.map(mod => toSplit(mod))
-            onReserveTokenSplitsChange(splits)
+            onReservedTokensSplitsChange(splits)
           }}
           formItemProps={{
             label: <Trans>Reserved token allocation (optional)</Trans>,

--- a/src/components/v2/V2Create/tabs/TokenTab/TokenTabContent.tsx
+++ b/src/components/v2/V2Create/tabs/TokenTab/TokenTabContent.tsx
@@ -47,7 +47,7 @@ export default function TokenTabContent({
     fundingCycleMetadata,
     fundingCycleData,
     fundAccessConstraints,
-    reserveTokenGroupedSplits: reduxReserveTokenGroupedSplits,
+    reservedTokensGroupedSplits: reduxReservedTokensGroupedSplits,
   } = useAppSelector(state => state.editingV2Project)
 
   const reduxDiscountRate = fundingCycleData?.discountRate
@@ -60,8 +60,8 @@ export default function TokenTabContent({
       fundAccessConstraints,
     )
 
-  const [reserveTokenSplits, setReserveTokenSplits] = useState<Split[]>(
-    reduxReserveTokenGroupedSplits?.splits ?? [],
+  const [reservedTokensSplits, setReservedTokensSplits] = useState<Split[]>(
+    reduxReservedTokensGroupedSplits?.splits ?? [],
   )
 
   const [discountRateDisabled, setDiscountRateDisabled] = useState<boolean>(
@@ -83,7 +83,7 @@ export default function TokenTabContent({
 
   const onTokenFormSaved = useCallback(
     (fields: TokenFormFields) => {
-      const newReserveTokenSplits = reserveTokenSplits.map(split =>
+      const newReservedTokensSplits = reservedTokensSplits.map(split =>
         sanitizeSplit(split),
       )
 
@@ -91,12 +91,14 @@ export default function TokenTabContent({
       dispatch(editingV2ProjectActions.setReservedRate(fields.reservedRate))
       dispatch(editingV2ProjectActions.setRedemptionRate(fields.redemptionRate))
       dispatch(
-        editingV2ProjectActions.setReserveTokenSplits(newReserveTokenSplits),
+        editingV2ProjectActions.setReservedTokensSplits(
+          newReservedTokensSplits,
+        ),
       )
 
       onFinish?.()
     },
-    [dispatch, reserveTokenSplits, onFinish],
+    [dispatch, reservedTokensSplits, onFinish],
   )
 
   const resetTokenForm = useCallback(() => {
@@ -111,12 +113,12 @@ export default function TokenTabContent({
         reduxRedemptionRate ??
         '100',
     })
-    setReserveTokenSplits(reserveTokenSplits)
+    setReservedTokensSplits(reservedTokensSplits)
   }, [
     reduxDiscountRate,
     reduxReservedRate,
     reduxRedemptionRate,
-    reserveTokenSplits,
+    reservedTokensSplits,
     tokenForm,
   ])
 
@@ -160,8 +162,8 @@ export default function TokenTabContent({
               }
               setReservedRateDisabled(!checked)
             }}
-            reserveTokenSplits={reserveTokenSplits}
-            onReserveTokenSplitsChange={setReserveTokenSplits}
+            reservedTokensSplits={reservedTokensSplits}
+            onReservedTokensSplitsChange={setReservedTokensSplits}
           />
           <br />
           <FormItems.ProjectDiscountRate

--- a/src/components/v2/V2Dashboard/Dashboard.tsx
+++ b/src/components/v2/V2Dashboard/Dashboard.tsx
@@ -91,13 +91,13 @@ export default function V2Dashboard() {
     domain: queuedFundingCycle?.configuration?.toString(),
   })
 
-  const { data: reserveTokenSplits } = useProjectSplits({
+  const { data: reservedTokensSplits } = useProjectSplits({
     projectId,
     splitGroup: RESERVE_TOKEN_SPLIT_GROUP,
     domain: fundingCycle?.configuration?.toString(),
   })
 
-  const { data: queuedReserveTokenSplits } = useProjectSplits({
+  const { data: queuedReservedTokensSplits } = useProjectSplits({
     projectId,
     splitGroup: RESERVE_TOKEN_SPLIT_GROUP,
     domain: queuedFundingCycle?.configuration?.toString(),
@@ -156,8 +156,8 @@ export default function V2Dashboard() {
     queuedDistributionLimit,
     payoutSplits,
     queuedPayoutSplits,
-    reserveTokenSplits,
-    queuedReserveTokenSplits,
+    reservedTokensSplits,
+    queuedReservedTokensSplits,
     tokenAddress,
     terminals,
     ETHBalance,

--- a/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
@@ -5,31 +5,16 @@ import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useContext } from 'react'
 import { V2FundingCycleRiskCount } from 'utils/v2/fundingCycle'
 
-import SplitList from 'components/v2/shared/SplitList'
-
-import { formatReservedRate } from 'utils/v2/math'
-
-import { Trans } from '@lingui/macro'
-import TooltipLabel from 'components/shared/TooltipLabel'
-import { tokenSymbolText } from 'utils/tokenSymbolText'
-
 import FundingCycleDetails from './FundingCycleDetails'
 import PayoutSplitsCard from './PayoutSplitsCard'
+import ReservedTokensSplitsCard from './ReservedTokensSplitsCard'
 
 export default function CurrentFundingCycle({
   showCurrentDetail,
 }: {
   showCurrentDetail?: boolean
 }) {
-  const {
-    fundingCycle,
-    reservedTokensSplits,
-    fundingCycleMetadata,
-    tokenSymbol,
-    distributionLimitCurrency,
-    distributionLimit,
-    projectOwnerAddress,
-  } = useContext(V2ProjectContext)
+  const { fundingCycle } = useContext(V2ProjectContext)
 
   if (!fundingCycle) return <LoadingOutlined />
 
@@ -50,41 +35,7 @@ export default function CurrentFundingCycle({
       </CardSection>
 
       <PayoutSplitsCard />
-
-      <CardSection>
-        <div>
-          <TooltipLabel
-            label={
-              <h4 style={{ display: 'inline-block' }}>
-                <Trans>
-                  Reserved{' '}
-                  {tokenSymbolText({
-                    tokenSymbol,
-                    capitalize: false,
-                    plural: true,
-                  })}
-                </Trans>{' '}
-                ({formatReservedRate(fundingCycleMetadata?.reservedRate)}%)
-              </h4>
-            }
-            tip={
-              <Trans>
-                A project can reserve a percentage of tokens minted from every
-                payment it receives. Reserved tokens can be distributed
-                according to the allocation below at any time.
-              </Trans>
-            }
-          />
-        </div>
-        {reservedTokensSplits ? (
-          <SplitList
-            splits={reservedTokensSplits}
-            distributionLimitCurrency={distributionLimitCurrency}
-            distributionLimit={distributionLimit}
-            projectOwnerAddress={projectOwnerAddress}
-          />
-        ) : null}
-      </CardSection>
+      <ReservedTokensSplitsCard />
     </div>
   )
 }

--- a/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
@@ -23,7 +23,7 @@ export default function CurrentFundingCycle({
 }) {
   const {
     fundingCycle,
-    reserveTokenSplits,
+    reservedTokensSplits,
     fundingCycleMetadata,
     tokenSymbol,
     distributionLimitCurrency,
@@ -76,9 +76,9 @@ export default function CurrentFundingCycle({
             }
           />
         </div>
-        {reserveTokenSplits ? (
+        {reservedTokensSplits ? (
           <SplitList
-            splits={reserveTokenSplits}
+            splits={reservedTokensSplits}
             distributionLimitCurrency={distributionLimitCurrency}
             distributionLimit={distributionLimit}
             projectOwnerAddress={projectOwnerAddress}

--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -81,8 +81,8 @@ export default function PayoutSplitsCard() {
           {payoutSplits ? (
             <SplitList
               splits={payoutSplits}
-              distributionLimitCurrency={distributionLimitCurrency}
-              distributionLimit={distributionLimit}
+              currency={distributionLimitCurrency}
+              totalValue={distributionLimit}
               projectOwnerAddress={projectOwnerAddress}
               showSplitValues
             />

--- a/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
@@ -1,0 +1,144 @@
+import { Trans } from '@lingui/macro'
+import { Button, Space } from 'antd'
+import { CardSection } from 'components/shared/CardSection'
+import TooltipLabel from 'components/shared/TooltipLabel'
+import SplitList from 'components/v2/shared/SplitList'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { CSSProperties, useContext, useState } from 'react'
+
+import { ThemeContext } from 'contexts/themeContext'
+
+import { formatReservedRate } from 'utils/v2/math'
+
+import { tokenSymbolText } from 'utils/tokenSymbolText'
+
+import useProjectReservedTokens from 'hooks/v2/contractReader/ProjectReservedTokens'
+
+import { formatWad } from 'utils/formatNumber'
+
+import FormattedAddress from 'components/shared/FormattedAddress'
+
+import * as constants from '@ethersproject/constants'
+
+import DistributeReservedTokensModal from './modals/DistributeReservedTokensModal'
+
+export default function ReservedTokensSplitsCard() {
+  const {
+    reservedTokensSplits,
+    fundingCycleMetadata,
+    tokenSymbol,
+    tokenAddress,
+    projectOwnerAddress,
+    projectId,
+  } = useContext(V2ProjectContext)
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const [
+    distributeReservedTokensModalVisible,
+    setDistributeReservedTokensModalVisible,
+  ] = useState<boolean>()
+  const { data: reservedTokens } = useProjectReservedTokens({
+    projectId,
+    reservedRate: fundingCycleMetadata?.reservedRate,
+  })
+
+  const smallHeaderStyle: CSSProperties = {
+    fontSize: '.7rem',
+    fontWeight: 500,
+    cursor: 'default',
+    color: colors.text.secondary,
+  }
+
+  const tokensText = tokenSymbolText({
+    tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })
+
+  const tokensTextSingular = tokenSymbolText({
+    tokenSymbol,
+    capitalize: true,
+    plural: false,
+  })
+
+  return (
+    <CardSection>
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div style={{ marginRight: '3rem' }}>
+            <span
+              style={{
+                fontSize: '1rem',
+                fontWeight: 500,
+              }}
+            >
+              {formatWad(reservedTokens)}
+            </span>{' '}
+            <TooltipLabel
+              style={{
+                ...smallHeaderStyle,
+                whiteSpace: 'nowrap',
+              }}
+              label={
+                <span style={{ textTransform: 'uppercase' }}>
+                  <Trans>{tokensText} reserved</Trans>
+                </span>
+              }
+              tip={
+                <Trans>
+                  The amount of tokens reserved for this project. These tokens
+                  can be distributed to reserved token beneficiaries.
+                </Trans>
+              }
+            />
+            {tokenAddress && tokenAddress !== constants.AddressZero ? (
+              <div style={smallHeaderStyle}>
+                {tokensTextSingular} contract address:{' '}
+                <FormattedAddress address={tokenAddress} />
+              </div>
+            ) : null}
+          </div>
+          <Button
+            type="ghost"
+            size="small"
+            onClick={() => setDistributeReservedTokensModalVisible(true)}
+          >
+            <Trans>Distribute {tokensText}</Trans>
+          </Button>
+        </div>
+
+        <div>
+          <TooltipLabel
+            label={
+              <h4 style={{ display: 'inline-block' }}>
+                <Trans>Reserved {tokensText}</Trans> (
+                {formatReservedRate(fundingCycleMetadata?.reservedRate)}%)
+              </h4>
+            }
+            tip={
+              <Trans>
+                A project can reserve a percentage of tokens minted from every
+                payment it receives. Reserved tokens can be distributed
+                according to the allocation below at any time.
+              </Trans>
+            }
+          />
+          {reservedTokensSplits ? (
+            <SplitList
+              splits={reservedTokensSplits}
+              projectOwnerAddress={projectOwnerAddress}
+              totalValue={undefined}
+            />
+          ) : null}
+        </div>
+      </Space>
+
+      <DistributeReservedTokensModal
+        visible={distributeReservedTokensModalVisible}
+        onCancel={() => setDistributeReservedTokensModalVisible(false)}
+      />
+    </CardSection>
+  )
+}

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
@@ -227,15 +227,15 @@ export default function DistributePayoutsModal({
           {payoutSplits?.length === 0 ? (
             <p>
               <Trans>
-                There are no payouts defined for this project. The project owner
-                will recieve all distributed funds.
+                There are no payouts defined for this funding cycle. The project
+                owner will recieve all available funds.
               </Trans>
             </p>
           ) : null}
 
           <SplitList
-            distributionLimit={netAvailableAmount}
-            distributionLimitCurrency={distributionLimitCurrency}
+            totalValue={netAvailableAmount}
+            currency={distributionLimitCurrency}
             splits={payoutSplits ?? []}
             projectOwnerAddress={projectOwnerAddress}
             showSplitValues

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
@@ -1,0 +1,105 @@
+import { Trans } from '@lingui/macro'
+import { Modal, Space } from 'antd'
+import { useDistributeReservedTokens } from 'hooks/v2/transactor/DistributeReservedTokensTx'
+import { useContext, useState } from 'react'
+import { formatWad } from 'utils/formatNumber'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
+import SplitList from 'components/v2/shared/SplitList'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import useProjectReservedTokens from 'hooks/v2/contractReader/ProjectReservedTokens'
+
+export default function DistributeReservedTokensModal({
+  visible,
+  onCancel,
+  onConfirmed,
+}: {
+  visible?: boolean
+  onCancel?: VoidFunction
+  onConfirmed?: VoidFunction
+}) {
+  const [loading, setLoading] = useState<boolean>()
+  const {
+    tokenSymbol,
+    reservedTokensSplits,
+    projectOwnerAddress,
+    fundingCycleMetadata,
+    projectId,
+  } = useContext(V2ProjectContext)
+  const distributeReservedTokensTx = useDistributeReservedTokens()
+  const { data: reservedTokens } = useProjectReservedTokens({
+    projectId,
+    reservedRate: fundingCycleMetadata?.reservedRate,
+  })
+
+  function distributeReservedTokens() {
+    setLoading(true)
+
+    distributeReservedTokensTx(
+      {},
+      {
+        onDone: () => setLoading(false),
+        onConfirmed: () => onConfirmed?.(),
+      },
+    )
+  }
+
+  const reservedTokensFormatted = formatWad(reservedTokens, { precision: 0 })
+  const tokenTextPlural = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: false,
+    plural: true,
+  })
+
+  const tokenTextSingular = tokenSymbolText({
+    tokenSymbol: tokenSymbol,
+    capitalize: true,
+    plural: false,
+  })
+
+  return (
+    <Modal
+      title={<Trans>Distribute reserved {tokenTextPlural}</Trans>}
+      visible={visible}
+      onOk={distributeReservedTokens}
+      okText={<Trans>Distribute {tokenTextPlural}</Trans>}
+      confirmLoading={loading}
+      onCancel={onCancel}
+      okButtonProps={{ disabled: !reservedTokens?.gt(0) }}
+      width={640}
+      centered={true}
+    >
+      <Space direction="vertical" style={{ width: '100%' }} size="large">
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Trans>
+            Reserved {tokenTextPlural}:{' '}
+            <span>
+              {reservedTokensFormatted} {tokenTextPlural}
+            </span>
+          </Trans>
+        </div>
+        <div>
+          <h4>
+            <Trans>{tokenTextSingular} recipients</Trans>
+          </h4>
+
+          {reservedTokensSplits?.length === 0 ? (
+            <p>
+              <Trans>
+                There are no reserved token recipients defined for this funding
+                cycle. The project owner will recieve all available tokens.
+              </Trans>
+            </p>
+          ) : null}
+
+          <SplitList
+            splits={reservedTokensSplits ?? []}
+            projectOwnerAddress={projectOwnerAddress}
+            totalValue={reservedTokens}
+            valueSuffix={tokenTextPlural}
+            showSplitValues
+          />
+        </div>
+      </Space>
+    </Modal>
+  )
+}

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -86,8 +86,8 @@ export default function V2ProjectReconfigureModal({
     fundingCycle,
     payoutSplits,
     queuedPayoutSplits,
-    reserveTokenSplits,
-    queuedReserveTokenSplits,
+    reservedTokensSplits,
+    queuedReservedTokensSplits,
     distributionLimit,
     queuedDistributionLimit,
     distributionLimitCurrency,
@@ -120,9 +120,9 @@ export default function V2ProjectReconfigureModal({
     ? queuedPayoutSplits
     : payoutSplits
 
-  const effectiveReserveTokenSplits = queuedFundingCycle?.number.gt(0)
-    ? queuedReserveTokenSplits
-    : reserveTokenSplits
+  const effectiveReservedTokensSplits = queuedFundingCycle?.number.gt(0)
+    ? queuedReservedTokensSplits
+    : reservedTokensSplits
 
   const effectiveDistributionLimit =
     queuedDistributionLimit ?? distributionLimit
@@ -178,15 +178,15 @@ export default function V2ProjectReconfigureModal({
 
     // Set reserve token splits
     dispatch(
-      editingV2ProjectActions.setReserveTokenSplits(
-        effectiveReserveTokenSplits ?? [],
+      editingV2ProjectActions.setReservedTokensSplits(
+        effectiveReservedTokensSplits ?? [],
       ),
     )
   }, [
     contracts,
     effectiveFundingCycle,
     effectivePayoutSplits,
-    effectiveReserveTokenSplits,
+    effectiveReservedTokensSplits,
     effectiveDistributionLimit,
     effectiveDistributionLimitCurrency,
     fundingCycle,
@@ -197,7 +197,7 @@ export default function V2ProjectReconfigureModal({
   // Gets values from the redux state to be used in the modal drawer fields
   const {
     payoutGroupedSplits: editingPayoutGroupedSplits,
-    reserveTokenGroupedSplits: editingReserveTokenGroupedSplits,
+    reservedTokensGroupedSplits: editingReservedTokensGroupedSplits,
   } = useAppSelector(state => state.editingV2Project)
   const editingFundingCycleMetadata = useEditingV2FundingCycleMetadataSelector()
   const editingFundingCycleData = useEditingV2FundingCycleDataSelector()
@@ -225,7 +225,7 @@ export default function V2ProjectReconfigureModal({
         fundAccessConstraints: editingFundAccessConstraints,
         groupedSplits: [
           editingPayoutGroupedSplits,
-          editingReserveTokenGroupedSplits,
+          editingReservedTokensGroupedSplits,
         ],
       },
       {
@@ -246,7 +246,7 @@ export default function V2ProjectReconfigureModal({
     editingFundingCycleData,
     reconfigureV2FundingCycleTx,
     editingPayoutGroupedSplits,
-    editingReserveTokenGroupedSplits,
+    editingReservedTokensGroupedSplits,
     onOk,
   ])
 

--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -17,16 +17,18 @@ import { formatSplitPercent, SPLITS_TOTAL_PERCENT } from 'utils/v2/math'
 
 export default function SplitItem({
   split,
-  showValue,
-  distributionLimitCurrency,
-  distributionLimit,
+  showSplitValue,
+  currency,
+  totalValue,
   projectOwnerAddress,
+  valueSuffix,
 }: {
   split: Split
-  distributionLimitCurrency: BigNumber | undefined
-  distributionLimit: BigNumber | undefined
+  currency?: BigNumber
+  totalValue: BigNumber | undefined
   projectOwnerAddress: string | undefined
-  showValue: boolean
+  showSplitValue: boolean
+  valueSuffix?: string | JSX.Element
 }) {
   const {
     theme: { colors },
@@ -102,9 +104,7 @@ export default function SplitItem({
   }
 
   const SplitValue = () => {
-    const splitValue = distributionLimit
-      ?.mul(split.percent)
-      .div(SPLITS_TOTAL_PERCENT)
+    const splitValue = totalValue?.mul(split.percent).div(SPLITS_TOTAL_PERCENT)
     const splitValueFormatted = formatWad(splitValue)
 
     return (
@@ -112,12 +112,11 @@ export default function SplitItem({
         (
         <CurrencySymbol
           currency={V2CurrencyName(
-            distributionLimitCurrency?.toNumber() as
-              | V2CurrencyOption
-              | undefined,
+            currency?.toNumber() as V2CurrencyOption | undefined,
           )}
         />
-        {splitValueFormatted})
+        {splitValueFormatted}
+        {valueSuffix ? <span> {valueSuffix}</span> : null})
       </>
     )
   }
@@ -146,8 +145,9 @@ export default function SplitItem({
       </div>
       <div>
         <span>{formatSplitPercent(BigNumber.from(split.percent))}%</span>
-        {distributionLimit?.gt(0) && showValue ? (
+        {totalValue?.gt(0) && showSplitValue ? (
           <span style={{ marginLeft: '0.2rem' }}>
+            {' '}
             <SplitValue />
           </span>
         ) : null}

--- a/src/components/v2/shared/SplitList.tsx
+++ b/src/components/v2/shared/SplitList.tsx
@@ -7,15 +7,17 @@ import SplitItem from './SplitItem'
 export default function SplitList({
   splits,
   showSplitValues = false,
-  distributionLimitCurrency,
-  distributionLimit,
+  currency,
+  totalValue,
   projectOwnerAddress,
+  valueSuffix,
 }: {
   splits: Split[]
-  distributionLimitCurrency: BigNumber | undefined
-  distributionLimit: BigNumber | undefined
+  currency?: BigNumber
+  totalValue: BigNumber | undefined
   projectOwnerAddress: string | undefined
   showSplitValues?: boolean
+  valueSuffix?: string | JSX.Element
 }) {
   const totalSplitPercentage =
     splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
@@ -32,10 +34,11 @@ export default function SplitList({
           >
             <SplitItem
               split={split}
-              showValue={showSplitValues}
-              distributionLimitCurrency={distributionLimitCurrency}
-              distributionLimit={distributionLimit}
+              showSplitValue={showSplitValues}
+              currency={currency}
+              totalValue={totalValue}
               projectOwnerAddress={projectOwnerAddress}
+              valueSuffix={valueSuffix}
             />
           </div>
         ))}
@@ -49,10 +52,11 @@ export default function SplitList({
             projectId: undefined,
             allocator: undefined,
           }}
-          showValue={showSplitValues}
-          distributionLimitCurrency={distributionLimitCurrency}
-          distributionLimit={distributionLimit}
+          showSplitValue={showSplitValues}
+          currency={currency}
+          totalValue={totalValue}
           projectOwnerAddress={projectOwnerAddress}
+          valueSuffix={valueSuffix}
         />
       ) : null}
     </div>

--- a/src/constants/v2/splits.ts
+++ b/src/constants/v2/splits.ts
@@ -1,4 +1,4 @@
-import { ETHPayoutSplitGroup, ReserveTokenSplitGroup } from 'models/v2/splits'
+import { ETHPayoutSplitGroup, ReservedTokensSplitGroup } from 'models/v2/splits'
 
 export const ETH_PAYOUT_SPLIT_GROUP: ETHPayoutSplitGroup = 1
-export const RESERVE_TOKEN_SPLIT_GROUP: ReserveTokenSplitGroup = 2
+export const RESERVE_TOKEN_SPLIT_GROUP: ReservedTokensSplitGroup = 2

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -14,8 +14,8 @@ export type V2ProjectContextType = {
   queuedDistributionLimit: BigNumber | undefined
   payoutSplits: Split[] | undefined
   queuedPayoutSplits: Split[] | undefined
-  reserveTokenSplits: Split[] | undefined
-  queuedReserveTokenSplits: Split[] | undefined
+  reservedTokensSplits: Split[] | undefined
+  queuedReservedTokensSplits: Split[] | undefined
   tokenAddress: string | undefined
   tokenSymbol: string | undefined
   terminals: string[] | undefined // array of terminal addresses, 0xABC...
@@ -37,8 +37,8 @@ export const V2ProjectContext = createContext<V2ProjectContextType>({
   queuedDistributionLimit: undefined,
   payoutSplits: undefined,
   queuedPayoutSplits: undefined,
-  reserveTokenSplits: undefined,
-  queuedReserveTokenSplits: undefined,
+  reservedTokensSplits: undefined,
+  queuedReservedTokensSplits: undefined,
   tokenAddress: undefined,
   tokenSymbol: undefined,
   terminals: undefined,

--- a/src/hooks/v2/contractReader/ProjectReservedTokens.ts
+++ b/src/hooks/v2/contractReader/ProjectReservedTokens.ts
@@ -1,0 +1,21 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { V2ContractName } from 'models/v2/contracts'
+
+import useContractReader from './V2ContractReader'
+
+export default function useProjectReservedTokens({
+  projectId,
+  reservedRate,
+}: {
+  projectId: BigNumber | undefined
+  reservedRate: BigNumber | undefined
+}) {
+  return useContractReader<BigNumber>({
+    contract: V2ContractName.JBController,
+    functionName: 'reservedTokenBalanceOf',
+    args:
+      projectId && reservedRate
+        ? [BigNumber.from(projectId).toHexString(), reservedRate]
+        : null,
+  })
+}

--- a/src/hooks/v2/transactor/DistributePayouts.ts
+++ b/src/hooks/v2/transactor/DistributePayouts.ts
@@ -8,7 +8,7 @@ import { V2CurrencyOption } from 'models/v2/currencyOption'
 
 import { TransactorInstance } from '../../Transactor'
 
-export type PayV2ProjectTxType = TransactorInstance<{
+export type DistributePayoutsTx = TransactorInstance<{
   memo?: string
   amount: BigNumber | undefined
   currency: V2CurrencyOption | undefined
@@ -16,7 +16,7 @@ export type PayV2ProjectTxType = TransactorInstance<{
 
 const minReturnedTokens = 0 // TODO will need a field for this in WithdrawModal for v2
 
-export function useDistributePayoutsTx(): PayV2ProjectTxType {
+export function useDistributePayoutsTx(): DistributePayoutsTx {
   const { transactor, contracts } = useContext(V2UserContext)
   const { projectId } = useContext(V2ProjectContext)
 

--- a/src/hooks/v2/transactor/DistributeReservedTokensTx.ts
+++ b/src/hooks/v2/transactor/DistributeReservedTokensTx.ts
@@ -1,0 +1,28 @@
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { V2UserContext } from 'contexts/v2/userContext'
+import { useContext } from 'react'
+
+import { TransactorInstance } from '../../Transactor'
+
+export type DistributeReserveTokensTx = TransactorInstance<{
+  memo?: string
+}>
+
+export function useDistributeReservedTokens(): DistributeReserveTokensTx {
+  const { transactor, contracts } = useContext(V2UserContext)
+  const { projectId } = useContext(V2ProjectContext)
+
+  return ({ memo = '' }, txOpts) => {
+    if (!transactor || !projectId || !contracts?.JBController) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      contracts.JBController,
+      'distributeReservedTokensOf',
+      [projectId, memo],
+      txOpts,
+    )
+  }
+}

--- a/src/hooks/v2/transactor/PayV2ProjectTx.ts
+++ b/src/hooks/v2/transactor/PayV2ProjectTx.ts
@@ -7,14 +7,14 @@ import { randomBytes } from '@ethersproject/random'
 
 import { TransactorInstance } from '../../Transactor'
 
-export type PayV2ProjectTxType = TransactorInstance<{
+export type PayV2ProjectTx = TransactorInstance<{
   memo: string
   preferClaimedTokens: boolean
   beneficiary?: string
   value: BigNumber
 }>
 
-export function usePayV2ProjectTx(): PayV2ProjectTxType {
+export function usePayV2ProjectTx(): PayV2ProjectTx {
   const { transactor, contracts } = useContext(V2UserContext)
   const { projectId } = useContext(V2ProjectContext)
   const minReturnedTokens = 0 // TODO will need a field for this in V2ConfirmPayOwnerModal

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -203,7 +203,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr ""
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 
@@ -665,9 +665,21 @@ msgstr "Distribute available funds to other Ethereum wallets or Juicebox project
 msgid "Distribute funds"
 msgstr "Distribute funds"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute reserved {tokenTextPlural}"
+msgstr "Distribute reserved {tokenTextPlural}"
+
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "Distribute {0}"
 msgstr "Distribute {0}"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute {tokenTextPlural}"
+msgstr "Distribute {tokenTextPlural}"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Distribute {tokensText}"
+msgstr "Distribute {tokensText}"
 
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
@@ -1589,7 +1601,6 @@ msgid "Reserved tokens"
 msgstr ""
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
 msgid "Reserved {0}"
 msgstr ""
 
@@ -1597,6 +1608,14 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "Reserved {tokenSymbolPlural}"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+msgstr "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Reserved {tokensText}"
+msgstr "Reserved {tokensText}"
 
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Reserves"
@@ -1817,6 +1836,10 @@ msgstr ""
 msgid "The address that should receive the tokens."
 msgstr "The address that should receive the tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+msgstr "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
@@ -1893,8 +1916,12 @@ msgid "The total amount received by this project through Juicebox since it was c
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-msgid "There are no payouts defined for this project. The project owner will recieve all distributed funds."
-msgstr "There are no payouts defined for this project. The project owner will recieve all distributed funds."
+msgid "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+msgstr "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
+msgstr "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
 
 #: src/components/Landing/QAs.tsx
 msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
@@ -2527,7 +2554,15 @@ msgstr "{tokenSymbolPlural} received per ETH paid to the treasury. This can chan
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr ""
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "{tokenTextSingular} recipients"
+msgstr "{tokenTextSingular} recipients"
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "{tokensText} reserved"
+msgstr "{tokensText} reserved"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -210,7 +210,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Un proyecto puede elegir reservar un porcentaje de tokens para sí mismo. En lugar de ser distribuidos para pagar a usuarios, este porcentaje de tokens es acuñado para el proyecto."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un proyecto puede reservar un porcentaje de tokens acuñados de cada pago que reciba. Los tokens reservados pueden ser distribuidos de acorde a la asignación que está debajo en cualquier momento."
 
@@ -672,9 +672,21 @@ msgstr "Distribuye fondos disponibles a otras wallets de Ethereum o proyectos de
 msgid "Distribute funds"
 msgstr "Distribuir fondos"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute reserved {tokenTextPlural}"
+msgstr ""
+
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "Distribute {0}"
 msgstr "Distribuir {0}"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute {tokenTextPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Distribute {tokensText}"
+msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
@@ -1596,13 +1608,20 @@ msgid "Reserved tokens"
 msgstr "Tokens reservados"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
 msgid "Reserved {0}"
 msgstr "{0} Reservados"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Reserved {tokensText}"
 msgstr ""
 
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -1824,6 +1843,10 @@ msgstr "La dirección que debería recibir los tokens acuñados por pagar este p
 msgid "The address that should receive the tokens."
 msgstr "La dirección que debería recibir los tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+msgstr ""
+
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
@@ -1900,7 +1923,11 @@ msgid "The total amount received by this project through Juicebox since it was c
 msgstr "El monto total recibido por este proyecto a través de Juicebox desde que fue creado."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-msgid "There are no payouts defined for this project. The project owner will recieve all distributed funds."
+msgid "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2534,7 +2561,15 @@ msgstr "{tokenSymbolPlural} recibidos por ETH pagado al tesoro. Esto puede cambi
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Tipo de cambio de {tokenSymbol}/ETH en {exchangeName}."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "{tokenTextSingular} recipients"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} son distribuidos a cualquiera que pague este proyecto. Si el proyecto tiene un objetivo de financiamiento, los tokens pueden ser canjeados por una porción del excedente del proyecto, hayan sido estos reclamados o no."
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "{tokensText} reserved"
+msgstr ""
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -210,7 +210,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Um projeto pode escolher reservar uma porcentagem de tokens para si mesmo. Em vez de ser distribuída para pagar os usuários, essa porcentagem de tokens é cunhada para o projeto."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Um projeto pode reservar uma porcentagem de tokens gerados por cada pagamento recebido. Tokens reservados podem ser distribuídos a qualquer momento conforme a alocação abaixo."
 
@@ -672,9 +672,21 @@ msgstr "Distribua fundos disponíveis para outras carteiras de Ethereum ou proje
 msgid "Distribute funds"
 msgstr "Distribuir fundos"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute reserved {tokenTextPlural}"
+msgstr ""
+
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "Distribute {0}"
 msgstr "Distribuir {0}"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute {tokenTextPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Distribute {tokensText}"
+msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
@@ -1596,7 +1608,6 @@ msgid "Reserved tokens"
 msgstr "Tokens reservados"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
 msgid "Reserved {0}"
 msgstr "{0} Reservados"
 
@@ -1604,6 +1615,14 @@ msgstr "{0} Reservados"
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "{tokenSymbolPlural} reservados"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Reserved {tokensText}"
+msgstr ""
 
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Reserves"
@@ -1824,6 +1843,10 @@ msgstr "O endereço que deve receber os tokens do pagamento deste projeto."
 msgid "The address that should receive the tokens."
 msgstr "O endereço que deve receber os tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+msgstr ""
+
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
@@ -1900,7 +1923,11 @@ msgid "The total amount received by this project through Juicebox since it was c
 msgstr "O montante total recebido por este projeto através do Juicebox desde que foi criado."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-msgid "There are no payouts defined for this project. The project owner will recieve all distributed funds."
+msgid "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2534,7 +2561,15 @@ msgstr "{tokenSymbolPlural} recebido por ETH pagos para o tesouro. Isso pode mod
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{tokenSymbol}/ETH taxa de câmbio em {exchangeName}."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "{tokenTextSingular} recipients"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} são distribuídos para qualquer pessoa que pague este projeto. Se o projeto já definiu o objetivo de financiamento, os tokens podem ser resgatados por uma porção de overflow do projeto caso eles tenham ou não sido reivindicados ainda."
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "{tokensText} reserved"
+msgstr ""
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -210,7 +210,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Проект может зарезервировать для себя процент токенов. Вместо того, чтобы распределяться среди платящих пользователей, этот процент токенов создается для проекта."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Проект может резервировать процент выпущенных токенов с каждого платежа, который он получает. Зарезервированные токены могут быть распределены в соответствии с приведенным ниже распределением в любое время."
 
@@ -672,9 +672,21 @@ msgstr "Распределяйте доступные средства на др
 msgid "Distribute funds"
 msgstr "Распределить средства"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute reserved {tokenTextPlural}"
+msgstr ""
+
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "Distribute {0}"
 msgstr "Распределение"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute {tokenTextPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Distribute {tokensText}"
+msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
@@ -1596,13 +1608,20 @@ msgid "Reserved tokens"
 msgstr "Зарезервированные токены"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
 msgid "Reserved {0}"
 msgstr "Зарезервировано {0}"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Reserved {tokensText}"
 msgstr ""
 
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -1824,6 +1843,10 @@ msgstr "Адрес, который должен получить токены, �
 msgid "The address that should receive the tokens."
 msgstr "Адрес, который должен получить токены."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+msgstr ""
+
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
@@ -1900,7 +1923,11 @@ msgid "The total amount received by this project through Juicebox since it was c
 msgstr "Общая сумма, полученная этим проектом через Juicebox с момента его создания."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-msgid "There are no payouts defined for this project. The project owner will recieve all distributed funds."
+msgid "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2534,7 +2561,15 @@ msgstr ""
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Обменный курс {tokenSymbol}/ETH на {exchangeName}."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "{tokenTextSingular} recipients"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} распространяются среди всех, кто оплачивает этот проект. Если проектустановил целевой показатель финансирования, токены могут быть выкуплены для частипереполнения проекта независимо от того, были ли они еще востребованы или нет."
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "{tokensText} reserved"
+msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -210,7 +210,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Bir proje, kendisi için tokenlerin bir yüzdesini ayırmayı seçebilir. Bu token yüzdesi, ödeme yapan kullanıcılara dağıtılmak yerine proje için kullanılabilir."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Bir proje, aldığı her ödemeden basılan token'ların belirli bir yüzdesini ayırabilir. Ayrılan token'lar, herhangi bir zamanda aşağıdaki tahsise göre dağıtılabilir."
 
@@ -672,9 +672,21 @@ msgstr "Uygun fonları diğer Ethereum cüzdanlarına veya Juicebox projelerine 
 msgid "Distribute funds"
 msgstr "Fonları dağıt"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute reserved {tokenTextPlural}"
+msgstr ""
+
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "Distribute {0}"
 msgstr "{0} dağıt"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute {tokenTextPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Distribute {tokensText}"
+msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
@@ -1596,13 +1608,20 @@ msgid "Reserved tokens"
 msgstr "Ayrılmış token'lar"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
 msgid "Reserved {0}"
 msgstr "Ayrılmış {0}"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Reserved {tokensText}"
 msgstr ""
 
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -1824,6 +1843,10 @@ msgstr "Bu projeye ödeme yaparak basılan token'ları alması gereken adres."
 msgid "The address that should receive the tokens."
 msgstr "Token'ları alması gereken adres."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+msgstr ""
+
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
@@ -1900,7 +1923,11 @@ msgid "The total amount received by this project through Juicebox since it was c
 msgstr "Oluşturulma tarihinden bu yana, bu proje tarafından Juicebox aracılığıyla alınan toplam miktar."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-msgid "There are no payouts defined for this project. The project owner will recieve all distributed funds."
+msgid "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2534,7 +2561,15 @@ msgstr ""
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{exchangeName} üzerinde {tokenSymbol}/ETH kuru."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "{tokenTextSingular} recipients"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "{tokensText} reserved"
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -210,7 +210,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "项目可以选择为自己保留一定比例的代币。这些代币不是分发给付费的用户，而是给到项目方。"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "项目每收到一笔付款都会铸造代币，其中某个百分比的代币会保留在项目内。保留代币可随时按以下分配方案进行分发。"
 
@@ -672,9 +672,21 @@ msgstr "把可用资金分发给其他以太坊钱包或者其他Juicebox项目�
 msgid "Distribute funds"
 msgstr "分发资金"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute reserved {tokenTextPlural}"
+msgstr ""
+
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "Distribute {0}"
 msgstr "分发 {0}"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Distribute {tokenTextPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Distribute {tokensText}"
+msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
@@ -1596,13 +1608,20 @@ msgid "Reserved tokens"
 msgstr "保留代币"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
 msgid "Reserved {0}"
 msgstr "已保留 {0}"
 
 #: src/components/v1/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "Reserved {tokensText}"
 msgstr ""
 
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -1824,6 +1843,10 @@ msgstr "项目收到付款时，应该接收到新铸造代币的地址。"
 msgid "The address that should receive the tokens."
 msgstr "应该收到代币的地址。"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "The amount of tokens reserved for this project. These tokens can be distributed to reserved token beneficiaries."
+msgstr ""
+
 #: src/components/v1/V1Project/Paid.tsx
 #: src/components/v2/V2Project/TreasuryStats.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
@@ -1900,7 +1923,11 @@ msgid "The total amount received by this project through Juicebox since it was c
 msgstr "该项目自创建以来通过 Juicebox 接收的总金额。"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-msgid "There are no payouts defined for this project. The project owner will recieve all distributed funds."
+msgid "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2534,7 +2561,15 @@ msgstr ""
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "在 {exchangeName} 的兑换率为 {tokenSymbol}/ETH"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "{tokenTextSingular} recipients"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} 会被分配给付款的人。如果项目设置了筹款目标，可以燃烧代币来按比例赎回溢出池中的 ETH。"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "{tokensText} reserved"
+msgstr ""
 

--- a/src/models/v2/splits.ts
+++ b/src/models/v2/splits.ts
@@ -8,8 +8,8 @@ export type Split = {
 }
 
 export type ETHPayoutSplitGroup = 1
-export type ReserveTokenSplitGroup = 2
-export type SplitGroup = ETHPayoutSplitGroup | ReserveTokenSplitGroup
+export type ReservedTokensSplitGroup = 2
+export type SplitGroup = ETHPayoutSplitGroup | ReservedTokensSplitGroup
 
 export interface GroupedSplits<G> {
   group: G
@@ -17,4 +17,5 @@ export interface GroupedSplits<G> {
 }
 
 export type ETHPayoutGroupedSplits = GroupedSplits<ETHPayoutSplitGroup>
-export type ReserveTokenGroupedSplits = GroupedSplits<ReserveTokenSplitGroup>
+export type ReservedTokensGroupedSplits =
+  GroupedSplits<ReservedTokensSplitGroup>

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -6,7 +6,7 @@ import { ProjectMetadataV4 } from 'models/project-metadata'
 
 import {
   ETHPayoutGroupedSplits,
-  ReserveTokenGroupedSplits,
+  ReservedTokensGroupedSplits,
   Split,
 } from 'models/v2/splits'
 import {
@@ -31,7 +31,7 @@ export interface V2ProjectState {
   fundingCycleMetadata: SerializedV2FundingCycleMetadata
   fundAccessConstraints: SerializedV2FundAccessConstraint[]
   payoutGroupedSplits: ETHPayoutGroupedSplits
-  reserveTokenGroupedSplits: ReserveTokenGroupedSplits
+  reservedTokensGroupedSplits: ReservedTokensGroupedSplits
 }
 
 const defaultProjectMetadataState: ProjectMetadataV4 = {
@@ -88,7 +88,7 @@ export const defaultProjectState: V2ProjectState = {
     group: ETH_PAYOUT_SPLIT_GROUP,
     splits: [],
   },
-  reserveTokenGroupedSplits: {
+  reservedTokensGroupedSplits: {
     group: RESERVE_TOKEN_SPLIT_GROUP,
     splits: [],
   },
@@ -162,8 +162,8 @@ export const editingV2ProjectSlice = createSlice({
     setPayoutSplits: (state, action: PayloadAction<Split[]>) => {
       state.payoutGroupedSplits.splits = action.payload
     },
-    setReserveTokenSplits: (state, action: PayloadAction<Split[]>) => {
-      state.reserveTokenGroupedSplits.splits = action.payload
+    setReservedTokensSplits: (state, action: PayloadAction<Split[]>) => {
+      state.reservedTokensGroupedSplits.splits = action.payload
     },
     setPausePay: (state, action: PayloadAction<boolean>) => {
       state.fundingCycleMetadata.pausePay = action.payload


### PR DESCRIPTION
## What does this PR do and why?

Closes #665, #662 

- add the card, the modal, and the transaction for reserved tokens (and distributing them)
- a few lil refactors along the way

## Screenshots or screen recordings

<img width="670" alt="Screen Shot 2022-04-02 at 1 39 24 pm" src="https://user-images.githubusercontent.com/94939382/161363592-f4e3fd8e-b5a3-4b35-912f-ea6810457fd5.png">
<img width="530" alt="Screen Shot 2022-04-02 at 1 39 19 pm" src="https://user-images.githubusercontent.com/94939382/161363593-e42ba91c-ef48-4aa6-9546-48e38d066983.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
