### PR TITLE
Improve wallet disconnect transaction modal state

### DIFF
--- a/src/components/shared/TransactionModal.tsx
+++ b/src/components/shared/TransactionModal.tsx
@@ -1,5 +1,6 @@
 import { t, Trans } from '@lingui/macro'
 import { Modal, ModalProps } from 'antd'
+import { NetworkContext } from 'contexts/networkContext'
 
 import { ThemeContext } from 'contexts/themeContext'
 import { PropsWithChildren, useContext } from 'react'
@@ -7,6 +8,7 @@ import { PropsWithChildren, useContext } from 'react'
 type TransactionModalProps = PropsWithChildren<
   ModalProps & {
     transactionPending?: boolean
+    connectWalletText?: string
   }
 >
 
@@ -51,11 +53,20 @@ const PendingTransactionModalBody = () => {
  * are replaced with a juicy loading state.
  */
 export default function TransactionModal(props: TransactionModalProps) {
+  const { userAddress } = useContext(NetworkContext)
+  const okText = userAddress
+    ? props.okText
+    : props.connectWalletText ?? t`Connect wallet`
   const modalProps = {
     ...props,
     ...{
       confirmLoading: props.transactionPending || props.confirmLoading,
       cancelText: t`Close`,
+      okButtonProps: {
+        ...props.okButtonProps,
+        disabled: !userAddress,
+      },
+      okText: okText,
     },
   }
 

--- a/src/components/shared/TransactorButton.tsx
+++ b/src/components/shared/TransactorButton.tsx
@@ -1,0 +1,18 @@
+import { Button, ButtonProps } from 'antd'
+import { PropsWithChildren } from 'react'
+
+type TransactorButtonProps = PropsWithChildren<
+  ButtonProps & {
+    text: string | JSX.Element
+    connectWalletText?: string | JSX.Element
+  }
+>
+
+export default function TransactorButton(props: TransactorButtonProps) {
+  const buttonText = props.disabled ? props.connectWalletText : props.text
+  return (
+    <Button {...props}>
+      <span>{buttonText}</span>
+    </Button>
+  )
+}

--- a/src/components/shared/modals/IssueTokenModal.tsx
+++ b/src/components/shared/modals/IssueTokenModal.tsx
@@ -60,6 +60,7 @@ export default function IssueTokenModal({
       title={t`Issue ERC-20 token`}
       okText={t`Issue token`}
       cancelText={t`Later`}
+      connectWalletText={t`Connect wallet to issue`}
       onOk={executeIssueTokensTx}
       onCancel={() => onClose()}
       confirmLoading={loading}

--- a/src/components/shared/modals/ProjectToolDrawerModal.tsx
+++ b/src/components/shared/modals/ProjectToolDrawerModal.tsx
@@ -20,6 +20,8 @@ import { ThemeContext } from 'contexts/themeContext'
 import { DeployProjectPayerTxArgs } from 'hooks/v2/transactor/DeployProjectPayerTx'
 import ArchiveV2Project from 'components/v2/V2Project/ArchiveV2Project'
 
+import TransactorButton from '../TransactorButton'
+
 export default function ProjectToolDrawerModal({
   visible,
   onClose,
@@ -258,16 +260,15 @@ export default function ProjectToolDrawerModal({
               />
             </Form.Item>
             <Form.Item>
-              <Button
+              <TransactorButton
                 onClick={() => transferTokens()}
                 loading={loadingTransferTokens}
                 size="small"
                 type="primary"
-              >
-                <span>
-                  <Trans>Transfer {tokenSymbolShort}</Trans>
-                </span>
-              </Button>
+                text={<Trans>Transfer {tokenSymbolShort}</Trans>}
+                disabled={!userAddress}
+                connectWalletText={t`Connect wallet to transfer`}
+              />
             </Form.Item>
           </Form>
         </section>
@@ -296,16 +297,15 @@ export default function ProjectToolDrawerModal({
               />
             </Form.Item>
             <Form.Item>
-              <Button
+              <TransactorButton
                 onClick={() => addToBalance()}
                 loading={loadingAddToBalance}
                 size="small"
                 type="primary"
-              >
-                <span>
-                  <Trans>Add to balance</Trans>
-                </span>
-              </Button>
+                text={t`Add to balance`}
+                disabled={!userAddress}
+                connectWalletText={t`Connect wallet to pay`}
+              />
             </Form.Item>
           </Form>
         </section>

--- a/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingSummarySection.tsx
+++ b/src/components/v2/V2Create/tabs/ReviewDeployTab/FundingSummarySection.tsx
@@ -140,13 +140,13 @@ export default function FundingSummarySection() {
           showDetail
         />
         <Row gutter={rowGutter} style={{ width: '100%' }}>
-          <Col md={6} xs={24}>
+          <Col md={8} xs={24}>
             <DurationStatistic
               showWarning={unsafeFundingCycleProperties.duration}
               duration={duration}
             />
           </Col>
-          <Col md={6} xs={24}>
+          <Col md={8} xs={24}>
             <InflationRateStatistic
               isInitial
               inflationRate={
@@ -156,41 +156,41 @@ export default function FundingSummarySection() {
               }
             />
           </Col>
-          <Col md={6} xs={24}>
+          <Col md={8} xs={24}>
             <IssuanceRateStatistic
               issuanceRate={initialIssuanceRate}
               isInitial
             />
           </Col>
-          <Col md={6} xs={24}>
+        </Row>
+        <Row gutter={rowGutter} style={{ width: '100%' }}>
+          <Col md={8} xs={24}>
             <ReservedTokensStatistic
               reservedRate={reservedRate}
               reservedPercentage={reservedPercentage}
             />
           </Col>
           {fundingCycle && hasDuration && (
-            <Col md={5} xs={24}>
+            <Col md={8} xs={24}>
               <DiscountRateStatistic discountRate={fundingCycle.discountRate} />
             </Col>
           )}
-        </Row>
-        <Row gutter={rowGutter} style={{ width: '100%' }}>
           {fundingCycleMetadata && hasDistributionLimit && (
-            <Col md={6} xs={24}>
+            <Col md={8} xs={24}>
               <RedemptionRateStatistic
                 redemptionRate={fundingCycleMetadata.redemptionRate}
               />
             </Col>
           )}
-          <Col md={6} xs={24}>
+          <Col md={8} xs={24}>
             <PausePayStatistic pausePay={fundingCycleMetadata?.pausePay} />
           </Col>
-          <Col md={6} xs={24}>
+          <Col md={8} xs={24}>
             <AllowMintingStatistic
               allowMinting={fundingCycleMetadata?.allowMinting}
             />
           </Col>
-          <Col md={6} xs={24}>
+          <Col md={8} xs={24}>
             {hasDuration && (
               <ReconfigurationStatistic ballotAddress={fundingCycle.ballot} />
             )}

--- a/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
@@ -113,6 +113,7 @@ export default function LaunchProjectPayerModal({
         visible={visible}
         title={t`Create payable address`}
         okText={t`Deploy project payer contract`}
+        connectWalletText={t`Connect wallet to deploy`}
         onOk={deployProjectPayer}
         onCancel={() => onClose()}
         confirmLoading={loadingProjectPayer}

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
@@ -146,6 +146,7 @@ export default function DistributePayoutsModal({
       confirmLoading={loading}
       transactionPending={transactionPending}
       okText={t`Distribute funds`}
+      connectWalletText={t`Connect wallet to distribute`}
       width={640}
     >
       <Space direction="vertical" size="large" style={{ width: '100%' }}>

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
@@ -77,6 +77,7 @@ export default function DistributeReservedTokensModal({
       visible={visible}
       onOk={() => distributeReservedTokens()}
       okText={t`Distribute ${tokenTextPlural}`}
+      connectWalletText={t`Connect wallet to distribute`}
       confirmLoading={loading}
       transactionPending={transactionPending}
       onCancel={onCancel}

--- a/src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
@@ -80,6 +80,7 @@ export default function V2ClaimTokensModal({
   return (
     <TransactionModal
       title={t`Claim ${tokenTextShort} as ERC-20 tokens`}
+      connectWalletText={t`Connect wallet to claim`}
       visible={visible}
       onOk={executeClaimTokensTx}
       okText={t`Claim ${tokenTextShort}`}

--- a/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -147,8 +147,8 @@ export default function V2ConfirmPayModal({
       title={t`Pay ${projectMetadata.name}`}
       visible={visible}
       onOk={pay}
-      okText={userAddress ? t`Pay` : t`Connect wallet to pay`}
-      okButtonProps={{ disabled: !userAddress }}
+      okText={t`Pay`}
+      connectWalletText={t`Connect wallet to pay`}
       onCancel={onCancel}
       confirmLoading={loading}
       width={640}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -691,10 +691,28 @@ msgstr "Congratulations on launching your project! The next steps are optional a
 msgid "Connect"
 msgstr ""
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr "Connect wallet"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr "Connect wallet to claim"
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "Connect wallet to deploy"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr "Connect wallet to distribute"
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr "Connect wallet to issue"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -714,10 +714,15 @@ msgstr "Connect wallet to distribute"
 msgid "Connect wallet to issue"
 msgstr "Connect wallet to issue"
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Connect wallet to pay"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr "Connect wallet to transfer"
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -696,10 +696,28 @@ msgstr ""
 msgid "Connect"
 msgstr "Conectar"
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr ""
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "Conecta tu billetera para desplegar"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr ""
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -719,10 +719,15 @@ msgstr ""
 msgid "Connect wallet to issue"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Conecta tu cartera para pagar"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr ""
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -719,10 +719,15 @@ msgstr ""
 msgid "Connect wallet to issue"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Connectez un portefeuille pour payer"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr ""
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -696,10 +696,28 @@ msgstr ""
 msgid "Connect"
 msgstr "Connectez-vous"
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr ""
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "Connectez un portefeuille à déployer"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr ""
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -719,10 +719,15 @@ msgstr ""
 msgid "Connect wallet to issue"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Conecte uma carteira para pagar"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr ""
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -696,10 +696,28 @@ msgstr ""
 msgid "Connect"
 msgstr "Conectar"
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr ""
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "Conecte uma carteira para implementar"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr ""
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -696,10 +696,28 @@ msgstr ""
 msgid "Connect"
 msgstr "Подключиться"
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr ""
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "Подключите кошелёк для развертывания"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr ""
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -719,10 +719,15 @@ msgstr ""
 msgid "Connect wallet to issue"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Подключите кошелёк для оплаты"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr ""
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -696,10 +696,28 @@ msgstr ""
 msgid "Connect"
 msgstr "Bağlan"
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr ""
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "Başlatmak için cüzdanınızı bağlayın"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr ""
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -719,10 +719,15 @@ msgstr ""
 msgid "Connect wallet to issue"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Ödemek için cüzdanınızı bağlayın"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr ""
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -696,10 +696,28 @@ msgstr ""
 msgid "Connect"
 msgstr "连接钱包"
 
+#: src/components/shared/TransactionModal.tsx
+msgid "Connect wallet"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
+msgid "Connect wallet to claim"
+msgstr ""
+
 #: src/components/v1/V1Create/index.tsx
 #: src/components/v2/V2Create/tabs/ReviewDeployTab/DeployProjectButton.tsx
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Connect wallet to deploy"
 msgstr "连接钱包以部署"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
+msgid "Connect wallet to distribute"
+msgstr ""
+
+#: src/components/shared/modals/IssueTokenModal.tsx
+msgid "Connect wallet to issue"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -719,10 +719,15 @@ msgstr ""
 msgid "Connect wallet to issue"
 msgstr ""
 
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal/index.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "连接钱包以支付"
+
+#: src/components/shared/modals/ProjectToolDrawerModal.tsx
+msgid "Connect wallet to transfer"
+msgstr ""
 
 #: src/components/Projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."


### PR DESCRIPTION
## What does this PR do and why?

Closes #911 

To me, having the OK button be enabled and the okText as 'Connect wallet to ...' and then opening the wallet select would be ideal if not for the fact that this causes a page reload and therefore closes the modal on the user unexpectedly once they connect their wallet. (reload occurs because setting wallet writes to local storage). 

So then, I think the next best option is just disabling the button with the 'Connect wallet to ...' text, and make the user back out to connect their wallet. 100% open to feedback or other ideas here though.

For every transaction modal that users can get to without a wallet connected, I've implemented this logic. 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/173198766-10551d5a-309f-40a0-9c97-9868c50e81de.mp4

## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
