### PR TITLE
Set Ballot Redemption rate when setting redemption rate

### DIFF
--- a/src/components/v2/V2Create/forms/FundingForm/index.tsx
+++ b/src/components/v2/V2Create/forms/FundingForm/index.tsx
@@ -256,6 +256,11 @@ export default function FundingForm({
             defaultFundingCycleMetadata.redemptionRate,
           ),
         )
+        dispatch(
+          editingV2ProjectActions.setBallotRedemptionRate(
+            defaultFundingCycleMetadata.ballotRedemptionRate,
+          ),
+        )
       }
 
       onFinish?.()

--- a/src/components/v2/V2Create/forms/TokenForm/index.tsx
+++ b/src/components/v2/V2Create/forms/TokenForm/index.tsx
@@ -243,7 +243,11 @@ export default function TokenForm({
     )
     dispatch(editingV2ProjectActions.setDiscountRate(discountRate ?? '0'))
     dispatch(editingV2ProjectActions.setReservedRate(reservedRate ?? '0'))
+
+    // When setting redemption rate, also set ballotRedemptionRate
     dispatch(editingV2ProjectActions.setRedemptionRate(redemptionRate))
+    dispatch(editingV2ProjectActions.setBallotRedemptionRate(redemptionRate))
+
     dispatch(
       editingV2ProjectActions.setReservedTokensSplits(newReservedTokensSplits),
     )

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -159,6 +159,9 @@ const editingV2ProjectSlice = createSlice({
     setRedemptionRate: (state, action: PayloadAction<string>) => {
       state.fundingCycleMetadata.redemptionRate = action.payload
     },
+    setBallotRedemptionRate: (state, action: PayloadAction<string>) => {
+      state.fundingCycleMetadata.ballotRedemptionRate = action.payload
+    },
     setWeight: (state, action: PayloadAction<string>) => {
       state.fundingCycleData.weight = action.payload
     },


### PR DESCRIPTION
## What does this PR do and why?

This will set the ballot redemption rate when setting the redemption rate.
Closes https://github.com/jbx-protocol/juice-interface/issues/1247

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
