### PR TITLE
More explanation to payout and reserved splits in FC details cards

### DIFF
--- a/src/components/v1/FundingCycle/ReservedTokens.tsx
+++ b/src/components/v1/FundingCycle/ReservedTokens.tsx
@@ -60,7 +60,7 @@ export default function ReservedTokens({
               ({perbicentToPercent(metadata?.reservedRate)}%)
             </h4>
           }
-          tip={t`A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time.`}
+          tip={t`A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time.`}
         />
       </div>
 

--- a/src/components/v1/FundingCycle/ReservedTokens.tsx
+++ b/src/components/v1/FundingCycle/ReservedTokens.tsx
@@ -60,7 +60,7 @@ export default function ReservedTokens({
               ({perbicentToPercent(metadata?.reservedRate)}%)
             </h4>
           }
-          tip={t`A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time.`}
+          tip={t`A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time.`}
         />
       </div>
 

--- a/src/components/v1/FundingCycle/Spending.tsx
+++ b/src/components/v1/FundingCycle/Spending.tsx
@@ -63,7 +63,7 @@ export default function Spending({
             <TooltipLabel
               label={
                 <h4 style={{ display: 'inline-block' }}>
-                  <Trans>Funding Distribution</Trans>
+                  <Trans>Funding distribution</Trans>
                 </h4>
               }
               tip={

--- a/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -280,19 +280,32 @@ export function DistributionSplitsStatistic({
   totalValue,
   projectOwnerAddress,
   showSplitValues,
+  fundingCycleDuration,
 }: {
   splits: Split[]
   currency: BigNumber | undefined
   totalValue: BigNumber | undefined
   projectOwnerAddress: string | undefined
   showSplitValues: boolean
+  fundingCycleDuration: BigNumber | undefined
 }) {
+  const formattedDuration = detailedTimeString({
+    timeSeconds: fundingCycleDuration?.toNumber(),
+    fullWords: true,
+  })
+  const hasDuration = fundingCycleDuration?.gt(0)
+
   return (
     <Statistic
       title={
         <TooltipLabel
-          label={t`Funding distribution`}
-          tip={t`Entities that will receive funds from the treasury each funding cycle.`}
+          label={t`Payouts`}
+          tip={
+            <Trans>
+              Available funds will be distributed according to the payouts below
+              {hasDuration ? ` every ${formattedDuration}` : null}.
+            </Trans>
+          }
         />
       }
       valueRender={() => (

--- a/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -302,7 +302,7 @@ export function DistributionSplitsStatistic({
           label={t`Payouts`}
           tip={
             <Trans>
-              Available funds will be distributed according to the payouts below
+              Available funds can be distributed according to the payouts below
               {hasDuration ? ` every ${formattedDuration}` : null}.
             </Trans>
           }

--- a/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingSummarySection.tsx
+++ b/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingSummarySection.tsx
@@ -180,6 +180,7 @@ export default function FundingSummarySection() {
                   totalValue={distributionLimit}
                   projectOwnerAddress={userAddress}
                   showSplitValues={hasDistributionLimit}
+                  fundingCycleDuration={duration}
                 />
               </Col>
               <Col md={2} xs={0}></Col>

--- a/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/CurrentFundingCycle.tsx
@@ -52,6 +52,7 @@ export default function CurrentFundingCycle({
         payoutSplits={payoutSplits}
         distributionLimitCurrency={distributionLimitCurrency}
         distributionLimit={distributionLimit}
+        fundingCycleDuration={fundingCycle.duration}
       />
       <ReservedTokensSplitsCard
         reservedTokensSplits={reservedTokensSplits}

--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -15,6 +15,7 @@ import { formatFee, MAX_DISTRIBUTION_LIMIT } from 'utils/v2/math'
 import { useETHPaymentTerminalFee } from 'hooks/v2/contractReader/ETHPaymentTerminalFee'
 import { Split } from 'models/v2/splits'
 import { BigNumber } from '@ethersproject/bignumber'
+import { detailedTimeString } from 'utils/formatTime'
 
 import DistributePayoutsModal from './modals/DistributePayoutsModal'
 
@@ -23,11 +24,13 @@ export default function PayoutSplitsCard({
   payoutSplits,
   distributionLimitCurrency,
   distributionLimit,
+  fundingCycleDuration,
 }: {
   hideDistributeButton?: boolean
   payoutSplits: Split[] | undefined
   distributionLimitCurrency: BigNumber | undefined
   distributionLimit: BigNumber | undefined
+  fundingCycleDuration: BigNumber | undefined
 }) {
   const {
     usedDistributionLimit,
@@ -46,6 +49,12 @@ export default function PayoutSplitsCard({
     loading.distributionLimitLoading ||
     loading.balanceInDistributionLimitCurrencyLoading ||
     loading.usedDistributionLimitLoading
+
+  const formattedDuration = detailedTimeString({
+    timeSeconds: fundingCycleDuration?.toNumber(),
+    fullWords: true,
+  })
+  const hasDuration = fundingCycleDuration?.gt(0)
 
   return (
     <CardSection>
@@ -102,7 +111,9 @@ export default function PayoutSplitsCard({
             }
             tip={
               <Trans>
-                Available funds are distributed according to the payouts below.
+                Available funds will be distributed according to the payouts
+                below
+                {hasDuration ? ` every ${formattedDuration}` : null}.
               </Trans>
             }
           />

--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -111,7 +111,7 @@ export default function PayoutSplitsCard({
             }
             tip={
               <Trans>
-                Available funds will be distributed according to the payouts
+                Available funds can be distributed according to the payouts
                 below
                 {hasDuration ? ` every ${formattedDuration}` : null}.
               </Trans>

--- a/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
@@ -142,6 +142,7 @@ export default function ReservedTokensSplitsCard({
               splits={reservedTokensSplits}
               projectOwnerAddress={projectOwnerAddress}
               totalValue={undefined}
+              reservedRate={parseFloat(formatReservedRate(reservedRate))}
             />
           ) : null}
         </div>

--- a/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
@@ -86,6 +86,7 @@ export default function UpcomingFundingCycle({
         payoutSplits={queuedPayoutSplits}
         distributionLimitCurrency={queuedDistributionLimitCurrency}
         distributionLimit={queuedDistributionLimit}
+        fundingCycleDuration={queuedFundingCycle.duration}
         hideDistributeButton
       />
       <ReservedTokensSplitsCard

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
@@ -153,6 +153,7 @@ export default function ReconfigurePreview({
           totalValue={distributionLimit}
           projectOwnerAddress={userAddress}
           showSplitValues={hasDistributionLimit}
+          fundingCycleDuration={duration}
         />
       )}
       {fundingCycleMetadata?.reservedRate.gt(0) && (

--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -16,6 +16,7 @@ import { V2CurrencyName } from 'utils/v2/currency'
 import { formatSplitPercent, SPLITS_TOTAL_PERCENT } from 'utils/v2/math'
 import useMobile from 'hooks/Mobile'
 import { Link } from 'react-router-dom'
+import TooltipIcon from 'components/shared/TooltipIcon'
 
 export default function SplitItem({
   split,
@@ -25,6 +26,7 @@ export default function SplitItem({
   projectOwnerAddress,
   valueSuffix,
   valueFormatProps,
+  reservedRate,
 }: {
   split: Split
   currency?: BigNumber
@@ -33,6 +35,7 @@ export default function SplitItem({
   showSplitValue: boolean
   valueSuffix?: string | JSX.Element
   valueFormatProps?: { precision?: number }
+  reservedRate?: number
 }) {
   const {
     theme: { colors },
@@ -149,6 +152,10 @@ export default function SplitItem({
     )
   }
 
+  const formattedSplitPercent = formatSplitPercent(
+    BigNumber.from(split.percent),
+  )
+
   return (
     <div
       style={{
@@ -172,12 +179,23 @@ export default function SplitItem({
         ) : null}
       </div>
       <div>
-        <span>{formatSplitPercent(BigNumber.from(split.percent))}%</span>
+        <span>{formattedSplitPercent}%</span>
         {totalValue?.gt(0) && showSplitValue ? (
           <span style={{ marginLeft: '0.2rem' }}>
             {' '}
             <SplitValue />
           </span>
+        ) : null}
+        {reservedRate ? (
+          <TooltipIcon
+            iconStyle={{ marginLeft: 7 }}
+            tip={
+              <Trans>
+                {(reservedRate * parseFloat(formattedSplitPercent)) / 100}% of
+                all newly minted tokens.
+              </Trans>
+            }
+          />
         ) : null}
       </div>
     </div>

--- a/src/components/v2/shared/SplitList.tsx
+++ b/src/components/v2/shared/SplitList.tsx
@@ -12,6 +12,7 @@ export default function SplitList({
   projectOwnerAddress,
   valueSuffix,
   valueFormatProps,
+  reservedRate,
 }: {
   splits: Split[]
   currency?: BigNumber
@@ -20,6 +21,7 @@ export default function SplitList({
   showSplitValues?: boolean
   valueSuffix?: string | JSX.Element
   valueFormatProps?: { precision?: number }
+  reservedRate?: number
 }) {
   const totalSplitPercentage =
     splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
@@ -42,6 +44,7 @@ export default function SplitList({
               projectOwnerAddress={projectOwnerAddress}
               valueSuffix={valueSuffix}
               valueFormatProps={valueFormatProps}
+              reservedRate={reservedRate}
             />
           </div>
         ))}
@@ -61,6 +64,7 @@ export default function SplitList({
           projectOwnerAddress={projectOwnerAddress}
           valueSuffix={valueSuffix}
           valueFormatProps={valueFormatProps}
+          reservedRate={reservedRate}
         />
       ) : null}
     </div>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -437,8 +437,8 @@ msgstr "Available funds are distributed according to the payouts below."
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
-msgstr "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
+msgstr "Available funds can be distributed according to the payouts below{0}."
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -206,6 +206,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr ""
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
@@ -429,9 +432,13 @@ msgid "Available after fee:"
 msgstr ""
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Available funds are distributed according to the payouts below."
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr "Available funds will be distributed according to the payouts below{0}."
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1096,10 +1103,6 @@ msgstr "Enabling token minting will appear risky to contributors. Only enable th
 msgid "End"
 msgstr ""
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr "Entities that will receive funds from the treasury each funding cycle."
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Error loading holders"
@@ -1159,7 +1162,6 @@ msgstr "Fund anything. Grow together."
 msgid "Funding"
 msgstr "Funding"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "Funding Distribution"
@@ -1204,10 +1206,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "Funding distribution"
 
@@ -1859,6 +1861,7 @@ msgid "Payout recipients"
 msgstr "Payout recipients"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "Payouts"
 
@@ -3336,6 +3339,10 @@ msgstr "{0} withdrawn"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0} {1} reserved"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr "{0}% of all newly minted tokens."
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -206,8 +206,8 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr ""
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
-msgstr "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -442,7 +442,7 @@ msgstr "Los fondos disponibles son distribuidos acorde a los pagos a continuaci√
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -211,6 +211,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Un proyecto puede elegir reservar un porcentaje de tokens para sí mismo. En lugar de ser distribuidos para pagar a usuarios, este porcentaje de tokens es acuñado para el proyecto."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr ""
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un proyecto puede reservar un porcentaje de tokens acuñados de cada pago que reciba. Los tokens reservados pueden ser distribuidos de acorde a la asignación que está debajo en cualquier momento."
@@ -434,9 +437,13 @@ msgid "Available after fee:"
 msgstr "Disponible tras comisión:"
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Los fondos disponibles son distribuidos acorde a los pagos a continuación."
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1101,10 +1108,6 @@ msgstr "Permitir la acuñación de tokens parecerá riesgoso para los contribuye
 msgid "End"
 msgstr "Fin"
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr "Las entidades que recibirán fondos del tesoro cada ciclo de financiamiento."
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Error al cargar holders"
@@ -1164,7 +1167,6 @@ msgstr "Financia lo que sea. Crezcan juntos."
 msgid "Funding"
 msgstr "Financiamiento"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "Distribución de fondos"
@@ -1209,10 +1211,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "Los ciclos de financiamiento pueden ser reconfigurados momentos antes de que empiece un nuevo ciclo, sin la necesidad de notificar a los contribuyentes."
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "Distribución de fondos"
 
@@ -1864,6 +1866,7 @@ msgid "Payout recipients"
 msgstr "Beneficiarios del pago"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
@@ -3341,6 +3344,10 @@ msgstr "{0} retirado"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0} {1} reservados"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -211,7 +211,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Un proyecto puede elegir reservar un porcentaje de tokens para sí mismo. En lugar de ser distribuidos para pagar a usuarios, este porcentaje de tokens es acuñado para el proyecto."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -211,6 +211,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Un projet peut choisir de réserver un pourcentage de tokens pour soi. À la place d'être distribué pour payer les utilisateurs, ce pourcentage de tokens est frappé pour le projet."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr ""
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un projet peut réserver un pourcentage de tokens frappés de chaque paiement reçu. Les tokens réservés peuvent être distribués à tout moment, selon les allocations ci-dessous."
@@ -434,9 +437,13 @@ msgid "Available after fee:"
 msgstr "Disponible après le frais :"
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Les fonds disponibles sont distribués selon les paiements ci-dessous."
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1101,10 +1108,6 @@ msgstr "Activer la frappe de tokens peut sembler risquée pour les contributeurs
 msgid "End"
 msgstr "Fin"
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr "Entités recevant des fonds de votre trésorerie à chaque cycle de financement."
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Erreur lors du chargement des titulaires"
@@ -1164,7 +1167,6 @@ msgstr "Financez quoi que ce soit. Grandissez ensemble."
 msgid "Funding"
 msgstr "Financement"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "Distribution du financement"
@@ -1209,10 +1211,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "Les cycles de financement peuvent être reconfigurés juste avant le début d'un nouveau cycle, sans que les contributeurs ne soient notifiés."
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "Distribution des fonds"
 
@@ -1864,6 +1866,7 @@ msgid "Payout recipients"
 msgstr "Bénéficiaires du paiement"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
@@ -3341,6 +3344,10 @@ msgstr "{0} retiré"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0} {1} réservé"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -442,7 +442,7 @@ msgstr "Les fonds disponibles sont distribués selon les paiements ci-dessous."
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -211,7 +211,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Un projet peut choisir de réserver un pourcentage de tokens pour soi. À la place d'être distribué pour payer les utilisateurs, ce pourcentage de tokens est frappé pour le projet."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -211,7 +211,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Um projeto pode escolher reservar uma porcentagem de tokens para si mesmo. Em vez de ser distribuída para pagar os usuários, essa porcentagem de tokens é cunhada para o projeto."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -442,7 +442,7 @@ msgstr "Fundos disponíveis são distribuídos conforme os pagamentos abaixo."
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -211,6 +211,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Um projeto pode escolher reservar uma porcentagem de tokens para si mesmo. Em vez de ser distribuída para pagar os usuários, essa porcentagem de tokens é cunhada para o projeto."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr ""
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Um projeto pode reservar uma porcentagem de tokens gerados por cada pagamento recebido. Tokens reservados podem ser distribuídos a qualquer momento conforme a alocação abaixo."
@@ -434,9 +437,13 @@ msgid "Available after fee:"
 msgstr "Disponível após a taxa:"
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Fundos disponíveis são distribuídos conforme os pagamentos abaixo."
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1101,10 +1108,6 @@ msgstr ""
 msgid "End"
 msgstr "Fim"
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr "Entidades que receberão fundos da tesouraria a cada ciclo de financiamento."
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Erro ao carregar titulares"
@@ -1164,7 +1167,6 @@ msgstr ""
 msgid "Funding"
 msgstr "Financiamento"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "Distribuição de financiamento"
@@ -1209,10 +1211,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "Ciclos de financiamento podem ser reconfigurados momentos antes de um novo ciclo começar, sem notificar os contribuidores."
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "Distribuição de fundos"
 
@@ -1864,6 +1866,7 @@ msgid "Payout recipients"
 msgstr "Recipientes de pagamento"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
@@ -3341,6 +3344,10 @@ msgstr "{0} retirado"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0} {1} reservados"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -211,7 +211,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Проект может зарезервировать для себя процент токенов. Вместо того, чтобы распределяться среди платящих пользователей, этот процент токенов создается для проекта."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -211,6 +211,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Проект может зарезервировать для себя процент токенов. Вместо того, чтобы распределяться среди платящих пользователей, этот процент токенов создается для проекта."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr ""
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Проект может резервировать процент выпущенных токенов с каждого платежа, который он получает. Зарезервированные токены могут быть распределены в соответствии с приведенным ниже распределением в любое время."
@@ -434,9 +437,13 @@ msgid "Available after fee:"
 msgstr "Доступно после комиссии:"
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Доступные средства распределяются в соответствии с приведенными ниже выплатами."
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1101,10 +1108,6 @@ msgstr "Включение выпуска токенов покажется вк
 msgid "End"
 msgstr "Конец"
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr "Организации, которые будут получать средства из казначейства в каждом цикле финансирования."
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Ошибка загрузки владельцев"
@@ -1164,7 +1167,6 @@ msgstr ""
 msgid "Funding"
 msgstr "Финансирование"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "Распределение финансирования"
@@ -1209,10 +1211,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "Циклы финансирования можно изменить за несколько минут до начала нового цикла без уведомления вкладчиков."
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "Распределение финансирования"
 
@@ -1864,6 +1866,7 @@ msgid "Payout recipients"
 msgstr "Получатели выплат"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
@@ -3341,6 +3344,10 @@ msgstr "{0} снято"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0} {1} зарезервировано"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -442,7 +442,7 @@ msgstr "Доступные средства распределяются в со
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -211,7 +211,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Bir proje, kendisi için tokenlerin bir yüzdesini ayırmayı seçebilir. Bu token yüzdesi, ödeme yapan kullanıcılara dağıtılmak yerine proje için kullanılabilir."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -211,6 +211,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "Bir proje, kendisi için tokenlerin bir yüzdesini ayırmayı seçebilir. Bu token yüzdesi, ödeme yapan kullanıcılara dağıtılmak yerine proje için kullanılabilir."
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr ""
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Bir proje, aldığı her ödemeden basılan token'ların belirli bir yüzdesini ayırabilir. Ayrılan token'lar, herhangi bir zamanda aşağıdaki tahsise göre dağıtılabilir."
@@ -434,9 +437,13 @@ msgid "Available after fee:"
 msgstr "Ücretten sonra kullanılabilir:"
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Mevcut fonlar aşağıdaki ödemelere göre dağıtılır."
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1101,10 +1108,6 @@ msgstr "Token basımının etkinleştirilmesi, katkıda bulunanlar açısından 
 msgid "End"
 msgstr "Son"
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr ""
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Sahipler yüklenirken hata oluştu"
@@ -1164,7 +1167,6 @@ msgstr ""
 msgid "Funding"
 msgstr "Finansman"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "Finansman Dağılımı"
@@ -1209,10 +1211,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "Finansman döngüleri, katkı sahiplerini bilgilendirmeden, yeni bir döngü başlangıcından dakikalar önce yeniden yapılandırılabilir."
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "Finansman dağılımı"
 
@@ -1864,6 +1866,7 @@ msgid "Payout recipients"
 msgstr "Ödeme alıcıları"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
@@ -3341,6 +3344,10 @@ msgstr "{0} çekildi"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0}{1} ayrıldı"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -442,7 +442,7 @@ msgstr "Mevcut fonlar aşağıdaki ödemelere göre dağıtılır."
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -211,6 +211,9 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "项目可以选择为自己保留一定比例的代币。这些代币不是分发给付费的用户，而是给到项目方。"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
+msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgstr ""
+
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "项目每收到一笔付款都会铸造代币，其中某个百分比的代币会保留在项目内。保留代币可随时按以下分配方案进行分发。"
@@ -434,9 +437,13 @@ msgid "Available after fee:"
 msgstr "扣除手续费后可用"
 
 #: src/components/v1/FundingCycle/Spending.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "可用资金会分发给以下支出对象。"
+
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "Available funds will be distributed according to the payouts below{0}."
+msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
@@ -1101,10 +1108,6 @@ msgstr "允许代币铸造会令捐款人感觉有风险。请仅在必要情况
 msgid "End"
 msgstr "结束时间"
 
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
-msgid "Entities that will receive funds from the treasury each funding cycle."
-msgstr "每个筹款周期从项目金库获得资金的项目或者个人。"
-
 #: src/components/v1/V1Project/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "加载持有人错误"
@@ -1164,7 +1167,6 @@ msgstr "运“筹”帷幄，共创未来。"
 msgid "Funding"
 msgstr "筹款"
 
-#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "Funding Distribution"
 msgstr "资金分发"
@@ -1209,10 +1211,10 @@ msgid "Funding cycles can be reconfigured moments before a new cycle begins, wit
 msgstr "新的筹款周期开始前即可重新配置筹款周期参数，无须通知捐款者。"
 
 #: src/components/shared/forms/PayModsForm.tsx
+#: src/components/v1/FundingCycle/Spending.tsx
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
-#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Funding distribution"
 msgstr "资金分发"
 
@@ -1864,6 +1866,7 @@ msgid "Payout recipients"
 msgstr "支出的收款人"
 
 #: src/components/v2/V2Create/forms/FundingForm/index.tsx
+#: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
@@ -3341,6 +3344,10 @@ msgstr "已提取 {0}"
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
 msgid "{0} {1} reserved"
 msgstr "{0}{1} 保留"
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "{0}% of all newly minted tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -442,7 +442,7 @@ msgstr "可用资金会分发给以下支出对象。"
 
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-msgid "Available funds will be distributed according to the payouts below{0}."
+msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
 #: src/components/v1/FundingCycle/modals/DistributeTokensModal.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -211,7 +211,7 @@ msgid "A project can choose to reserve a percentage of tokens for itself. Instea
 msgstr "项目可以选择为自己保留一定比例的代币。这些代币不是分发给付费的用户，而是给到项目方。"
 
 #: src/components/v1/FundingCycle/ReservedTokens.tsx
-msgid "A project can reserve a percentage of tokens minted as a result of all payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
+msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx


### PR DESCRIPTION
## What does this PR do and why?

- Mentions FC length in tooltip of 'Distribution splits'
- Adds tooltip icon next to reserved splits explaining % of all newly minted tokens

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/170857236-f89722a9-d551-4afa-a764-0a67aec1856f.mp4

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
