### PR TITLE
Add fallback if project logo fails to load

### DIFF
--- a/src/components/shared/ProjectLogo.tsx
+++ b/src/components/shared/ProjectLogo.tsx
@@ -1,5 +1,5 @@
 import { ThemeContext } from 'contexts/themeContext'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 
 export default function ProjectLogo({
   uri,
@@ -10,6 +10,8 @@ export default function ProjectLogo({
   name: string | undefined
   size?: number
 }) {
+  const [srcLoadError, setSrcLoadError] = useState(false)
+  const validImg = uri && !srcLoadError
   const {
     theme: { colors, radii },
   } = useContext(ThemeContext)
@@ -25,10 +27,10 @@ export default function ProjectLogo({
         height: _size,
         width: _size,
         borderRadius: radii.xl,
-        background: uri ? undefined : colors.background.l1,
+        background: validImg ? undefined : colors.background.l1,
       }}
     >
-      {uri ? (
+      {validImg ? (
         <img
           style={{
             maxHeight: '100%',
@@ -38,6 +40,7 @@ export default function ProjectLogo({
           }}
           src={uri}
           alt={name + ' logo'}
+          onError={() => setSrcLoadError(true)}
         />
       ) : (
         <div


### PR DESCRIPTION
## What does this PR do and why?

Closes #988 

## Screenshots or screen recordings

Before:

![image](https://user-images.githubusercontent.com/33093632/168090275-01d5f0c1-4865-4b17-b80b-1f5620d5f24c.png)

After:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/33093632/168090311-00b356af-9c8f-4737-8a92-df7eeb42648f.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
