### PR TITLE
Hide V2 Edit Payouts if no permission

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -17,6 +17,10 @@ import { useETHPaymentTerminalFee } from 'hooks/v2/contractReader/ETHPaymentTerm
 import { Split } from 'models/v2/splits'
 import { BigNumber } from '@ethersproject/bignumber'
 import { detailedTimeString } from 'utils/formatTime'
+import {
+  useHasPermission,
+  V2OperatorPermission,
+} from 'hooks/v2/contractReader/HasPermission'
 
 import DistributePayoutsModal from './modals/DistributePayoutsModal'
 import { EditPayoutsModal } from './modals/EditPayoutsModal'
@@ -58,6 +62,7 @@ export default function PayoutSplitsCard({
     fullWords: true,
   })
   const hasDuration = fundingCycleDuration?.gt(0)
+  const canEditPayouts = useHasPermission(V2OperatorPermission.SET_SPLITS)
 
   return (
     <CardSection>
@@ -128,15 +133,18 @@ export default function PayoutSplitsCard({
                 </Trans>
               }
             />
-            <Button
-              size="small"
-              onClick={() => setEditPayoutModalVisible(true)}
-              icon={<SettingOutlined />}
-            >
-              <span>
-                <Trans>Edit payouts</Trans>
-              </span>
-            </Button>
+            {canEditPayouts && (
+              <Button
+                size="small"
+                onClick={() => setEditPayoutModalVisible(true)}
+                icon={<SettingOutlined />}
+                style={{ marginBottom: '1rem' }}
+              >
+                <span>
+                  <Trans>Edit payouts</Trans>
+                </span>
+              </Button>
+            )}
           </div>
           {payoutSplits ? (
             <SplitList


### PR DESCRIPTION
## What does this PR do and why?

Fixes bug where Edit Payouts button was visible to users without permissoin.

## Screenshots or screen recordings

NA

## Acceptance checklist

- [x] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [x] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [-] I have tested this PR in dark mode and light mode (if applicable).
