### PR TITLE
[899] Label overflowing on "add to balance" input 

### DIFF
--- a/src/components/shared/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/shared/modals/ProjectToolDrawerModal.tsx
@@ -179,11 +179,7 @@ export default function ProjectToolDrawerModal({
               Your balance: {formatWad(unclaimedTokenBalance, { precision: 0 })}
             </Trans>
           </p>
-          <Form
-            form={transferTokensForm}
-            labelCol={{ span: 4 }}
-            wrapperCol={{ span: 20 }}
-          >
+          <Form form={transferTokensForm} layout="vertical">
             <Form.Item name="amount" label="Amount">
               <FormattedNumberInput
                 placeholder="0"
@@ -238,11 +234,7 @@ export default function ProjectToolDrawerModal({
               Add funds to this project's balance without minting tokens.
             </Trans>
           </p>
-          <Form
-            form={addToBalanceForm}
-            labelCol={{ span: 4 }}
-            wrapperCol={{ span: 20 }}
-          >
+          <Form form={addToBalanceForm} layout="vertical">
             <Form.Item name="amount" label={t`Pay amount`}>
               <FormattedNumberInput
                 placeholder="0"

--- a/src/components/shared/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/shared/modals/ProjectToolDrawerModal.tsx
@@ -243,7 +243,7 @@ export default function ProjectToolDrawerModal({
             labelCol={{ span: 4 }}
             wrapperCol={{ span: 20 }}
           >
-            <Form.Item name="amount" label={t`Payout amount`}>
+            <Form.Item name="amount" label={t`Pay amount`}>
               <FormattedNumberInput
                 placeholder="0"
                 onChange={amount =>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1476,6 +1476,7 @@ msgstr ""
 msgid "Pay"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1531,7 +1532,6 @@ msgstr ""
 msgid "Payments paused"
 msgstr ""
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr "Payout amount"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1481,6 +1481,7 @@ msgstr "Pausado"
 msgid "Pay"
 msgstr "Pagar"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1536,7 +1537,6 @@ msgstr "Los pagos están pausados para el ciclo de financiamiento en curso."
 msgid "Payments paused"
 msgstr "Pagos pausados"
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr ""

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1481,6 +1481,7 @@ msgstr "Suspendu"
 msgid "Pay"
 msgstr "Payer"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1536,7 +1537,6 @@ msgstr "Les paiements sont suspendus pour le cycle de financement en cours."
 msgid "Payments paused"
 msgstr "Paiements suspendus"
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr ""

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1481,6 +1481,7 @@ msgstr "Pausado"
 msgid "Pay"
 msgstr "Pagar"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1536,7 +1537,6 @@ msgstr "Os pagamentos estão pausados para para o atual ciclo de financiamento."
 msgid "Payments paused"
 msgstr "Pagamentos pausados"
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1481,6 +1481,7 @@ msgstr "Приостановлено"
 msgid "Pay"
 msgstr "Оплатить"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1536,7 +1537,6 @@ msgstr "Платежи приостановлены для текущего ци
 msgid "Payments paused"
 msgstr "Платежи приостановлены"
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr ""

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1481,6 +1481,7 @@ msgstr "Duraklatıldı"
 msgid "Pay"
 msgstr "Ödeme"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1536,7 +1537,6 @@ msgstr "Mevcut finansman döngüsü için ödemeler duraklatıldı."
 msgid "Payments paused"
 msgstr "Ödemeler duraklatıldı"
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr ""

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1481,6 +1481,7 @@ msgstr "已暂停"
 msgid "Pay"
 msgstr "支付"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
@@ -1536,7 +1537,6 @@ msgstr "当前筹款周期暂停付款。"
 msgid "Payments paused"
 msgstr "付款已暂停"
 
-#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payout amount"
 msgstr ""


### PR DESCRIPTION
## What does this PR do and why?

Closes #899 partially. To truly solve label overlap in a columnar form, we should bump antd to 4.18.0+ to use the labelWrap property in the form API though

## Screenshots or screen recordings

<img width="580" alt="image" src="https://user-images.githubusercontent.com/33093632/166317228-207cb094-bd87-48ea-8221-856154251350.png">


## Acceptance checklist

- [ x ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ x ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
