### PR TITLE
Flex display languages horizontally

### DIFF
--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -52,7 +52,7 @@ export default function Footer() {
         textAlign: 'center',
       }}
     >
-      <div style={footerLinksStyles}>
+      <div style={{ ...footerLinksStyles, display: 'flex', flexWrap: 'wrap' }}>
         {Object.keys(Languages).map(languageLink)}
       </div>
       <div style={{ ...footerLinksStyles, display: 'flex' }}>


### PR DESCRIPTION
## What does this PR do and why?

Display languages horizontally.

## Screenshots or screen recordings

### Browser 
![image](https://user-images.githubusercontent.com/104132113/164456871-d6bc11fb-8acc-468e-abb3-1a6c8eccca82.png)

### iPhone SE Portrait (375x667)
![image](https://user-images.githubusercontent.com/104132113/164874219-ca0f1bfd-375d-405e-97e9-896a574c13ed.png)

### iPhone 12 Pro Portrait (390x844)
![image](https://user-images.githubusercontent.com/104132113/164874270-c0ed38f1-5c94-497c-9fc6-fa1ff3a16ee4.png)

### iPhone SE Landscape (667x375)
![image](https://user-images.githubusercontent.com/104132113/164874401-48b3ca3a-950b-4a8c-96ad-1b3be15acb70.png)

### iPhone 12 Pro Landscape (844x390)
![image](https://user-images.githubusercontent.com/104132113/164874315-a7508ac4-9761-4585-9d60-3b43ae892b61.png)


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).

Closes https://github.com/jbx-protocol/juice-interface/issues/837