### PR TITLE
[Critical] Pay bug for very small amounts and issuance rate

### DIFF
--- a/src/components/shared/inputs/Pay/PayInputSubText.tsx
+++ b/src/components/shared/inputs/Pay/PayInputSubText.tsx
@@ -66,7 +66,11 @@ export default function PayInputSubText({
 
   const receiveText = useMemo(() => {
     const formatReceivedTickets = (wei: BigNumber) => {
-      const exchangeRate = weightingFn(weight, reservedRate, wei, 'payer')
+      let exchangeRate = weightingFn(weight, reservedRate, wei, 'payer')
+      // Round to nearest wei
+      if (exchangeRate.split('.').length) {
+        exchangeRate = exchangeRate.split('.')[0]
+      }
       return formattedNum(formatIssuanceRate(exchangeRate))
     }
 

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
@@ -32,7 +32,8 @@ import {
   weightedAmount,
 } from 'utils/v2/math'
 import { Split } from 'models/v2/splits'
-import { formattedNum, fromWad } from 'utils/formatNumber'
+import { formattedNum } from 'utils/formatNumber'
+import { parseEther } from 'ethers/lib/utils'
 
 export default function ReconfigurePreview({
   payoutSplits,
@@ -80,7 +81,7 @@ export default function ReconfigurePreview({
         weightedAmount(
           fundingCycle?.weight,
           fundingCycleMetadata?.reservedRate.toNumber(),
-          BigNumber.from(1),
+          parseEther('1'),
           'payer',
         ),
       ),
@@ -101,7 +102,7 @@ export default function ReconfigurePreview({
         weightedAmount(
           fundingCycle?.weight,
           fundingCycleMetadata?.reservedRate.toNumber(),
-          BigNumber.from(1),
+          parseEther('1'),
           'reserved',
         ) ?? '',
       ),
@@ -122,8 +123,9 @@ export default function ReconfigurePreview({
         <Col md={8} sm={12}>
           <InflationRateStatistic
             inflationRate={
-              formattedNum(formatIssuanceRate(fromWad(fundingCycle?.weight))) ??
-              '0'
+              formattedNum(
+                formatIssuanceRate(fundingCycle?.weight.toString()),
+              ) ?? '0'
             }
           />
         </Col>


### PR DESCRIPTION
## What does this PR do and why?

On V2 projects, with very small pay amounts and issuance rate, `exchangeRate` was coming through a decimal wei value, causing the `BigNumber.from` in `formattedIssuanceRate` to fail. 

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the
changes._

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
