### PR TITLE
Fix initial value bug on reserved split slider

### DIFF
--- a/src/components/shared/modals/ReservedTokenReceiverModal.tsx
+++ b/src/components/shared/modals/ReservedTokenReceiverModal.tsx
@@ -95,17 +95,15 @@ export default function ReservedTokenReceiverModal({
           onAddressChange={beneficiary => form.setFieldsValue({ beneficiary })}
         />
 
-        <Form.Item
-          label={t`Percentage allocation`}
-          rules={[{ required: true }]}
-        >
+        <Form.Item label={t`Percentage allocation`} required={true}>
           <NumberSlider
             onChange={(percent: number | undefined) => {
               setPercent(percent ?? form.getFieldValue('percent'))
               form.setFieldsValue({ percent })
             }}
             step={0.01}
-            defaultValue={form.getFieldValue('percent') || 0}
+            defaultValue={0}
+            sliderValue={form.getFieldValue('percent') ?? 0}
             suffix="%"
             name="percent"
             formItemProps={{


### PR DESCRIPTION
## What does this PR do and why?

Fixes initial value of the reserved split slider being 0 (closes #1269 )

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/175803546-63bddd65-e00d-4351-bc82-53228a2f5d30.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
