### PR TITLE
Use beneficiaryDistributionAmount in distributePayoutsEventElem

### DIFF
--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
@@ -23,6 +23,7 @@ export default function DistributePayoutsElem({
         | 'txHash'
         | 'caller'
         | 'beneficiary'
+        | 'beneficiaryDistributionAmount'
         | 'distributedAmount'
         | 'memo'
       >
@@ -112,7 +113,7 @@ export default function DistributePayoutsElem({
           </div>
         ))}
 
-        {event.distributedAmount?.gt(0) && (
+        {event.beneficiaryDistributionAmount?.gt(0) && (
           <div
             style={{
               display: 'flex',
@@ -132,7 +133,7 @@ export default function DistributePayoutsElem({
               }
             >
               <CurrencySymbol currency="ETH" />
-              {formatWad(event.distributedAmount, { precision: 4 })}
+              {formatWad(event.beneficiaryDistributionAmount, { precision: 4 })}
             </div>
           </div>
         )}

--- a/src/components/v2/V2Project/ProjectActivity/index.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/index.tsx
@@ -158,6 +158,7 @@ export default function ProjectActivity() {
           'txHash',
           'caller',
           'beneficiary',
+          'beneficiaryDistributionAmount',
           'distributedAmount',
           'memo',
         ],

--- a/src/models/subgraph-entities/v2/distribute-payouts-event.ts
+++ b/src/models/subgraph-entities/v2/distribute-payouts-event.ts
@@ -54,8 +54,8 @@ export const parseDistributePayoutsEventJson = (
   distributedAmount: j.distributedAmount
     ? BigNumber.from(j.distributedAmount)
     : undefined,
-  beneficiaryDistributionAmount: j.distributedAmount
-    ? BigNumber.from(j.distributedAmount)
+  beneficiaryDistributionAmount: j.beneficiaryDistributionAmount
+    ? BigNumber.from(j.beneficiaryDistributionAmount)
     : undefined,
   fee: j.fee ? BigNumber.from(j.fee) : undefined,
   memo: j.memo,


### PR DESCRIPTION
## What does this PR do and why?

Includes the `beneficiaryDistributionAmount` in the `DistributePayoutsEventElem` component that was accidentally omitted before, and fixes a bug in parsing `distributePayoutsEvent` json.

## Acceptance checklist

- [x] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [x] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
