### PR TITLE
Clean up v2 project context

### DIFF
--- a/src/components/v2/V2Create/ProjectPreview.tsx
+++ b/src/components/v2/V2Create/ProjectPreview.tsx
@@ -50,31 +50,33 @@ export default function ProjectPreview({
 
     projectId: BigNumber.from(0),
     projectMetadata,
+
     fundingCycle,
     fundingCycleMetadata,
-    queuedFundingCycleMetadata: undefined,
+
     distributionLimit: fundAccessConstraint?.distributionLimit,
+    distributionLimitCurrency: fundAccessConstraint?.distributionLimitCurrency,
+
     payoutSplits: payoutGroupedSplits?.splits,
     reservedTokensSplits: reservedTokensGroupedSplits?.splits,
-    distributionLimitCurrency: fundAccessConstraint?.distributionLimitCurrency,
 
     usedDistributionLimit: BigNumber.from(0),
     ETHBalance: BigNumber.from(0),
     balanceInDistributionLimitCurrency: BigNumber.from(0),
 
-    queuedFundingCycle: undefined,
-    queuedDistributionLimit: undefined,
-    queuedDistributionLimitCurrency: undefined,
-    queuedPayoutSplits: undefined,
-    queuedReservedTokensSplits: undefined,
-
     tokenAddress: undefined,
     terminals: [],
+    primaryTerminal: undefined,
     tokenSymbol: undefined,
     projectOwnerAddress: userAddress,
     ballotState: undefined,
     primaryTerminalCurrentOverflow: undefined,
     totalTokenSupply: undefined,
+
+    loading: {
+      ETHBalanceLoading: false,
+      balanceInDistributionLimitCurrencyLoading: false,
+    },
   }
 
   return (

--- a/src/components/v2/V2Create/ProjectPreview.tsx
+++ b/src/components/v2/V2Create/ProjectPreview.tsx
@@ -76,6 +76,7 @@ export default function ProjectPreview({
     loading: {
       ETHBalanceLoading: false,
       balanceInDistributionLimitCurrencyLoading: false,
+      distributionLimitLoading: false,
     },
   }
 

--- a/src/components/v2/V2Dashboard/Dashboard.tsx
+++ b/src/components/v2/V2Dashboard/Dashboard.tsx
@@ -73,11 +73,12 @@ export default function V2Dashboard() {
 
   const primaryTerminal = terminals?.[0] // TODO: make primaryTerminalOf hook and use it
 
-  const { data: distributionLimitData } = useProjectDistributionLimit({
-    projectId,
-    configuration: fundingCycle?.configuration?.toString(),
-    terminal: primaryTerminal,
-  })
+  const { data: distributionLimitData, loading: distributionLimitLoading } =
+    useProjectDistributionLimit({
+      projectId,
+      configuration: fundingCycle?.configuration?.toString(),
+      terminal: primaryTerminal,
+    })
 
   const { data: usedDistributionLimit } = useUsedDistributionLimit({
     projectId,
@@ -166,6 +167,7 @@ export default function V2Dashboard() {
     loading: {
       ETHBalanceLoading,
       balanceInDistributionLimitCurrencyLoading,
+      distributionLimitLoading,
     },
   }
 

--- a/src/components/v2/V2Dashboard/Dashboard.tsx
+++ b/src/components/v2/V2Dashboard/Dashboard.tsx
@@ -13,7 +13,6 @@ import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
 import useProjectTerminals from 'hooks/v2/contractReader/ProjectTerminals'
 import { usePaymentTerminalBalance } from 'hooks/v2/contractReader/PaymentTerminalBalance'
 import useProjectToken from 'hooks/v2/contractReader/ProjectToken'
-import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
 import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
 import { useMemo } from 'react'
 import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
@@ -62,14 +61,6 @@ export default function V2Dashboard() {
     ? decodeV2FundingCycleMetadata(fundingCycle?.metadata)
     : undefined
 
-  const { data: queuedFundingCycle } = useProjectQueuedFundingCycle({
-    projectId,
-  })
-
-  const queuedFundingCycleMetadata = queuedFundingCycle
-    ? decodeV2FundingCycleMetadata(queuedFundingCycle?.metadata)
-    : undefined
-
   const { data: payoutSplits } = useProjectSplits({
     projectId,
     splitGroup: ETH_PAYOUT_SPLIT_GROUP,
@@ -97,28 +88,17 @@ export default function V2Dashboard() {
   const [distributionLimit, distributionLimitCurrency] =
     distributionLimitData ?? []
 
-  const { data: queuedPayoutSplits } = useProjectSplits({
-    projectId,
-    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
-    domain: queuedFundingCycle?.configuration?.toString(),
-  })
-
   const { data: reservedTokensSplits } = useProjectSplits({
     projectId,
     splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
     domain: fundingCycle?.configuration?.toString(),
   })
 
-  const { data: queuedReservedTokensSplits } = useProjectSplits({
-    projectId,
-    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
-    domain: queuedFundingCycle?.configuration?.toString(),
-  })
-
-  const { data: ETHBalance } = usePaymentTerminalBalance({
-    terminal: primaryTerminal,
-    projectId,
-  })
+  const { data: ETHBalance, loading: ETHBalanceLoading } =
+    usePaymentTerminalBalance({
+      terminal: primaryTerminal,
+      projectId,
+    })
 
   const { data: tokenAddress } = useProjectToken({
     projectId,
@@ -126,32 +106,29 @@ export default function V2Dashboard() {
 
   const tokenSymbol = useSymbolOfERC20(tokenAddress)
 
-  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
-    projectId,
-    configuration: queuedFundingCycle?.configuration.toString(),
-    terminal: primaryTerminal,
-  })
-  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
-    queuedDistributionLimitData ?? []
-
   const { data: primaryTerminalCurrentOverflow } = useTerminalCurrentOverflow({
     projectId,
     terminal: primaryTerminal,
   })
 
   const converter = useCurrencyConverter()
-  const balanceInDistributionLimitCurrency = useMemo(
-    () =>
-      ETHBalance &&
-      converter.wadToCurrency(
+  const {
+    data: balanceInDistributionLimitCurrency,
+    loading: balanceInDistributionLimitCurrencyLoading,
+  } = useMemo(() => {
+    if (ETHBalanceLoading) return { loading: true }
+
+    return {
+      data: converter.wadToCurrency(
         ETHBalance,
         V2CurrencyName(
           distributionLimitCurrency?.toNumber() as V2CurrencyOption,
         ),
         V2CurrencyName(V2_CURRENCY_ETH),
       ),
-    [ETHBalance, converter, distributionLimitCurrency],
-  )
+      loading: false,
+    }
+  }, [ETHBalance, ETHBalanceLoading, converter, distributionLimitCurrency])
 
   const { data: projectOwnerAddress } = useProjectOwner(projectId)
 
@@ -170,26 +147,26 @@ export default function V2Dashboard() {
     projectMetadata,
     fundingCycle,
     fundingCycleMetadata,
-    queuedFundingCycle,
-    queuedFundingCycleMetadata,
     distributionLimit,
     usedDistributionLimit,
-    queuedDistributionLimit,
     payoutSplits,
-    queuedPayoutSplits,
     reservedTokensSplits,
-    queuedReservedTokensSplits,
     tokenAddress,
     terminals,
+    primaryTerminal,
     ETHBalance,
     distributionLimitCurrency,
-    queuedDistributionLimitCurrency,
     balanceInDistributionLimitCurrency,
     tokenSymbol,
     projectOwnerAddress,
     primaryTerminalCurrentOverflow,
     totalTokenSupply,
     ballotState,
+
+    loading: {
+      ETHBalanceLoading,
+      balanceInDistributionLimitCurrencyLoading,
+    },
   }
 
   return (

--- a/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
@@ -17,6 +17,7 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
     distributionLimit,
     usedDistributionLimit,
     distributionLimitCurrency,
+    loading: { distributionLimitLoading },
   } = useContext(V2ProjectContext)
 
   const secondaryTextStyle = textSecondary(theme)
@@ -24,7 +25,7 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
   return (
     <StatLine
       style={style}
-      loading={!Boolean(distributionLimit)}
+      loading={distributionLimitLoading}
       statLabel={<Trans>Distributed</Trans>}
       statLabelTip={
         <Trans>

--- a/src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
@@ -18,11 +18,12 @@ export default function ProjectBalance({ style }: { style?: CSSProperties }) {
     ETHBalance,
     balanceInDistributionLimitCurrency,
     distributionLimitCurrency,
+    loading: { balanceInDistributionLimitCurrencyLoading },
   } = useContext(V2ProjectContext)
 
   return (
     <StatLine
-      loading={!Boolean(balanceInDistributionLimitCurrency)}
+      loading={balanceInDistributionLimitCurrencyLoading}
       statLabel={<Trans>In Juicebox</Trans>}
       statLabelTip={
         <Trans>The balance of this project in the Juicebox contract.</Trans>

--- a/src/components/v2/V2Project/TreasuryStats/index.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/index.tsx
@@ -14,6 +14,7 @@ export default function TreasuryStats() {
     distributionLimit,
     terminals,
     projectId,
+    loading: { distributionLimitLoading },
   } = useContext(V2ProjectContext)
 
   const { data: overflow, loading: overflowLoading } =
@@ -22,7 +23,7 @@ export default function TreasuryStats() {
       projectId,
     })
 
-  const fundingProgressBarLoading = overflowLoading || !distributionLimit
+  const fundingProgressBarLoading = overflowLoading || distributionLimitLoading
 
   return (
     <Space direction="vertical" style={{ display: 'flex' }}>
@@ -34,7 +35,7 @@ export default function TreasuryStats() {
         paragraph={{ rows: 1, width: ['100%'] }}
         active
       >
-        {!fundingProgressBarLoading ? (
+        {!fundingProgressBarLoading && distributionLimit ? (
           <FundingProgressBar
             targetAmount={distributionLimit}
             balanceInTargetCurrency={balanceInDistributionLimitCurrency}

--- a/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
@@ -3,25 +3,57 @@ import FundingCycleDetailsCard from 'components/shared/Project/FundingCycleDetai
 import { LoadingOutlined } from '@ant-design/icons'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useContext } from 'react'
-import { V2FundingCycleRiskCount } from 'utils/v2/fundingCycle'
+import {
+  decodeV2FundingCycleMetadata,
+  V2FundingCycleRiskCount,
+} from 'utils/v2/fundingCycle'
+
+import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
+
+import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
+
+import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
 
 import FundingCycleDetails from './FundingCycleDetails'
 import PayoutSplitsCard from './PayoutSplitsCard'
 import ReservedTokensSplitsCard from './ReservedTokensSplitsCard'
+import {
+  ETH_PAYOUT_SPLIT_GROUP,
+  RESERVED_TOKEN_SPLIT_GROUP,
+} from 'constants/v2/splits'
 
 export default function UpcomingFundingCycle({
   expandCard,
 }: {
   expandCard?: boolean
 }) {
-  const {
-    queuedFundingCycle,
-    queuedPayoutSplits,
-    queuedDistributionLimitCurrency,
-    queuedDistributionLimit,
-    queuedReservedTokensSplits,
-    queuedFundingCycleMetadata,
-  } = useContext(V2ProjectContext)
+  const { projectId, primaryTerminal } = useContext(V2ProjectContext)
+
+  const { data: queuedFundingCycle } = useProjectQueuedFundingCycle({
+    projectId,
+  })
+  const { data: queuedPayoutSplits } = useProjectSplits({
+    projectId,
+    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
+    domain: queuedFundingCycle?.configuration?.toString(),
+  })
+
+  const { data: queuedReservedTokensSplits } = useProjectSplits({
+    projectId,
+    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
+    domain: queuedFundingCycle?.configuration?.toString(),
+  })
+
+  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
+    projectId,
+    configuration: queuedFundingCycle?.configuration.toString(),
+    terminal: primaryTerminal,
+  })
+  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
+    queuedDistributionLimitData ?? []
+  const queuedFundingCycleMetadata = queuedFundingCycle
+    ? decodeV2FundingCycleMetadata(queuedFundingCycle?.metadata)
+    : undefined
 
   if (!queuedFundingCycle) return <LoadingOutlined />
 

--- a/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
@@ -29,9 +29,10 @@ export default function UpcomingFundingCycle({
 }) {
   const { projectId, primaryTerminal } = useContext(V2ProjectContext)
 
-  const { data: queuedFundingCycle } = useProjectQueuedFundingCycle({
-    projectId,
-  })
+  const { data: queuedFundingCycle, loading: queuedFundingCycleLoading } =
+    useProjectQueuedFundingCycle({
+      projectId,
+    })
   const { data: queuedPayoutSplits } = useProjectSplits({
     projectId,
     splitGroup: ETH_PAYOUT_SPLIT_GROUP,
@@ -55,7 +56,8 @@ export default function UpcomingFundingCycle({
     ? decodeV2FundingCycleMetadata(queuedFundingCycle?.metadata)
     : undefined
 
-  if (!queuedFundingCycle) return <LoadingOutlined />
+  if (queuedFundingCycleLoading || !queuedFundingCycle)
+    return <LoadingOutlined />
 
   const queuedReservedRate = queuedFundingCycleMetadata?.reservedRate
 
@@ -69,7 +71,7 @@ export default function UpcomingFundingCycle({
           }
           fundingCycleDurationSeconds={queuedFundingCycle.duration}
           fundingCycleStartTime={queuedFundingCycle.start}
-          isFundingCycleRecurring={true}
+          isFundingCycleRecurring
           fundingCycleRiskCount={V2FundingCycleRiskCount(queuedFundingCycle)}
           expand={expandCard}
         />

--- a/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
@@ -3,10 +3,7 @@ import FundingCycleDetailsCard from 'components/shared/Project/FundingCycleDetai
 import { LoadingOutlined } from '@ant-design/icons'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useContext } from 'react'
-import {
-  decodeV2FundingCycleMetadata,
-  V2FundingCycleRiskCount,
-} from 'utils/v2/fundingCycle'
+import { V2FundingCycleRiskCount } from 'utils/v2/fundingCycle'
 
 import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
 
@@ -29,10 +26,16 @@ export default function UpcomingFundingCycle({
 }) {
   const { projectId, primaryTerminal } = useContext(V2ProjectContext)
 
-  const { data: queuedFundingCycle, loading: queuedFundingCycleLoading } =
-    useProjectQueuedFundingCycle({
-      projectId,
-    })
+  const {
+    data: queuedFundingCycleResponse,
+    loading: queuedFundingCycleLoading,
+  } = useProjectQueuedFundingCycle({
+    projectId,
+  })
+
+  const [queuedFundingCycle, queuedFundingCycleMetadata] =
+    queuedFundingCycleResponse || []
+
   const { data: queuedPayoutSplits } = useProjectSplits({
     projectId,
     splitGroup: ETH_PAYOUT_SPLIT_GROUP,
@@ -52,9 +55,6 @@ export default function UpcomingFundingCycle({
   })
   const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
     queuedDistributionLimitData ?? []
-  const queuedFundingCycleMetadata = queuedFundingCycle
-    ? decodeV2FundingCycleMetadata(queuedFundingCycle?.metadata)
-    : undefined
 
   if (queuedFundingCycleLoading || !queuedFundingCycle)
     return <LoadingOutlined />

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -29,9 +29,19 @@ import FundingTabContent from 'components/v2/V2Create/forms/FundingForm'
 import TokenTabContent from 'components/v2/V2Create/forms/TokenForm'
 import RulesTabContent from 'components/v2/V2Create/forms/RulesForm'
 
+import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
+
+import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
+
+import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
+
 import { V2ReconfigureFundingDrawer } from './drawers/V2ReconfigureFundingDrawer'
 import { V2ReconfigureProjectDetailsDrawer } from './drawers/V2ReconfigureProjectDetailsDrawer'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
+import {
+  ETH_PAYOUT_SPLIT_GROUP,
+  RESERVED_TOKEN_SPLIT_GROUP,
+} from 'constants/v2/splits'
 
 function ReconfigureButton({
   title,
@@ -82,17 +92,38 @@ export default function V2ProjectReconfigureModal({
   hideProjectDetails?: boolean
 }) {
   const {
-    queuedFundingCycle,
     fundingCycle,
     payoutSplits,
-    queuedPayoutSplits,
     reservedTokensSplits,
-    queuedReservedTokensSplits,
     distributionLimit,
-    queuedDistributionLimit,
     distributionLimitCurrency,
-    queuedDistributionLimitCurrency,
   } = useContext(V2ProjectContext)
+
+  const { projectId, primaryTerminal } = useContext(V2ProjectContext)
+
+  const { data: queuedFundingCycle } = useProjectQueuedFundingCycle({
+    projectId,
+  })
+  const { data: queuedPayoutSplits } = useProjectSplits({
+    projectId,
+    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
+    domain: queuedFundingCycle?.configuration?.toString(),
+  })
+
+  const { data: queuedReservedTokensSplits } = useProjectSplits({
+    projectId,
+    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
+    domain: queuedFundingCycle?.configuration?.toString(),
+  })
+
+  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
+    projectId,
+    configuration: queuedFundingCycle?.configuration.toString(),
+    terminal: primaryTerminal,
+  })
+
+  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
+    queuedDistributionLimitData ?? []
 
   const { contracts } = useContext(V2UserContext)
 

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -101,9 +101,11 @@ export default function V2ProjectReconfigureModal({
 
   const { projectId, primaryTerminal } = useContext(V2ProjectContext)
 
-  const { data: queuedFundingCycle } = useProjectQueuedFundingCycle({
+  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
     projectId,
   })
+
+  const [queuedFundingCycle] = queuedFundingCycleResponse || []
   const { data: queuedPayoutSplits } = useProjectSplits({
     projectId,
     splitGroup: ETH_PAYOUT_SPLIT_GROUP,

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -8,6 +8,7 @@ import { createContext } from 'react'
 type V2ProjectLoadingStates = {
   ETHBalanceLoading: boolean
   balanceInDistributionLimitCurrencyLoading: boolean
+  distributionLimitLoading: boolean
 }
 
 export type V2ProjectContextType = {
@@ -70,5 +71,6 @@ export const V2ProjectContext = createContext<V2ProjectContextType>({
   loading: {
     ETHBalanceLoading: false,
     balanceInDistributionLimitCurrencyLoading: false,
+    distributionLimitLoading: false,
   },
 })

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { BallotState } from 'models/ballot'
+import { V2BallotState } from 'models/ballot'
 import { ProjectMetadataV4 } from 'models/project-metadata'
 import { V2FundingCycle, V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 import { Split } from 'models/v2/splits'
@@ -26,7 +26,7 @@ export type V2ProjectContextType = {
 
   fundingCycleMetadata: V2FundingCycleMetadata | undefined
   fundingCycle: V2FundingCycle | undefined
-  ballotState: BallotState | undefined
+  ballotState: V2BallotState | undefined
 
   distributionLimit: BigNumber | undefined
   distributionLimitCurrency: BigNumber | undefined

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -5,6 +5,11 @@ import { V2FundingCycle, V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 import { Split } from 'models/v2/splits'
 import { createContext } from 'react'
 
+type V2ProjectLoadingStates = {
+  ETHBalanceLoading: boolean
+  balanceInDistributionLimitCurrencyLoading: boolean
+}
+
 export type V2ProjectContextType = {
   isPreviewMode?: boolean
 
@@ -13,30 +18,26 @@ export type V2ProjectContextType = {
   tokenAddress: string | undefined
   tokenSymbol: string | undefined
   terminals: string[] | undefined // array of terminal addresses, 0xABC...
+  primaryTerminal: string | undefined
   ETHBalance: BigNumber | undefined
   projectOwnerAddress: string | undefined
   balanceInDistributionLimitCurrency: BigNumber | undefined
   usedDistributionLimit: BigNumber | undefined // how much has been distributed
 
   fundingCycleMetadata: V2FundingCycleMetadata | undefined
-  queuedFundingCycleMetadata: V2FundingCycleMetadata | undefined
   fundingCycle: V2FundingCycle | undefined
-  queuedFundingCycle: V2FundingCycle | undefined
   ballotState: BallotState | undefined
 
-  distributionLimit: BigNumber | undefined // previously funding target
+  distributionLimit: BigNumber | undefined
   distributionLimitCurrency: BigNumber | undefined
-  queuedDistributionLimit: BigNumber | undefined
-  queuedDistributionLimitCurrency: BigNumber | undefined
 
   payoutSplits: Split[] | undefined
-  queuedPayoutSplits: Split[] | undefined
-
   reservedTokensSplits: Split[] | undefined
-  queuedReservedTokensSplits: Split[] | undefined
 
   primaryTerminalCurrentOverflow: BigNumber | undefined
   totalTokenSupply: BigNumber | undefined
+
+  loading: V2ProjectLoadingStates
 }
 
 export const V2ProjectContext = createContext<V2ProjectContextType>({
@@ -47,28 +48,27 @@ export const V2ProjectContext = createContext<V2ProjectContextType>({
   tokenAddress: undefined,
   tokenSymbol: undefined,
   terminals: undefined,
+  primaryTerminal: undefined,
   ETHBalance: undefined,
   projectOwnerAddress: undefined,
   balanceInDistributionLimitCurrency: undefined,
   usedDistributionLimit: undefined,
 
   fundingCycleMetadata: undefined,
-  queuedFundingCycleMetadata: undefined,
   fundingCycle: undefined,
-  queuedFundingCycle: undefined,
   ballotState: undefined,
 
   distributionLimit: undefined,
   distributionLimitCurrency: undefined,
-  queuedDistributionLimit: undefined,
-  queuedDistributionLimitCurrency: undefined,
 
   payoutSplits: undefined,
-  queuedPayoutSplits: undefined,
-
   reservedTokensSplits: undefined,
-  queuedReservedTokensSplits: undefined,
 
   primaryTerminalCurrentOverflow: undefined,
   totalTokenSupply: undefined,
+
+  loading: {
+    ETHBalanceLoading: false,
+    balanceInDistributionLimitCurrencyLoading: false,
+  },
 })

--- a/src/hooks/v1/contractReader/RedeemRate.ts
+++ b/src/hooks/v1/contractReader/RedeemRate.ts
@@ -1,6 +1,6 @@
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { BigNumber } from '@ethersproject/bignumber'
-import { BallotState } from 'models/ballot'
+import { V1BallotState } from 'models/ballot'
 import { V1ContractName } from 'models/v1/contracts'
 import { V1FundingCycle } from 'models/v1/fundingCycle'
 import { useContext, useMemo } from 'react'
@@ -46,7 +46,7 @@ export function useRedeemRate({
     valueDidChange: bigNumbersDiff,
   })?.add(reservedTicketBalance ? reservedTicketBalance : BigNumber.from(0))
 
-  const currentBallotState = useContractReader<BallotState>({
+  const currentBallotState = useContractReader<V1BallotState>({
     contract: V1ContractName.FundingCycles,
     functionName: 'currentBallotStateOf',
     args: projectId ? [projectId.toHexString()] : null,
@@ -56,7 +56,7 @@ export function useRedeemRate({
     if (!metadata || !totalSupply?.gt(0)) return BigNumber.from(0)
 
     const bondingCurveRate =
-      currentBallotState === BallotState.Active
+      currentBallotState === V1BallotState.Active
         ? metadata.reconfigurationBondingCurveRate
         : metadata.bondingCurveRate
 

--- a/src/hooks/v2/contractReader/BallotState.ts
+++ b/src/hooks/v2/contractReader/BallotState.ts
@@ -1,12 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { BallotState } from 'models/ballot'
+import { V2BallotState } from 'models/ballot'
 
 import { V2ContractName } from 'models/v2/contracts'
 
 import useV2ContractReader from './V2ContractReader'
 
 export function useBallotState(projectId: BigNumber | undefined) {
-  return useV2ContractReader<BallotState>({
+  return useV2ContractReader<V2BallotState>({
     contract: V2ContractName.JBFundingCycleStore,
     functionName: 'currentBallotStateOf',
     args: projectId ? [projectId.toHexString()] : null,

--- a/src/hooks/v2/contractReader/ETHReceivedFromTokens.ts
+++ b/src/hooks/v2/contractReader/ETHReceivedFromTokens.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { BallotState } from 'models/ballot'
+import { V2BallotState } from 'models/ballot'
 import { useContext } from 'react'
 import { parseWad } from 'utils/formatNumber'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
@@ -54,7 +54,7 @@ export function useETHReceivedFromTokens({
     return BigNumber.from(0)
 
   const redemptionRate =
-    ballotState === BallotState.Active
+    ballotState === V2BallotState.Active
       ? fundingCycleMetadata.ballotRedemptionRate
       : fundingCycleMetadata.redemptionRate
 

--- a/src/hooks/v2/contractReader/ProjectQueuedFundingCycle.ts
+++ b/src/hooks/v2/contractReader/ProjectQueuedFundingCycle.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { V2ContractName } from 'models/v2/contracts'
-import { V2FundingCycle } from 'models/v2/fundingCycle'
+import { V2FundingCycle, V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 
 import useV2ContractReader from './V2ContractReader'
 
@@ -9,9 +9,9 @@ export default function useProjectQueuedFundingCycle({
 }: {
   projectId?: BigNumber
 }) {
-  return useV2ContractReader<V2FundingCycle>({
-    contract: V2ContractName.JBFundingCycleStore,
-    functionName: 'queuedOf',
+  return useV2ContractReader<[V2FundingCycle, V2FundingCycleMetadata]>({
+    contract: V2ContractName.JBController,
+    functionName: 'queuedFundingCycleOf',
     args: projectId ? [projectId.toHexString()] : null,
   })
 }

--- a/src/models/ballot.ts
+++ b/src/models/ballot.ts
@@ -1,8 +1,14 @@
-export enum BallotState {
+export enum V1BallotState {
   'Approved' = 0,
   'Active' = 1,
   'Failed' = 2,
   'Standby' = 3,
+}
+
+export enum V2BallotState {
+  'Active' = 0,
+  'Approved' = 1,
+  'Failed' = 2,
 }
 
 export type BallotStrategy = {


### PR DESCRIPTION
- move queued data to where it's needed only
- start adding some loading states


This fixes an issue where skeleton loaders showing on the create project preview (there should be no loading states).
Also ensure we load the most up to date queued fc data, and saves us a few queries on initial page load.

Closes https://github.com/jbx-protocol/juice-interface/issues/796

## What does this PR do and why?

_Provide a description of what this PR does. Link to any relevant GitHub issues,
Notion tasks or Discord discussions._

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
