### PR TITLE
Disable project creation ahead of v2 redeploy

### DIFF
--- a/src/components/v2/V2Create/index.tsx
+++ b/src/components/v2/V2Create/index.tsx
@@ -13,6 +13,7 @@ import FundingCycleTabContent from './tabs/FundingCycleTab/FundingCycleTabConten
 import { TabContentProps } from './models'
 import ReviewDeployTab from './tabs/ReviewDeployTab'
 import V2WarningBanner from './V2WarningBanner'
+import V2BugNotice from '../shared/V2BugNotice'
 
 const { TabPane } = Tabs
 
@@ -50,6 +51,9 @@ export default function V2Create() {
     <V2UserProvider>
       <V2CurrencyProvider>
         <V2WarningBanner />
+        <div style={{ padding: 20 }}>
+          <V2BugNotice />
+        </div>
         <div
           style={{
             maxWidth: 1300,

--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -73,7 +73,7 @@ export default function V2Project({
         actions={!isPreviewMode ? <V2ProjectHeaderActions /> : undefined}
         isArchived={isArchived}
       />
-      <V2BugNotice />
+      {!isPreviewMode && <V2BugNotice />}
       <Row gutter={GUTTER_PX} align="bottom">
         <Col md={colSizeMd} xs={24}>
           <TreasuryStats />


### PR DESCRIPTION
## What does this PR do and why?

Disable project creation and add notice to create form

## Screenshots or screen recordings

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/79433522/170141494-e72995df-d899-4024-afa0-f80162fd2faa.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
