### PR TITLE
Various small v2 bug fixes

### DIFF
--- a/src/components/shared/Project/FundingCycleDetailsCard.tsx
+++ b/src/components/shared/Project/FundingCycleDetailsCard.tsx
@@ -17,6 +17,7 @@ export default function FundingCycleDetailsCard({
   isFundingCycleRecurring,
   fundingCycleDetails,
   expand,
+  isPreviewMode,
 }: {
   fundingCycleNumber: BigNumber
   fundingCycleStartTime: BigNumber
@@ -25,6 +26,7 @@ export default function FundingCycleDetailsCard({
   fundingCycleDetails: JSX.Element
   isFundingCycleRecurring: boolean
   expand?: boolean
+  isPreviewMode?: boolean
 }) {
   const {
     theme: { colors },
@@ -36,7 +38,9 @@ export default function FundingCycleDetailsCard({
     const endTimeSeconds = fundingCycleStartTime.add(
       fundingCycleDurationSeconds,
     )
-    const formattedTimeLeft = detailedTimeUntil(endTimeSeconds)
+    const formattedTimeLeft = !isPreviewMode
+      ? detailedTimeUntil(endTimeSeconds)
+      : detailedTimeUntil(fundingCycleDurationSeconds)
 
     return (
       <span style={{ color: colors.text.secondary, marginLeft: 10 }}>

--- a/src/components/shared/formItems/ProjectReserved.tsx
+++ b/src/components/shared/formItems/ProjectReserved.tsx
@@ -27,12 +27,14 @@ export default function ProjectReserved({
   onChange,
   checked,
   onToggled,
+  isCreate,
 }: {
   value: number | undefined
   style?: CSSProperties
   onChange: (val?: number) => void
   checked?: boolean
   onToggled?: (checked: boolean) => void
+  isCreate?: boolean // Instance of this form item is in the create flow (not reconfig)
 } & FormItemExt) {
   const {
     theme: { colors },
@@ -64,14 +66,16 @@ export default function ProjectReserved({
     <Form.Item
       extra={
         <>
-          <TabDescription>
-            <Trans>
-              Initial issuance rate will be {formattedNum(initialIssuanceRate)}{' '}
-              tokens / ETH for contributors.{' '}
-              {formattedNum(initialReservedTokensPerEth)} tokens / ETH will be
-              reserved by the project.
-            </Trans>
-          </TabDescription>
+          {isCreate && (
+            <TabDescription>
+              <Trans>
+                Initial issuance rate will be{' '}
+                {formattedNum(initialIssuanceRate)} tokens / ETH for
+                contributors. {formattedNum(initialReservedTokensPerEth)} tokens
+                / ETH will be reserved by the project.
+              </Trans>
+            </TabDescription>
+          )}
           <p>
             <Trans>
               Whenever someone pays your project, this percentage of tokens will

--- a/src/components/v2/V2Create/forms/FundingForm/index.tsx
+++ b/src/components/v2/V2Create/forms/FundingForm/index.tsx
@@ -134,7 +134,8 @@ export default function FundingForm({ onFinish }: { onFinish: VoidFunction }) {
   const resetProjectForm = useCallback(() => {
     const _target = fundAccessConstraint?.distributionLimit ?? '0'
     const _targetCurrency = parseInt(
-      fundAccessConstraint?.distributionLimitCurrency ?? '0',
+      fundAccessConstraint?.distributionLimitCurrency ??
+        V2_CURRENCY_ETH.toString(),
     ) as V2CurrencyOption
 
     const durationSeconds = fundingCycleData

--- a/src/components/v2/V2Create/forms/TokenForm/ReservedTokensFormItem.tsx
+++ b/src/components/v2/V2Create/forms/TokenForm/ReservedTokensFormItem.tsx
@@ -14,12 +14,14 @@ export default function ReservedTokensFormItem({
   onReservedTokensSplitsChange,
   style = {},
   onChange,
+  isCreate,
 }: {
   initialValue: number | undefined
   reservedTokensSplits: Split[]
   onReservedTokensSplitsChange: (splits: Split[]) => void
   onChange: (val?: number) => void
   style?: CSSProperties
+  isCreate?: boolean // Instance of this form item is in the create flow (not reconfig)
 } & FormItemExt) {
   // Using a state here because relying on the form does not
   // pass through updated reservedRate to ProjectTicketMods
@@ -50,6 +52,7 @@ export default function ReservedTokensFormItem({
             onChange(parseInt(defaultFundingCycleMetadata.reservedRate))
         }}
         hideLabel={hideLabel}
+        isCreate={isCreate}
       />
 
       {hasReservedRate ? (

--- a/src/components/v2/V2Create/forms/TokenForm/index.tsx
+++ b/src/components/v2/V2Create/forms/TokenForm/index.tsx
@@ -56,10 +56,12 @@ function DiscountRateExtra({
   hasDuration,
   initialIssuanceRate,
   discountRatePercent,
+  isCreate,
 }: {
   hasDuration?: boolean
   initialIssuanceRate: number
   discountRatePercent: number
+  isCreate?: boolean
 }) {
   const discountRateDecimal = discountRatePercent * 0.01
 
@@ -83,7 +85,7 @@ function DiscountRateExtra({
           pay your project earlier than later.
         </Trans>
       </p>
-      {discountRatePercent > 0 && (
+      {discountRatePercent > 0 && isCreate && (
         <>
           <TabDescription style={{ marginTop: 20 }}>
             The issuance rate of your second funding cycle will be{' '}
@@ -97,7 +99,13 @@ function DiscountRateExtra({
   )
 }
 
-export default function TokenForm({ onFinish }: { onFinish: VoidFunction }) {
+export default function TokenForm({
+  onFinish,
+  isCreate,
+}: {
+  onFinish: VoidFunction
+  isCreate?: boolean // If the instance of this form is in the create flow (not reconfig)
+}) {
   const {
     theme,
     theme: { colors },
@@ -197,14 +205,16 @@ export default function TokenForm({ onFinish }: { onFinish: VoidFunction }) {
   return (
     <Form layout="vertical" onFinish={onTokenFormSaved}>
       <Space size="middle" direction="vertical">
-        <TabDescription>
-          <Trans>
-            By default, the issuance rate for your project's token is 1,000,000
-            tokens / 1 ETH. For example, a 1 ETH contribution to your project
-            will return 1,000,000 tokens. You can manipulate the issuance rate
-            with the following configurations.
-          </Trans>
-        </TabDescription>
+        {isCreate && (
+          <TabDescription>
+            <Trans>
+              By default, the issuance rate for your project's token is
+              1,000,000 tokens / 1 ETH. For example, a 1 ETH contribution to
+              your project will return 1,000,000 tokens. You can manipulate the
+              issuance rate with the following configurations.
+            </Trans>
+          </TabDescription>
+        )}
 
         <div>
           <ReservedTokensFormItem
@@ -219,6 +229,7 @@ export default function TokenForm({ onFinish }: { onFinish: VoidFunction }) {
             style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}
             reservedTokensSplits={reservedTokensSplits}
             onReservedTokensSplitsChange={setReservedTokensSplits}
+            isCreate={isCreate}
           />
 
           <Form.Item
@@ -227,6 +238,7 @@ export default function TokenForm({ onFinish }: { onFinish: VoidFunction }) {
                 hasDuration={canSetDiscountRate}
                 initialIssuanceRate={initialIssuanceRate}
                 discountRatePercent={discountRatePercent}
+                isCreate={isCreate}
               />
             }
             label={

--- a/src/components/v2/V2Create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
+++ b/src/components/v2/V2Create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
@@ -135,6 +135,7 @@ export default function FundingCycleTabContent({
           onFinish={() => {
             setTokenDrawerVisible(false)
           }}
+          isCreate
         />
       </Drawer>
       <Drawer

--- a/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
@@ -63,9 +63,10 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
             <TooltipLabel
               tip={
                 <Trans>
-                  The target for this funding cycle is 0, meaning all funds in
-                  Juicebox are currently considered overflow. Overflow can be
-                  redeemed by token holders, but not distributed.
+                  The distribution limit for this funding cycle is 0, meaning
+                  all funds in Juicebox are currently considered overflow.
+                  Overflow can be redeemed by token holders, but not
+                  distributed.
                 </Trans>
               }
               label={<Trans>100% overflow</Trans>}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2154,6 +2154,10 @@ msgstr "The code could always use more eyes and more critique to further the com
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
@@ -2197,7 +2201,6 @@ msgid "The rest is left to share between token holders."
 msgstr "The rest is left to share between token holders."
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr ""
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2159,6 +2159,10 @@ msgstr "El código siempre podrá usar más ojos y más críticas para acrecenta
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "El equipo de contratos va a estar trabajando pronto en terminales de pago L2 para los proyectos en Juicebox."
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr ""
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
@@ -2202,7 +2206,6 @@ msgid "The rest is left to share between token holders."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "El objetivo para este ciclo de financiamiento es 0, lo que significa que todos los fondos en Juicebox actualmente se consideran excedente. El excedente puede canjearse por poseedores de tokens, pero no distribuidos."
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2159,6 +2159,10 @@ msgstr ""
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "L'équipe du contrat commencera bientôt à travailler sur les terminaux de paiement L2 pour les projets Juicebox."
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr ""
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
@@ -2202,7 +2206,6 @@ msgid "The rest is left to share between token holders."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr ""
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2159,6 +2159,10 @@ msgstr "O código sempre poderia usar mais olhos e mais críticas para proseguir
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "Os contribuintes fundadores, então, trabalharão nos terminais de pagamento L2 para projetos do Juicebox."
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr ""
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
@@ -2202,7 +2206,6 @@ msgid "The rest is left to share between token holders."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "O objetivo desse ciclo de financiamento é 0, o que significa que todos os fundos no Juicebox são atualmente considerados overflow. Overflow pode ser resgatado por detentores de tokens, mas não distribuído."
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2159,6 +2159,10 @@ msgstr "Коду всегда не помешает больше глаз и б�
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "В ближайшее время контрактная команда начнет работу над платежными терминалами L2 для проектов Juicebox."
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr ""
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
@@ -2202,7 +2206,6 @@ msgid "The rest is left to share between token holders."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Целью данного цикла финансирования является 0, то есть все средства в Juicebox в настоящее время считаются переполнением. Переполнение может быть использовано держателями токенов, но не распределено."
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2159,6 +2159,10 @@ msgstr "Kod, topluluğun güvenini artırmak için her zaman daha fazla göz ve 
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "Sözleşme ekibi yakında, Juicebox projeleri için L2 ödeme terminalleri üzerinde çalışmaya başlayacak."
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr ""
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
@@ -2202,7 +2206,6 @@ msgid "The rest is left to share between token holders."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Bu finansman döngüsü için hedef 0'dır, yani Juicebox'taki tüm fonlar şu anda taşma olarak kabul edilir. Taşma, token sahipleri tarafından talep edilerek kullanılabilir, ancak dağıtılamaz."
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2159,6 +2159,10 @@ msgstr "如果有更多人来帮助审阅代码，将能够进一步增强社区
 msgid "The contract team will soon start working on L2 payment terminals for Juicebox projects."
 msgstr "合约开发团队将很快开始为 Juicebox 上的项目提供 L2层支付终端。"
 
+#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
+msgstr ""
+
 #: src/components/shared/Project/SpendingStats.tsx
 msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
@@ -2202,7 +2206,6 @@ msgid "The rest is left to share between token holders."
 msgstr ""
 
 #: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "当前筹款周期的目标为零，意味着目前所有资金都视作溢出。代币持有者可以从溢出池中赎回 ETH，但是项目方不能从溢出池中提取资金。"
 

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -31,11 +31,14 @@ export function detailedTimeString({
 
 export function detailedTimeUntil(endTimeSeconds?: BigNumberish) {
   const nowSeconds = Math.floor(Date.now().valueOf() / 1000)
-  const secondsLeft = Math.floor(
-    BigNumber.from(endTimeSeconds).sub(Math.floor(nowSeconds)).toNumber(),
-  )
+  const secondsLeft = BigNumber.from(endTimeSeconds)
+    .sub(Math.floor(nowSeconds))
+    .toNumber()
 
-  return detailedTimeString({ timeSeconds: secondsLeft, roundToMinutes: true })
+  return detailedTimeString({
+    timeSeconds: secondsLeft,
+    roundToMinutes: secondsLeft > 120,
+  })
 }
 
 export const secondsToDays = (seconds: number) => seconds / SECONDS_IN_DAY

--- a/src/utils/v2/math.ts
+++ b/src/utils/v2/math.ts
@@ -6,8 +6,9 @@ import { WeightFunction } from 'utils/math'
 
 const TEN_THOUSAND = 10000
 const ONE_BILLION = 1000000000
-const MaxUint248 = constants.MaxUint256.add(1)
-  .div(2 ** 8)
+
+const MaxUint232 = constants.MaxUint256.add(1)
+  .div(2 ** 24)
   .sub(1)
 
 export const MAX_RESERVED_RATE = TEN_THOUSAND
@@ -15,7 +16,7 @@ export const MAX_REDEMPTION_RATE = TEN_THOUSAND
 export const MAX_DISCOUNT_RATE = ONE_BILLION
 export const SPLITS_TOTAL_PERCENT = ONE_BILLION
 export const MAX_FEE = ONE_BILLION
-export const MAX_DISTRIBUTION_LIMIT = MaxUint248
+export const MAX_DISTRIBUTION_LIMIT = MaxUint232
 
 export const DEFAULT_ISSUANCE_RATE = 10 ** 6
 export const DEFAULT_FUNDING_CYCLE_DURATION = 14


### PR DESCRIPTION
## What does this PR do and why?

1. 'target' -> 'distribution limit' on 'Distributed' tooltip

<img width="282" alt="Screen Shot 2022-04-29 at 9 35 10 pm" src="https://user-images.githubusercontent.com/96150256/166106526-c0bc2ea0-e65d-481b-877e-2c3102616c9c.png">

2. Prevent 'time until next FC' from counting down in the create flow FC preview

3. Fixes failing deploy/reconfig tx when distribution limit = 'No limit' (changes `MAX_DISTRIBUTION_LIMIT` from maxuint248 to maxuint232)

4. Fixes `distributionLimitCurrency` submitting as 0 by default:
	- This fixes the distribute being blank by default ( '/' ):
	
<img width="537" alt="Screen Shot 2022-04-30 at 2 00 54 pm" src="https://user-images.githubusercontent.com/96150256/166106651-c6e14b7a-47d9-4ff3-aac2-4fb0c4b0abe6.png">
	
5. Fixes time until next FC showing as '- -' when it's less than 1min (makes `detailedTimeUntil` round to seconds if the `timeUntil` is less than 2 mins)

6. Hide all the messages about 'initial' token issuance on the reconfig modal since they aren't relavent anymore:

<img width="601" alt="Screen Shot 2022-04-30 at 2 04 40 pm" src="https://user-images.githubusercontent.com/96150256/166106765-0cc9f808-935b-483a-9014-7657cac55314.png">

<img width="554" alt="Screen Shot 2022-04-30 at 2 04 43 pm" src="https://user-images.githubusercontent.com/96150256/166106751-40978ccc-9d5f-4cc2-b5e1-ddc396459a07.png">

<img width="612" alt="Screen Shot 2022-04-30 at 1 42 39 pm" src="https://user-images.githubusercontent.com/96150256/166106737-0e64afa6-9f08-4abd-bea6-54a71f01c961.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).

Closes #882, #850, #864