### PR TITLE
Add Etherscan links to FundingCycleDetails

### DIFF
--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -28,7 +28,7 @@ import { V1CurrencyName } from 'utils/v1/currency'
 import TooltipLabel from 'components/shared/TooltipLabel'
 
 import FundingCycleDetailWarning from 'components/shared/Project/FundingCycleDetailWarning'
-import EtherscanLink from 'components/shared/EtherscanLink'
+import FormattedAddress from 'components/shared/FormattedAddress'
 
 import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
 import { FUNDING_CYCLE_WARNING_TEXT } from 'constants/fundingWarningText'
@@ -306,8 +306,7 @@ export default function FundingCycleDetails({
         <div style={{ color: colors.text.secondary }}>
           <div style={{ fontSize: '0.7rem' }}>
             <Trans>
-              Address:{' '}
-              <EtherscanLink value={ballotStrategy.address} type="address" />
+              Address: <FormattedAddress address={ballotStrategy.address} />
             </Trans>
             <br />
             {ballotStrategy.description}

--- a/src/components/v1/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/FundingCycle/FundingCycleDetails.tsx
@@ -28,6 +28,7 @@ import { V1CurrencyName } from 'utils/v1/currency'
 import TooltipLabel from 'components/shared/TooltipLabel'
 
 import FundingCycleDetailWarning from 'components/shared/Project/FundingCycleDetailWarning'
+import EtherscanLink from 'components/shared/EtherscanLink'
 
 import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
 import { FUNDING_CYCLE_WARNING_TEXT } from 'constants/fundingWarningText'
@@ -304,7 +305,10 @@ export default function FundingCycleDetails({
         </FundingCycleDetailWarning>
         <div style={{ color: colors.text.secondary }}>
           <div style={{ fontSize: '0.7rem' }}>
-            <Trans>Address: {ballotStrategy.address}</Trans>
+            <Trans>
+              Address:{' '}
+              <EtherscanLink value={ballotStrategy.address} type="address" />
+            </Trans>
             <br />
             {ballotStrategy.description}
           </div>

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -15,7 +15,7 @@ import { V2CurrencyName } from 'utils/v2/currency'
 import TooltipLabel from 'components/shared/TooltipLabel'
 
 import FundingCycleDetailWarning from 'components/shared/Project/FundingCycleDetailWarning'
-import EtherscanLink from 'components/shared/EtherscanLink'
+import FormattedAddress from 'components/shared/FormattedAddress'
 
 import { getUnsafeV2FundingCycleProperties } from 'utils/v2/fundingCycle'
 
@@ -318,8 +318,7 @@ export default function FundingCycleDetails({
         <div style={{ color: colors.text.secondary }}>
           <div style={{ fontSize: '0.7rem' }}>
             <Trans>
-              Address:{' '}
-              <EtherscanLink value={ballotStrategy.address} type="address" />
+              Address: <FormattedAddress address={ballotStrategy.address} />
             </Trans>
             <br />
             {ballotStrategy.description}

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -15,6 +15,7 @@ import { V2CurrencyName } from 'utils/v2/currency'
 import TooltipLabel from 'components/shared/TooltipLabel'
 
 import FundingCycleDetailWarning from 'components/shared/Project/FundingCycleDetailWarning'
+import EtherscanLink from 'components/shared/EtherscanLink'
 
 import { getUnsafeV2FundingCycleProperties } from 'utils/v2/fundingCycle'
 
@@ -316,7 +317,10 @@ export default function FundingCycleDetails({
         </FundingCycleDetailWarning>
         <div style={{ color: colors.text.secondary }}>
           <div style={{ fontSize: '0.7rem' }}>
-            <Trans>Address: {ballotStrategy.address}</Trans>
+            <Trans>
+              Address:{' '}
+              <EtherscanLink value={ballotStrategy.address} type="address" />
+            </Trans>
             <br />
             {ballotStrategy.description}
           </div>


### PR DESCRIPTION
## What does this PR do and why?

Add a clickable Etherscan address link to the FundingCycleDetails component for v1 and v2.
Handles #839 

## Screenshots or screen recordings

v1

<img width="585" alt="image" src="https://user-images.githubusercontent.com/33093632/164750689-a9f4c142-95a4-4013-8a7e-f99a59abf0a5.png">


v2

<img width="601" alt="image" src="https://user-images.githubusercontent.com/33093632/164750617-b3f77128-ef14-4c80-a08d-b3e17170bf0c.png">


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
