### PR TITLE
Track deprecated ballot addresses + use in V2 project reconfig

### DIFF
--- a/src/components/v2/V2Project/banners/RelaunchFundingCycleBanner/index.tsx
+++ b/src/components/v2/V2Project/banners/RelaunchFundingCycleBanner/index.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Button, Form, Input } from 'antd'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 
 import Banner from 'components/shared/Banner'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
@@ -24,6 +24,11 @@ import {
 } from 'constants/v2/splits'
 import ReconfigurePreview from '../../V2ProjectReconfigureModal/ReconfigurePreview'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
+import {
+  BALLOT_ADDRESSES,
+  DEPRECATED_BALLOT_ADDRESSES,
+} from 'constants/v2/ballotStrategies'
+import { readNetwork } from 'constants/networks'
 
 export default function RelaunchFundingCycleBanner() {
   const { projectId } = useContext(V2ProjectContext)
@@ -88,6 +93,19 @@ export default function RelaunchFundingCycleBanner() {
 
   const launchFundingCycleTx = useLaunchFundingCyclesTx()
 
+  const newBallot = useMemo(() => {
+    if (!deprecatedFundingCycle) return
+
+    switch (deprecatedFundingCycle.ballot) {
+      case DEPRECATED_BALLOT_ADDRESSES.THREE_DAY[readNetwork.name]:
+        return BALLOT_ADDRESSES.THREE_DAY[readNetwork.name]!
+      // case DEPRECATED_BALLOT_ADDRESSES.SEVEN_DAY[readNetwork.name]:
+      //   return BALLOT_ADDRESSES.SEVEN_DAY[readNetwork.name]!
+      default:
+        return deprecatedFundingCycle.ballot
+    }
+  }, [deprecatedFundingCycle])
+
   const loading =
     payoutSplitsLoading ||
     deprecatedFundingCycleLoading ||
@@ -105,7 +123,7 @@ export default function RelaunchFundingCycleBanner() {
   const onLaunchModalOk = async () => {
     const fundingCycleData: V2FundingCycleData = {
       duration: newDuration ?? deprecatedFundingCycle.duration,
-      ballot: deprecatedFundingCycle.ballot,
+      ballot: newBallot ?? deprecatedFundingCycle.ballot,
       weight: deprecatedFundingCycle.weight,
       discountRate: deprecatedFundingCycle.discountRate,
     }
@@ -240,6 +258,7 @@ export default function RelaunchFundingCycleBanner() {
               fundingCycleData={{
                 ...deprecatedFundingCycle,
                 duration: newDuration ?? deprecatedFundingCycle.duration,
+                ballot: newBallot ?? deprecatedFundingCycle.ballot,
               }}
               fundAccessConstraints={[deprecatedFundAccessConstraint]}
             />

--- a/src/constants/v2/ballotStrategies/index.ts
+++ b/src/constants/v2/ballotStrategies/index.ts
@@ -1,10 +1,29 @@
 import * as constants from '@ethersproject/constants'
 import { t } from '@lingui/macro'
 
+import { NetworkName } from 'models/network-name'
+
 import { readNetwork } from 'constants/networks'
 import { SECONDS_IN_DAY } from 'constants/numbers'
 
-const BALLOT_ADDRESSES: { [k: string]: { [j: string]: string } } = {
+type BallotOption = Record<
+  'THREE_DAY' | 'SEVEN_DAY',
+  Partial<Record<NetworkName, string>>
+>
+
+export const DEPRECATED_BALLOT_ADDRESSES: BallotOption = {
+  THREE_DAY: {
+    rinkeby: '0xf91150aa07a1AC707148420713cefd299b8D094A',
+    mainnet: '0x9733F02d3A1068A11B07516fa2f3C3BaEf90e7eF',
+  },
+  SEVEN_DAY: {
+    // No 7 day delay contract deployed with original V2
+    rinkeby: constants.AddressZero,
+    mainnet: constants.AddressZero,
+  },
+}
+
+export const BALLOT_ADDRESSES: BallotOption = {
   THREE_DAY: {
     rinkeby: '0xbb5fe3f1c422a13700d8F990a17813e554c5b380',
     mainnet: '0x138D6d59afC6DbBD1DC0bDdF05Ae27f645Eb4305',
@@ -26,13 +45,13 @@ export function ballotStrategies() {
     {
       name: t`3-day delay`,
       description: t`A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts.`,
-      address: BALLOT_ADDRESSES.THREE_DAY[readNetwork.name as string],
+      address: BALLOT_ADDRESSES.THREE_DAY[readNetwork.name]!,
       durationSeconds: SECONDS_IN_DAY * 3,
     },
     {
       name: t`7-day delay`,
       description: t`A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts.`,
-      address: BALLOT_ADDRESSES.SEVEN_DAY[readNetwork.name as string],
+      address: BALLOT_ADDRESSES.SEVEN_DAY[readNetwork.name]!,
       durationSeconds: SECONDS_IN_DAY * 7,
     },
   ]


### PR DESCRIPTION
## What does this PR do and why?

**Awaiting verification on deprecated 7-day ballot**

Adds mapping for deprecated ballot addresses, and maps deprecated ballots to newly deployed ballots when configuring V2 project funding cycles.

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
