### PR TITLE
Various improvements to reserved tokens form

### DIFF
--- a/src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
+++ b/src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
@@ -108,7 +108,7 @@ export default function ProjectPayoutMods({
         >
           <div
             style={{
-              color: total > 100 ? colors.text.warn : colors.text.secondary,
+              color: total > 100 ? colors.text.failure : colors.text.secondary,
             }}
           >
             <Trans>Total: {total.toFixed(2)}%</Trans>

--- a/src/components/v1/shared/ProjectTicketMods.tsx
+++ b/src/components/v1/shared/ProjectTicketMods.tsx
@@ -236,6 +236,8 @@ export default function ProjectTicketMods({
     return validatePercentage(form.getFieldValue('percent'))
   }
 
+  const totalSplitsPercentageInvalid = total > 100
+
   return (
     <Form.Item
       name={name}
@@ -275,27 +277,31 @@ export default function ProjectTicketMods({
           <div style={{ textAlign: 'right' }}>
             <span
               style={{
-                color: total > 100 ? colors.text.warn : colors.text.secondary,
+                color:
+                  total > 100 ? colors.text.failure : colors.text.secondary,
               }}
             >
-              <Trans>
-                Total:{' '}
-                {total
-                  .toString()
-                  .split('.')
-                  .map((x, i) => (i > 0 ? x[0] : x))
-                  .join('.')}
-                %
-              </Trans>
+              <Trans>Total: {total.toFixed(2)}%</Trans>
             </span>
           </div>
-          <div>
-            <Trans>
-              {100 - total}% to{' '}
-              {owner ? <FormattedAddress address={owner} /> : t`project owner`}
-            </Trans>
-          </div>
+          {total < 100 ? (
+            <div>
+              <Trans>
+                {(100 - total).toFixed(2)}% to{' '}
+                {owner ? (
+                  <FormattedAddress address={owner} />
+                ) : (
+                  t`project owner`
+                )}
+              </Trans>
+            </div>
+          ) : null}
         </div>
+        {totalSplitsPercentageInvalid ? (
+          <span style={{ color: colors.text.failure, fontWeight: 600 }}>
+            <Trans>Sum of percentages cannot exceed 100%.</Trans>
+          </span>
+        ) : null}
         <Button
           type="dashed"
           onClick={() => {

--- a/src/components/v2/V2Create/forms/TokenForm/index.tsx
+++ b/src/components/v2/V2Create/forms/TokenForm/index.tsx
@@ -4,6 +4,7 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useAppDispatch } from 'hooks/AppDispatch'
 import { useAppSelector } from 'hooks/AppSelector'
 import ReservedTokensFormItem from 'components/v2/V2Create/forms/TokenForm/ReservedTokensFormItem'
+import { ItemNoInput } from 'components/shared/formItems/ItemNoInput'
 
 import {
   CSSProperties,
@@ -55,6 +56,8 @@ import { formattedNum } from 'utils/formatNumber'
 import { DEFAULT_BONDING_CURVE_RATE_PERCENTAGE } from 'components/shared/formItems/ProjectRedemptionRate'
 
 import { DISCOUNT_RATE_EXPLANATION } from 'components/v2/V2Project/V2FundingCycleSection/settingExplanations'
+import { getTotalSplitsPercentage } from 'utils/v2/distributions'
+import { useForm } from 'antd/lib/form/Form'
 
 import { shadowCard } from 'constants/styles/shadowCard'
 import TabDescription from '../../TabDescription'
@@ -139,6 +142,8 @@ export default function TokenForm({
     theme: { colors },
   } = useContext(ThemeContext)
 
+  const [tokenForm] = useForm<{ totalReservedSplitPercent: number }>()
+
   const dispatch = useAppDispatch()
   const {
     fundingCycleMetadata,
@@ -206,7 +211,8 @@ export default function TokenForm({
     reservedTokensGroupedSplits?.splits,
   )
 
-  const onTokenFormSaved = useCallback(() => {
+  const onTokenFormSaved = useCallback(async () => {
+    await tokenForm.validateFields()
     const newReservedTokensSplits = reservedTokensSplits.map(split =>
       sanitizeSplit(split),
     )
@@ -230,6 +236,7 @@ export default function TokenForm({
     discountRate,
     reservedRate,
     redemptionRate,
+    tokenForm,
   ])
 
   useEffect(() => {
@@ -256,8 +263,15 @@ export default function TokenForm({
   const initialIssuanceRate =
     DEFAULT_ISSUANCE_RATE - reservedRatePercent * MAX_RESERVED_RATE
 
+  const validateTotalReservedPercent = () => {
+    if (getTotalSplitsPercentage(reservedTokensSplits) > 100) {
+      return Promise.reject(`Reserved allocations exceed 100%.`)
+    }
+    return Promise.resolve()
+  }
+
   return (
-    <Form layout="vertical" onFinish={onTokenFormSaved}>
+    <Form layout="vertical" onFinish={onTokenFormSaved} form={tokenForm}>
       <Space size="middle" direction="vertical">
         <div>
           <ReservedTokensFormItem
@@ -346,6 +360,14 @@ export default function TokenForm({
             disabled={!canSetRedemptionRate}
           />
         </div>
+        <ItemNoInput
+          name={'totalSplitsPercentage'}
+          rules={[
+            {
+              validator: validateTotalReservedPercent,
+            },
+          ]}
+        />
         <Form.Item>
           <Button htmlType="submit" type="primary">
             <Trans>Save token configuration</Trans>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2418,6 +2418,7 @@ msgstr "Start time (seconds, Unix time)"
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Sum of percentages cannot exceed 100%"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2423,6 +2423,7 @@ msgstr "Hora de inicio (segundos, tiempo Unix)"
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "La suma de los porcentajes no puede exceder 100%"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2423,6 +2423,7 @@ msgstr "Heure de début (secondes, heure Unix)"
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "La somme des pourcentages ne peut pas dépasser 100%"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2423,6 +2423,7 @@ msgstr "Hora de início (segundos, tempo Unix)"
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Soma de porcentagens não pode exceder 100%"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2423,6 +2423,7 @@ msgstr ""
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Сумма процентов не может превышать 100%"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2423,6 +2423,7 @@ msgstr ""
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Yüzdelerin toplamı %100'ü aşamaz"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2423,6 +2423,7 @@ msgstr ""
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "百分比合计不能超过 100%"
 
+#: src/components/v1/shared/ProjectTicketMods.tsx
 #: src/components/v1/shared/forms/PayModsForm.tsx
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."


### PR DESCRIPTION
## What does this PR do and why?

Closes #1189 (hid the owner % when total splits >= 100)
Closes #1190 (cannot submit form when total splits >= 100) Note: the dark text on 'Sum of payouts cannot...' is fixed in my latest #1198 PR
Closes #1191 (remaining owner % rounds to 2dp)

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/173159960-ef21443a-9416-4c20-9a42-7eaaba43397c.mp4

## Acceptance checklist

- [x] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [x] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
