### PR TITLE
Exclude project activity events

### DIFF
--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -53,6 +53,14 @@ export default function ProjectActivity() {
         operator: 'in',
         value: ['1', '1.1'],
       },
+      {
+        key: 'mintTokensEvent',
+        value: null, // Exclude all mintTokensEvents. One of these events is created for every Pay event, and showing both event types may lead to confusion
+      },
+      {
+        key: 'useAllowanceEvent',
+        value: null, // Exclude all useAllowanceEvents, no UI support yet
+      },
     ]
 
     if (projectId) {

--- a/src/components/v2/V2Project/ProjectActivity/index.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/index.tsx
@@ -53,6 +53,14 @@ export default function ProjectActivity() {
         key: 'cv',
         value: '2',
       },
+      {
+        key: 'mintTokensEvent',
+        value: null, // Exclude all mintTokensEvents. One of these events is created for every Pay event, and showing both event types may lead to confusion
+      },
+      {
+        key: 'useAllowanceEvent',
+        value: null, // Exclude all useAllowanceEvents, no UI support yet
+      },
     ]
 
     if (projectId) {

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -238,9 +238,9 @@ export const formatGraphQuery = <E extends EntityKey, K extends EntityKeys<E>>(
       ? `[${where.value
           .map(v => (typeof v === 'string' ? `"${v}"` : v))
           .join(',')}]`
-      : typeof where.value === 'number'
-      ? where.value
-      : `"${where.value}"`)
+      : typeof where.value === 'string'
+      ? `"${where.value}"`
+      : where.value)
 
   addArg('text', opts.text ? `"${opts.text}"` : undefined)
   addArg('first', opts.first)


### PR DESCRIPTION
## What does this PR do and why?

Excludes graph entities MintTokensEvents and UseAllowanceEvents from project activity list.

__MintTokensEvents:__ These events were intended to reflect when a project owner mints tokens manually. By mistake (in V2), one is created every time a payment to a project is made (and tokens are minted to the payer). Since including them could be confusing, they'll be excluded for now. These events do work as intended in V1.

__UseAllowanceEvents:__ There is no UI support for displaying (or creating transactions for) these events yet.

Excluding these events also fixes #1034 , where the total events count previously included these events that were not displayed in the UI.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
