### PR TITLE
Fix FC metadata sync on preview

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
@@ -35,6 +35,7 @@ export default function CurrentFundingCycle({
           fundingCycleDetails={
             <FundingCycleDetails
               fundingCycle={fundingCycle}
+              fundingCycleMetadata={fundingCycleMetadata}
               distributionLimit={distributionLimit}
               distributionLimitCurrency={distributionLimitCurrency}
             />

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -6,7 +6,7 @@ import CurrencySymbol from 'components/shared/CurrencySymbol'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { V2CurrencyOption } from 'models/v2/currencyOption'
-import { V2FundingCycle } from 'models/v2/fundingCycle'
+import { V2FundingCycle, V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 import { useContext } from 'react'
 import { formatDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
@@ -17,10 +17,7 @@ import TooltipLabel from 'components/shared/TooltipLabel'
 import FundingCycleDetailWarning from 'components/shared/Project/FundingCycleDetailWarning'
 import EtherscanLink from 'components/shared/EtherscanLink'
 
-import {
-  decodeV2FundingCycleMetadata,
-  getUnsafeV2FundingCycleProperties,
-} from 'utils/v2/fundingCycle'
+import { getUnsafeV2FundingCycleProperties } from 'utils/v2/fundingCycle'
 
 import { detailedTimeString } from 'utils/formatTime'
 
@@ -43,10 +40,12 @@ import {
 
 export default function FundingCycleDetails({
   fundingCycle,
+  fundingCycleMetadata,
   distributionLimit,
   distributionLimitCurrency,
 }: {
   fundingCycle: V2FundingCycle | undefined
+  fundingCycleMetadata: V2FundingCycleMetadata | undefined
   distributionLimit: BigNumber | undefined
   distributionLimitCurrency: BigNumber | undefined
 }) {
@@ -57,10 +56,6 @@ export default function FundingCycleDetails({
   const { tokenSymbol } = useContext(V2ProjectContext)
 
   if (!fundingCycle) return null
-
-  const fundingCycleMetadata = decodeV2FundingCycleMetadata(
-    fundingCycle.metadata,
-  )
 
   const formattedDuration = detailedTimeString({
     timeSeconds: fundingCycle.duration.toNumber(),

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
@@ -21,6 +21,7 @@ import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistribu
 import useUsedDistributionLimit from 'hooks/v2/contractReader/UsedDistributionLimit'
 import { V2UserContext } from 'contexts/v2/userContext'
 import { formatDiscountRate, MAX_DISTRIBUTION_LIMIT } from 'utils/v2/math'
+import { decodeV2FundingCycleMetadata } from 'utils/v2/fundingCycle'
 
 // Fill in gaps between first funding cycle of each configuration:
 //     - derives starts from duration and start time of the first FC of that configuration
@@ -325,6 +326,9 @@ export default function FundingCycleHistory() {
         >
           <FundingCycleDetails
             fundingCycle={selectedFundingCycle}
+            fundingCycleMetadata={decodeV2FundingCycleMetadata(
+              selectedFundingCycle.metadata,
+            )}
             distributionLimit={distributionLimit}
             distributionLimitCurrency={distributionLimitCurrency}
           />

--- a/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
@@ -69,6 +69,7 @@ export default function UpcomingFundingCycle({
           fundingCycleDetails={
             <FundingCycleDetails
               fundingCycle={queuedFundingCycle}
+              fundingCycleMetadata={queuedFundingCycleMetadata}
               distributionLimit={queuedDistributionLimit}
               distributionLimitCurrency={queuedDistributionLimitCurrency}
             />


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/1023

Funding cycle metadata wasn't being sourced from Context on the project preview. This caused a bug where any edits to metadata wouldn't be reflected in the project preview.

The solution is to pass metadata in as prop to "details" card.

## Screenshots or screen recordings

NA

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
