### PR TITLE
Antd date picker today button disabled styling

### DIFF
--- a/src/styles/antd-overrides/picker.scss
+++ b/src/styles/antd-overrides/picker.scss
@@ -8,6 +8,10 @@
   color: var(--text-action-primary);
 }
 
+.ant-picker-today-btn-disabled {
+  color: var(--text-disabled);
+}
+
 .ant-picker-focused {
   border-color: var(--stroke-action-secondary);
 }


### PR DESCRIPTION
## What does this PR do and why?

It applies the color for disabled text on the Date pickers Today button. In darkmode, the button isn't visible if not overridden and it appears to be just two lines with dark matter in between.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
