### PR TITLE
Fix misrounding formattedNum

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -153,6 +153,7 @@ export default function PayoutSplitsCard({
               totalValue={distributionLimit}
               projectOwnerAddress={projectOwnerAddress}
               showSplitValues={!distributionLimit?.eq(MAX_DISTRIBUTION_LIMIT)}
+              valueFormatProps={{ precision: 4 }}
             />
           ) : null}
         </div>

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,5 +1,6 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { formatUnits, parseUnits } from '@ethersproject/units'
+import { round } from 'lodash'
 
 import { WAD_DECIMALS } from 'constants/numbers'
 
@@ -31,7 +32,7 @@ export const parseWad = (value?: BigNumberish) =>
   parseUnits(value?.toString() || '0', WAD_DECIMALS)
 
 /**
- * Returns a string representation of a given [wadValue] with [decimials] digits.
+ * Returns a string representation of a given [wadValue]
  *
  * A wad is a decimal number with 18 digits of precision.
  * Wad: 1e-18
@@ -42,11 +43,8 @@ export const parseWad = (value?: BigNumberish) =>
  * fromWad(1000000000000000000);
  *
  */
-export const fromWad = (
-  wadValue?: BigNumberish,
-  decimals: number = WAD_DECIMALS,
-) => {
-  const result = formatUnits(wadValue ?? '0', decimals)
+export const fromWad = (wadValue?: BigNumberish) => {
+  const result = formatUnits(wadValue ?? '0')
   return result.substring(result.length - 2) === '.0'
     ? result.substring(0, result.length - 2)
     : result
@@ -75,7 +73,7 @@ export const formatWad = (
     _wadValue = _wadValue.toString().split('.')[0]
   }
 
-  return formattedNum(fromWad(_wadValue, formatConfig?.decimals), formatConfig)
+  return formattedNum(fromWad(_wadValue), formatConfig)
 }
 
 /**
@@ -180,6 +178,11 @@ export const formattedNum = (
   }
 
   if (!str.length) return _empty
+
+  // Round if precision specified in config
+  if (config?.precision) {
+    str = round(parseFloat(str), config?.precision).toString()
+  }
 
   // Return ~0 for >0 numbers trimmed to only zeros
   function formatNearZero(formatted: string) {


### PR DESCRIPTION
## What does this PR do and why?



## Screenshots or screen recordings
BEFORE: 

<img width="865" alt="Screen Shot 2022-07-02 at 12 03 42 pm" src="https://user-images.githubusercontent.com/96150256/176982878-8db261e8-ebc7-48e6-88da-390a4028cd2d.png">

With the code before this PR, passing precision into `formattedWad()` would result in the bottom one being rounded to .99 which is actually incorrect. 

AFTER:

<img width="509" alt="Screen Shot 2022-07-02 at 12 00 00 pm" src="https://user-images.githubusercontent.com/96150256/176982982-f602ea03-c7d3-445c-ab40-c2eba5826f97.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
