### PR TITLE
Fix amount<->percent conversions on v2 payout modal 

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,7 @@ import V1Create from 'components/v1/V1Create'
 import Projects from 'components/Projects'
 import V2UserProvider from 'providers/v2/UserProvider'
 import Loading from 'components/shared/Loading'
+import V1CurrencyProvider from 'providers/v1/V1CurrencyProvider'
 
 const V2Create = lazy(() => import('components/v2/V2Create'))
 const V2Dashboard = lazy(() => import('components/v2/V2Dashboard'))
@@ -21,10 +22,14 @@ export default function Router() {
     <HashRouter>
       <Switch>
         <Route exact path="/">
-          <Landing />
+          <V1CurrencyProvider>
+            <Landing />
+          </V1CurrencyProvider>
         </Route>
         <Route path="/create">
-          <V1Create />
+          <V1CurrencyProvider>
+            <V1Create />
+          </V1CurrencyProvider>
         </Route>
 
         <Route path="/projects/:owner">

--- a/src/components/shared/formItems/formHelpers.tsx
+++ b/src/components/shared/formItems/formHelpers.tsx
@@ -1,5 +1,5 @@
 import { PayoutMod } from 'models/mods'
-import { permyriadToPercent } from 'utils/formatNumber'
+import { percentToPerbicent, permyriadToPercent } from 'utils/formatNumber'
 import * as constants from '@ethersproject/constants'
 import { isAddress } from '@ethersproject/address'
 
@@ -86,10 +86,13 @@ export const targetSubFeeToTargetFormatted = (
 export function getAmountFromPercent(
   percent: number,
   target: string,
-  fee: BigNumber | undefined,
+  feePercentage: string | undefined,
 ) {
   const amount = fromWad(
-    amountSubFee(parseWad(stripCommas(target)), fee)
+    amountSubFee(
+      parseWad(stripCommas(target)),
+      percentToPerbicent(feePercentage),
+    )
       ?.mul(Math.floor((percent ?? 0) * 100))
       .div(10000),
   )
@@ -101,9 +104,12 @@ export function getAmountFromPercent(
 export function getPercentFromAmount(
   amount: number | undefined,
   target: string,
-  fee: BigNumber | undefined,
+  feePercentage: string | undefined,
 ) {
-  const targetSubFeeBN = amountSubFee(parseWad(stripCommas(target)), fee)
+  const targetSubFeeBN = amountSubFee(
+    parseWad(stripCommas(target)),
+    percentToPerbicent(feePercentage),
+  )
   const targetSubFee = stripCommas(formatWad(targetSubFeeBN) ?? '0')
   const percent = (((amount ?? 0) * 1.0) / parseFloat(targetSubFee)) * 100
   return parseFloat(percent.toFixed(8))

--- a/src/components/shared/forms/PayModsForm.tsx
+++ b/src/components/shared/forms/PayModsForm.tsx
@@ -8,9 +8,10 @@ import { useForm } from 'antd/lib/form/Form'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { PayoutMod } from 'models/mods'
 import { useContext, useLayoutEffect, useState } from 'react'
-import { fromWad } from 'utils/formatNumber'
+import { fromWad, perbicentToPercent } from 'utils/formatNumber'
 
 import { getTotalPercentage } from 'components/shared/formItems/formHelpers'
+import { CurrencyContext } from 'contexts/currencyContext'
 
 export default function PayModsForm({
   initialMods,
@@ -35,6 +36,10 @@ export default function PayModsForm({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+
+  const {
+    currencies: { ETH },
+  } = useContext(CurrencyContext)
 
   // Calculates sum of percentages of given payouts
   function calculateTotalPercentage(newMods: PayoutMod[] | undefined) {
@@ -97,14 +102,14 @@ export default function PayModsForm({
         <FormItems.ProjectPayoutMods
           mods={mods}
           target={fromWad(target)}
-          currency={currency}
+          currencyName={currency === ETH ? 'ETH' : 'USD'}
           onModsChanged={new_mods => {
             setMods(new_mods)
             form.setFieldsValue({
               totalPercent: calculateTotalPercentage(new_mods),
             })
           }}
-          feePerbicent={fee}
+          feePercentage={perbicentToPercent(fee)}
           formItemProps={{
             label: t`Payouts (optional)`,
           }}

--- a/src/components/v1/FundingCycle/QueuedFundingCycle.tsx
+++ b/src/components/v1/FundingCycle/QueuedFundingCycle.tsx
@@ -4,7 +4,7 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 
 import ReservedTokens from './ReservedTokens'
-import PayoutModsList from '../../shared/PayoutModsList'
+import PayoutModsList from '../PayoutModsList'
 import FundingCycleDetails from './FundingCycleDetails'
 
 export default function QueuedFundingCycle() {

--- a/src/components/v1/FundingCycle/Spending.tsx
+++ b/src/components/v1/FundingCycle/Spending.tsx
@@ -5,7 +5,7 @@ import TooltipLabel from 'components/shared/TooltipLabel'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { PayoutMod } from 'models/mods'
 import { useContext, useState } from 'react'
-import PayoutModsList from 'components/shared/PayoutModsList'
+import PayoutModsList from 'components/v1/PayoutModsList'
 
 import { hasFundingTarget } from 'utils/v1/fundingCycle'
 import { V1CurrencyName } from 'utils/v1/currency'

--- a/src/components/v1/FundingCycle/modals/WithdrawModal.tsx
+++ b/src/components/v1/FundingCycle/modals/WithdrawModal.tsx
@@ -6,7 +6,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import PayoutModsList from 'components/shared/PayoutModsList'
+import PayoutModsList from 'components/v1/PayoutModsList'
 
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'

--- a/src/components/v1/PayoutModsList.tsx
+++ b/src/components/v1/PayoutModsList.tsx
@@ -17,13 +17,18 @@ import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { V1FundingCycle } from 'models/v1/fundingCycle'
 import { PayoutMod } from 'models/mods'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
-import { formatWad, permyriadToPercent, fromWad } from 'utils/formatNumber'
+import {
+  formatWad,
+  permyriadToPercent,
+  fromWad,
+  perbicentToPercent,
+} from 'utils/formatNumber'
 import { amountSubFee } from 'utils/math'
 
 import { V1CurrencyName } from 'utils/v1/currency'
 
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
-import ProjectPayoutMods from './formItems/ProjectPayoutMods'
+import ProjectPayoutMods from '../shared/formItems/ProjectPayoutMods'
 
 export default function PayoutModsList({
   mods,
@@ -228,8 +233,8 @@ export default function PayoutModsList({
               lockedMods={lockedMods}
               onModsChanged={setEditingMods}
               target={fromWad(fundingCycle.target)}
-              currency={fundingCycle.currency.toNumber() as V1CurrencyOption}
-              feePerbicent={feePerbicent}
+              currencyName={fundingCycleCurrency}
+              feePercentage={perbicentToPercent(feePerbicent)}
             />
           </Modal>
         </Form>

--- a/src/components/v1/V1Create/ConfirmDeployProject.tsx
+++ b/src/components/v1/V1Create/ConfirmDeployProject.tsx
@@ -3,7 +3,7 @@ import { Col, Row, Space, Statistic } from 'antd'
 import { Gutter } from 'antd/lib/grid/row'
 
 import CurrencySymbol from 'components/shared/CurrencySymbol'
-import PayoutModsList from 'components/shared/PayoutModsList'
+import PayoutModsList from 'components/v1/PayoutModsList'
 import ProjectLogo from 'components/shared/ProjectLogo'
 import TicketModsList from 'components/shared/TicketModsList'
 

--- a/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
@@ -8,7 +8,7 @@ import RestrictedActionsForm, {
   RestrictedActionsFormFields,
 } from 'components/shared/forms/RestrictedActionsForm'
 import CurrencySymbol from 'components/shared/CurrencySymbol'
-import PayoutModsList from 'components/shared/PayoutModsList'
+import PayoutModsList from 'components/v1/PayoutModsList'
 import TicketModsList from 'components/shared/TicketModsList'
 import ReconfigurationStrategyDrawer from 'components/shared/ReconfigurationStrategyDrawer'
 

--- a/src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
+++ b/src/components/v2/V2Create/tabs/FundingTab/FundingTabContent.tsx
@@ -30,6 +30,7 @@ import { Split } from 'models/v2/splits'
 import { formatFee } from 'utils/v2/math'
 
 import BudgetTargetInput from 'components/shared/inputs/BudgetTargetInput'
+import { CurrencyContext } from 'contexts/currencyContext'
 
 import { shadowCard } from 'constants/styles/shadowCard'
 import FormActionbar from '../../FormActionBar'
@@ -50,6 +51,10 @@ export default function FundingTabContent({
 }: TabContentProps) {
   const { theme } = useContext(ThemeContext)
   const { contracts } = useContext(V2UserContext)
+  const {
+    currencies: { ETH },
+  } = useContext(CurrencyContext)
+
   const dispatch = useAppDispatch()
 
   const [fundingForm] = Form.useForm<FundingFormFields>()
@@ -245,8 +250,12 @@ export default function FundingTabContent({
           <ProjectPayoutMods
             mods={splits.map(toMod)}
             target={target ?? '0'}
-            currency={toV1Currency(targetCurrency)}
-            feePerbicent={ETHPaymentTerminalFee}
+            currencyName={targetCurrency === ETH ? 'ETH' : 'USD'}
+            feePercentage={
+              ETHPaymentTerminalFee
+                ? formatFee(ETHPaymentTerminalFee)
+                : undefined
+            }
             onModsChanged={newMods => {
               setSplits(newMods.map(toSplit))
             }}

--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -46,7 +46,11 @@ export default function PayoutSplitsCard() {
               projectBalanceInCurrency={balanceInDistributionLimitCurrency}
               targetAmount={distributionLimit}
               distributedAmount={usedDistributionLimit}
-              feePercentage={formatFee(ETHPaymentTerminalFee)} // TODO
+              feePercentage={
+                ETHPaymentTerminalFee
+                  ? formatFee(ETHPaymentTerminalFee)
+                  : undefined
+              }
               ownerAddress={projectOwnerAddress}
             />
           ) : (

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1845,7 +1845,7 @@ msgstr ""
 msgid "Start Over"
 msgstr ""
 
-#: src/components/shared/PayoutModsList.tsx
+#: src/components/v1/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Sum of percentages cannot exceed 100%"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1850,7 +1850,7 @@ msgstr "Empezar"
 msgid "Start Over"
 msgstr "Empezar de Nuevo"
 
-#: src/components/shared/PayoutModsList.tsx
+#: src/components/v1/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "La suma de los porcentajes no puede exceder 100%"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1850,7 +1850,7 @@ msgstr "Começo"
 msgid "Start Over"
 msgstr "Comece novamente"
 
-#: src/components/shared/PayoutModsList.tsx
+#: src/components/v1/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Soma de porcentagens não pode exceder 100%"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1850,7 +1850,7 @@ msgstr "Начать"
 msgid "Start Over"
 msgstr "Начать заново"
 
-#: src/components/shared/PayoutModsList.tsx
+#: src/components/v1/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Сумма процентов не может превышать 100%"
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1850,7 +1850,7 @@ msgstr "Başlangıç"
 msgid "Start Over"
 msgstr "Baştan Başla"
 
-#: src/components/shared/PayoutModsList.tsx
+#: src/components/v1/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Yüzdelerin toplamı %100'ü aşamaz"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1850,7 +1850,7 @@ msgstr "开始时间"
 msgid "Start Over"
 msgstr "重新来过"
 
-#: src/components/shared/PayoutModsList.tsx
+#: src/components/v1/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "百分比合计不能超过 100%"
 


### PR DESCRIPTION
## What does this PR do and why?

- Fix amount<->percent conversions by using `feePercentage` in converter functions 
- Adds `currencyContext` to `projectPayoutMods` to make it actually version-agnostic
- Moves `PayoutModsList` back to v1 since it's got a lot of v1 stuff and not currently used in v2 

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
