### PR TITLE
Refactor Reconfigure to break down into smaller parts

### DIFF
--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/editingProjectData.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/editingProjectData.ts
@@ -1,0 +1,43 @@
+import {
+  useAppSelector,
+  useEditingV2FundAccessConstraintsSelector,
+  useEditingV2FundingCycleDataSelector,
+  useEditingV2FundingCycleMetadataSelector,
+} from 'hooks/AppSelector'
+import {
+  V2FundingCycleMetadata,
+  V2FundingCycleData,
+  V2FundAccessConstraint,
+} from 'models/v2/fundingCycle'
+import {
+  ETHPayoutGroupedSplits,
+  ReservedTokensGroupedSplits,
+} from 'models/v2/splits'
+
+export interface EditingProjectData {
+  editingPayoutGroupedSplits: ETHPayoutGroupedSplits
+  editingReservedTokensGroupedSplits: ReservedTokensGroupedSplits
+  editingFundingCycleMetadata: Omit<V2FundingCycleMetadata, 'version'>
+  editingFundingCycleData: V2FundingCycleData
+  editingFundAccessConstraints: V2FundAccessConstraint[]
+}
+
+export const useEditingProjectData = () => {
+  // Gets values from the redux state to be used in the modal drawer fields
+  const {
+    payoutGroupedSplits: editingPayoutGroupedSplits,
+    reservedTokensGroupedSplits: editingReservedTokensGroupedSplits,
+  } = useAppSelector(state => state.editingV2Project)
+  const editingFundingCycleMetadata = useEditingV2FundingCycleMetadataSelector()
+  const editingFundingCycleData = useEditingV2FundingCycleDataSelector()
+  const editingFundAccessConstraints =
+    useEditingV2FundAccessConstraintsSelector()
+
+  return {
+    editingPayoutGroupedSplits,
+    editingReservedTokensGroupedSplits,
+    editingFundingCycleMetadata,
+    editingFundingCycleData,
+    editingFundAccessConstraints,
+  }
+}

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/fundingHasSavedChanges.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/fundingHasSavedChanges.ts
@@ -1,0 +1,158 @@
+import { isEqual } from 'lodash'
+import { useMemo } from 'react'
+import {
+  serializeFundAccessConstraint,
+  serializeV2FundingCycleMetadata,
+  serializeV2FundingCycleData,
+} from 'utils/v2/serializers'
+
+import { EditingProjectData } from './editingProjectData'
+import { InitialEditingData, useInitialEditingData } from './initialEditingData'
+
+export const useFundingHasSavedChanges = (
+  editingProjectData: EditingProjectData,
+  visible: boolean,
+) => {
+  const {
+    editingPayoutGroupedSplits,
+    editingReservedTokensGroupedSplits,
+    editingFundingCycleMetadata,
+    editingFundingCycleData,
+    editingFundAccessConstraints,
+  } = editingProjectData
+
+  const { initialEditingData } = useInitialEditingData(visible)
+
+  const fundingHasSavedChanges = useMemo(() => {
+    if (!initialEditingData) {
+      // Nothing to compare so return false
+      return false
+    }
+    const editedChanges: InitialEditingData = {
+      fundAccessConstraints: editingFundAccessConstraints.map(
+        serializeFundAccessConstraint,
+      ),
+      fundingCycleMetadata: serializeV2FundingCycleMetadata(
+        editingFundingCycleMetadata,
+      ),
+      fundingCycleData: serializeV2FundingCycleData(editingFundingCycleData),
+      payoutGroupedSplits: {
+        payoutGroupedSplits: editingPayoutGroupedSplits.splits,
+        reservedTokensGroupedSplits: editingReservedTokensGroupedSplits.splits,
+      },
+    }
+    return !isEqual(initialEditingData, editedChanges)
+  }, [
+    editingFundAccessConstraints,
+    editingFundingCycleData,
+    editingFundingCycleMetadata,
+    editingPayoutGroupedSplits,
+    editingReservedTokensGroupedSplits,
+    initialEditingData,
+  ])
+
+  const fundingDrawerHasSavedChanges = () => {
+    const fundingCycleData = serializeV2FundingCycleData(
+      editingFundingCycleData,
+    )
+    const fundAccessConstraints = editingFundAccessConstraints.length
+      ? serializeFundAccessConstraint(editingFundAccessConstraints?.[0])
+      : undefined
+    const payoutGroupedSplits = editingPayoutGroupedSplits.splits
+
+    if (!fundAccessConstraints || !initialEditingData) {
+      return false
+    }
+    const durationUpdated =
+      fundingCycleData.duration !== initialEditingData.fundingCycleData.duration
+    const distributionLimitUpdated =
+      fundAccessConstraints.distributionLimit !==
+      initialEditingData.fundAccessConstraints?.[0].distributionLimit
+    const distributionLimitCurrencyUpdated =
+      fundAccessConstraints.distributionLimitCurrency !==
+      initialEditingData.fundAccessConstraints?.[0].distributionLimitCurrency
+    const payoutGroupedSplitsUpdated = !isEqual(
+      payoutGroupedSplits,
+      initialEditingData.payoutGroupedSplits?.payoutGroupedSplits ?? [],
+    )
+    return (
+      durationUpdated ||
+      distributionLimitUpdated ||
+      distributionLimitCurrencyUpdated ||
+      payoutGroupedSplitsUpdated
+    )
+  }
+
+  const tokenDrawerHasSavedChanges = () => {
+    const fundingCycleData = serializeV2FundingCycleData(
+      editingFundingCycleData,
+    )
+    const fundingCycleMetadata = serializeV2FundingCycleMetadata(
+      editingFundingCycleMetadata,
+    )
+    const fundAccessConstraints = editingFundAccessConstraints.length
+      ? serializeFundAccessConstraint(editingFundAccessConstraints?.[0])
+      : undefined
+    const reservedTokensGroupedSplits =
+      editingReservedTokensGroupedSplits.splits
+
+    if (!fundAccessConstraints || !initialEditingData) {
+      return false
+    }
+
+    const reservedRateUpdated =
+      fundingCycleMetadata.reservedRate !==
+      initialEditingData.fundingCycleMetadata.reservedRate
+    const reservedTokensGroupedSplitsUpdated = !isEqual(
+      reservedTokensGroupedSplits,
+      initialEditingData.payoutGroupedSplits.reservedTokensGroupedSplits ?? [],
+    )
+    const discountRateUpdated =
+      fundingCycleData.discountRate !==
+      initialEditingData.fundingCycleData.discountRate
+    const redemptionRateUpdated =
+      fundingCycleMetadata.redemptionRate !==
+      initialEditingData.fundingCycleMetadata.redemptionRate
+
+    return (
+      reservedRateUpdated ||
+      reservedTokensGroupedSplitsUpdated ||
+      discountRateUpdated ||
+      redemptionRateUpdated
+    )
+  }
+
+  const rulesDrawerHasSavedChanges = () => {
+    const fundingCycleData = serializeV2FundingCycleData(
+      editingFundingCycleData,
+    )
+    const fundingCycleMetadata = serializeV2FundingCycleMetadata(
+      editingFundingCycleMetadata,
+    )
+    const fundAccessConstraints = editingFundAccessConstraints.length
+      ? serializeFundAccessConstraint(editingFundAccessConstraints?.[0])
+      : undefined
+
+    if (!fundAccessConstraints || !initialEditingData) {
+      return false
+    }
+
+    const pausePaymentsUpdated =
+      fundingCycleMetadata.pausePay !==
+      initialEditingData.fundingCycleMetadata.pausePay
+    const allowMintingUpdated =
+      fundingCycleMetadata.allowMinting !==
+      initialEditingData.fundingCycleMetadata.allowMinting
+    const ballotUpdated =
+      fundingCycleData.ballot !== initialEditingData.fundingCycleData.ballot
+
+    return pausePaymentsUpdated || allowMintingUpdated || ballotUpdated
+  }
+
+  return {
+    fundingHasSavedChanges,
+    fundingDrawerHasSavedChanges,
+    tokenDrawerHasSavedChanges,
+    rulesDrawerHasSavedChanges,
+  }
+}

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/fundingHasSavedChanges.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/fundingHasSavedChanges.ts
@@ -52,7 +52,7 @@ export const useFundingHasSavedChanges = ({
     initialEditingData,
   ])
 
