### PR TITLE
Set tx metadata args to constant 0 value

### DIFF
--- a/src/hooks/v2/transactor/AddToBalanceTx.ts
+++ b/src/hooks/v2/transactor/AddToBalanceTx.ts
@@ -2,10 +2,11 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { useContext } from 'react'
 import { V2UserContext } from 'contexts/v2/userContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { randomBytes } from '@ethersproject/random'
 
 import { TransactorInstance } from '../../Transactor'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
+
+const DEFAULT_METADATA = 0
 
 export function useAddToBalanceTx(): TransactorInstance<{
   value: BigNumber
@@ -24,7 +25,7 @@ export function useAddToBalanceTx(): TransactorInstance<{
     return transactor(
       contracts?.JBETHPaymentTerminal,
       'addToBalanceOf',
-      [projectId, value, ETH_TOKEN_ADDRESS, DEFAULT_MEMO, randomBytes(1)],
+      [projectId, value, ETH_TOKEN_ADDRESS, DEFAULT_MEMO, DEFAULT_METADATA],
       {
         ...txOpts,
         value,

--- a/src/hooks/v2/transactor/PayV2ProjectTx.ts
+++ b/src/hooks/v2/transactor/PayV2ProjectTx.ts
@@ -3,10 +3,11 @@ import { V2UserContext } from 'contexts/v2/userContext'
 import { useContext } from 'react'
 
 import { BigNumber } from '@ethersproject/bignumber'
-import { randomBytes } from '@ethersproject/random'
 
 import { TransactorInstance } from '../../Transactor'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
+
+const DEFAULT_DELEGATE_METADATA = 0
 
 type PayV2ProjectTx = TransactorInstance<{
   memo: string
@@ -42,7 +43,7 @@ export function usePayV2ProjectTx(): PayV2ProjectTx {
         minReturnedTokens,
         preferClaimedTokens,
         memo || '',
-        randomBytes(1), //delegateMetadata
+        DEFAULT_DELEGATE_METADATA, //delegateMetadata
       ],
       {
         ...txOpts,

--- a/src/hooks/v2/transactor/RedeemTokensTx.ts
+++ b/src/hooks/v2/transactor/RedeemTokensTx.ts
@@ -1,13 +1,14 @@
 import { NetworkContext } from 'contexts/networkContext'
 import { BigNumber } from '@ethersproject/bignumber'
 import * as constants from '@ethersproject/constants'
-import { randomBytes } from '@ethersproject/random'
 import { useContext } from 'react'
 
 import { V2UserContext } from 'contexts/v2/userContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import { TransactorInstance } from '../../Transactor'
+
+const DEFAULT_METADATA = 0
 
 export function useRedeemTokensTx(): TransactorInstance<{
   redeemAmount: BigNumber
@@ -41,7 +42,7 @@ export function useRedeemTokensTx(): TransactorInstance<{
         minReturnedTokens, // _minReturnedTokens, min amount of ETH to receive
         userAddress, // _beneficiary
         memo, // _memo
-        randomBytes(1), // _metadata, TODO: metadata
+        DEFAULT_METADATA, // _metadata, TODO: metadata
       ],
       txOpts,
     )


### PR DESCRIPTION
## What does this PR do and why?

Random bytes may cause issue in future. Plus it looks weird in the on-chain logs. Setting to 0 is a better soln.