### PR TITLE
add v2-bug-updates page

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,7 @@ import Projects from 'components/Projects'
 import Loading from 'components/shared/Loading'
 import V1CurrencyProvider from 'providers/v1/V1CurrencyProvider'
 import PrivacyPolicy from 'components/PrivacyPolicy'
+import V2BugUpdates from 'components/V2BugUpdates'
 import { t } from '@lingui/macro'
 
 import { V2UserProvider } from 'providers/v2/UserProvider'
@@ -103,6 +104,9 @@ function JuiceboxSwitch() {
 
       <Route path="/privacy">
         <PrivacyPolicy />
+      </Route>
+      <Route path="/v2-bug-updates">
+        <V2BugUpdates />
       </Route>
       <Route path="/:route">
         <CatchallRedirect />

--- a/src/components/V2BugUpdates/index.tsx
+++ b/src/components/V2BugUpdates/index.tsx
@@ -1,0 +1,56 @@
+export default function V2BugUpdates() {
+  return (
+    <div style={{ maxWidth: 800, margin: '0 auto', padding: 20 }}>
+      <h1>Juicebox V2 Contracts Bug</h1>
+      <p>
+        A minor bug has been identified in the Juicebox protocol V2 contracts.
+        No funds are in danger, and projects are unlikely to be affected. Link
+        to bug description and fix:{' '}
+        <a
+          href="https://github.com/jbx-protocol/juice-contracts-v2/pull/265"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          github.com/jbx-protocol/juice-contracts-v2/pull/265
+        </a>
+      </p>
+      <p>The bug has no impact on Juicebox V1 projects. </p>
+      <br />
+      <br />
+      <section>
+        <h2>Roadmap</h2>
+        <h4>(Done) Disable project creation + V2 payments</h4>
+        <p>
+          To make project migration easier, creating projects on juicebox.money
+          will be temporarily disabled along with payments to existing V2
+          projects with a 0 treasury balance.
+        </p>
+        <h4>(In progress) Redeploy Juicebox V2 protocol contracts</h4>
+        <p>
+          Redeployed contracts will include a fix, but will otherwise be
+          functionally identical to the current protocol contracts.
+        </p>
+        <h4>Update juicebox.money app to use new contracts</h4>
+        <p>
+          Once the contracts have been redeployed, the app will be updated to
+          use these contracts. This may take up to 48 hours.{' '}
+          <a
+            href="https://twitter.com/PeelDao"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Peel
+          </a>{' '}
+          will ensure that existing V2 projects will still be accessible in the
+          app or via a separate interface.
+        </p>
+        <h4>Project migration</h4>
+        <p>
+          Existing V2 projects will have support from JuiceboxDAO and Peel to
+          reconfigure on the new V2 contracts as needed, and ensure all token
+          balances are migrated.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/src/components/v2/shared/V2BugNotice.tsx
+++ b/src/components/v2/shared/V2BugNotice.tsx
@@ -26,7 +26,7 @@ export default function V2BugNotice() {
         While the current V2 contracts are being deprecated, creating new
         Juicebox projects has been temporarily disabled on the juicebox.money
         app. Payments to V2 projects with a 0 treasury balance have also been
-        disabled.
+        disabled. <a href="/#/v2-bug-updates">More details</a>
       </p>
     </div>
   )


### PR DESCRIPTION
## What does this PR do and why?

Adds new updates page for V2 contracts bug

## Screenshots or screen recordings

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/79433522/170132385-7a807a55-c7fb-4d7c-8546-42c9fc5389a2.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
