### PR TITLE
Improve UX paying project with wallet disconnected

### DIFF
--- a/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -147,7 +147,8 @@ export default function V2ConfirmPayModal({
       title={t`Pay ${projectMetadata.name}`}
       visible={visible}
       onOk={pay}
-      okText={t`Pay`}
+      okText={userAddress ? t`Pay` : t`Connect wallet to pay`}
+      okButtonProps={{ disabled: !userAddress }}
       onCancel={onCancel}
       confirmLoading={loading}
       width={640}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -680,6 +680,7 @@ msgid "Connect wallet to deploy"
 msgstr "Connect wallet to deploy"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Connect wallet to pay"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -685,6 +685,7 @@ msgid "Connect wallet to deploy"
 msgstr "Conecta tu billetera para desplegar"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Conecta tu cartera para pagar"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -685,6 +685,7 @@ msgid "Connect wallet to deploy"
 msgstr "Connectez un portefeuille à déployer"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Connectez un portefeuille pour payer"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -685,6 +685,7 @@ msgid "Connect wallet to deploy"
 msgstr "Conecte uma carteira para implementar"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Conecte uma carteira para pagar"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -685,6 +685,7 @@ msgid "Connect wallet to deploy"
 msgstr "Подключите кошелёк для развертывания"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Подключите кошелёк для оплаты"
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -685,6 +685,7 @@ msgid "Connect wallet to deploy"
 msgstr "Başlatmak için cüzdanınızı bağlayın"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Ödemek için cüzdanınızı bağlayın"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -685,6 +685,7 @@ msgid "Connect wallet to deploy"
 msgstr "连接钱包以部署"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
+#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "连接钱包以支付"
 


### PR DESCRIPTION
## What does this PR do and why?

Slight improvement made in consideration to Jmill's issue here: (closes #1014).

Ideally we'd enable users to connect wallets from the modal, then keep it open when wallet is connected. However, `onSelectWallet` always causes a page reload, which currently causes the modal to close (unexpectedly from user's POV). 

Without overhauling `onSelectWallet()` and doing some fancy shit to prevent reload there, I think it's better UI to at least make users have to back out of the modal and connect the wallet manually. LMK what y'all think though

## Screenshots or screen recordings

Before:

<img width="982" alt="Screen Shot 2022-06-05 at 6 14 08 pm" src="https://user-images.githubusercontent.com/96150256/172062198-64579cc0-8aa2-4f24-aa66-09ed267db14b.png">

After:

<img width="963" alt="Screen Shot 2022-06-05 at 5 54 49 pm" src="https://user-images.githubusercontent.com/96150256/172062254-41e5965b-3726-4a24-bc9b-10c751a5e3a1.png">


## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
