### PR TITLE
Payout refactor (re-enable setting specific limit)

### DIFF
--- a/src/components/shared/InputAccessoryButton.tsx
+++ b/src/components/shared/InputAccessoryButton.tsx
@@ -37,7 +37,7 @@ export default function InputAccessoryButton({
         marginRight: placement === 'prefix' ? 8 : 0,
         borderRadius: radii.sm,
       }}
-      onClick={onClick}
+      onClick={!disabled ? onClick : () => null}
     >
       {content}
       {withArrow && (

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionLimitInput.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionLimitInput.tsx
@@ -1,0 +1,58 @@
+import InputAccessoryButton from 'components/shared/InputAccessoryButton'
+import FormattedNumberInput from 'components/shared/inputs/FormattedNumberInput'
+
+import { CurrencyName } from 'constants/currency'
+
+export function DistributionLimitInput({
+  value,
+  onChange,
+  currencyName,
+  onCurrencyChange,
+  disabled,
+}: {
+  value: string | undefined
+  onChange: (value: string | undefined) => void
+  currencyName: CurrencyName
+  onCurrencyChange: (currency: CurrencyName) => void
+  disabled?: boolean
+}) {
+  const toggleCurrency = () => {
+    const newCurrency = currencyName === 'ETH' ? 'USD' : 'ETH'
+    onCurrencyChange(newCurrency)
+  }
+
+  return (
+    <FormattedNumberInput
+      placeholder="0"
+      onChange={onChange}
+      value={value}
+      disabled={disabled}
+      formItemProps={{
+        rules: [{ required: true }],
+        // extra: (
+        // <TooltipLabel
+        //   label={t`No more than this amount can be distributed from the treasury in a funding cycle.`}
+        //   tip={
+        //     <Trans>
+        //       Each payout will receive their percent of this total each
+        //       funding cycle if there is enough in the treasury. Otherwise,
+        //       they will receive their percent of whatever is in the
+        //       treasury.
+        //     </Trans>
+        //   }
+        // />
+        // <Trans>No more than this amount can be distributed from the treasury in a funding cycle.</Trans>
+        // ),
+      }}
+      min={0}
+      accessory={
+        <InputAccessoryButton
+          withArrow
+          content={currencyName}
+          onClick={toggleCurrency}
+          disabled={disabled}
+        />
+      }
+    />
+  )
+}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -65,6 +65,7 @@ export default function DistributionSplitModal({
   onClose,
   currencyName,
   onCurrencyChange,
+  sumPayoutsEnabled,
 }: {
   visible: boolean
   mode: ModalMode // 'Add' or 'Edit' or 'Undefined'
@@ -77,6 +78,7 @@ export default function DistributionSplitModal({
   onClose: VoidFunction
   currencyName: CurrencyName
   onCurrencyChange?: (currencyName: CurrencyName) => void
+  sumPayoutsEnabled?: boolean
 }) {
   const {
     theme: { colors },
@@ -303,6 +305,8 @@ export default function DistributionSplitModal({
     ? amount - (amount * parseFloat(feePercentage ?? '0')) / 100
     : undefined
 
+  console.info('sumPayoutsEnabled: ', sumPayoutsEnabled)
+
   function AfterFeeMessage() {
     return amountSubFee && amountSubFee > 0 ? (
       <TooltipLabel
@@ -407,7 +411,7 @@ export default function DistributionSplitModal({
         ) : null}
 
         {/* Only show amount input if project distribution limit is not infinite */}
-        {distributionLimit && distributionType === 'amount' ? (
+        {distributionLimit && sumPayoutsEnabled ? (
           <Form.Item
             className="ant-form-item-extra-only"
             label={t`Distribution`}
@@ -501,6 +505,7 @@ export default function DistributionSplitModal({
                   }}
                 />
               </span>
+              {distributionType === 'amount' ? <span>TODO: Amount</span> : null}
             </div>
           </Form.Item>
         )}

--- a/src/components/v2/shared/DistributionSplitsSection/index.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/index.tsx
@@ -62,7 +62,7 @@ export default function DistributionSplitsSection({
     distributionLimitIsInfinite ? 'infinite' : 'limit',
   )
 
-  const [sumOfPayoutsEnabled, setSumOfPayoutsEnabled] = useState<boolean>(false)
+  const [sumPayoutsEnabled, setSumPayoutsEnabled] = useState<boolean>(false)
 
   const [specificLimitModalOpen, setSpecificLimitModalOpen] =
     useState<boolean>(false)
@@ -225,13 +225,20 @@ export default function DistributionSplitsSection({
                       onChange={setDistributionLimit}
                       currencyName={currencyName}
                       onCurrencyChange={onCurrencyChange}
-                      disabled={sumOfPayoutsEnabled}
+                      disabled={sumPayoutsEnabled}
                     />
                   </div>
-                  <div style={{ width: '100%', display: 'flex' }}>
+                  <div
+                    style={{
+                      width: '100%',
+                      display: 'flex',
+                      marginTop: 15,
+                      marginBottom: 15,
+                    }}
+                  >
                     <Switch
-                      checked={sumOfPayoutsEnabled}
-                      onChange={setSumOfPayoutsEnabled}
+                      checked={sumPayoutsEnabled}
+                      onChange={setSumPayoutsEnabled}
                       style={{ marginRight: 10 }}
                     />
                     <label>
@@ -342,6 +349,7 @@ export default function DistributionSplitsSection({
         currencyName={currencyName}
         onCurrencyChange={onCurrencyChange}
         onClose={() => setAddSplitModalVisible(false)}
+        sumPayoutsEnabled={sumPayoutsEnabled}
       />
       <SpecificLimitModal
         visible={specificLimitModalOpen}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -451,10 +451,6 @@ msgstr "Amount to distribute"
 msgid "Amount:"
 msgstr "Amount:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr "Amounts"
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
@@ -1025,8 +1021,8 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
-msgstr "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
+msgstr "Distribute a specific amount of funds to entities each funding cycle."
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
@@ -1109,6 +1105,10 @@ msgstr "Distribution limit is infinite. <0>The project will control how all fund
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Distribution limit, duration and payouts"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr "Distribution limit:"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1663,6 +1663,10 @@ msgstr ""
 msgid "MAX"
 msgstr "MAX"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr "Make distribution limit the sum of payouts"
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr ""
@@ -1827,6 +1831,10 @@ msgstr ""
 msgid "No target set."
 msgstr ""
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr "None"
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr "Not a valid ETH address"
@@ -1846,6 +1854,10 @@ msgstr "Note"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2042,10 +2054,6 @@ msgstr "Percentage allocation"
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Percentage:"
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
-msgstr "Percentages"
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
@@ -2574,6 +2582,14 @@ msgstr "Something went wrong."
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr "Split all funds"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr "Split within a distribution limit"
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -456,10 +456,6 @@ msgstr "Monto a distribuir"
 msgid "Amount:"
 msgstr "Cantidad:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr "Cantidades"
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Cualquier cambio que hagas surtirá efecto en el <0>ciclo de financiamiento#{0}</0>. El ciclo de financiamiento actual. (#{currentFCNumber}) no será alterado."
@@ -1030,8 +1026,8 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr "Distribuye un porcentaje de todos los fondos recibidos a entidades. Tu límite de distribución será <0>infinito</0>."
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
-msgstr "Distribuye una cantidad específica de fondos a entidades cada ciclo de financiamiento. Tu límite de distribución será igual a la <0>suma de todas las cantidades de tus pagos.</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
+msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
@@ -1114,6 +1110,10 @@ msgstr "El límite de distribución es infinito. <0>El proyecto controlará como
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Límite de distribución, duración y pagos"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1668,6 +1668,10 @@ msgstr "Logo"
 msgid "MAX"
 msgstr "MÁXIMO"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Administra"
@@ -1832,6 +1836,10 @@ msgstr "Sin meta-objetivo de financiamiento"
 msgid "No target set."
 msgstr "Sin meta-objetivo establecida."
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr "No es una dirección de ETH"
@@ -1851,6 +1859,10 @@ msgstr "Nota"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Nota: los tokens pueden ser acuñados manualmente cuando se permita en el ciclo de financiamiento actual. Esto puede ser cambiado por dueño del proyecto para ciclos próximos."
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2047,10 +2059,6 @@ msgstr "Asignación porcentual"
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Porcentaje:"
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
-msgstr "Porcentajes"
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
@@ -2579,6 +2587,14 @@ msgstr "Algo salió mal."
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr "Gasto"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -456,10 +456,6 @@ msgstr "Montant à distribuer"
 msgid "Amount:"
 msgstr "Montant :"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr "Montants"
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Toutes les modifications que vous apportez prendront effet dans le <0>cycle de financement #{0}</0>. Le cycle de financement actuel (#{currentFCNumber}) ne sera pas modifié."
@@ -1030,8 +1026,8 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr "Distribuer à des entités un pourcentage de tous les fonds reçus. Votre limite de distribution sera <0>infinie</0>."
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
-msgstr "Distribuer à des entités un montant spécifique de fonds, à chaque cycle de financement. Votre limite de distribution sera égale à la <0>somme de tous les montants de paiement.</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
+msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
@@ -1114,6 +1110,10 @@ msgstr "La limite de distribution est infinie. <0>Le projet contrôlera la mani�
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Limite de distribution, durée et paiements"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1668,6 +1668,10 @@ msgstr "Logo"
 msgid "MAX"
 msgstr "MAX"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Gérer"
@@ -1832,6 +1836,10 @@ msgstr "Aucun objectif"
 msgid "No target set."
 msgstr "Aucun objectif défini."
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
@@ -1851,6 +1859,10 @@ msgstr "Remarque"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Remarque : Les tokens peuvent être frappés manuellement lorsqu'ils sont autorisés dans le cycle de financement en cours. Cela peut être modifié par le propriétaire du projet pour les prochains cycles."
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2047,10 +2059,6 @@ msgstr "Pourcentage d'allocation"
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Pourcentage :"
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
-msgstr "Pourcentages"
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
@@ -2579,6 +2587,14 @@ msgstr "Quelque chose a mal tourné."
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr "Dépenses"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -456,10 +456,6 @@ msgstr "Quantidade para distribuir"
 msgid "Amount:"
 msgstr "Quantidade:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr "Quantidades"
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Quaisquer mudanças que você fizer terão efeitos no <0>ciclo de financiamento #{0}</0>. O ciclo de financiamento atual (#{currentFCNumber}) não será alterado."
@@ -1030,8 +1026,8 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr "Distribua a porcentagem de todos os fundos recebidos por entidades. O seu limite de distribuição será de <0>infinito</0>."
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
-msgstr "Distribua uma quantidade específica de fundos a entidades a cada ciclo de financiamento. O seu limite de distribuição será igual a <0>soma de toda a quantidade de pagamentos.</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
+msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
@@ -1114,6 +1110,10 @@ msgstr "O limite de distribuição é infinito. <0>O projeto controlará como to
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Limite de distribuição, duração e pagamentos"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1668,6 +1668,10 @@ msgstr "Logotipo"
 msgid "MAX"
 msgstr "MÁX"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Administrar"
@@ -1832,6 +1836,10 @@ msgstr "Sem meta"
 msgid "No target set."
 msgstr "Sem meta definida."
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
@@ -1851,6 +1859,10 @@ msgstr "Nota"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Nota: Tokens podem ser criados manualmente quando permitidos no atual ciclo de financiamento. Isso pode ser modificado pelo proprietário do projeto para os próximos ciclos."
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2047,10 +2059,6 @@ msgstr "Porcentagem de alocação"
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Porcentagem:"
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
-msgstr "Porcentagens"
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
@@ -2579,6 +2587,14 @@ msgstr "Algo deu errado."
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr "Gastos"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -456,10 +456,6 @@ msgstr "Сумма к распределению"
 msgid "Amount:"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr ""
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Любые внесенные вами изменения вступят в силу в <0>цикле финансирования #{0}</0>. Текущий цикл финансирования (#{currentFCNumber}) не будет изменен."
@@ -1030,7 +1026,7 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
 msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
@@ -1114,6 +1110,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Лимит распределения, продолжительность и выплаты"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1668,6 +1668,10 @@ msgstr "Логотип"
 msgid "MAX"
 msgstr "Максимум"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Управление"
@@ -1832,6 +1836,10 @@ msgstr "Нет цели"
 msgid "No target set."
 msgstr "Цель не установлена."
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
@@ -1851,6 +1859,10 @@ msgstr "Примечание"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Примечание: Токены могут быть отчеканены вручную, если это разрешено в текущем цикле финансирования. Это может быть изменено владельцем проекта для последующих циклов."
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2046,10 +2058,6 @@ msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
-msgstr ""
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
 msgstr ""
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
@@ -2579,6 +2587,14 @@ msgstr "Что-то пошло не так."
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr "Расходы"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -456,10 +456,6 @@ msgstr "Dağıtılacak miktar"
 msgid "Amount:"
 msgstr "Miktar:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr "Miktarlar"
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Yaptığınız tüm değişiklikler <0>finansman döngüsü #{0}</0> içinde geçerli olacaktır. Mevcut finansman döngüsü (#{currentFCNumber}) değiştirilmeyecektir."
@@ -1030,7 +1026,7 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
 msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
@@ -1114,6 +1110,10 @@ msgstr "Dağıtım sınırı sonsuzdur. <0>Tüm fonların nasıl dağıtılacağ
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Dağıtım sınırı, süre ve ödemeler"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1668,6 +1668,10 @@ msgstr "Logo"
 msgid "MAX"
 msgstr "MAKS"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Yönet"
@@ -1832,6 +1836,10 @@ msgstr "Hedef yok"
 msgid "No target set."
 msgstr "Hedef belirlenmedi."
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
@@ -1851,6 +1859,10 @@ msgstr "Not"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Not: Token'lar, mevcut finansman döngüsünde izin verildiğinde manuel olarak basılabilir. İzin, sonraki döngüler için proje sahibi tarafından değiştirilebilir."
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2047,10 +2059,6 @@ msgstr "Yüzde tahsisi"
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Yüzde:"
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
-msgstr "Yüzdeler"
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
@@ -2579,6 +2587,14 @@ msgstr "Bir şeyler yanlış gitti."
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr "Harcama"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -456,10 +456,6 @@ msgstr "分发数量"
 msgid "Amount:"
 msgstr "金额："
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Amounts"
-msgstr "金额"
-
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "你做出的任何变更将会在 <0>筹款周期 #{0}</0>生效。目前的 (#{currentFCNumber}) 筹款周期将不会受到影响。"
@@ -1030,8 +1026,8 @@ msgid "Distribute a percentage of all funds received to entities. Your distribut
 msgstr "把资金按百分比分配给各个实体。项目的分配限额将为 <0>无限</0>。"
 
 #: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
-msgstr "每个筹款周期把特定金额的资金分配给各个实体。项目的分配限额将等于<0>所有支出金额的总和。</0>"
+msgid "Distribute a specific amount of funds to entities each funding cycle."
+msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
@@ -1114,6 +1110,10 @@ msgstr "分配限额为无限。<0>项目将决定所有资金应该如何分配
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "分配上限、时长及支出"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Distribution limit:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
@@ -1668,6 +1668,10 @@ msgstr "标志"
 msgid "MAX"
 msgstr "最大值"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Make distribution limit the sum of payouts"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "管理代币"
@@ -1832,6 +1836,10 @@ msgstr "没有筹款目标"
 msgid "No target set."
 msgstr "不设定筹款目标。"
 
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "None"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
@@ -1851,6 +1859,10 @@ msgstr "请注意："
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "请注意：当前筹款周期允许的情况下，可以手动进行代币铸造。项目方可以在以后的筹款周期变更这一设置。"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Nothing can be distributed from the treasury. Funds can only be accessed by token holders redeeming their tokens."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -2047,10 +2059,6 @@ msgstr "分配百分比"
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "百分比："
-
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
-msgid "Percentages"
-msgstr "百分比"
 
 #: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
@@ -2579,6 +2587,14 @@ msgstr "出错了。"
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Spending"
 msgstr "资金分配"
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split all funds"
+msgstr ""
+
+#: src/components/v2/shared/DistributionSplitsSection/index.tsx
+msgid "Split within a distribution limit"
+msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx


### PR DESCRIPTION
## What does this PR do and why?

Todo:
- if sum of payouts enable: show same modal as 'amounts' produces now 
- If ! sum of payouts: show same modal as 'percents' now, but also show read-only amount if distribution limit not infinite
- Tidy the fuck out of `DistributionSplitModal`

WIP

<img width="592" alt="Screen Shot 2022-07-01 at 12 48 59 pm" src="https://user-images.githubusercontent.com/96150256/176813717-df480827-44cc-4602-bb1a-ed883bdf562f.png">

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
