### PR TITLE
Fix bug on v1 reserved rate

### DIFF
--- a/src/components/shared/forms/TicketingForm.tsx
+++ b/src/components/shared/forms/TicketingForm.tsx
@@ -73,6 +73,7 @@ export default function TicketingForm({
               Boolean(val && val >= reservedRateRiskyMin),
             )
           }}
+          checked
         />
         {showReservedRateWarning && (
           <Form.Item>

--- a/src/components/shared/inputs/NumberSlider.tsx
+++ b/src/components/shared/inputs/NumberSlider.tsx
@@ -50,7 +50,9 @@ export default function NumberSlider({
 
   return (
     <div style={style}>
-      <div style={{ display: 'flex', alignItems: 'baseline' }}>
+      <div
+        style={{ display: 'flex', alignItems: 'baseline', marginBottom: 15 }}
+      >
         <Slider
           {...inputConfig}
           tooltipVisible={false}


### PR DESCRIPTION
## What does this PR do and why?

- Fixes reserved rate not showing up on v1 create.
- Also fixes a small spacing issue on the number sliders which has arisen in the last few days

BEFORE:

<img width="601" alt="Screen Shot 2022-04-15 at 8 12 15 pm" src="https://user-images.githubusercontent.com/96150256/163622544-08ab9904-6693-491b-8f0e-0b8129c9a19a.png">

AFTER: 

<img width="622" alt="Screen Shot 2022-04-15 at 8 12 40 pm" src="https://user-images.githubusercontent.com/96150256/163622531-12668254-dca7-42bf-9dc6-f1df43c5a495.png">

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
