### PR TITLE
add background to project logo

### DIFF
--- a/src/components/shared/ProjectLogo.tsx
+++ b/src/components/shared/ProjectLogo.tsx
@@ -29,15 +29,16 @@ export default function ProjectLogo({
       }}
     >
       {uri ? (
-        <div
+        <img
           style={{
-            height: '100%',
-            width: '100%',
-            backgroundPosition: 'center',
-            backgroundSize: 'cover',
-            backgroundImage: `url(${uri})`,
+            maxHeight: '100%',
+            minWidth: '100%',
+            objectPosition: 'center',
+            objectFit: 'cover',
             backgroundColor: '#fbf9f6',
           }}
+          src={uri}
+          alt={name + ' logo'}
         />
       ) : (
         <div

--- a/src/components/shared/ProjectLogo.tsx
+++ b/src/components/shared/ProjectLogo.tsx
@@ -29,15 +29,15 @@ export default function ProjectLogo({
       }}
     >
       {uri ? (
-        <img
+        <div
           style={{
-            maxHeight: '100%',
-            minWidth: '100%',
-            objectFit: 'cover',
-            objectPosition: 'center',
+            height: '100%',
+            width: '100%',
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+            backgroundImage: `url(${uri})`,
+            backgroundColor: '#fbf9f6',
           }}
-          src={uri}
-          alt={name + ' logo'}
         />
       ) : (
         <div


### PR DESCRIPTION
## What does this PR do and why?

Adds a background to project logos, due to low visibility for some logos on dark theme, as outlined in https://github.com/jbx-protocol/juice-interface/issues/848

## Screenshots or screen recordings

<img width="432" alt="Screen Shot 2022-05-11 at 7 28 49" src="https://user-images.githubusercontent.com/35680780/167769653-4633f3ba-b428-421f-810d-fdf77fdb1f58.png">


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
