### PR TITLE
Improve project search UI

### DIFF
--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -210,20 +210,6 @@ export default function Projects() {
         />
       </div>
 
-      {!!searchText && (
-        <div
-          style={{
-            marginBottom: 20,
-            textAlign: 'center',
-            color: colors.text.secondary,
-          }}
-        >
-          <Trans>
-            <InfoCircleOutlined /> Search results don't include V2 projects yet.
-          </Trans>
-        </div>
-      )}
-
       {selectedTab === 'all' ? (
         <React.Fragment>
           {concatenatedPages && (
@@ -265,6 +251,7 @@ export default function Projects() {
                   textAlign: 'center',
                   color: colors.text.disabled,
                   padding: 20,
+                  paddingTop: concatenatedPages?.length === 0 ? 0 : 20,
                 }}
               >
                 {concatenatedPages?.length}{' '}
@@ -287,6 +274,18 @@ export default function Projects() {
           <TrendingProjects count={12} trendingWindowDays={7} />
         </div>
       ) : null}
+      {Boolean(searchText) && !isLoading && (
+        <div
+          style={{
+            textAlign: 'center',
+            color: colors.text.secondary,
+          }}
+        >
+          <Trans>
+            <InfoCircleOutlined /> Search results don't include V2 projects yet.
+          </Trans>
+        </div>
+      )}
       <FeedbackFormButton />
     </div>
   )


### PR DESCRIPTION
## What does this PR do and why?

- Moves the V2 project notice below the search results
- Hides it when projects still loading
- Improves project count message padding-top when 0 projects

## Screenshots or screen recordings

Before:

https://user-images.githubusercontent.com/96150256/172064533-f12b14a4-62ab-4cac-ab9f-3289b28b01a2.mp4

After (excuse my terrible internet):

https://user-images.githubusercontent.com/96150256/172064549-6f27dde3-bfae-4b4b-bc13-433821eb0c5c.mp4

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
