### PR TITLE
Fix distribute reserved button not wrapping on mobile

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
@@ -76,7 +76,14 @@ export default function ReservedTokensSplitsCard({
     <CardSection>
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
         {hideDistributeButton ? null : (
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              flexWrap: 'wrap',
+              gap: '10px',
+            }}
+          >
             <div style={{ marginRight: '3rem' }}>
               <span
                 style={{


### PR DESCRIPTION
## What does this PR do and why?

BEFORE:
<img width="360" alt="Screen Shot 2022-06-02 at 9 51 20 pm" src="https://user-images.githubusercontent.com/96150256/171735990-4043d783-b674-417d-a68c-fcd301083bec.png">

AFTER:
<img width="237" alt="Screen Shot 2022-06-02 at 9 51 05 pm" src="https://user-images.githubusercontent.com/96150256/171736005-1e323127-f9f8-4835-a55f-cd54ca8b5e14.png">

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
