### PR TITLE
Fix dark text bug on payouts form

### DIFF
--- a/src/components/shared/TooltipIcon.tsx
+++ b/src/components/shared/TooltipIcon.tsx
@@ -1,6 +1,7 @@
 import { QuestionCircleOutlined } from '@ant-design/icons'
 import { Tooltip, TooltipProps } from 'antd'
-import { CSSProperties } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+import { CSSProperties, useContext } from 'react'
 
 export default function TooltipIcon({
   tip,
@@ -11,9 +12,14 @@ export default function TooltipIcon({
   placement?: TooltipProps['placement']
   iconStyle?: CSSProperties
 }) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
   return (
     <Tooltip title={tip} placement={placement} trigger={['hover', 'click']}>
-      <QuestionCircleOutlined style={iconStyle} />
+      <QuestionCircleOutlined
+        style={{ color: colors.text.primary, ...iconStyle }}
+      />
     </Tooltip>
   )
 }

--- a/src/components/v2/V2Project/DistributionLimit.tsx
+++ b/src/components/v2/V2Project/DistributionLimit.tsx
@@ -5,6 +5,9 @@ import { formatWad } from 'utils/formatNumber'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2/math'
 import TooltipIcon from 'components/shared/TooltipIcon'
 
+import { useContext } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+
 import { CurrencyName } from 'constants/currency'
 
 export default function DistributionLimit({
@@ -16,6 +19,10 @@ export default function DistributionLimit({
   currencyName: CurrencyName | undefined
   showTooltip?: boolean
 }) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
   const distributionLimitIsInfinite = distributionLimit?.eq(
     MAX_DISTRIBUTION_LIMIT,
   )
@@ -59,9 +66,9 @@ export default function DistributionLimit({
   )
 
   return (
-    <>
+    <span style={{ color: colors.text.primary }}>
       {_text}
       {_tooltip}
-    </>
+    </span>
   )
 }

--- a/src/components/v2/shared/DistributionSplitsSection/index.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/index.tsx
@@ -198,7 +198,7 @@ export default function DistributionSplitsSection({
           <Trans>Add payout</Trans>
         </Button>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <span>
+          <span style={{ color: colors.text.primary }}>
             <Trans>
               Distribution Limit{' '}
               <TooltipIcon

--- a/src/styles/antd-overrides/drawer.scss
+++ b/src/styles/antd-overrides/drawer.scss
@@ -5,3 +5,7 @@
 .ant-drawer-close {
   color: var(--icon-secondary);
 }
+
+.ant-drawer-header {
+  background: var(--background-l0);
+}

--- a/src/styles/antd-overrides/radio.scss
+++ b/src/styles/antd-overrides/radio.scss
@@ -5,3 +5,7 @@
 .ant-radio-inner::after {
   background-color: var(--background-action-primary);
 }
+
+.ant-radio-wrapper {
+  color: var(--text-primary);
+}


### PR DESCRIPTION
## What does this PR do and why?
Fixes various darkmode bugs on funding form

BEFORE:
![dark bug!](https://user-images.githubusercontent.com/96150256/170889940-e8a94e26-92a7-4f5a-803c-37f31c2e5d13.png)

AFTER: 
<img width="595" alt="Screen Shot 2022-05-29 at 9 21 46 pm" src="https://user-images.githubusercontent.com/96150256/170889945-be922bf3-7355-4a61-8da5-77b59e1b67a8.png">

ALSO FIXES: 

<img width="629" alt="Screen Shot 2022-05-29 at 11 14 58 pm" src="https://user-images.githubusercontent.com/96150256/170893464-db14ea92-877f-4ad7-8358-0f1c1c3100ed.png">


## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
