### PR TITLE
update-docs-nvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Notice something broken? Create a
    [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of this
    repository.
 1. Clone your fork and navigate to the root directory.
+1. [`nvm use`](https://github.com/nvm-sh/nvm#nvmrc) to match the version of node
+   specified in the
+   [`.nvmrc`](https://github.com/jbx-protocol/juice-interface/blob/main/.nvmrc)
 1. Install project dependencies.
 
    ```bash


### PR DESCRIPTION
## What does this PR do and why?

I was trying to figure out which version of node we use for a different PR and noticed we use `.nvmrc`. I figured prompting new contributors to use the right version of `node` could suss out many questions the dev team might get.

More here about `.nvmrc`: https://github.com/nvm-sh/nvm#nvmrc


Additionally, should we instruct contributors to use NVM? Happy to add it to the docs too.

## Screenshots or screen recordings

N/A

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
