### PR TITLE
Close modal on network change

### DIFF
--- a/src/providers/NetworkProvider.tsx
+++ b/src/providers/NetworkProvider.tsx
@@ -68,6 +68,7 @@ export default function NetworkProvider({
     const config: Subscriptions = {
       address: setAccount,
       wallet: selectWallet,
+      network: networkId => setNetwork(NETWORKS[networkId]?.name),
     }
     setOnboard(initOnboard(config, isDarkMode))
   }, [isDarkMode, onboard, resetWallet])


### PR DESCRIPTION
## What does this PR do and why?

Subscribe to network change events. Means that the modal closes when user changes network.

Closes https://github.com/jbx-protocol/juice-interface/issues/407

This doesn't add an explicit "Switch Network" button to the modal, but this can be handled in https://github.com/jbx-protocol/juice-interface/issues/290

## Screenshots or screen recordings


https://user-images.githubusercontent.com/94939382/167236990-8cf38d1f-9d4a-4a6c-9b00-c01c9a511883.mp4



## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
