### PR TITLE
Add message notifying users that v2 projects do not currently appear

### DIFF
--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -247,6 +247,24 @@ export default function Projects() {
               </div>
             )
           )}
+          {concatenatedPages?.length === 0 &&
+            v2Enabled &&
+            !isLoadingSearch &&
+            !isLoadingProjects && (
+              <div
+                style={{
+                  textAlign: 'center',
+                  color: colors.text.disabled,
+                  padding: 20,
+                }}
+              >
+                <InfoCircleOutlined />{' '}
+                <Trans>
+                  Projects on Juicebox V2 don't currently appear in these
+                  results.
+                </Trans>
+              </div>
+            )}
         </React.Fragment>
       ) : selectedTab === 'holdings' ? (
         <div style={{ paddingBottom: 50 }}>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1862,6 +1862,10 @@ msgstr "Projects can be created with an optional discount rate designed to incen
 msgid "Projects on Juicebox"
 msgstr ""
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr "Projects on Juicebox V2 don't currently appear in these results."
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr ""

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1867,6 +1867,10 @@ msgstr "Los proyectos pueden ser creados con una tasa de descuento opcional para
 msgid "Projects on Juicebox"
 msgstr "Proyectos en Juicebox"
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr "Proyectos usando Juicebox"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1867,6 +1867,10 @@ msgstr "Les projets peuvent être créés avec un taux de remise facultatif con�
 msgid "Projects on Juicebox"
 msgstr "Les projets dans Juicebox"
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr "Les projets utilisant Juicebox"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1867,6 +1867,10 @@ msgstr "Os projetos podem ser criados com uma taxa de desconto opcional com intu
 msgid "Projects on Juicebox"
 msgstr "Projetos no Juicebox"
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr "Projetos usando o Juicebox"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1867,6 +1867,10 @@ msgstr "Проекты могут быть созданы с дополните�
 msgid "Projects on Juicebox"
 msgstr "Проекты в Juicebox"
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr "Проекты с использованием Juicebox"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1867,6 +1867,10 @@ msgstr ""
 msgid "Projects on Juicebox"
 msgstr "Juicebox'taki projeler"
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr "Juicebox kullanan projeler"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1867,6 +1867,10 @@ msgstr "创建项目时，可选择配置一个折扣率用于激励早期支持
 msgid "Projects on Juicebox"
 msgstr "Juicebox 上的项目"
 
+#: src/components/Projects/index.tsx
+msgid "Projects on Juicebox V2 don't currently appear in these results."
+msgstr ""
+
 #: src/components/Landing/index.tsx
 msgid "Projects using Juicebox"
 msgstr "正在使用 Juicebox 的项目"


### PR DESCRIPTION
## What does this PR do and why?

Closes #928 

## Screenshots or screen recordings

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/33093632/167256939-76cb9ff5-8ff5-4ccd-a911-465bd6f4d003.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
