### PR TITLE
V2 redeploy prep

### DIFF
--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -17,6 +17,7 @@ import V2ManageTokensSection from './V2ManageTokensSection'
 import NewDeployModal from './NewDeployModal'
 import V2PayButton from './V2PayButton'
 import V2ProjectHeaderActions from './V2ProjectHeaderActions'
+import V2BugNotice from '../shared/V2BugNotice'
 
 const GUTTER_PX = 40
 
@@ -40,6 +41,7 @@ export default function V2Project({
     tokenAddress,
     cv,
     isArchived,
+    ETHBalance,
   } = useContext(V2ProjectContext)
 
   // Checks URL to see if user was just directed from project deploy
@@ -71,6 +73,7 @@ export default function V2Project({
         actions={!isPreviewMode ? <V2ProjectHeaderActions /> : undefined}
         isArchived={isArchived}
       />
+      <V2BugNotice />
       <Row gutter={GUTTER_PX} align="bottom">
         <Col md={colSizeMd} xs={24}>
           <TreasuryStats />
@@ -83,7 +86,7 @@ export default function V2Project({
             weightingFn={weightedAmount}
             tokenSymbol={tokenSymbol}
             tokenAddress={tokenAddress}
-            disabled={isPreviewMode}
+            disabled={isPreviewMode || ETHBalance?.eq(0)}
           />
         </Col>
       </Row>

--- a/src/components/v2/shared/V2BugNotice.tsx
+++ b/src/components/v2/shared/V2BugNotice.tsx
@@ -6,6 +6,8 @@ export default function V2BugNotice() {
     theme: { colors },
   } = useContext(ThemeContext)
 
+  // This copy has not been prepped for translations due to being a hot fix that is likely to change.
+
   return (
     <div
       style={{

--- a/src/components/v2/shared/V2BugNotice.tsx
+++ b/src/components/v2/shared/V2BugNotice.tsx
@@ -1,0 +1,31 @@
+import { useContext } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+
+export default function V2BugNotice() {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  return (
+    <div
+      style={{
+        padding: 20,
+        color: colors.text.warn,
+        border: `1px solid ${colors.stroke.warn}`,
+      }}
+    >
+      <h2 style={{ color: colors.text.warn }}>Heads up</h2>
+      <p>
+        A minor bug has been found in the V2 Juicebox protocol contracts. The
+        contracts have been fixed and will be redeployed soon.{' '}
+        <b>No funds are in danger</b> and projects are unlikely to be affected.
+      </p>
+      <p>
+        While the current V2 contracts are being deprecated, creating new
+        Juicebox projects has been temporarily disabled on the juicebox.money
+        app. Payments to V2 projects with a 0 treasury balance have also been
+        disabled.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## What does this PR do and why?

- Adds a notice to V2 projects of the recently identified bug in jb V2 contracts.
- Disabled pay button for V2 projects with 0 balance.

## Screenshots or screen recordings

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/79433522/170125074-ed986dd3-4b01-4d9c-a5a1-aa6bf319fd63.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
