### PR TITLE
Wrap and expand pay button better, v1/v2

### DIFF
--- a/src/components/shared/inputs/Pay/PayInputGroup.tsx
+++ b/src/components/shared/inputs/Pay/PayInputGroup.tsx
@@ -67,9 +67,11 @@ export default function PayInputGroup({
         style={{
           display: 'flex',
           width: '100%',
+          flexWrap: 'wrap',
+          gap: 10,
         }}
       >
-        <div style={{ flex: 1, marginRight: 10 }}>
+        <div style={{ flex: 3, minWidth: '50%' }}>
           <FormattedNumberInput
             placeholder="0"
             onChange={val => {
@@ -97,14 +99,12 @@ export default function PayInputGroup({
           />
         </div>
 
-        <div style={{ textAlign: 'center', minWidth: 150 }}>
-          <PayButton
-            payAmount={payAmount}
-            payInCurrency={payInCurrency}
-            onError={() => setIsErrorField(true)}
-            disabled={disabled}
-          />
-        </div>
+        <PayButton
+          payAmount={payAmount}
+          payInCurrency={payInCurrency}
+          onError={() => setIsErrorField(true)}
+          disabled={disabled}
+        />
       </div>
     </>
   )

--- a/src/components/v1/V1Project/V1PayButton.tsx
+++ b/src/components/v1/V1Project/V1PayButton.tsx
@@ -93,7 +93,7 @@ export default function V1PayButton({
   return (
     <>
       <Button
-        style={{ width: '100%' }}
+        style={{ flex: 1 }}
         type="primary"
         onClick={
           parseFloat(fromWad(weiPayAmt))

--- a/src/components/v2/V2Project/V2PayButton/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/index.tsx
@@ -49,10 +49,9 @@ export default function V2PayButton({
       <Tooltip
         visible={isPayDisabled ? undefined : false}
         title={disabledMessage}
-        className="block"
       >
         <Button
-          style={{ width: '100%' }}
+          style={{ flex: 1 }}
           type="primary"
           onClick={() => {
             if (weiPayAmt?.eq(0)) {


### PR DESCRIPTION
## What does this PR do and why?

Handles looong custom pay buttons. This is future-mitigated in https://github.com/jbx-protocol/juice-interface/pull/1003, but we need to fix for existing projects too.

## Screenshots or screen recordings

Towards https://github.com/jbx-protocol/juice-interface/issues/1001 

| default | custom short | custom long |
| --- | --- | --- |
| <img width="539" alt="Screen Shot 2022-05-14 at 9 35 22 am" src="https://user-images.githubusercontent.com/94939382/168402860-54472834-e50e-41cf-86fc-39ceae936355.png"> | <img width="545" alt="Screen Shot 2022-05-14 at 9 35 06 am" src="https://user-images.githubusercontent.com/94939382/168402867-f7872450-1a4a-4e5f-a0ca-b457edf80cc8.png"> | <img width="548" alt="Screen Shot 2022-05-14 at 9 34 52 am" src="https://user-images.githubusercontent.com/94939382/168402882-ea4470f9-fccb-42fc-a8d4-cbe4ada41b78.png"> |


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
