### PR TITLE
Various fixes and feature updates for V2 Reconfigure

### DIFF
--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureFundingDrawer.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureFundingDrawer.tsx
@@ -15,7 +15,7 @@ export function V2ReconfigureFundingDrawer({
   content: JSX.Element
 }) {
   return (
-    <Drawer visible={visible} {...drawerStyle} onClose={onClose}>
+    <Drawer visible={visible} {...drawerStyle} onClose={onClose} destroyOnClose>
       <h3>{title}</h3>
       {FundingDrawersSubtitles}
       <br />


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/888
Closes https://github.com/jbx-protocol/juice-interface/issues/930
Closes https://github.com/jbx-protocol/juice-interface/issues/917

Adds modal feedback for unsaved changes to reconfigure drawers and reconfigure modal.

## Screenshots or screen recordings
### Modal when you first hit reconfigure
![Screen Shot 2022-05-06 at 3 23 31 pm](https://user-images.githubusercontent.com/104132113/167073057-7efd26f0-ef51-4a00-95af-74434fb2df40.png)

### Modal after making a change in a drawer
![Screen Shot 2022-05-06 at 3 23 42 pm](https://user-images.githubusercontent.com/104132113/167073109-953b99a8-3859-4543-a66d-77b04cd6a10b.png)

### Drawer Unsaved Changes Modal
![Screen Shot 2022-05-06 at 3 23 52 pm](https://user-images.githubusercontent.com/104132113/167073121-89d9927a-f092-4c39-9692-aaee70361716.png)

### Global Modal Unsaved Changes Modal
![Screen Shot 2022-05-06 at 3 24 08 pm](https://user-images.githubusercontent.com/104132113/167073157-e0230685-26df-4058-9ffb-906618f03c74.png)

### Video Demo
https://user-images.githubusercontent.com/104132113/167073383-7b7ed975-d5e8-4c11-ba01-9203365344e0.mov

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
