### PR TITLE
Fix locked splits bugs payouts modal

### DIFF
--- a/src/components/v2/V2Create/forms/FundingForm/index.tsx
+++ b/src/components/v2/V2Create/forms/FundingForm/index.tsx
@@ -60,6 +60,7 @@ import FormItemWarningText from 'components/shared/FormItemWarningText'
 import SwitchHeading from 'components/shared/SwitchHeading'
 import DistributionSplitsSection from 'components/v2/shared/DistributionSplitsSection'
 import { getTotalSplitsPercentage } from 'utils/v2/distributions'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import isEqual from 'lodash/isEqual'
 
@@ -80,12 +81,15 @@ type FundingFormFields = {
 export default function FundingForm({
   onFormUpdated,
   onFinish,
+  isCreate,
 }: {
   onFormUpdated?: (updated: boolean) => void
   onFinish: VoidFunction
+  isCreate?: boolean // Instance of FundingForm in create flow
 }) {
   const { theme } = useContext(ThemeContext)
   const { contracts } = useContext(V2UserContext)
+  const { payoutSplits } = useContext(V2ProjectContext)
 
   const dispatch = useAppDispatch()
 
@@ -144,16 +148,35 @@ export default function FundingForm({
   } = useMemo(() => {
     const now = new Date().valueOf() / 1000
 
-    return {
-      editableSplits:
-        splits?.filter(
-          split => !split.lockedUntil || split.lockedUntil < now,
-        ) ?? [],
-      lockedSplits:
-        splits?.filter(split => split.lockedUntil && split.lockedUntil > now) ??
-        [],
+    // Checks if the given split exists in the projectContext splits.
+    // If it doesn't, then it means it was just added or edited is which case
+    // we want to still be able to edit it
+    const confirmedSplitsIncludesSplit = (split: Split) => {
+      let includes = false
+      payoutSplits?.forEach(confirmedSplit => {
+        if (isEqual(confirmedSplit, split)) {
+          includes = true
+        }
+      })
+      return includes
     }
-  }, [splits])
+
+    const isLockedSplit = (split: Split) => {
+      return (
+        split.lockedUntil &&
+        split.lockedUntil > now &&
+        !isCreate &&
+        confirmedSplitsIncludesSplit(split)
+      )
+    }
+
+    const lockedSplits = splits?.filter(split => isLockedSplit(split)) ?? []
+    const editableSplits = splits?.filter(split => !isLockedSplit(split)) ?? []
+    return {
+      lockedSplits,
+      editableSplits,
+    }
+  }, [splits, isCreate, payoutSplits])
 
   useLayoutEffect(() => setEditingSplits(editableSplits), [editableSplits])
 

--- a/src/components/v2/V2Create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
+++ b/src/components/v2/V2Create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
@@ -150,6 +150,7 @@ export default function FundingCycleTabContent({
           onFinish={() => {
             setFundingDrawerVisible(false)
           }}
+          isCreate
         />
       </Drawer>
       <Drawer

--- a/src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+++ b/src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
@@ -48,7 +48,7 @@ const findTransactionReceipt = async (txHash: string) => {
  */
 const getProjectIdFromReceipt = (txReceipt: TransactionReceipt): number => {
   const projectIdHex =
-    txReceipt.logs[CREATE_EVENT_IDX]?.topics?.[PROJECT_ID_TOPIC_IDX]
+    txReceipt?.logs[CREATE_EVENT_IDX]?.topics?.[PROJECT_ID_TOPIC_IDX]
   const projectId = BigNumber.from(projectIdHex).toNumber()
 
   return projectId

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
@@ -24,8 +24,9 @@ import { CurrencyName } from 'constants/currency'
 
 export default function DistributionSplitCard({
   split,
-  splitIndex,
+  editableSplitIndex,
   splits,
+  editableSplits,
   onSplitsChanged,
   distributionLimit,
   currencyName,
@@ -33,7 +34,8 @@ export default function DistributionSplitCard({
 }: {
   split: Split
   splits: Split[]
-  splitIndex: number
+  editableSplits: Split[]
+  editableSplitIndex: number
   onSplitsChanged: (splits: Split[]) => void
   distributionLimit: string | undefined
   currencyName: CurrencyName
@@ -70,7 +72,7 @@ export default function DistributionSplitCard({
           (isLocked ? colors.stroke.disabled : colors.stroke.tertiary),
         borderRadius: radii.md,
       }}
-      key={split.beneficiary ?? '' + splitIndex}
+      key={split.beneficiary ?? '' + editableSplitIndex}
     >
       <Space
         direction="vertical"
@@ -141,7 +143,9 @@ export default function DistributionSplitCard({
 
         <Row gutter={gutter} style={{ width: '100%' }} align="middle">
           <Col span={labelColSpan}>
-            <label>Percentage:</label>
+            <label>
+              <Trans>Percentage:</Trans>
+            </label>
           </Col>
           <Col span={dataColSpan}>
             <div
@@ -201,24 +205,27 @@ export default function DistributionSplitCard({
           type="text"
           onClick={e => {
             onSplitsChanged([
-              ...splits.slice(0, splitIndex),
-              ...splits.slice(splitIndex + 1),
+              ...splits.slice(0, editableSplitIndex),
+              ...splits.slice(editableSplitIndex + 1),
             ])
             e.stopPropagation()
           }}
           icon={<CloseCircleOutlined />}
         />
       )}
-      <DistributionSplitModal
-        visible={editSplitModalOpen}
-        onSplitsChanged={onSplitsChanged}
-        mode={'Edit'}
-        splits={splits}
-        distributionLimit={distributionLimit}
-        onClose={() => setEditSplitModalOpen(false)}
-        currencyName={currencyName}
-        splitIndex={splitIndex}
-      />
+      {!isLocked ? (
+        <DistributionSplitModal
+          visible={editSplitModalOpen}
+          onSplitsChanged={onSplitsChanged}
+          editableSplits={editableSplits}
+          mode={'Edit'}
+          splits={splits}
+          distributionLimit={distributionLimit}
+          onClose={() => setEditSplitModalOpen(false)}
+          currencyName={currencyName}
+          editableSplitIndex={editableSplitIndex}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/v2/shared/DistributionSplitsSection/index.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/index.tsx
@@ -47,7 +47,8 @@ export default function DistributionSplitsSection({
         <DistributionSplitCard
           split={split}
           splits={allSplits}
-          splitIndex={index}
+          editableSplits={editableSplits}
+          editableSplitIndex={index}
           distributionLimit={distributionLimit}
           onSplitsChanged={onSplitsChanged}
           currencyName={currencyName}
@@ -55,7 +56,13 @@ export default function DistributionSplitsSection({
         />
       )
     },
-    [distributionLimit, onSplitsChanged, allSplits, currencyName],
+    [
+      distributionLimit,
+      onSplitsChanged,
+      allSplits,
+      currencyName,
+      editableSplits,
+    ],
   )
 
   if (!allSplits) return null
@@ -120,6 +127,7 @@ export default function DistributionSplitsSection({
         onSplitsChanged={onSplitsChanged}
         mode={'Add'}
         splits={allSplits}
+        editableSplits={editableSplits}
         distributionLimit={distributionLimit}
         currencyName={currencyName}
         onClose={() => setAddSplitModalVisible(false)}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1742,6 +1742,10 @@ msgstr "Percentage of the distribution limit this payee will receive."
 msgid "Percentage this payee will receive of all funds raised."
 msgstr "Percentage this payee will receive of all funds raised."
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr "Percentage:"
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Percentages must add up to 100% or less"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1747,6 +1747,10 @@ msgstr ""
 msgid "Percentage this payee will receive of all funds raised."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Los porcentajes deben sumar 100% o menos"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1747,6 +1747,10 @@ msgstr ""
 msgid "Percentage this payee will receive of all funds raised."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Les pourcentages doivent totaliser 100% ou moins"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1747,6 +1747,10 @@ msgstr ""
 msgid "Percentage this payee will receive of all funds raised."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Porcentagens devem atingir 100% ou menos"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1747,6 +1747,10 @@ msgstr ""
 msgid "Percentage this payee will receive of all funds raised."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Сумма процентов должна составлять 100 % или меньше"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1747,6 +1747,10 @@ msgstr ""
 msgid "Percentage this payee will receive of all funds raised."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Yüzdelerin toplamı %100 veya daha az olmalıdır"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1747,6 +1747,10 @@ msgstr ""
 msgid "Percentage this payee will receive of all funds raised."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+msgid "Percentage:"
+msgstr ""
+
 #: src/components/shared/formItems/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "百分比总数相加必须少于或等于100%"


### PR DESCRIPTION
## What does this PR do and why?

Kinda a messy one here. This fixes several problems around adding locked splits (if you play around with them on Rinkeby right now you'll see how many problems there are). 

The way it works now is this:
- In create flow, all splits (even with lockedUntil set are editable)
- In reconfig, if a split has a lockedUntil it can't be edited. But, if a split is added with a lockedUntil, it can be edited. And if an existing split is edited and given a lockedUntil, it can be reedited. 

Please have a good click around the payouts on create and reconfig with locked and unlocked splits. Edit and re-edit them, submit, etc. and see if it's all behaving as you'd expect. 

## Screenshots or screen recordings

Not necessary

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
