### PR TITLE
Add deployed git commit hash to footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,9 @@
   },
   "scripts": {
     "compile-styles": "lessc ./node_modules/antd/dist/antd.less ./src/styles/antd.css --js",
-    "start": "yarn compile-styles && ESLINT_NO_DEV_ERRORS=true react-scripts start",
-    "build": "react-scripts build",
+    "prestart": "yarn compile-styles",
+    "start": "ESLINT_NO_DEV_ERRORS=true REACT_APP_VERSION=$(git rev-parse --short HEAD) react-scripts start",
+    "build": "REACT_APP_VERSION=$(git rev-parse --short HEAD) react-scripts build",
     "prebuild": "yarn compile-styles && yarn i18n:compile",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/components/Landing/Footer.tsx
+++ b/src/components/Landing/Footer.tsx
@@ -1,8 +1,8 @@
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 import { CSSProperties } from 'react'
-
 import { Button } from 'antd'
+import ExternalLink from 'components/shared/ExternalLink'
 
 import { Languages } from 'constants/languages/language-options'
 
@@ -43,6 +43,9 @@ export default function Footer() {
     window.scrollTo(0, 0) // scroll to top of page after reload
   }
 
+  const gitCommit = process.env.REACT_APP_VERSION
+  const gitCommitLink = `https://github.com/jbx-protocol/juice-interface/commit/${gitCommit}`
+
   return (
     <div
       style={{
@@ -62,6 +65,15 @@ export default function Footer() {
         {link('Twitter', 'https://twitter.com/juiceboxETH')}
         {link('Privacy Policy', '/#/privacy')}
       </div>
+
+      {gitCommit ? (
+        <span style={{ color: 'white' }}>
+          Version:{' '}
+          <ExternalLink href={gitCommitLink} style={{ fontSize: '0.8rem' }}>
+            #{gitCommit}
+          </ExternalLink>
+        </span>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
<img width="966" alt="Screen Shot 2022-05-27 at 5 45 38 PM" src="https://user-images.githubusercontent.com/94939382/170659868-a0478a7d-8a65-422c-aa78-6b8a958ae37c.png">

Closes https://github.com/jbx-protocol/juice-interface/issues/775