### PR TITLE
Remove conversion tooltip if ETH amount is zero

### DIFF
--- a/src/components/shared/currency/ETHAmount.tsx
+++ b/src/components/shared/currency/ETHAmount.tsx
@@ -49,6 +49,14 @@ export default function ETHAmount({
   })
 
   if (amount) {
+    if (Number(formattedETHAmount) === 0) {
+      return (
+        <>
+          <CurrencySymbol currency="ETH" />
+          {formattedETHAmount}
+        </>
+      )
+    }
     return (
       <Tooltip title={<ETHToUSD ethAmount={amount} />}>
         <CurrencySymbol currency="ETH" />


### PR DESCRIPTION
## What does this PR do and why?

Closes #820 

## Screenshots or screen recordings

<img width="182" alt="image" src="https://user-images.githubusercontent.com/33093632/166324003-4291e514-c79f-4192-97d8-15acbb978832.png">

(I am hovering over the zero)


## Acceptance checklist

- [ x ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ x ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
