### PR TITLE
Fix rounding error in reserved token split

### DIFF
--- a/src/components/v1/shared/ProjectTicketMods.tsx
+++ b/src/components/v1/shared/ProjectTicketMods.tsx
@@ -7,7 +7,13 @@ import { useForm } from 'antd/lib/form/Form'
 import { ThemeContext } from 'contexts/themeContext'
 import { TicketMod } from 'models/mods'
 import * as moment from 'moment'
-import { CSSProperties, useCallback, useContext, useState } from 'react'
+import {
+  CSSProperties,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
 import { formatDate } from 'utils/formatDate'
 import { permyriadToPercent, percentToPermyriad } from 'utils/formatNumber'
 
@@ -184,9 +190,12 @@ export default function ProjectTicketMods({
 
   if (!mods) return null
 
-  const total = mods.reduce(
-    (acc, curr) => acc + parseFloat(permyriadToPercent(curr.percent ?? '0')),
-    0,
+  const total = useMemo(
+    () =>
+      parseFloat(
+        permyriadToPercent(mods.map(m => m.percent).reduce((a, b) => a + b, 0)),
+      ),
+    [mods],
   )
 
   const setReceiver = async () => {


### PR DESCRIPTION
## What does this PR do and why?

Original bug: **Can't submit form when sum of percentages is 100%**

Identified as being caused by a rounding error where the number would appear as: `100.00000000000001`.

The fix instead makes the calculation before converting to a percentage (in its permyriad) and converts after the fact, avoiding the rounding error.

Closes https://github.com/jbx-protocol/juice-interface/issues/1243.

## Screenshots or screen recordings

### At 99.99%

![image](https://user-images.githubusercontent.com/104132113/174573476-adce4997-6d3c-469b-8f8c-60b627221dfb.png)

### At 100.00%

![image](https://user-images.githubusercontent.com/104132113/174573630-4e98a188-a093-438d-9932-dcb0c5d69e82.png)

### At 100.01%

![image](https://user-images.githubusercontent.com/104132113/174573722-40c8f3f1-3756-4c84-bbea-149a326921e4.png)


## Acceptance checklist

- [ ] I have evaluated the
      [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines)
      for this PR.
- [ ] I have tested this PR in
      [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
