### PR TITLE
Add link to v2 project in activity feed

### DIFF
--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -60,7 +60,6 @@ export default function Payments() {
                 borderBottom: '1px solid ' + colors.stroke.tertiary,
               }}
             >
-              <ProjectHandle project={e.project} />
               <div
                 style={{
                   display: 'flex',
@@ -68,6 +67,8 @@ export default function Payments() {
                   alignItems: 'baseline',
                 }}
               >
+                <ProjectHandle project={e.project} />
+
                 <div
                   style={{ fontSize: '.7rem', color: colors.text.secondary }}
                 >

--- a/src/components/Landing/Payments.tsx
+++ b/src/components/Landing/Payments.tsx
@@ -9,6 +9,8 @@ import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 
 import ETHAmount from 'components/shared/currency/ETHAmount'
+import { Project } from 'models/subgraph-entities/vX/project'
+import V2ProjectHandle from 'components/v2/shared/V2ProjectHandle'
 
 export default function Payments() {
   const {
@@ -23,12 +25,26 @@ export default function Payments() {
       'note',
       'timestamp',
       'id',
-      { entity: 'project', keys: ['id'] },
+      { entity: 'project', keys: ['id', 'projectId', 'cv'] },
     ],
     first: 20,
     orderDirection: 'desc',
     orderBy: 'timestamp',
   })
+
+  const ProjectHandle = ({ project }: { project: Partial<Project> }) => {
+    if (!project?.projectId) return null
+
+    return (
+      <div style={{ color: colors.text.action.primary, fontWeight: 500 }}>
+        {project.cv === '2' ? (
+          <V2ProjectHandle projectId={project.projectId} />
+        ) : (
+          <V1ProjectHandle projectId={project.projectId} />
+        )}
+      </div>
+    )
+  }
 
   return (
     <div>
@@ -44,6 +60,7 @@ export default function Payments() {
                 borderBottom: '1px solid ' + colors.stroke.tertiary,
               }}
             >
+              <ProjectHandle project={e.project} />
               <div
                 style={{
                   display: 'flex',
@@ -51,13 +68,6 @@ export default function Payments() {
                   alignItems: 'baseline',
                 }}
               >
-                <div
-                  style={{ color: colors.text.action.primary, fontWeight: 500 }}
-                >
-                  {e.project?.projectId && (
-                    <V1ProjectHandle projectId={e.project.projectId} />
-                  )}
-                </div>
                 <div
                   style={{ fontSize: '.7rem', color: colors.text.secondary }}
                 >

--- a/src/components/shared/ProjectVersionBadge.tsx
+++ b/src/components/shared/ProjectVersionBadge.tsx
@@ -1,0 +1,27 @@
+import { ThemeContext } from 'contexts/themeContext'
+import { useContext } from 'react'
+
+export default function ProjectVersionBadge({
+  versionText,
+  size,
+}: {
+  versionText: string
+  size?: 'small'
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  return (
+    <span
+      style={{
+        padding: size === 'small' ? '0 2px' : '2px 4px',
+        background: colors.background.l1,
+        color: colors.text.tertiary,
+        fontSize: size === 'small' ? '0.7rem' : 'auto',
+      }}
+    >
+      {versionText}
+    </span>
+  )
+}

--- a/src/components/v2/V2Project/V2ProjectHeaderActions.tsx
+++ b/src/components/v2/V2Project/V2ProjectHeaderActions.tsx
@@ -16,6 +16,8 @@ import { useTransferUnclaimedTokensTx } from 'hooks/v2/transactor/TransferUnclai
 import useUserUnclaimedTokenBalance from 'hooks/v2/contractReader/UserUnclaimedTokenBalance'
 import { useDeployProjectPayerTx } from 'hooks/v2/transactor/DeployProjectPayerTx'
 
+import ProjectVersionBadge from 'components/shared/ProjectVersionBadge'
+
 import V2ReconfigureFundingModalTrigger from './V2ProjectReconfigureModal/V2ReconfigureModalTrigger'
 
 export default function V2ProjectHeaderActions() {
@@ -51,14 +53,7 @@ export default function V2ProjectHeaderActions() {
         <Tooltip
           title={t`This project uses the V2 version of the Juicebox contracts.`}
         >
-          <span
-            style={{
-              padding: '2px 4px',
-              background: colors.background.l1,
-            }}
-          >
-            V2
-          </span>
+          <ProjectVersionBadge versionText="V2" />
         </Tooltip>
       </span>
       <ProjectToolDrawerModal

--- a/src/components/v2/shared/V2ProjectHandle.tsx
+++ b/src/components/v2/shared/V2ProjectHandle.tsx
@@ -1,0 +1,28 @@
+import { BigNumberish } from '@ethersproject/bignumber'
+import { Trans } from '@lingui/macro'
+import ProjectVersionBadge from 'components/shared/ProjectVersionBadge'
+import { CSSProperties } from 'react'
+import { Link } from 'react-router-dom'
+
+export default function V2ProjectHandle({
+  projectId,
+  style,
+}: {
+  projectId: BigNumberish
+  style?: CSSProperties
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Link
+        to={`/v2/p/${projectId}`}
+        style={{ fontWeight: 500, ...style }}
+        className="text-primary hover-text-action-primary hover-text-decoration-underline"
+      >
+        <span style={{ marginRight: '0.5rem' }}>
+          <Trans>Project {projectId}</Trans>
+        </span>
+      </Link>
+      <ProjectVersionBadge versionText="V2" size="small" />
+    </div>
+  )
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1934,6 +1934,10 @@ msgstr "Project token"
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "Project {name} will be available soon! Try refreshing the page shortly."
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr "Project {projectId}"
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Project {projectId} not found"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1939,6 +1939,10 @@ msgstr "Token de proyecto"
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr ""
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Proyecto {projectId} no encontrado"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1939,6 +1939,10 @@ msgstr "Token du projet"
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr ""
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Projet {projectId} introuvable"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1939,6 +1939,10 @@ msgstr ""
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr ""
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Projeto {projectId} não encontrado"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1939,6 +1939,10 @@ msgstr ""
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr ""
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Проект {projectId} не найден"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1939,6 +1939,10 @@ msgstr ""
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr ""
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Proje {projectId} bulunamadı"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1939,6 +1939,10 @@ msgstr ""
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
+#: src/components/v2/shared/V2ProjectHandle.tsx
+msgid "Project {projectId}"
+msgstr ""
+
 #: src/components/shared/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "项目 {projectId} 未找到"


### PR DESCRIPTION
## What does this PR do and why?

On homepage activity feed (latest payments:
- fix v1 handles not rendering
- add something for v2


## Screenshots or screen recordings

<img width="556" alt="Screen Shot 2022-05-12 at 9 54 52 am" src="https://user-images.githubusercontent.com/94939382/167968827-363bc3fd-caf0-4a65-8b15-58d04551a5bb.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
