### PR TITLE
add clickable timestamp

### DIFF
--- a/src/components/shared/EtherscanLink.tsx
+++ b/src/components/shared/EtherscanLink.tsx
@@ -3,6 +3,7 @@ import { t } from '@lingui/macro'
 import { NetworkName } from 'models/network-name'
 import { LinkOutlined } from '@ant-design/icons'
 import { CSSProperties } from 'react'
+import { formatHistoricalDate } from 'utils/formatDate'
 
 import { readNetwork } from 'constants/networks'
 import ExternalLink from './ExternalLink'
@@ -12,11 +13,13 @@ export default function EtherscanLink({
   type,
   truncated,
   style,
+  timestamp,
 }: {
   value: string | undefined
   type: 'tx' | 'address'
   truncated?: boolean
   style?: CSSProperties
+  timestamp?: number
 }) {
   if (!value) return null
   let truncatedValue: string | undefined
@@ -34,6 +37,16 @@ export default function EtherscanLink({
     className: 'hover-action',
     style: { ...style, fontWeight: 400 },
     href: `https://${subdomain}etherscan.io/${type}/${value}`,
+  }
+
+  if (timestamp) {
+    return (
+      <Tooltip title={t`Go to Etherscan`}>
+        <ExternalLink {...linkProps}>
+          {formatHistoricalDate(timestamp * 1000)}
+        </ExternalLink>
+      </Tooltip>
+    )
   }
 
   if (type === 'tx') {

--- a/src/components/v1/V1Project/ProjectActivity/PaymentActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/PaymentActivity.tsx
@@ -7,7 +7,6 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import { PayEvent } from 'models/subgraph-entities/pay-event'
 import React, { useCallback, useContext } from 'react'
-import { formatHistoricalDate } from 'utils/formatDate'
 
 import ActivityTabContent from './ActivityTabContent'
 import RichNote from '../../../shared/RichNote'
@@ -115,8 +114,11 @@ export function PaymentActivity({ pageSize }: { pageSize: number }) {
                 <div style={{ textAlign: 'right' }}>
                   {e.timestamp && (
                     <div style={smallHeaderStyle(colors)}>
-                      {formatHistoricalDate(e.timestamp * 1000)}{' '}
-                      <EtherscanLink value={e.txHash} type="tx" />
+                      <EtherscanLink
+                        timestamp={e.timestamp}
+                        value={e.txHash}
+                        type="tx"
+                      />
                     </div>
                   )}
                   <div

--- a/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/RedeemActivity.tsx
@@ -6,7 +6,6 @@ import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import React, { useContext } from 'react'
-import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -99,10 +98,11 @@ export function RedeemActivity({ pageSize }: { pageSize: number }) {
                       textAlign: 'right',
                     }}
                   >
-                    {e.timestamp && (
-                      <span>{formatHistoricalDate(e.timestamp * 1000)}</span>
-                    )}{' '}
-                    <EtherscanLink value={e.txHash} type="tx" />
+                    <EtherscanLink
+                      timestamp={e.timestamp}
+                      value={e.txHash}
+                      type="tx"
+                    />
                   </div>
                   <div
                     style={{

--- a/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/ReservesEventElem.tsx
@@ -6,7 +6,6 @@ import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { PrintReservesEvent } from 'models/subgraph-entities/print-reserves-event'
 import { useContext } from 'react'
-import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -77,12 +76,11 @@ export default function ReservesEventElem({
 
         <div style={{ textAlign: 'right' }}>
           <div style={smallHeaderStyle(colors)}>
-            {printReservesEvent.timestamp && (
-              <span>
-                {formatHistoricalDate(printReservesEvent.timestamp * 1000)}
-              </span>
-            )}{' '}
-            <EtherscanLink value={printReservesEvent.txHash} type="tx" />
+            <EtherscanLink
+              timestamp={printReservesEvent.timestamp}
+              value={printReservesEvent.txHash}
+              type="tx"
+            />
           </div>
           <div style={smallHeaderStyle(colors)}>
             called by <FormattedAddress address={printReservesEvent.caller} />

--- a/src/components/v1/V1Project/ProjectActivity/TapEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/TapEventElem.tsx
@@ -7,7 +7,6 @@ import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { TapEvent } from 'models/subgraph-entities/tap-event'
 import { useContext } from 'react'
-import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 
 import { smallHeaderStyle } from '../styles'
@@ -76,10 +75,11 @@ export default function TapEventElem({
           }}
         >
           <div style={smallHeaderStyle(colors)}>
-            {tapEvent.timestamp && (
-              <span>{formatHistoricalDate(tapEvent.timestamp * 1000)}</span>
-            )}{' '}
-            <EtherscanLink value={tapEvent.txHash} type="tx" />
+            <EtherscanLink
+              timestamp={tapEvent.timestamp}
+              value={tapEvent.txHash}
+              type="tx"
+            />
           </div>
           <div style={smallHeaderStyle(colors)}>
             called by <FormattedAddress address={tapEvent.caller} />


### PR DESCRIPTION
## What does this PR do and why?

This adds a clickable timestamp that links to etherscan, as outlined in issue https://github.com/jbx-protocol/juice-interface/issues/838

The timestamp was previously duplicated in four components, but is now moved in to the EtherscanLink component as an optional `timestamp` parameter.

## Screenshots or screen recordings


https://user-images.githubusercontent.com/35680780/167772090-3a21e1e8-0b53-4712-a04c-dc438131deaa.mov



## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
