### PR TITLE
Projects query fix - archivedProjectIds

### DIFF
--- a/src/hooks/Projects.ts
+++ b/src/hooks/Projects.ts
@@ -92,7 +92,7 @@ const queryOpts = (
       value: archivedProjectIds,
       operator: 'in',
     })
-  } else {
+  } else if (archivedProjectIds.length) {
     where.push({
       key: 'projectId',
       value: archivedProjectIds,


### PR DESCRIPTION
## What does this PR do and why?

No data is being returned when querying "all" projects on Rinkeby, due to an odd reason: the `archivedProjectIds` array is empty on Rinkeby, and querying the graph with `projectId_not_in: []` results in no data returned.

This fix ensures that the `projectId_not_in` param is not included if the `archivedProjectIds` array is empty.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
