### PR TITLE
Fix beneficiary not being set to active wallet

### DIFF
--- a/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -9,7 +9,7 @@ import { NetworkContext } from 'contexts/networkContext'
 import { useCurrencyConverter } from 'hooks/v1/CurrencyConverter'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { formattedNum, formatWad } from 'utils/formatNumber'
 
 import { tokenSymbolText } from 'utils/tokenSymbolText'
@@ -69,6 +69,10 @@ export default function V2ConfirmPayModal({
   const [transactionPending, setTransactionPending] = useState<boolean>()
 
   const [form] = useForm<{ memo: string; beneficiary: string }>()
+
+  useEffect(() => {
+    setBeneficiary(userAddress)
+  }, [userAddress])
 
   const usdAmount = converter.weiToUsd(weiAmount)
 


### PR DESCRIPTION
## What does this PR do and why?

Closes #860. We can get away without using a custom hook for the wallet address and simply using `useEffect` since we're already reacting to changes in address using the network context, but it could be an interesting future feature. I'm just not entirely sure how to implement it.

## Screenshots or screen recordings

## Acceptance checklist

- [ x ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ x ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
