### PR TITLE
Add google site verification via `meta` tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,10 @@
       name="twitter:image"
       content="https://jbx.mypinata.cloud/ipfs/QmQYomY5sFvG96FKy3BKFU7mmcSiJsRjSHURmJSMPHrALJ"
     />
+    <meta
+      name="google-site-verification"
+      content="0Jp7zERBL5i76DiM-bODvBGgbjuVMEQGSuwOchP_ZnE"
+    />
     <title>Juicebox</title>
     <script
       async


### PR DESCRIPTION
This is to get us access to Google Search Console.

Usually we'd do this using a DNS TXT record, but there's some problem with the way our records are configured currently. This is the issue https://support.google.com/webmasters/thread/73081980/ownership-verification-failed-txt-records-appear-in-dns?hl=en.

I would try to fix it but I don't want to risk taking the site down for an extended period. I think it's fine to add this meta tag for now.