### PR TITLE
Standardize error notifications

### DIFF
--- a/src/components/shared/ArchiveProject/emitErrorNotification.ts
+++ b/src/components/shared/ArchiveProject/emitErrorNotification.ts
@@ -1,9 +1,0 @@
-import { notification } from 'antd'
-
-export const emitErrorNotification = (message: string) => {
-  notification.error({
-    key: new Date().valueOf().toString(),
-    message,
-    duration: 0,
-  })
-}

--- a/src/components/shared/ArchiveProject/index.tsx
+++ b/src/components/shared/ArchiveProject/index.tsx
@@ -7,7 +7,7 @@ import { ProjectMetadataV4 } from 'models/project-metadata'
 import { useContext, useState } from 'react'
 import { uploadProjectMetadata } from 'utils/ipfs'
 
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 
 import { postGitHubIssueForArchive } from './postGitHubIssueForArchive'
 

--- a/src/components/shared/ArchiveProject/index.tsx
+++ b/src/components/shared/ArchiveProject/index.tsx
@@ -7,7 +7,8 @@ import { ProjectMetadataV4 } from 'models/project-metadata'
 import { useContext, useState } from 'react'
 import { uploadProjectMetadata } from 'utils/ipfs'
 
-import { emitErrorNotification } from './emitErrorNotification'
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+
 import { postGitHubIssueForArchive } from './postGitHubIssueForArchive'
 
 export default function ArchiveProject({
@@ -57,7 +58,7 @@ export default function ArchiveProject({
       },
     )
     if (!txSuccessful) {
-      emitErrorNotification('Transaction unsuccessful')
+      emitErrorNotification(t`Transaction unsuccessful`)
       setIsLoadingArchive(false)
     }
   }

--- a/src/components/shared/Notifications/emitErrorNotification.ts
+++ b/src/components/shared/Notifications/emitErrorNotification.ts
@@ -1,0 +1,18 @@
+import { notification } from 'antd'
+
+export const emitErrorNotification = (
+  message: string,
+  description?: string,
+  duration?: number,
+) => {
+  const key = new Date().valueOf().toString()
+  return notification.error({
+    key,
+    message,
+    description,
+    duration: duration || 3,
+    onClick: () => {
+      notification.close(key)
+    },
+  })
+}

--- a/src/components/shared/formItems/ProjectDescription.tsx
+++ b/src/components/shared/formItems/ProjectDescription.tsx
@@ -5,7 +5,7 @@ import TextArea from 'antd/lib/input/TextArea'
 
 import { FormItemExt } from './formItemExt'
 
-const MAX_DESCRIPTION_LENGTH = 1000
+const MAX_DESCRIPTION_LENGTH = 5000
 
 export default function ProjectDescription({
   name,

--- a/src/components/shared/modals/DownloadParticipantsModal.tsx
+++ b/src/components/shared/modals/DownloadParticipantsModal.tsx
@@ -1,7 +1,8 @@
 import { t, Trans } from '@lingui/macro'
-import { Modal, notification } from 'antd'
+import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
 
 import { useCallback, useEffect, useState } from 'react'
 import { fromWad } from 'utils/formatNumber'
@@ -71,9 +72,7 @@ export default function DownloadParticipantsModal({
       })
 
       if (!participants) {
-        notification.error({
-          message: t`Error loading holders`,
-        })
+        emitErrorNotification(t`Error loading holders`)
         throw new Error('No data.')
       }
 

--- a/src/components/shared/modals/DownloadParticipantsModal.tsx
+++ b/src/components/shared/modals/DownloadParticipantsModal.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 
 import { useCallback, useEffect, useState } from 'react'
 import { fromWad } from 'utils/formatNumber'

--- a/src/components/v1/V1DownloadPaymentsModal.tsx
+++ b/src/components/v1/V1DownloadPaymentsModal.tsx
@@ -8,7 +8,7 @@ import { useCallback, useContext, useEffect, useState } from 'react'
 import { fromWad } from 'utils/formatNumber'
 import { querySubgraphExhaustive } from 'utils/graph'
 
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 
 import { readProvider } from 'constants/readProvider'
 

--- a/src/components/v1/V1DownloadPaymentsModal.tsx
+++ b/src/components/v1/V1DownloadPaymentsModal.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Modal, notification } from 'antd'
+import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
 
@@ -7,6 +7,8 @@ import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { fromWad } from 'utils/formatNumber'
 import { querySubgraphExhaustive } from 'utils/graph'
+
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
 
 import { readProvider } from 'constants/readProvider'
 
@@ -60,9 +62,7 @@ export default function V1DownloadPaymentsModal({
       })
 
       if (!payments) {
-        notification.error({
-          message: t`Error loading payments`,
-        })
+        emitErrorNotification(t`Error loading payments`)
         throw new Error('No data.')
       }
 

--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
@@ -1,10 +1,10 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
-import { notification } from 'antd'
 import { Checkbox, Descriptions, Form, Input, Modal, Space } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import ImageUploader from 'components/shared/inputs/ImageUploader'
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
 import { NetworkContext } from 'contexts/networkContext'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import * as constants from '@ethersproject/constants'
@@ -75,12 +75,7 @@ export default function V1ConfirmPayOwnerModal({
         onDone: () => setLoading(false),
         onError: (error: Error) => {
           setLoading(false)
-          notification.error({
-            key: new Date().valueOf().toString(),
-            message: 'Transaction failed',
-            description: error.message,
-            duration: 0,
-          })
+          emitErrorNotification(t`Transaction failed`, error.message)
         },
       },
     )

--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
@@ -4,7 +4,7 @@ import { Checkbox, Descriptions, Form, Input, Modal, Space } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import FormattedAddress from 'components/shared/FormattedAddress'
 import ImageUploader from 'components/shared/inputs/ImageUploader'
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 import { NetworkContext } from 'contexts/networkContext'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import * as constants from '@ethersproject/constants'
@@ -75,7 +75,9 @@ export default function V1ConfirmPayOwnerModal({
         onDone: () => setLoading(false),
         onError: (error: Error) => {
           setLoading(false)
-          emitErrorNotification(t`Transaction failed`, error.message)
+          emitErrorNotification(t`Transaction failed`, {
+            description: error.message,
+          })
         },
       },
     )

--- a/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
@@ -8,7 +8,7 @@ import { Modal } from 'antd'
 import { JBDiscordLink } from 'components/Landing/QAs'
 import EtherscanLink from 'components/shared/EtherscanLink'
 import CopyTextButton from 'components/shared/CopyTextButton'
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 
 import { DeployProjectPayerTxArgs } from 'hooks/v2/transactor/DeployProjectPayerTx'
 import { useForm } from 'antd/lib/form/Form'

--- a/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
@@ -4,10 +4,11 @@ import { useState } from 'react'
 import { TransactionReceipt } from '@ethersproject/providers'
 import { TransactorInstance } from 'hooks/Transactor'
 
-import { Modal, notification } from 'antd'
+import { Modal } from 'antd'
 import { JBDiscordLink } from 'components/Landing/QAs'
 import EtherscanLink from 'components/shared/EtherscanLink'
 import CopyTextButton from 'components/shared/CopyTextButton'
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
 
 import { DeployProjectPayerTxArgs } from 'hooks/v2/transactor/DeployProjectPayerTx'
 import { useForm } from 'antd/lib/form/Form'
@@ -88,11 +89,7 @@ export default function LaunchProjectPayerModal({
           const newProjectPayerAddress =
             getProjectPayerAddressFromReceipt(txReceipt)
           if (newProjectPayerAddress === undefined) {
-            notification.error({
-              key: new Date().valueOf().toString(),
-              message: t`Something went wrong.`,
-              duration: 0,
-            })
+            emitErrorNotification(t`Something went wrong.`)
             return
           }
           if (onConfirmed) onConfirmed()

--- a/src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+++ b/src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
@@ -1,7 +1,8 @@
 import { t, Trans } from '@lingui/macro'
-import { Modal, notification } from 'antd'
+import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
 
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useCallback, useContext, useEffect, useState } from 'react'
@@ -60,9 +61,7 @@ export default function V2DownloadPaymentsModal({
       })
 
       if (!payments) {
-        notification.error({
-          message: t`Error loading payments`,
-        })
+        emitErrorNotification(t`Error loading payments`)
         throw new Error('No data.')
       }
 

--- a/src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+++ b/src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Modal } from 'antd'
 import InputAccessoryButton from 'components/shared/InputAccessoryButton'
 import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useCallback, useContext, useEffect, useState } from 'react'

--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -9,7 +9,7 @@ import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useCallback, useContext } from 'react'
 
