### PR TITLE
Route updates for V2

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,13 +3,14 @@ import { Redirect, useParams } from 'react-router'
 import { Suspense, lazy } from 'react'
 import V1Dashboard from 'components/v1/V1Dashboard'
 import Landing from 'components/Landing'
-import V1Create from 'components/v1/V1Create'
 import Projects from 'components/Projects'
 import V2UserProvider from 'providers/v2/UserProvider'
 import Loading from 'components/shared/Loading'
 import V1CurrencyProvider from 'providers/v1/V1CurrencyProvider'
 import V2EntryGuard from 'components/v2/V2EntryGuard'
+import { featureFlagEnabled, FEATURE_FLAGS } from 'utils/featureFlags'
 
+const V1Create = lazy(() => import('components/v1/V1Create'))
 const V2Create = lazy(() => import('components/v2/V2Create'))
 const V2DashboardGateway = lazy(
   () => import('components/v2/V2Dashboard/Gateway'),
@@ -20,7 +21,25 @@ function CatchallRedirect() {
   return <Redirect to={'/p/' + route} />
 }
 
+const V1CreateRoute = () => (
+  <V1CurrencyProvider>
+    <Suspense fallback={<Loading />}>
+      <V1Create />
+    </Suspense>
+  </V1CurrencyProvider>
+)
+
+const V2CreateRoute = () => (
+  <V2EntryGuard>
+    <Suspense fallback={<Loading />}>
+      <V2Create />
+    </Suspense>
+  </V2EntryGuard>
+)
+
 export default function Router() {
+  const isV2Enabled = featureFlagEnabled(FEATURE_FLAGS.ENABLE_V2)
+
   return (
     <HashRouter>
       <Switch>
@@ -30,10 +49,17 @@ export default function Router() {
           </V1CurrencyProvider>
         </Route>
         <Route path="/create">
-          <V1CurrencyProvider>
-            <V1Create />
-          </V1CurrencyProvider>
+          {isV2Enabled ? <V2CreateRoute /> : <V1CreateRoute />}
         </Route>
+        {isV2Enabled ? (
+          <Route path="/v1/create">
+            <V1CreateRoute />
+          </Route>
+        ) : (
+          <Route path="/v2/create">
+            <V2CreateRoute />
+          </Route>
+        )}
 
         <Route path="/projects/:owner">
           <Projects />
@@ -53,13 +79,6 @@ export default function Router() {
         </Route>
         <Route path="/p/:handle">
           <V1Dashboard />
-        </Route>
-        <Route path="/v2/create">
-          <V2EntryGuard>
-            <Suspense fallback={<Loading />}>
-              <V2Create />
-            </Suspense>
-          </V2EntryGuard>
         </Route>
 
         <Route path="/v2/p/:projectId">

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -61,7 +61,7 @@ export default function Footer() {
         {link('Twitter', 'https://twitter.com/juiceboxETH')}
       </div>
       <div style={{ display: 'flex', margin: 'auto' }}>
-        <V2Switch />
+        <V2Switch labelStyle={{ color: '#fff' }} />
       </div>
     </div>
   )

--- a/src/components/Landing/V2Switch.tsx
+++ b/src/components/Landing/V2Switch.tsx
@@ -1,20 +1,26 @@
 import { Switch, Tooltip } from 'antd'
 import { ExclamationCircleOutlined } from '@ant-design/icons'
-
 import {
   FEATURE_FLAGS,
   featureFlagEnabled,
   setFeatureFlag,
+  featureFlagDefaultEnabled,
 } from 'utils/featureFlags'
-
-import { useState } from 'react'
+import { CSSProperties, useContext, useState } from 'react'
 import { Trans } from '@lingui/macro'
-
 import { NetworkName } from 'models/network-name'
+import { ThemeContext } from 'contexts/themeContext'
 
 import { readNetwork } from 'constants/networks'
 
-export default function V2Switch() {
+export default function V2Switch({
+  labelStyle,
+}: {
+  labelStyle?: CSSProperties
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
   const [checked, setChecked] = useState<boolean>(
     featureFlagEnabled(FEATURE_FLAGS.ENABLE_V2),
   )
@@ -31,22 +37,36 @@ export default function V2Switch() {
   // don't show the switch on mainnet for now.
   if (readNetwork.name === NetworkName.mainnet) return null
 
+  const isV2DefaultEnabled = featureFlagDefaultEnabled(FEATURE_FLAGS.ENABLE_V2)
+
   return (
     <Tooltip
       title={
         <>
           <p>
-            <Trans>
-              The Juicebox V2 frontend is still in development. It is{' '}
-              <strong>not recommended</strong> for use on mainnet. Some features
-              are missing and there are known bugs.{' '}
-              <strong>Use with caution.</strong>
-            </Trans>
+            <Trans>Create and view projects on the V2 Juicebox protocol.</Trans>
           </p>
+          {!isV2DefaultEnabled ? (
+            <p>
+              <Trans>
+                The Juicebox V2 frontend is still in development. It is{' '}
+                <strong>not recommended</strong> for use on mainnet. Some
+                features are missing and there are known bugs.{' '}
+                <strong>Use with caution.</strong>
+              </Trans>
+            </p>
+          ) : null}
         </>
       }
     >
-      <label style={{ marginBottom: 5, color: 'white', display: 'block' }}>
+      <label
+        style={{
+          marginBottom: 5,
+          color: colors.text.primary,
+          display: 'block',
+          ...labelStyle,
+        }}
+      >
         <Trans>Enable Juicebox V2</Trans> <ExclamationCircleOutlined />
       </label>
       <Switch onChange={onChange} checked={checked} />

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -168,7 +168,7 @@ export default function Landing() {
                 <div className="hide-mobile">
                   <div style={{ display: 'inline-block' }}>
                     {v2Enabled ? (
-                      <Link to={'/v2/create'}>
+                      <Link to={'/create'}>
                         <Button type="primary" size="large">
                           <Trans>Design your project</Trans>
                         </Button>

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -19,8 +19,6 @@ import { V1TerminalVersion } from 'models/v1/terminals'
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 
-import { featureFlagEnabled, FEATURE_FLAGS } from 'utils/featureFlags'
-
 import { layouts } from 'constants/styles/layouts'
 import TrendingProjects from './TrendingProjects'
 import ProjectsTabs from './ProjectsTabs'
@@ -121,7 +119,6 @@ export default function Projects() {
   }, [selectedTab, fetchNextPage, hasNextPage])
 
   const isLoading = isLoadingProjects || isLoadingSearch
-  const v2Enabled = featureFlagEnabled(FEATURE_FLAGS.ENABLE_V2)
 
   const concatenatedPages = searchText?.length
     ? searchPages
@@ -141,7 +138,7 @@ export default function Projects() {
             <Trans>Projects on Juicebox</Trans>
           </h1>
 
-          <Link to={v2Enabled ? '/v2/create' : '/create'}>
+          <Link to="/create">
             <Button type="primary" size="large">
               <Trans>Create project</Trans>
             </Button>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -659,6 +659,10 @@ msgstr "Create a payable address"
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Create an Ethereum address that can be used to pay your project directly."
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr "Create and view projects on the V2 Juicebox protocol."
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr ""
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr ""
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr ""
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr ""
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr ""
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
+#: src/components/Landing/V2Switch.tsx
+msgid "Create and view projects on the V2 Juicebox protocol."
+msgstr ""
+
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v2/V2Project/LaunchProjectPayerModal.tsx
 msgid "Create payable address"

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -6,12 +6,13 @@ export const FEATURE_FLAGS = {
   ENABLE_V2: 'ENABLE_V2',
 }
 
-const DEFAULTS: { [k: string]: { [j: string]: boolean } } = {
-  [FEATURE_FLAGS.ENABLE_V2]: {
-    [NetworkName.rinkeby]: true,
-    [NetworkName.mainnet]: false,
-  },
-}
+export const FEATURE_FLAG_DEFAULTS: { [k: string]: { [j: string]: boolean } } =
+  {
+    [FEATURE_FLAGS.ENABLE_V2]: {
+      [NetworkName.rinkeby]: true,
+      [NetworkName.mainnet]: false,
+    },
+  }
 
 const featureFlagKey = (baseKey: string) => {
   return `${baseKey}_${readNetwork.name}`
@@ -29,9 +30,17 @@ export const disableFeatureFlag = (featureFlag: string) => {
   setFeatureFlag(featureFlag, false)
 }
 
+export const featureFlagDefaultEnabled = (featureFlag: string) => {
+  // if default-enabled for this environment, return true
+  const defaultEnabled =
+    FEATURE_FLAG_DEFAULTS[featureFlag][readNetwork.name as string]
+
+  return defaultEnabled
+}
+
 export const featureFlagEnabled = (featureFlag: string) => {
   // if default-enabled for this environment, return trues
-  const defaultEnabled = DEFAULTS[featureFlag][readNetwork.name as string]
+  const defaultEnabled = featureFlagDefaultEnabled(featureFlag)
 
   try {
     return JSON.parse(


### PR DESCRIPTION
## What does this PR do and why?

- make `/create` be V2 create when V2 feature flag is enabled
- if  V2 feature flag enabled, add a `/v1/create` route for v1
- if V2 feature flag disabled, add a `/v2/create` route for v2