### PR TITLE
[refactor] use optional chaining syntax in `Transactor.ts` 

### DIFF
--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -91,11 +91,11 @@ export function useTransactor({
         transactionHandler: txInformation => {
           console.info('HANDLE TX', txInformation)
           if (options && txInformation.transaction.status === 'confirmed') {
-            options.onConfirmed && options.onConfirmed(txInformation, signer)
-            options.onDone && options.onDone()
+            options?.onConfirmed?.(txInformation, signer)
+            options?.onDone?.()
           }
           if (options && txInformation.transaction.status === 'cancelled') {
-            options.onCancelled && options.onCancelled(txInformation, signer)
+            options?.onCancelled?.(txInformation, signer)
           }
         },
       }
@@ -162,13 +162,13 @@ export function useTransactor({
         } else {
           console.info('LOCAL TX SENT', result.hash)
           if (result.confirmations) {
-            options?.onConfirmed && options.onConfirmed(result, signer)
+            options?.onConfirmed?.(result, signer)
           } else {
-            options?.onCancelled && options.onCancelled(result, signer)
+            options?.onCancelled?.(result, signer)
           }
         }
 
-        options?.onDone && options.onDone()
+        options?.onDone?.()
 
         return true
       } catch (e) {
@@ -198,7 +198,7 @@ export function useTransactor({
           duration: 0,
         })
 
-        options?.onDone && options.onDone()
+        options?.onDone?.()
 
         return false
       }


### PR DESCRIPTION
## What does this PR do and why?

- Updates syntax to use optional chaining syntax that is used in other parts of the front-end. While working on #789 I saw these lines of code could use optional chaining syntax, which is used in other parts of the codebase.


<img src="https://user-images.githubusercontent.com/2502947/162635863-ac98b393-1c78-475d-8560-632611fdbeab.jpg" height=400 />


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
