### PR TITLE
Fix dark mode failure text color

### DIFF
--- a/src/components/v2/shared/DistributionSplitsSection/index.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/index.tsx
@@ -205,7 +205,7 @@ export default function DistributionSplitsSection({
           </Space>
         ) : null}
         {totalSplitsPercentageInvalid ? (
-          <span style={{ color: colors.text.failure }}>
+          <span style={{ color: colors.text.failure, fontWeight: 600 }}>
             <Trans>Sum of percentages cannot exceed 100%.</Trans>
           </span>
         ) : remainingSplitsPercentage > 0 && distributionLimit !== '0' ? (

--- a/src/constants/styles/colors.ts
+++ b/src/constants/styles/colors.ts
@@ -31,6 +31,6 @@ export const darkColors = {
   ctaHighlight: '#38e9ff',
   ctaHint: '#32c8db22',
   green: '#A0F3BA',
-  red: '#FF9B8',
+  red: '#ff6c6c',
   yellow: '#FCDC9C',
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes #1197 

Not sure if this is the perfect color, was trying to make it readable on the background shown here while still being obviously red. Feel free to suggest differently 

## Screenshots or screen recordings

Before:

<img width="618" alt="Screen Shot 2022-06-10 at 11 43 50 pm" src="https://user-images.githubusercontent.com/96150256/173157063-2bc9cfd4-5b4d-4cde-98ac-62068e6f59bb.png">

After:

<img width="576" alt="Screen Shot 2022-06-11 at 12 03 50 am" src="https://user-images.githubusercontent.com/96150256/173157055-74c6f6ee-5d92-4a88-96f2-465eeeff079c.png">

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