-  const fundingDrawerHasSavedChanges = () => {
+  const fundingDrawerHasSavedChanges = useMemo(() => {
     const fundingCycleData = serializeV2FundingCycleData(
       editingFundingCycleData,
     )
@@ -82,9 +82,14 @@ export const useFundingHasSavedChanges = ({
       distributionLimitCurrencyUpdated ||
       payoutGroupedSplitsUpdated
     )
-  }
+  }, [
+    editingFundAccessConstraints,
+    editingFundingCycleData,
+    editingPayoutGroupedSplits.splits,
+    initialEditingData,
+  ])
 
-  const tokenDrawerHasSavedChanges = () => {
+  const tokenDrawerHasSavedChanges = useMemo(() => {
     const fundingCycleData = serializeV2FundingCycleData(
       editingFundingCycleData,
     )
@@ -121,9 +126,15 @@ export const useFundingHasSavedChanges = ({
       discountRateUpdated ||
       redemptionRateUpdated
     )
-  }
+  }, [
+    editingFundAccessConstraints,
+    editingFundingCycleData,
+    editingFundingCycleMetadata,
+    editingReservedTokensGroupedSplits.splits,
+    initialEditingData,
+  ])
 
-  const rulesDrawerHasSavedChanges = () => {
+  const rulesDrawerHasSavedChanges = useMemo(() => {
     const fundingCycleData = serializeV2FundingCycleData(
       editingFundingCycleData,
     )
@@ -148,7 +159,12 @@ export const useFundingHasSavedChanges = ({
       fundingCycleData.ballot !== initialEditingData.fundingCycleData.ballot
 
     return pausePaymentsUpdated || allowMintingUpdated || ballotUpdated
-  }
+  }, [
+    editingFundAccessConstraints,
+    editingFundingCycleData,
+    editingFundingCycleMetadata,
+    initialEditingData,
+  ])
 
   return {
     fundingHasSavedChanges,

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/fundingHasSavedChanges.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/fundingHasSavedChanges.ts
@@ -7,12 +7,15 @@ import {
 } from 'utils/v2/serializers'
 
 import { EditingProjectData } from './editingProjectData'
-import { InitialEditingData, useInitialEditingData } from './initialEditingData'
+import { InitialEditingData } from './initialEditingData'
 
-export const useFundingHasSavedChanges = (
-  editingProjectData: EditingProjectData,
-  visible: boolean,
-) => {
+export const useFundingHasSavedChanges = ({
+  editingProjectData,
+  initialEditingData,
+}: {
+  editingProjectData: EditingProjectData
+  initialEditingData: InitialEditingData | undefined
+}) => {
   const {
     editingPayoutGroupedSplits,
     editingReservedTokensGroupedSplits,
@@ -20,8 +23,6 @@ export const useFundingHasSavedChanges = (
     editingFundingCycleData,
     editingFundAccessConstraints,
   } = editingProjectData
-
-  const { initialEditingData } = useInitialEditingData(visible)
 
   const fundingHasSavedChanges = useMemo(() => {
     if (!initialEditingData) {

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/initialEditingData.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/initialEditingData.ts
@@ -1,0 +1,211 @@
+import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
+import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
+import { Split } from 'models/v2/splits'
+import { useContext, useEffect, useState } from 'react'
+import {
+  editingV2ProjectActions,
+  defaultFundingCycleMetadata,
+} from 'redux/slices/editingV2Project'
+import { fromWad } from 'utils/formatNumber'
+import { V2_CURRENCY_ETH, NO_CURRENCY } from 'utils/v2/currency'
+import { decodeV2FundingCycleMetadata } from 'utils/v2/fundingCycle'
+import {
+  SerializedV2FundAccessConstraint,
+  SerializedV2FundingCycleData,
+  SerializedV2FundingCycleMetadata,
+  serializeV2FundingCycleData,
+  serializeV2FundingCycleMetadata,
+} from 'utils/v2/serializers'
+
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+
+import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
+
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { useAppDispatch } from 'hooks/AppDispatch'
+
+import {
+  ETH_PAYOUT_SPLIT_GROUP,
+  RESERVED_TOKEN_SPLIT_GROUP,
+} from 'constants/v2/splits'
+import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
+
+export interface InitialEditingData {
+  fundAccessConstraints: SerializedV2FundAccessConstraint[]
+  fundingCycleData: SerializedV2FundingCycleData
+  fundingCycleMetadata: SerializedV2FundingCycleMetadata
+  payoutGroupedSplits: {
+    payoutGroupedSplits: Split[]
+    reservedTokensGroupedSplits: Split[]
+  }
+}
+
+export const useInitialEditingData = (visible: boolean) => {
+  const [initialEditingData, setInitialEditingData] = useState<{
+    fundAccessConstraints: SerializedV2FundAccessConstraint[]
+    fundingCycleData: SerializedV2FundingCycleData
+    fundingCycleMetadata: SerializedV2FundingCycleMetadata
+    payoutGroupedSplits: {
+      payoutGroupedSplits: Split[]
+      reservedTokensGroupedSplits: Split[]
+    }
+  }>()
+
+  const { contracts } = useContext(V2UserContext)
+  const dispatch = useAppDispatch()
+
+  const {
+    projectId,
+    primaryTerminal,
+    fundingCycle,
+    payoutSplits,
+    reservedTokensSplits,
+    distributionLimit,
+    distributionLimitCurrency,
+  } = useContext(V2ProjectContext)
+
+  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
+    projectId,
+  })
+
+  const [queuedFundingCycle] = queuedFundingCycleResponse ?? []
+  const { data: queuedPayoutSplits } = useProjectSplits({
+    projectId,
+    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
+    domain: queuedFundingCycle?.configuration?.toString(),
+  })
+
+  const { data: queuedReservedTokensSplits } = useProjectSplits({
+    projectId,
+    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
+    domain: queuedFundingCycle?.configuration?.toString(),
+  })
+
+  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
+    projectId,
+    configuration: queuedFundingCycle?.configuration.toString(),
+    terminal: primaryTerminal,
+  })
+
+  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
+    queuedDistributionLimitData ?? []
+
+  const effectiveFundingCycle = queuedFundingCycle?.number.gt(0)
+    ? queuedFundingCycle
+    : fundingCycle
+
+  const effectivePayoutSplits = queuedFundingCycle?.number.gt(0)
+    ? queuedPayoutSplits
+    : payoutSplits
+
+  const effectiveReservedTokensSplits = queuedFundingCycle?.number.gt(0)
+    ? queuedReservedTokensSplits
+    : reservedTokensSplits
+
+  let effectiveDistributionLimit = distributionLimit
+  if (effectiveFundingCycle?.duration.gt(0) && queuedDistributionLimit) {
+    effectiveDistributionLimit = queuedDistributionLimit
+  }
+
+  let effectiveDistributionLimitCurrency = distributionLimitCurrency
+  if (
+    effectiveFundingCycle?.duration.gt(0) &&
+    queuedDistributionLimitCurrency
+  ) {
+    effectiveDistributionLimitCurrency = queuedDistributionLimitCurrency
+  }
+
+  // Creates the local redux state from V2ProjectContext values
+  useEffect(() => {
+    if (!visible || !effectiveFundingCycle) return
+
+    // Build fundAccessConstraint
+    let fundAccessConstraint: SerializedV2FundAccessConstraint | undefined =
+      undefined
+    if (effectiveDistributionLimit) {
+      const distributionLimitCurrency =
+        effectiveDistributionLimitCurrency?.toNumber() ?? V2_CURRENCY_ETH
+
+      fundAccessConstraint = {
+        terminal: contracts?.JBETHPaymentTerminal.address ?? '',
+        token: ETH_TOKEN_ADDRESS,
+        distributionLimit: fromWad(effectiveDistributionLimit),
+        distributionLimitCurrency:
+          distributionLimitCurrency === NO_CURRENCY
+            ? V2_CURRENCY_ETH.toString()
+            : distributionLimitCurrency.toString(),
+        overflowAllowance: '0', // nothing for the time being.
+        overflowAllowanceCurrency: '0',
+      }
+    }
+    const editingFundAccessConstraints = fundAccessConstraint
+      ? [fundAccessConstraint]
+      : []
+    dispatch(
+      editingV2ProjectActions.setFundAccessConstraints(
+        fundAccessConstraint ? [fundAccessConstraint] : [],
+      ),
+    )
+
+    // Set editing funding cycle
+    const editingFundingCycleData = serializeV2FundingCycleData(
+      effectiveFundingCycle,
+    )
+    dispatch(
+      editingV2ProjectActions.setFundingCycleData(
+        serializeV2FundingCycleData(effectiveFundingCycle),
+      ),
+    )
+
+    // Set editing funding metadata
+    const editingFundingCycleMetadata = effectiveFundingCycle.metadata
+      ? serializeV2FundingCycleMetadata(
+          decodeV2FundingCycleMetadata(effectiveFundingCycle.metadata),
+        )
+      : defaultFundingCycleMetadata
+    if (effectiveFundingCycle?.metadata) {
+      dispatch(
+        editingV2ProjectActions.setFundingCycleMetadata(
+          serializeV2FundingCycleMetadata(
+            decodeV2FundingCycleMetadata(effectiveFundingCycle.metadata),
+          ),
+        ),
+      )
+    }
+
+    // Set editing payout splits
+    dispatch(
+      editingV2ProjectActions.setPayoutSplits(effectivePayoutSplits ?? []),
+    )
+
+    // Set reserve token splits
+    dispatch(
+      editingV2ProjectActions.setReservedTokensSplits(
+        effectiveReservedTokensSplits ?? [],
+      ),
+    )
+
+    setInitialEditingData({
+      fundAccessConstraints: editingFundAccessConstraints,
+      fundingCycleData: editingFundingCycleData,
+      fundingCycleMetadata: editingFundingCycleMetadata,
+      payoutGroupedSplits: {
+        payoutGroupedSplits: effectivePayoutSplits ?? [],
+        reservedTokensGroupedSplits: effectiveReservedTokensSplits ?? [],
+      },
+    })
+  }, [
+    contracts,
+    effectiveFundingCycle,
+    effectivePayoutSplits,
+    effectiveReservedTokensSplits,
+    effectiveDistributionLimit,
+    effectiveDistributionLimitCurrency,
+    fundingCycle,
+    visible,
+    dispatch,
+  ])
+
+  return { initialEditingData }
+}

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/reconfigureFundingCycle.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/reconfigureFundingCycle.ts
@@ -1,0 +1,74 @@
+import { useReconfigureV2FundingCycleTx } from 'hooks/v2/transactor/ReconfigureV2FundingCycleTx'
+import { useCallback, useState } from 'react'
+
+import { EditingProjectData } from './editingProjectData'
+
+export const useReconfigureFundingCycle = ({
+  editingProjectData,
+  exit,
+}: {
+  editingProjectData: EditingProjectData
+  exit: VoidFunction
+}) => {
+  const {
+    editingPayoutGroupedSplits,
+    editingReservedTokensGroupedSplits,
+    editingFundingCycleMetadata,
+    editingFundingCycleData,
+    editingFundAccessConstraints,
+  } = editingProjectData
+  const reconfigureV2FundingCycleTx = useReconfigureV2FundingCycleTx()
+  const [reconfigureTxLoading, setReconfigureTxLoading] =
+    useState<boolean>(false)
+
+  const reconfigureFundingCycle = useCallback(async () => {
+    setReconfigureTxLoading(true)
+    if (
+      !(
+        editingFundingCycleData &&
+        editingFundingCycleMetadata &&
+        editingFundAccessConstraints
+      )
+    ) {
+      setReconfigureTxLoading(false)
+      throw new Error('Error deploying project.')
+    }
+
+    const txSuccessful = await reconfigureV2FundingCycleTx(
+      {
+        fundingCycleData: editingFundingCycleData,
+        fundingCycleMetadata: editingFundingCycleMetadata,
+        fundAccessConstraints: editingFundAccessConstraints,
+        groupedSplits: [
+          editingPayoutGroupedSplits,
+          editingReservedTokensGroupedSplits,
+        ],
+      },
+      {
+        onDone() {
+          console.info(
+            'Reconfigure transaction executed. Awaiting confirmation...',
+          )
+        },
+        onConfirmed() {
+          setReconfigureTxLoading(false)
+          exit()
+        },
+      },
+    )
+
+    if (!txSuccessful) {
+      setReconfigureTxLoading(false)
+    }
+  }, [
+    editingFundAccessConstraints,
+    editingFundingCycleData,
+    editingFundingCycleMetadata,
+    editingPayoutGroupedSplits,
+    editingReservedTokensGroupedSplits,
+    exit,
+    reconfigureV2FundingCycleTx,
+  ])
+
+  return { reconfigureLoading: reconfigureTxLoading, reconfigureFundingCycle }
+}

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -18,6 +18,7 @@ import ReconfigurePreview from './ReconfigurePreview'
 import { useEditingProjectData } from './hooks/editingProjectData'
 import { useFundingHasSavedChanges } from './hooks/fundingHasSavedChanges'
 import { useReconfigureFundingCycle } from './hooks/reconfigureFundingCycle'
+import { useInitialEditingData } from './hooks/initialEditingData'
 
 function ReconfigureButton({
   title,
@@ -75,13 +76,17 @@ export default function V2ProjectReconfigureModal({
   onCancel: VoidFunction
   hideProjectDetails?: boolean
 }) {
+  const { initialEditingData } = useInitialEditingData(visible)
   const editingProjectData = useEditingProjectData()
   const {
     fundingHasSavedChanges,
     fundingDrawerHasSavedChanges,
     tokenDrawerHasSavedChanges,
     rulesDrawerHasSavedChanges,
-  } = useFundingHasSavedChanges(editingProjectData, visible)
+  } = useFundingHasSavedChanges({
+    editingProjectData,
+    initialEditingData,
+  })
   const { reconfigureLoading, reconfigureFundingCycle } =
     useReconfigureFundingCycle({ editingProjectData, exit })
 

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -1,55 +1,10 @@
 import { t, Trans } from '@lingui/macro'
 import { Modal, Space } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
-import {
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { useCallback, useContext, useState } from 'react'
 import { CaretRightFilled } from '@ant-design/icons'
 
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
-
-import {
-  defaultFundingCycleMetadata,
-  editingV2ProjectActions,
-} from 'redux/slices/editingV2Project'
-import { fromWad } from 'utils/formatNumber'
-import {
-  SerializedV2FundAccessConstraint,
-  SerializedV2FundingCycleData,
-  SerializedV2FundingCycleMetadata,
-  serializeFundAccessConstraint,
-  serializeV2FundingCycleData,
-  serializeV2FundingCycleMetadata,
-} from 'utils/v2/serializers'
-import { useAppDispatch } from 'hooks/AppDispatch'
-
-import {
-  useAppSelector,
-  useEditingV2FundAccessConstraintsSelector,
-  useEditingV2FundingCycleDataSelector,
-  useEditingV2FundingCycleMetadataSelector,
-} from 'hooks/AppSelector'
-import { useReconfigureV2FundingCycleTx } from 'hooks/v2/transactor/ReconfigureV2FundingCycleTx'
-import { decodeV2FundingCycleMetadata } from 'utils/v2/fundingCycle'
-
-import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
-
-import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
-
-import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
-
 import UnsavedChangesModal from 'components/v2/shared/UnsavedChangesModal'
-
-import { isEqual } from 'lodash'
-
-import { Split } from 'models/v2/splits'
-
-import { NO_CURRENCY, V2_CURRENCY_ETH } from 'utils/v2/currency'
 
 import FundingDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer'
 
@@ -58,13 +13,11 @@ import TokenDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/T
 import RulesDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer'
 
 import { V2ReconfigureProjectDetailsDrawer } from './drawers/V2ReconfigureProjectDetailsDrawer'
-import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
-import {
-  ETH_PAYOUT_SPLIT_GROUP,
-  RESERVED_TOKEN_SPLIT_GROUP,
-} from 'constants/v2/splits'
 import V2ReconfigureUpcomingMessage from './V2ReconfigureUpcomingMessage'
 import ReconfigurePreview from './ReconfigurePreview'
+import { useEditingProjectData } from './hooks/editingProjectData'
+import { useFundingHasSavedChanges } from './hooks/fundingHasSavedChanges'
+import { useReconfigureFundingCycle } from './hooks/reconfigureFundingCycle'
 
 function ReconfigureButton({
   title,
@@ -122,55 +75,15 @@ export default function V2ProjectReconfigureModal({
   onCancel: VoidFunction
   hideProjectDetails?: boolean
 }) {
+  const editingProjectData = useEditingProjectData()
   const {
-    fundingCycle,
-    payoutSplits,
-    reservedTokensSplits,
-    distributionLimit,
-    distributionLimitCurrency,
-  } = useContext(V2ProjectContext)
-
-  const { projectId, primaryTerminal } = useContext(V2ProjectContext)
-
-  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
-    projectId,
-  })
-
-  const [queuedFundingCycle] = queuedFundingCycleResponse ?? []
-  const { data: queuedPayoutSplits } = useProjectSplits({
-    projectId,
-    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
-    domain: queuedFundingCycle?.configuration?.toString(),
-  })
-
-  const { data: queuedReservedTokensSplits } = useProjectSplits({
-    projectId,
-    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
-    domain: queuedFundingCycle?.configuration?.toString(),
-  })
-
-  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
-    projectId,
-    configuration: queuedFundingCycle?.configuration.toString(),
-    terminal: primaryTerminal,
-  })
-
-  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
-    queuedDistributionLimitData ?? []
-
-  const { contracts } = useContext(V2UserContext)
-
-  const dispatch = useAppDispatch()
-
-  const [initialEditingData, setInitialEditingData] = useState<{
-    fundAccessConstraints: SerializedV2FundAccessConstraint[]
-    fundingCycleData: SerializedV2FundingCycleData
-    fundingCycleMetadata: SerializedV2FundingCycleMetadata
-    payoutGroupedSplits: {
-      payoutGroupedSplits: Split[]
-      reservedTokensGroupedSplits: Split[]
-    }
-  }>()
+    fundingHasSavedChanges,
+    fundingDrawerHasSavedChanges,
+    tokenDrawerHasSavedChanges,
+    rulesDrawerHasSavedChanges,
+  } = useFundingHasSavedChanges(editingProjectData, visible)
+  const { reconfigureLoading, reconfigureFundingCycle } =
+    useReconfigureFundingCycle({ editingProjectData, exit })
 
   const [projectDetailsDrawerVisible, setProjectDetailsDrawerVisible] =
     useState<boolean>(false)
@@ -179,179 +92,22 @@ export default function V2ProjectReconfigureModal({
   const [tokenDrawerVisible, setTokenDrawerVisible] = useState<boolean>(false)
   const [rulesDrawerVisible, setRulesDrawerVisible] = useState<boolean>(false)
 
-  const [unsavedChangesModalVisibile, setUnsavedChangesModalVisible] =
-    useState<boolean>(false)
-
-  const openUnsavedChangesModal = () => setUnsavedChangesModalVisible(true)
-  const closeUnsavedChangesModal = () => setUnsavedChangesModalVisible(false)
-
   const closeReconfigureDrawer = () => {
     setFundingDrawerVisible(false)
     setTokenDrawerVisible(false)
     setRulesDrawerVisible(false)
   }
 
+  const [unsavedChangesModalVisibile, setUnsavedChangesModalVisible] =
+    useState<boolean>(false)
+
+  const openUnsavedChangesModal = () => setUnsavedChangesModalVisible(true)
+  const closeUnsavedChangesModal = () => setUnsavedChangesModalVisible(false)
+
   const closeUnsavedChangesModalAndExit = () => {
     closeUnsavedChangesModal()
     onCancel()
   }
-
-  const [reconfigureTxLoading, setReconfigureTxLoading] =
-    useState<boolean>(false)
-
-  const effectiveFundingCycle = queuedFundingCycle?.number.gt(0)
-    ? queuedFundingCycle
-    : fundingCycle
-
-  const effectivePayoutSplits = queuedFundingCycle?.number.gt(0)
-    ? queuedPayoutSplits
-    : payoutSplits
-
-  const effectiveReservedTokensSplits = queuedFundingCycle?.number.gt(0)
-    ? queuedReservedTokensSplits
-    : reservedTokensSplits
-
-  let effectiveDistributionLimit = distributionLimit
-  if (effectiveFundingCycle?.duration.gt(0) && queuedDistributionLimit) {
-    effectiveDistributionLimit = queuedDistributionLimit
-  }
-
-  let effectiveDistributionLimitCurrency = distributionLimitCurrency
-  if (
-    effectiveFundingCycle?.duration.gt(0) &&
-    queuedDistributionLimitCurrency
-  ) {
-    effectiveDistributionLimitCurrency = queuedDistributionLimitCurrency
-  }
-
-  // Creates the local redux state from V2ProjectContext values
-  useLayoutEffect(() => {
-    if (!visible || !effectiveFundingCycle) return
-
-    // Build fundAccessConstraint
-    let fundAccessConstraint: SerializedV2FundAccessConstraint | undefined =
-      undefined
-    if (effectiveDistributionLimit) {
-      const distributionLimitCurrency =
-        effectiveDistributionLimitCurrency?.toNumber() ?? V2_CURRENCY_ETH
-
-      fundAccessConstraint = {
-        terminal: contracts?.JBETHPaymentTerminal.address ?? '',
-        token: ETH_TOKEN_ADDRESS,
-        distributionLimit: fromWad(effectiveDistributionLimit),
-        distributionLimitCurrency:
-          distributionLimitCurrency === NO_CURRENCY
-            ? V2_CURRENCY_ETH.toString()
-            : distributionLimitCurrency.toString(),
-        overflowAllowance: '0', // nothing for the time being.
-        overflowAllowanceCurrency: '0',
-      }
-    }
-    const editingFundAccessConstraints = fundAccessConstraint
-      ? [fundAccessConstraint]
-      : []
-    dispatch(
-      editingV2ProjectActions.setFundAccessConstraints(
-        fundAccessConstraint ? [fundAccessConstraint] : [],
-      ),
-    )
-
-    // Set editing funding cycle
-    const editingFundingCycleData = serializeV2FundingCycleData(
-      effectiveFundingCycle,
-    )
-    dispatch(
-      editingV2ProjectActions.setFundingCycleData(
-        serializeV2FundingCycleData(effectiveFundingCycle),
-      ),
-    )
-
-    // Set editing funding metadata
-    const editingFundingCycleMetadata = effectiveFundingCycle.metadata
-      ? serializeV2FundingCycleMetadata(
-          decodeV2FundingCycleMetadata(effectiveFundingCycle.metadata),
-        )
-      : defaultFundingCycleMetadata
-    if (effectiveFundingCycle?.metadata) {
-      dispatch(
-        editingV2ProjectActions.setFundingCycleMetadata(
-          serializeV2FundingCycleMetadata(
-            decodeV2FundingCycleMetadata(effectiveFundingCycle.metadata),
-          ),
-        ),
-      )
-    }
-
-    // Set editing payout splits
-    dispatch(
-      editingV2ProjectActions.setPayoutSplits(effectivePayoutSplits ?? []),
-    )
-
-    // Set reserve token splits
-    dispatch(
-      editingV2ProjectActions.setReservedTokensSplits(
-        effectiveReservedTokensSplits ?? [],
-      ),
-    )
-
-    setInitialEditingData({
-      fundAccessConstraints: editingFundAccessConstraints,
-      fundingCycleData: editingFundingCycleData,
-      fundingCycleMetadata: editingFundingCycleMetadata,
-      payoutGroupedSplits: {
-        payoutGroupedSplits: effectivePayoutSplits ?? [],
-        reservedTokensGroupedSplits: effectiveReservedTokensSplits ?? [],
-      },
-    })
-  }, [
-    contracts,
-    effectiveFundingCycle,
-    effectivePayoutSplits,
-    effectiveReservedTokensSplits,
-    effectiveDistributionLimit,
-    effectiveDistributionLimitCurrency,
-    fundingCycle,
-    visible,
-    dispatch,
-  ])
-
-  // Gets values from the redux state to be used in the modal drawer fields
-  const {
-    payoutGroupedSplits: editingPayoutGroupedSplits,
-    reservedTokensGroupedSplits: editingReservedTokensGroupedSplits,
-  } = useAppSelector(state => state.editingV2Project)
-  const editingFundingCycleMetadata = useEditingV2FundingCycleMetadataSelector()
-  const editingFundingCycleData = useEditingV2FundingCycleDataSelector()
-  const editingFundAccessConstraints =
-    useEditingV2FundAccessConstraintsSelector()
-
-  const fundingHasSavedChanges = useMemo(() => {
-    if (!initialEditingData) {
-      // Nothing to compare so return false
-      return false
-    }
-    const editedChanges: typeof initialEditingData = {
-      fundAccessConstraints: editingFundAccessConstraints.map(
-        serializeFundAccessConstraint,
-      ),
-      fundingCycleMetadata: serializeV2FundingCycleMetadata(
-        editingFundingCycleMetadata,
-      ),
-      fundingCycleData: serializeV2FundingCycleData(editingFundingCycleData),
-      payoutGroupedSplits: {
-        payoutGroupedSplits: editingPayoutGroupedSplits.splits,
-        reservedTokensGroupedSplits: editingReservedTokensGroupedSplits.splits,
-      },
-    }
-    return !isEqual(initialEditingData, editedChanges)
-  }, [
-    editingFundAccessConstraints,
-    editingFundingCycleData,
-    editingFundingCycleMetadata,
-    editingPayoutGroupedSplits,
-    editingReservedTokensGroupedSplits,
-    initialEditingData,
-  ])
 
   const handleGlobalModalClose = useCallback(() => {
     if (!fundingHasSavedChanges) {
@@ -359,155 +115,6 @@ export default function V2ProjectReconfigureModal({
     }
     openUnsavedChangesModal()
   }, [fundingHasSavedChanges, onCancel])
-
-  const reconfigureV2FundingCycleTx = useReconfigureV2FundingCycleTx()
-
-  const reconfigureFundingCycle = useCallback(async () => {
-    setReconfigureTxLoading(true)
-    if (
-      !(
-        editingFundingCycleData &&
-        editingFundingCycleMetadata &&
-        editingFundAccessConstraints
-      )
-    ) {
-      setReconfigureTxLoading(false)
-      throw new Error('Error deploying project.')
-    }
-
-    const txSuccessful = await reconfigureV2FundingCycleTx(
-      {
-        fundingCycleData: editingFundingCycleData,
-        fundingCycleMetadata: editingFundingCycleMetadata,
-        fundAccessConstraints: editingFundAccessConstraints,
-        groupedSplits: [
-          editingPayoutGroupedSplits,
-          editingReservedTokensGroupedSplits,
-        ],
-      },
-      {
-        onDone() {
-          console.info(
-            'Reconfigure transaction executed. Awaiting confirmation...',
-          )
-        },
-        onConfirmed() {
-          setReconfigureTxLoading(false)
-          exit()
-        },
-      },
-    )
-
-    if (!txSuccessful) {
-      setReconfigureTxLoading(false)
-    }
-  }, [
-    editingFundAccessConstraints,
-    editingFundingCycleMetadata,
-    editingFundingCycleData,
-    reconfigureV2FundingCycleTx,
-    editingPayoutGroupedSplits,
-    editingReservedTokensGroupedSplits,
-    exit,
-  ])
-
-  const fundingDrawerHasSavedChanges = () => {
-    const fundingCycleData = serializeV2FundingCycleData(
-      editingFundingCycleData,
-    )
-    const fundAccessConstraints = editingFundAccessConstraints.length
-      ? serializeFundAccessConstraint(editingFundAccessConstraints?.[0])
-      : undefined
-    const payoutGroupedSplits = editingPayoutGroupedSplits.splits
-
-    if (!fundAccessConstraints || !initialEditingData) {
-      return false
-    }
-    const durationUpdated =
-      fundingCycleData.duration !== initialEditingData.fundingCycleData.duration
-    const distributionLimitUpdated =
-      fundAccessConstraints.distributionLimit !==
-      initialEditingData.fundAccessConstraints?.[0].distributionLimit
-    const distributionLimitCurrencyUpdated =
-      fundAccessConstraints.distributionLimitCurrency !==
-      initialEditingData.fundAccessConstraints?.[0].distributionLimitCurrency
-    const payoutGroupedSplitsUpdated = !isEqual(
-      payoutGroupedSplits,
-      initialEditingData.payoutGroupedSplits?.payoutGroupedSplits ?? [],
-    )
-    return (
-      durationUpdated ||
-      distributionLimitUpdated ||
-      distributionLimitCurrencyUpdated ||
-      payoutGroupedSplitsUpdated
-    )
-  }
-
-  const tokenDrawerHasSavedChanges = () => {
-    const fundingCycleData = serializeV2FundingCycleData(
-      editingFundingCycleData,
-    )
-    const fundingCycleMetadata = serializeV2FundingCycleMetadata(
-      editingFundingCycleMetadata,
-    )
-    const fundAccessConstraints = editingFundAccessConstraints.length
-      ? serializeFundAccessConstraint(editingFundAccessConstraints?.[0])
-      : undefined
-    const reservedTokensGroupedSplits =
-      editingReservedTokensGroupedSplits.splits
-
-    if (!fundAccessConstraints || !initialEditingData) {
-      return false
-    }
-
-    const reservedRateUpdated =
-      fundingCycleMetadata.reservedRate !==
-      initialEditingData.fundingCycleMetadata.reservedRate
-    const reservedTokensGroupedSplitsUpdated = !isEqual(
-      reservedTokensGroupedSplits,
-      initialEditingData.payoutGroupedSplits.reservedTokensGroupedSplits ?? [],
-    )
-    const discountRateUpdated =
-      fundingCycleData.discountRate !==
-      initialEditingData.fundingCycleData.discountRate
-    const redemptionRateUpdated =
-      fundingCycleMetadata.redemptionRate !==
-      initialEditingData.fundingCycleMetadata.redemptionRate
-
-    return (
-      reservedRateUpdated ||
-      reservedTokensGroupedSplitsUpdated ||
-      discountRateUpdated ||
-      redemptionRateUpdated
-    )
-  }
-
-  const rulesDrawerHasSavedChanges = () => {
-    const fundingCycleData = serializeV2FundingCycleData(
-      editingFundingCycleData,
-    )
-    const fundingCycleMetadata = serializeV2FundingCycleMetadata(
-      editingFundingCycleMetadata,
-    )
-    const fundAccessConstraints = editingFundAccessConstraints.length
-      ? serializeFundAccessConstraint(editingFundAccessConstraints?.[0])
-      : undefined
-
-    if (!fundAccessConstraints || !initialEditingData) {
-      return false
-    }
-
-    const pausePaymentsUpdated =
-      fundingCycleMetadata.pausePay !==
-      initialEditingData.fundingCycleMetadata.pausePay
-    const allowMintingUpdated =
-      fundingCycleMetadata.allowMinting !==
-      initialEditingData.fundingCycleMetadata.allowMinting
-    const ballotUpdated =
-      fundingCycleData.ballot !== initialEditingData.fundingCycleData.ballot
-
-    return pausePaymentsUpdated || allowMintingUpdated || ballotUpdated
-  }
 
   return (
     <Modal
@@ -520,7 +127,7 @@ export default function V2ProjectReconfigureModal({
         disabled: !fundingHasSavedChanges,
         style: { marginBottom: '15px' },
       }}
-      confirmLoading={reconfigureTxLoading}
+      confirmLoading={reconfigureLoading}
       width={650}
       style={{ paddingBottom: 20, paddingTop: 20 }}
       centered
@@ -572,11 +179,13 @@ export default function V2ProjectReconfigureModal({
         />
       </Space>
       <ReconfigurePreview
-        payoutSplits={editingPayoutGroupedSplits.splits}
-        reserveSplits={editingReservedTokensGroupedSplits.splits}
-        fundingCycleMetadata={editingFundingCycleMetadata}
-        fundingCycleData={editingFundingCycleData}
-        fundAccessConstraints={editingFundAccessConstraints}
+        payoutSplits={editingProjectData.editingPayoutGroupedSplits.splits}
+        reserveSplits={
+          editingProjectData.editingReservedTokensGroupedSplits.splits
+        }
+        fundingCycleMetadata={editingProjectData.editingFundingCycleMetadata}
+        fundingCycleData={editingProjectData.editingFundingCycleData}
+        fundAccessConstraints={editingProjectData.editingFundAccessConstraints}
       />
       {hideProjectDetails ? null : (
         <V2ReconfigureProjectDetailsDrawer

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -169,17 +169,17 @@ export default function V2ProjectReconfigureModal({
         </p>
         <ReconfigureButton
           title={t`Distribution limit, duration and payouts`}
-          reconfigureHasChanges={fundingDrawerHasSavedChanges()}
+          reconfigureHasChanges={fundingDrawerHasSavedChanges}
           onClick={() => setFundingDrawerVisible(true)}
         />
         <ReconfigureButton
           title={t`Token`}
-          reconfigureHasChanges={tokenDrawerHasSavedChanges()}
+          reconfigureHasChanges={tokenDrawerHasSavedChanges}
           onClick={() => setTokenDrawerVisible(true)}
         />
         <ReconfigureButton
           title={t`Rules`}
-          reconfigureHasChanges={rulesDrawerHasSavedChanges()}
+          reconfigureHasChanges={rulesDrawerHasSavedChanges}
           onClick={() => setRulesDrawerVisible(true)}
         />
       </Space>


### PR DESCRIPTION
## What does this PR do and why?

Refactors the reconfigure form to break into smaller testable hooks. Makes understanding the responsibilities of the modal a bit easier as well.

## Changes
The code itself is wholly unchanged (I think I changed a `useLayoutEffect` to `useEffect`).

Four new hooks have been added for handling state in the modal:

### useInitialEditingData

This hook is used to read the initial editing data from the project and write to the redux store. The `visible` it takes in is a bit hacky, but ensures that the useEffect to update the data is called when the visibility changes. This could be something a bit more generic to make the hook more reusable, but for now it is fine.

### useEditingProjectData

This hook is used to define the data being read from redux. Potentially could be reused everywhere that this data is used, but for now just exists here.

### useFundingHasSavedChanges

This hook manages the state of the overall changes and the drawer changes of the reconfigure. It returns 1 var and 3 functions used in reconfigure. ~~Realistically, we should update the 3 functions to just be memos... Might do that before I merge.~~ Done

### useReconfigureFundingCycle

The real meat and potatoes of why we're here. This is the actual transaction hook of the reconfigure. Takes in the editingProjectData and an exit call. We could likely rename this exit to something like `onConfirmed`.


## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