-import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+import { emitErrorNotification } from 'utils/notifications'
 
 import * as Sentry from '@sentry/browser'
 import { t } from '@lingui/macro'
@@ -195,7 +195,7 @@ export function useTransactor({
           description = message
         }
 
-        emitErrorNotification(t`Transaction failed`, description)
+        emitErrorNotification(t`Transaction failed`, { description })
 
         options?.onDone?.()
 

--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -4,12 +4,15 @@ import { Contract } from '@ethersproject/contracts'
 import { Deferrable } from '@ethersproject/properties'
 import { JsonRpcSigner, TransactionRequest } from '@ethersproject/providers'
 import { parseUnits } from '@ethersproject/units'
-import { notification } from 'antd'
 import Notify, { InitOptions, TransactionEvent } from 'bnc-notify'
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useCallback, useContext } from 'react'
+
+import { emitErrorNotification } from 'components/shared/Notifications/emitErrorNotification'
+
 import * as Sentry from '@sentry/browser'
+import { t } from '@lingui/macro'
 
 export type TransactorCallback = (
   e?: TransactionEvent,
@@ -192,12 +195,7 @@ export function useTransactor({
           description = message
         }
 
-        notification.error({
-          key: new Date().valueOf().toString(),
-          message: 'Transaction failed',
-          description,
-          duration: 0,
-        })
+        emitErrorNotification(t`Transaction failed`, description)
 
         options?.onDone?.()
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2832,9 +2832,18 @@ msgstr ""
 msgid "Total: {0}%"
 msgstr ""
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr "Transaction failed"
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transaction pending..."
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr "Transaction unsuccessful"
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2837,9 +2837,18 @@ msgstr "Suministro total"
 msgid "Total: {0}%"
 msgstr "Total: {0}%"
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr ""
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transacción pendiente..."
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr ""
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2837,9 +2837,18 @@ msgstr "Offre totale"
 msgid "Total: {0}%"
 msgstr "Total : {0}%"
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr ""
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transaction en attente..."
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr ""
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2837,9 +2837,18 @@ msgstr "Fornecimento total"
 msgid "Total: {0}%"
 msgstr "Total: {0}%"
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr ""
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transação pendente..."
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr ""
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2837,9 +2837,18 @@ msgstr "Общее предложение"
 msgid "Total: {0}%"
 msgstr "Итого: {0}%"
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr ""
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Транзакция ожидается..."
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr ""
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2837,9 +2837,18 @@ msgstr "Toplam arz"
 msgid "Total: {0}%"
 msgstr "Toplam: %{0}"
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr ""
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "İşlem beklemede..."
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr ""
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2837,9 +2837,18 @@ msgstr "总供应量"
 msgid "Total: {0}%"
 msgstr "总共：{0}%"
 
+#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/hooks/Transactor.ts
+msgid "Transaction failed"
+msgstr ""
+
 #: src/components/shared/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "交易进行中......"
+
+#: src/components/shared/ArchiveProject/index.tsx
+msgid "Transaction unsuccessful"
+msgstr ""
 
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/shared/modals/ProjectToolDrawerModal.tsx

--- a/src/styles/antd-overrides/notification.scss
+++ b/src/styles/antd-overrides/notification.scss
@@ -8,7 +8,7 @@
     color: var(--text-secondary);
   }
 
-  .ant-notification-close-x {
+  .ant-notification-notice-close-icon {
     color: var(--icon-secondary);
   }
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,17 +1,24 @@
 import { notification } from 'antd'
 
+const DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS = 3
+
 export const emitErrorNotification = (
   message: string,
-  description?: string,
-  duration?: number,
+  {
+    description,
+    duration,
+  }: {
+    description?: string
+    duration?: number
+  } = { duration: DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS },
 ) => {
   const key = new Date().valueOf().toString()
   return notification.error({
     key,
     message,
     description,
-    duration: duration || 3,
-    onClick: () => {
+    duration,
+    onClick() {
       notification.close(key)
     },
   })


### PR DESCRIPTION
## What does this PR do and why?

Closes #1016. Standardizes error notification handling across the application. Error notifications all now use the current date for key and close automatically after 3 seconds or on click.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
