### PR TITLE
Add ENS Name routing support for V2 projects

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -42,7 +42,7 @@ export default function Router() {
           <Projects />
         </Route>
 
-        <Route path="/p/:ensName(*.eth)">
+        <Route path="/p/:ensName(.*.eth)">
           <V2EntryGuard>
             <Suspense fallback={<Loading />}>
               <V2UserProvider>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -11,7 +11,9 @@ import V1CurrencyProvider from 'providers/v1/V1CurrencyProvider'
 import V2EntryGuard from 'components/v2/V2EntryGuard'
 
 const V2Create = lazy(() => import('components/v2/V2Create'))
-const V2Dashboard = lazy(() => import('components/v2/V2Dashboard'))
+const V2DashboardGateway = lazy(
+  () => import('components/v2/V2Dashboard/Gateway'),
+)
 
 function CatchallRedirect() {
   const route = useParams<{ route: string }>()['route']
@@ -39,6 +41,16 @@ export default function Router() {
         <Route path="/projects">
           <Projects />
         </Route>
+
+        <Route path="/p/:ensName(*.eth)">
+          <V2EntryGuard>
+            <Suspense fallback={<Loading />}>
+              <V2UserProvider>
+                <V2DashboardGateway />
+              </V2UserProvider>
+            </Suspense>
+          </V2EntryGuard>
+        </Route>
         <Route path="/p/:handle">
           <V1Dashboard />
         </Route>
@@ -54,7 +66,7 @@ export default function Router() {
           <V2EntryGuard>
             <Suspense fallback={<Loading />}>
               <V2UserProvider>
-                <V2Dashboard />
+                <V2DashboardGateway />
               </V2UserProvider>
             </Suspense>
           </V2EntryGuard>

--- a/src/components/v2/V2Dashboard/Dashboard404.tsx
+++ b/src/components/v2/V2Dashboard/Dashboard404.tsx
@@ -7,8 +7,10 @@ import { padding } from 'constants/styles/padding'
 
 export default function Dashboard404({
   projectId,
+  ensName,
 }: {
   projectId: BigNumber | string | undefined
+  ensName?: string
 }) {
   return (
     <div
@@ -19,7 +21,11 @@ export default function Dashboard404({
       }}
     >
       <h2>
-        <Trans>Project {projectId} not found</Trans>
+        {ensName ? (
+          <Trans>Project for {ensName} not found</Trans>
+        ) : (
+          <Trans>Project {projectId} not found</Trans>
+        )}
       </h2>
     </div>
   )

--- a/src/components/v2/V2Dashboard/Gateway.tsx
+++ b/src/components/v2/V2Dashboard/Gateway.tsx
@@ -1,0 +1,35 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import useProjectENSNameResolver from 'hooks/ProjectENSNameResolver'
+import { useParams } from 'react-router-dom'
+import Loading from 'components/shared/Loading'
+
+import V2Dashboard from '.'
+import Dashboard404 from './Dashboard404'
+
+const parseProjectIdParameter = (projectIdParameter?: string) => {
+  try {
+    return BigNumber.from(projectIdParameter)
+  } catch (e) {
+    return undefined
+  }
+}
+
+export default function V2DashboardGateway() {
+  const {
+    projectId: projectIdParameter,
+    ensName,
+  }: { projectId?: string; ensName?: string } = useParams()
+
+  const { loading, projectId: projectIdForName } = useProjectENSNameResolver({
+    ensName,
+  })
+
+  if (loading) return <Loading />
+
+  const projectId =
+    projectIdForName ?? parseProjectIdParameter(projectIdParameter)
+  if (!projectId)
+    return <Dashboard404 projectId={projectId} ensName={ensName} />
+
+  return <V2Dashboard projectId={projectId} />
+}

--- a/src/components/v2/V2Dashboard/index.tsx
+++ b/src/components/v2/V2Dashboard/index.tsx
@@ -3,7 +3,6 @@ import {
   V2ProjectContextType,
 } from 'contexts/v2/projectContext'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
-import { useParams } from 'react-router-dom'
 import Loading from 'components/shared/Loading'
 import { BigNumber } from '@ethersproject/bignumber'
 import useProjectMetadataContent from 'hooks/v2/contractReader/ProjectMetadataContent'
@@ -39,19 +38,7 @@ import {
   RESERVED_TOKEN_SPLIT_GROUP,
 } from 'constants/v2/splits'
 
-const parseProjectIdParameter = (projectIdParameter?: string) => {
-  try {
-    return BigNumber.from(projectIdParameter)
-  } catch (e) {
-    return undefined
-  }
-}
-
-export default function V2Dashboard() {
-  const { projectId: projectIdParameter }: { projectId?: string } = useParams()
-
-  const projectId = parseProjectIdParameter(projectIdParameter)
-
+export default function V2Dashboard({ projectId }: { projectId: BigNumber }) {
   const { data: metadataCID, loading: metadataURILoading } =
     useProjectMetadataContent(projectId)
 
@@ -149,7 +136,6 @@ export default function V2Dashboard() {
   const { data: ballotState } = useBallotState(projectId)
 
   if (metadataLoading || metadataURILoading) return <Loading />
-
   if (projectId?.eq(0) || metadataError || !metadataCID) {
     return <Dashboard404 projectId={projectId} />
   }

--- a/src/hooks/ProjectENSNameResolver.ts
+++ b/src/hooks/ProjectENSNameResolver.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+
+import { BigNumber } from '@ethersproject/bignumber'
+
+import { readProvider } from 'constants/readProvider'
+
+const JUICEBOX_V2_TXT_RECORD_KEY = 'juicebox_v2'
+
+export const getProjectIdFromENSName = async (ensName: string) => {
+  const resolver = await readProvider.getResolver(ensName)
+
+  const projectId = await resolver?.getText(JUICEBOX_V2_TXT_RECORD_KEY)
+  if (!projectId) return null
+
+  return projectId
+}
+
+export default function useProjectENSNameResolver({
+  ensName,
+}: {
+  ensName?: string
+}) {
+  const [loading, setLoading] = useState<boolean>(false)
+  const [projectId, setProjectId] = useState<BigNumber | null>(null)
+
+  useEffect(() => {
+    const resolve = async () => {
+      setLoading(true)
+      try {
+        if (!ensName) throw new Error('No ENS name')
+
+        const newProjectId = await getProjectIdFromENSName(ensName)
+        if (!newProjectId)
+          throw new Error(`No project ID for ENS name: ${ensName}`)
+
+        setProjectId(BigNumber.from(newProjectId))
+      } catch {
+        setProjectId(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    resolve()
+  }, [ensName])
+
+  return { loading, projectId }
+}

--- a/src/hooks/ProjectENSNameResolver.ts
+++ b/src/hooks/ProjectENSNameResolver.ts
@@ -4,7 +4,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 
 import { readProvider } from 'constants/readProvider'
 
-const JUICEBOX_V2_TXT_RECORD_KEY = 'juicebox_v2'
+const JUICEBOX_V2_TXT_RECORD_KEY = 'juicebox'
 
 export const getProjectIdFromENSName = async (ensName: string) => {
   const resolver = await readProvider.getResolver(ensName)
@@ -25,10 +25,10 @@ export default function useProjectENSNameResolver({
 
   useEffect(() => {
     const resolve = async () => {
-      setLoading(true)
       try {
         if (!ensName) throw new Error('No ENS name')
 
+        setLoading(true)
         const newProjectId = await getProjectIdFromENSName(ensName)
         if (!newProjectId)
           throw new Error(`No project ID for ENS name: ${ensName}`)

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1577,6 +1577,10 @@ msgstr ""
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Project details reconfigurations will create a separate transaction."
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr "Project for {ensName} not found"
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1582,6 +1582,10 @@ msgstr "Detalles del proyecto"
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Las reconfiguraciones de los detalles del proyecto, crearán una transacción separada."
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1582,6 +1582,10 @@ msgstr "Détails du projet"
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Les modifications des détails du projet créeront une transaction à part."
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1582,6 +1582,10 @@ msgstr "Detalhes do projeto"
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "As reconfiguracões dos detalhes do projeto irão criar uma transação separada."
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1582,6 +1582,10 @@ msgstr "Детали проекта"
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Для изменения конфигурации деталей проекта будет создана отдельная транзакция."
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1582,6 +1582,10 @@ msgstr "Proje ayrıntıları"
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr ""
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1582,6 +1582,10 @@ msgstr "项目详情"
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr ""
 
+#: src/components/v2/V2Dashboard/Dashboard404.tsx
+msgid "Project for {ensName} not found"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
 #: src/components/shared/formItems/ProjectPayoutMods.tsx
 msgid "Project handle"


### PR DESCRIPTION
## What does this PR do and why?

What it says on the tin.

Closes https://github.com/jbx-protocol/juice-interface/issues/855

## Screenshots or screen recordings

This ENS name has a text record `juicebox_v2` set to `2` (project ID `2`):

https://app.ens.domains/name/chasemcdude.eth/details

| project ID not found | ens fails (i.e. has no text record) | ens resolves |
| --- | --- | ---|
| <img width="331" alt="Screen Shot 2022-04-24 at 12 34 38 pm" src="https://user-images.githubusercontent.com/94939382/164954856-b5fbe767-e19d-468e-b35e-eb1f1b88d8d8.png"> | <img width="956" alt="Screen Shot 2022-04-24 at 12 45 43 pm" src="https://user-images.githubusercontent.com/94939382/164954860-e594f2bc-930d-4188-957e-c3e2e4971cc6.png"> | <img width="1050" alt="Screen Shot 2022-04-24 at 12 34 52 pm" src="https://user-images.githubusercontent.com/94939382/164954865-8f52a6fc-2f3a-43a3-8024-4fb9af734e43.png"> |




## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
