### PR TITLE
Re-organise env var comments to before env to avoid malformed variables

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,12 +1,20 @@
-REACT_APP_INFURA_ID= # Infura project id
-REACT_APP_INFURA_NETWORK=mainnet # Name of Infura network (e.g. 'mainnet', 'rinkeby')
+# Infura project id
+REACT_APP_INFURA_ID=
+# Name of Infura network (e.g. 'mainnet', 'rinkeby')
+REACT_APP_INFURA_NETWORK=mainnet
 
-REACT_APP_SUBGRAPH_URL= # URL of Juicebox subgraph from thegraph.com
+# URL of Juicebox subgraph from thegraph.com
+REACT_APP_SUBGRAPH_URL=
 
-REACT_APP_PINATA_PINNER_KEY= # Pinata API key
-REACT_APP_PINATA_PINNER_SECRET= # Pinata API secret
-REACT_APP_PINATA_GATEWAY_HOSTNAME= # Pinata gateway e.g. 'gateway.pinata.cloud'
+# Pinata API key
+REACT_APP_PINATA_PINNER_KEY=
+
+# Pinata API secret
+REACT_APP_PINATA_PINNER_SECRET=
+# Pinata gateway e.g. 'gateway.pinata.cloud'
+REACT_APP_PINATA_GATEWAY_HOSTNAME=
 
 REACT_APP_BLOCKNATIVE_API_KEY=
 
-REACT_APP_SENTRY_DSN= # sentry url. Not needed for development
+# sentry url. Not needed for development
+REACT_APP_SENTRY_DSN=


### PR DESCRIPTION
## What does this PR do and why?

This re-organises the comments in the `example.env` folder to be before the env itself to avoid malformed variables (when left in the final `.env` file).

## Screenshots or screen recordings

NA

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
