### PR TITLE
Load FundingForm properly in reconfig

### DIFF
--- a/src/components/v2/V2Create/ProjectPreview.tsx
+++ b/src/components/v2/V2Create/ProjectPreview.tsx
@@ -17,6 +17,7 @@ import { NetworkContext } from 'contexts/networkContext'
 import { V2FundingCycle } from 'models/v2/fundingCycle'
 
 import { getDefaultFundAccessConstraint } from 'utils/v2/fundingCycle'
+import { V2_CURRENCY_ETH } from 'utils/v2/currency'
 
 import V2Project from '../V2Project'
 
@@ -55,7 +56,10 @@ export default function ProjectPreview({
     fundingCycleMetadata,
 
     distributionLimit: fundAccessConstraint?.distributionLimit,
-    distributionLimitCurrency: fundAccessConstraint?.distributionLimitCurrency,
+    distributionLimitCurrency:
+      fundAccessConstraint?.distributionLimitCurrency.eq(0)
+        ? BigNumber.from(V2_CURRENCY_ETH)
+        : fundAccessConstraint?.distributionLimitCurrency,
 
     payoutSplits: payoutGroupedSplits?.splits,
     reservedTokensSplits: reservedTokensGroupedSplits?.splits,

--- a/src/components/v2/V2Create/ProjectPreview.tsx
+++ b/src/components/v2/V2Create/ProjectPreview.tsx
@@ -17,7 +17,6 @@ import { NetworkContext } from 'contexts/networkContext'
 import { V2FundingCycle } from 'models/v2/fundingCycle'
 
 import { getDefaultFundAccessConstraint } from 'utils/v2/fundingCycle'
-import { V2_CURRENCY_ETH } from 'utils/v2/currency'
 
 import V2Project from '../V2Project'
 
@@ -56,10 +55,7 @@ export default function ProjectPreview({
     fundingCycleMetadata,
 
     distributionLimit: fundAccessConstraint?.distributionLimit,
-    distributionLimitCurrency:
-      fundAccessConstraint?.distributionLimitCurrency.eq(0)
-        ? BigNumber.from(V2_CURRENCY_ETH)
-        : fundAccessConstraint?.distributionLimitCurrency,
+    distributionLimitCurrency: fundAccessConstraint?.distributionLimitCurrency,
 
     payoutSplits: payoutGroupedSplits?.splits,
     reservedTokensSplits: reservedTokensGroupedSplits?.splits,
@@ -81,6 +77,7 @@ export default function ProjectPreview({
       ETHBalanceLoading: false,
       balanceInDistributionLimitCurrencyLoading: false,
       distributionLimitLoading: false,
+      fundingCycleLoading: false,
     },
   }
 

--- a/src/components/v2/V2Create/forms/FundingForm/index.tsx
+++ b/src/components/v2/V2Create/forms/FundingForm/index.tsx
@@ -2,13 +2,7 @@ import { Trans } from '@lingui/macro'
 
 import { Button, Form, Space } from 'antd'
 
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from 'react'
+import { useCallback, useContext, useLayoutEffect, useState } from 'react'
 
 import { ThemeContext } from 'contexts/themeContext'
 import { helpPagePath } from 'utils/helpPageHelper'
@@ -40,9 +34,6 @@ import ExternalLink from 'components/shared/ExternalLink'
 import { Split } from 'models/v2/splits'
 
 import { formatFee, MAX_DISTRIBUTION_LIMIT } from 'utils/v2/math'
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
-import { V2FundingCycle } from 'models/v2/fundingCycle'
 import { CurrencyContext } from 'contexts/currencyContext'
 import {
   deriveDurationUnit,
@@ -52,8 +43,6 @@ import {
 import { fromWad, parseWad } from 'utils/formatNumber'
 import BudgetTargetInput from 'components/shared/inputs/BudgetTargetInput'
 import { Link } from 'react-router-dom'
-import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
-import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
 
 import FormItemWarningText from 'components/shared/FormItemWarningText'
 
@@ -65,7 +54,6 @@ import { shadowCard } from 'constants/styles/shadowCard'
 import TargetTypeSelect, { TargetType } from './TargetTypeSelect'
 import DurationInputAndSelect from './DurationInputAndSelect'
 import { DurationUnitsOption } from 'constants/time'
-import { ETH_PAYOUT_SPLIT_GROUP } from 'constants/v2/splits'
 
 type FundingFormFields = {
   duration?: string
@@ -76,8 +64,6 @@ type FundingFormFields = {
 export default function FundingForm({ onFinish }: { onFinish: VoidFunction }) {
   const { theme } = useContext(ThemeContext)
   const { contracts } = useContext(V2UserContext)
-  const { projectId, primaryTerminal, fundingCycle } =
-    useContext(V2ProjectContext)
 
   const {
     currencies: { ETH },
@@ -95,80 +81,18 @@ export default function FundingForm({ onFinish }: { onFinish: VoidFunction }) {
   const [durationEnabled, setDurationEnabled] = useState<boolean>(false)
   const [targetType, setTargetType] = useState<TargetType>('specific')
 
-  // Load redux state (may not exist)
+  const ETHPaymentTerminalFee = useETHPaymentTerminalFee()
+  const feeFormatted = ETHPaymentTerminalFee
+    ? formatFee(ETHPaymentTerminalFee)
+    : undefined
+
+  // Load redux state (will be empty in create flow)
   const { fundAccessConstraints, fundingCycleData, payoutGroupedSplits } =
     useAppSelector(state => state.editingV2Project)
   const fundAccessConstraint =
     getDefaultFundAccessConstraint<SerializedV2FundAccessConstraint>(
       fundAccessConstraints,
     )
-
-  // Load queued FC data of project
-  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
-    projectId,
-  })
-
-  const [queuedFundingCycle] = queuedFundingCycleResponse || []
-
-  let effectiveFundingCycle: V2FundingCycle | undefined
-  // If duration is 0, use current FC (not queued)
-  if (!fundingCycle?.duration || fundingCycle?.duration.eq(0)) {
-    effectiveFundingCycle = fundingCycle
-  } else {
-    effectiveFundingCycle = queuedFundingCycle
-  }
-
-  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
-    projectId,
-    configuration: effectiveFundingCycle?.configuration.toString(),
-    terminal: primaryTerminal,
-  })
-  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
-    queuedDistributionLimitData ?? []
-
-  const { data: queuedPayoutSplits } = useProjectSplits({
-    projectId,
-    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
-    domain: effectiveFundingCycle?.configuration?.toString(),
-  })
-
-  const ETHPaymentTerminalFee = useETHPaymentTerminalFee()
-  const feeFormatted = ETHPaymentTerminalFee
-    ? formatFee(ETHPaymentTerminalFee)
-    : undefined
-
-  // Load queued FC data (if it exists) into redux
-  useEffect(() => {
-    if (queuedDistributionLimitData) {
-      dispatch(
-        editingV2ProjectActions.setDistributionLimit(
-          fromWad(queuedDistributionLimit),
-        ),
-      )
-      dispatch(
-        editingV2ProjectActions.setDistributionLimitCurrency(
-          queuedDistributionLimitCurrency.toNumber().toString(),
-        ),
-      )
-    }
-    if (effectiveFundingCycle?.duration) {
-      dispatch(
-        editingV2ProjectActions.setDuration(
-          effectiveFundingCycle?.duration.toNumber().toString(),
-        ),
-      )
-    }
-    if (queuedPayoutSplits) {
-      dispatch(editingV2ProjectActions.setPayoutSplits(queuedPayoutSplits))
-    }
-  }, [
-    queuedDistributionLimitData,
-    dispatch,
-    effectiveFundingCycle,
-    queuedDistributionLimit,
-    queuedDistributionLimitCurrency,
-    queuedPayoutSplits,
-  ])
 
   // Loads redux state into form
   const resetProjectForm = useCallback(() => {

--- a/src/components/v2/V2Dashboard/Dashboard.tsx
+++ b/src/components/v2/V2Dashboard/Dashboard.tsx
@@ -53,9 +53,10 @@ export default function V2Dashboard() {
   } = useProjectMetadata(metadataCID)
 
   // Calls JBFundingCycleStore.currentOf
-  const { data: fundingCycle } = useProjectCurrentFundingCycle({
-    projectId,
-  })
+  const { data: fundingCycle, loading: fundingCycleLoading } =
+    useProjectCurrentFundingCycle({
+      projectId,
+    })
 
   const fundingCycleMetadata = fundingCycle
     ? decodeV2FundingCycleMetadata(fundingCycle?.metadata)
@@ -168,6 +169,7 @@ export default function V2Dashboard() {
       ETHBalanceLoading,
       balanceInDistributionLimitCurrencyLoading,
       distributionLimitLoading,
+      fundingCycleLoading,
     },
   }
 

--- a/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
@@ -48,7 +48,7 @@ export default function V2FundingCycleSection({
   }
 
   if (!fundingCycle) {
-    return null
+    return <p>No funding cycle</p>
   }
 
   const tabText = ({ text }: { text: string }) => {
@@ -88,7 +88,6 @@ export default function V2FundingCycleSection({
       content: <CurrentFundingCycle expandCard={expandCard} />,
     },
     !isPreviewMode &&
-      fundingCycle &&
       hasFundingDuration(fundingCycleData) && {
         key: 'upcoming',
         label: tabText({ text: t`Upcoming` }),

--- a/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
@@ -34,13 +34,21 @@ export default function V2FundingCycleSection({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const { fundingCycle, isPreviewMode } = useContext(V2ProjectContext)
+  const {
+    fundingCycle,
+    isPreviewMode,
+    loading: { fundingCycleLoading },
+  } = useContext(V2ProjectContext)
 
   const canReconfigure = useHasPermission(V2OperatorPermission.RECONFIGURE)
   const showReconfigureButton = canReconfigure && !isPreviewMode
 
-  if (!fundingCycle) {
+  if (fundingCycleLoading) {
     return <Loading />
+  }
+
+  if (!fundingCycle) {
+    return null
   }
 
   const tabText = ({ text }: { text: string }) => {

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
@@ -102,7 +102,7 @@ export default function DistributeReservedTokensModal({
             <p>
               <Trans>
                 There are no reserved token recipients defined for this funding
-                cycle. The project owner will recieve all available tokens.
+                cycle. The project owner will receive all available tokens.
               </Trans>
             </p>
           ) : null}

--- a/src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -248,10 +248,10 @@ export default function V2RedeemModal({
             <div style={{ fontWeight: 500, marginTop: 20 }}>
               {distributionLimitCurrency?.eq(V2_CURRENCY_USD) ? (
                 <Trans>
-                  You will recieve minimum {minReturnedTokensFormatted} ETH
+                  You will receive minimum {minReturnedTokensFormatted} ETH
                 </Trans>
               ) : (
-                <Trans>You will recieve {minReturnedTokensFormatted} ETH</Trans>
+                <Trans>You will receive {minReturnedTokensFormatted} ETH</Trans>
               )}
             </div>
           ) : null}

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
@@ -1,10 +1,19 @@
 import { Button } from 'antd'
-import { useRef, useState } from 'react'
-import { Provider } from 'react-redux'
+import { useContext, useEffect, useRef, useState } from 'react'
+import { Provider, useDispatch } from 'react-redux'
 import store, { createStore } from 'redux/store'
 
 import { SettingOutlined } from '@ant-design/icons'
 
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
+import { V2FundingCycle } from 'models/v2/fundingCycle'
+import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
+import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
+import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
+import { fromWad } from 'utils/formatNumber'
+
+import { ETH_PAYOUT_SPLIT_GROUP } from 'constants/v2/splits'
 import V2ProjectReconfigureModal from './index'
 
 // This component uses a local version of the entire Redux store
@@ -20,6 +29,9 @@ export default function V2ReconfigureFundingModalTrigger({
   triggerButton?: (onClick: VoidFunction) => JSX.Element
 }) {
   const localStoreRef = useRef<typeof store>()
+  const dispatch = useDispatch()
+  const { projectId, fundingCycle, primaryTerminal } =
+    useContext(V2ProjectContext)
 
   const [reconfigureModalVisible, setReconfigureModalVisible] =
     useState<boolean>(false)
@@ -28,6 +40,68 @@ export default function V2ReconfigureFundingModalTrigger({
     localStoreRef.current = createStore()
     setReconfigureModalVisible(true)
   }
+
+  // Load queued FC data of project
+  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
+    projectId,
+  })
+
+  const [queuedFundingCycle] = queuedFundingCycleResponse || []
+
+  let effectiveFundingCycle: V2FundingCycle | undefined
+  // If duration is 0, use current FC (not queued)
+  if (!fundingCycle?.duration || fundingCycle?.duration.eq(0)) {
+    effectiveFundingCycle = fundingCycle
+  } else {
+    effectiveFundingCycle = queuedFundingCycle
+  }
+
+  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
+    projectId,
+    configuration: effectiveFundingCycle?.configuration.toString(),
+    terminal: primaryTerminal,
+  })
+  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
+    queuedDistributionLimitData ?? []
+
+  const { data: queuedPayoutSplits } = useProjectSplits({
+    projectId,
+    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
+    domain: effectiveFundingCycle?.configuration?.toString(),
+  })
+
+  // Load queued FC data (if it exists) into redux
+  useEffect(() => {
+    if (queuedDistributionLimitData) {
+      dispatch(
+        editingV2ProjectActions.setDistributionLimit(
+          fromWad(queuedDistributionLimit),
+        ),
+      )
+      dispatch(
+        editingV2ProjectActions.setDistributionLimitCurrency(
+          queuedDistributionLimitCurrency.toNumber().toString(),
+        ),
+      )
+    }
+    if (effectiveFundingCycle?.duration) {
+      dispatch(
+        editingV2ProjectActions.setDuration(
+          effectiveFundingCycle?.duration.toNumber().toString(),
+        ),
+      )
+    }
+    if (queuedPayoutSplits) {
+      dispatch(editingV2ProjectActions.setPayoutSplits(queuedPayoutSplits))
+    }
+  }, [
+    queuedDistributionLimitData,
+    dispatch,
+    effectiveFundingCycle,
+    queuedDistributionLimit,
+    queuedDistributionLimitCurrency,
+    queuedPayoutSplits,
+  ])
 
   return (
     <div style={{ textAlign: 'right' }}>

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
@@ -46,7 +46,7 @@ export default function V2ReconfigureFundingModalTrigger({
     projectId,
   })
 
-  const [queuedFundingCycle] = queuedFundingCycleResponse || []
+  const [queuedFundingCycle] = queuedFundingCycleResponse ?? []
 
   let effectiveFundingCycle: V2FundingCycle | undefined
   // If duration is 0, use current FC (not queued)

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -105,7 +105,7 @@ export default function V2ProjectReconfigureModal({
     projectId,
   })
 
-  const [queuedFundingCycle] = queuedFundingCycleResponse || []
+  const [queuedFundingCycle] = queuedFundingCycleResponse ?? []
   const { data: queuedPayoutSplits } = useProjectSplits({
     projectId,
     splitGroup: ETH_PAYOUT_SPLIT_GROUP,

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -9,6 +9,7 @@ type V2ProjectLoadingStates = {
   ETHBalanceLoading: boolean
   balanceInDistributionLimitCurrencyLoading: boolean
   distributionLimitLoading: boolean
+  fundingCycleLoading: boolean
 }
 
 export type V2ProjectContextType = {
@@ -72,5 +73,6 @@ export const V2ProjectContext = createContext<V2ProjectContextType>({
     ETHBalanceLoading: false,
     balanceInDistributionLimitCurrencyLoading: false,
     distributionLimitLoading: false,
+    fundingCycleLoading: false,
   },
 })

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1675,6 +1675,7 @@ msgid "Reconfiguration strategy"
 msgstr ""
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Reconfigure"
 
@@ -2116,8 +2117,8 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr "There are no payouts defined for this funding cycle. The project owner will recieve all available funds."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
-msgstr "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
+msgstr "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 
 #: src/components/Landing/QAs.tsx
 msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
@@ -2523,17 +2524,17 @@ msgstr "You can still redeem your {tokenSymbol} tokens for overflow without clai
 msgid "You have set a funding cycle target."
 msgstr ""
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr "You will receive minimum {minReturnedTokensFormatted} ETH"
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "You will receive {0}{1} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr "You will recieve minimum {minReturnedTokensFormatted} ETH"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
-msgstr "You will recieve {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
+msgstr "You will receive {minReturnedTokensFormatted} ETH"
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1680,6 +1680,7 @@ msgid "Reconfiguration strategy"
 msgstr "Estrategia de reconfiguración"
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
@@ -2121,8 +2122,8 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr "No hay pago definidos para este ciclo de financiamiento. El dueño del proyecto recibirá todos los fondos disponibles."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
-msgstr "No hay beneficiarios de tokens reservados definidos para este ciclo de financiamiento. El dueño del proyecto recibirá todos los tokens disponibles."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
+msgstr ""
 
 #: src/components/Landing/QAs.tsx
 msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
@@ -2528,17 +2529,17 @@ msgstr "Todavía, puedes canjear tus tokens {tokenSymbol} por el exceso sin recl
 msgid "You have set a funding cycle target."
 msgstr "Has establecido un objetivo del ciclo de financiamiento."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Vas a recibir {0}{1} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr "Recibirás al menos {minReturnedTokensFormatted} ETH"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
-msgstr "Recibirás {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1680,6 +1680,7 @@ msgid "Reconfiguration strategy"
 msgstr "Stratégie de reparamétrage"
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr ""
 
@@ -2121,7 +2122,7 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2528,16 +2529,16 @@ msgstr "Vous pouvez toujours récupérer vos tokens {tokenSymbol} de l'overflow 
 msgid "You have set a funding cycle target."
 msgstr "Vous avez défini un objectif du cycle de financement."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Vous recevrez {0}{1} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr ""
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1680,6 +1680,7 @@ msgid "Reconfiguration strategy"
 msgstr "Estratégia de configuração"
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
@@ -2121,8 +2122,8 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr "Não há pagamentos definidos para este ciclo de financiamento. O dono do projeto receberá todos os fundos disponíveis."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
-msgstr "Não há recipientes de tokens reservados definidos para este ciclo de financiamento. O dono do projeto receberá todos os fundos disponíveis."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
+msgstr ""
 
 #: src/components/Landing/QAs.tsx
 msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
@@ -2528,16 +2529,16 @@ msgstr "Você ainda pode resgatar seus tokens {tokenSymbol} para overflow sem re
 msgid "You have set a funding cycle target."
 msgstr "Você definiu a meta do ciclo de financiamento."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Você receberá {0}{1} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr ""
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1680,6 +1680,7 @@ msgid "Reconfiguration strategy"
 msgstr "Стратегия изменения конфигурации"
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Перенастройте"
 
@@ -2121,7 +2122,7 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2528,16 +2529,16 @@ msgstr "Вы по-прежнему можете выкупить свои {token
 msgid "You have set a funding cycle target."
 msgstr "Вы установили цель цикла финансирования."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Вы получите {0}{1} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr ""
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1680,6 +1680,7 @@ msgid "Reconfiguration strategy"
 msgstr "Yeniden yapılandırma stratejisi"
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Yeniden yapılandır"
 
@@ -2121,8 +2122,8 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr "Bu finansman döngüsü için tanımlı ödeme yok. Mevcut tüm fonları proje sahibi alacak."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
-msgstr "Bu finansman döngüsü için tanımlı ayrılmış token yok. Mevcut tüm token'ları proje sahibi alacak."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
+msgstr ""
 
 #: src/components/Landing/QAs.tsx
 msgid "There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports."
@@ -2528,16 +2529,16 @@ msgstr "{tokenSymbol} token'larınızı taşma için talep etmeden de kullanabil
 msgid "You have set a funding cycle target."
 msgstr "Bir finansman döngüsü hedefi belirlediniz."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "{0}{1} ETH alacaksınız"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr ""
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1680,6 +1680,7 @@ msgid "Reconfiguration strategy"
 msgstr "重新配置策略"
 
 #: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "重新配置"
 
@@ -2121,7 +2122,7 @@ msgid "There are no payouts defined for this funding cycle. The project owner wi
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
-msgid "There are no reserved token recipients defined for this funding cycle. The project owner will recieve all available tokens."
+msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr ""
 
 #: src/components/Landing/QAs.tsx
@@ -2528,16 +2529,16 @@ msgstr "未领取的 {tokenSymbol} 代币，依然可以用来赎回溢出池中
 msgid "You have set a funding cycle target."
 msgstr "您设定了一个筹款周期目标。"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "你会收到 {0}{1} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve minimum {minReturnedTokensFormatted} ETH"
-msgstr ""
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will recieve {minReturnedTokensFormatted} ETH"
+msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/shared/forms/TicketingForm.tsx

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -165,6 +165,12 @@ export const editingV2ProjectSlice = createSlice({
         state.fundAccessConstraints[0].distributionLimit = action.payload
       }
     },
+    setDistributionLimitCurrency: (state, action: PayloadAction<string>) => {
+      if (state.fundAccessConstraints.length) {
+        state.fundAccessConstraints[0].distributionLimitCurrency =
+          action.payload
+      }
+    },
     setPayoutSplits: (state, action: PayloadAction<Split[]>) => {
       state.payoutGroupedSplits = {
         ...EMPTY_PAYOUT_GROUPED_SPLITS,

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -15,15 +15,18 @@ import {
   SerializedV2FundingCycleData,
   SerializedV2FundingCycleMetadata,
   SerializedV2FundAccessConstraint,
+  serializeFundAccessConstraint,
 } from 'utils/v2/serializers'
 
 import { redemptionRateFrom } from 'utils/v2/math'
+import { V2_CURRENCY_ETH } from 'utils/v2/currency'
 
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
 } from 'constants/v2/splits'
 import { DEFAULT_BALLOT_STRATEGY } from 'constants/v2/ballotStrategies'
+import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 
 export interface V2ProjectState {
   version: number
@@ -81,6 +84,16 @@ export const defaultFundingCycleMetadata: SerializedV2FundingCycleMetadata =
     dataSource: constants.AddressZero,
   })
 
+export const defaultFundAccessConstraint: SerializedV2FundAccessConstraint =
+  serializeFundAccessConstraint({
+    terminal: '',
+    token: ETH_TOKEN_ADDRESS,
+    distributionLimit: BigNumber.from(0),
+    distributionLimitCurrency: BigNumber.from(V2_CURRENCY_ETH),
+    overflowAllowance: BigNumber.from(0),
+    overflowAllowanceCurrency: BigNumber.from(0),
+  })
+
 export const EMPTY_PAYOUT_GROUPED_SPLITS = {
   group: ETH_PAYOUT_SPLIT_GROUP,
   splits: [],
@@ -96,7 +109,7 @@ export const defaultProjectState: V2ProjectState = {
   projectMetadata: { ...defaultProjectMetadataState },
   fundingCycleData: { ...defaultFundingCycleData },
   fundingCycleMetadata: { ...defaultFundingCycleMetadata },
-  fundAccessConstraints: [],
+  fundAccessConstraints: [defaultFundAccessConstraint],
   payoutGroupedSplits: EMPTY_PAYOUT_GROUPED_SPLITS,
   reservedTokensGroupedSplits: EMPTY_RESERVED_TOKENS_GROUPED_SPLITS,
 }

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -15,19 +15,15 @@ import {
   SerializedV2FundingCycleData,
   SerializedV2FundingCycleMetadata,
   SerializedV2FundAccessConstraint,
-  serializeFundAccessConstraint,
 } from 'utils/v2/serializers'
 
 import { redemptionRateFrom } from 'utils/v2/math'
-import { V2_CURRENCY_ETH } from 'utils/v2/currency'
 
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
 } from 'constants/v2/splits'
 import { DEFAULT_BALLOT_STRATEGY } from 'constants/v2/ballotStrategies'
-import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
-
 export interface V2ProjectState {
   version: number
   projectMetadata: ProjectMetadataV4
@@ -84,16 +80,6 @@ export const defaultFundingCycleMetadata: SerializedV2FundingCycleMetadata =
     dataSource: constants.AddressZero,
   })
 
-export const defaultFundAccessConstraint: SerializedV2FundAccessConstraint =
-  serializeFundAccessConstraint({
-    terminal: '',
-    token: ETH_TOKEN_ADDRESS,
-    distributionLimit: BigNumber.from(0),
-    distributionLimitCurrency: BigNumber.from(V2_CURRENCY_ETH),
-    overflowAllowance: BigNumber.from(0),
-    overflowAllowanceCurrency: BigNumber.from(0),
-  })
-
 export const EMPTY_PAYOUT_GROUPED_SPLITS = {
   group: ETH_PAYOUT_SPLIT_GROUP,
   splits: [],
@@ -109,7 +95,7 @@ export const defaultProjectState: V2ProjectState = {
   projectMetadata: { ...defaultProjectMetadataState },
   fundingCycleData: { ...defaultFundingCycleData },
   fundingCycleMetadata: { ...defaultFundingCycleMetadata },
-  fundAccessConstraints: [defaultFundAccessConstraint],
+  fundAccessConstraints: [],
   payoutGroupedSplits: EMPTY_PAYOUT_GROUPED_SPLITS,
   reservedTokensGroupedSplits: EMPTY_RESERVED_TOKENS_GROUPED_SPLITS,
 }


### PR DESCRIPTION
## What does this PR do and why?

- After redoing the V2ProjectContext, the fundingForm on the reconfig was no longer loading upcoming stuff. Fixed this (Closes #827 )
- Hide upcoming tab and reword 'Reconfigure upcoming' -> 'Reconfigure' when duration is zero:

<img width="565" alt="Screen Shot 2022-04-18 at 5 55 27 pm" src="https://user-images.githubusercontent.com/96150256/163848627-a5226ed3-93f1-4fed-ae61-cc082065a664.png">

(Closes #828 )

- Minor spelling mistake fixes brought to my attention by translators 

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
