### PR TITLE
Add project config option for `allowSetTerminals`

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -295,6 +295,25 @@ export default function FundingCycleDetails({
             )}
           </FundingCycleDetailWarning>
         </Descriptions.Item>
+        <Descriptions.Item
+          span={2}
+          label={
+            <TooltipLabel
+              label={<Trans>Terminal configuration</Trans>}
+              tip={
+                <Trans>
+                  The project owner can add and remove payment terminals.
+                </Trans>
+              }
+            />
+          }
+        >
+          {fundingCycleMetadata?.global.allowSetTerminals ? (
+            <Trans>Allowed</Trans>
+          ) : (
+            <Trans>Disabled</Trans>
+          )}
+        </Descriptions.Item>
       </Descriptions>
 
       <div>

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
@@ -1,6 +1,7 @@
 import { Col, Row } from 'antd'
 import {
   AllowMintingStatistic,
+  AllowSetTerminalsStatistic,
   DiscountRateStatistic,
   DistributionLimitStatistic,
   DistributionSplitsStatistic,
@@ -156,12 +157,17 @@ export default function ReconfigurePreview({
         ) : null}
       </Row>
       <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
-        <Col md={12} sm={12}>
+        <Col md={8}>
           <PausePayStatistic pausePay={fundingCycleMetadata.pausePay} />
         </Col>
-        <Col md={12} sm={12}>
+        <Col md={8}>
           <AllowMintingStatistic
             allowMinting={fundingCycleMetadata.allowMinting}
+          />
+        </Col>
+        <Col md={8}>
+          <AllowSetTerminalsStatistic
+            allowSetTerminals={fundingCycleMetadata.global.allowSetTerminals}
           />
         </Col>
       </Row>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -451,6 +451,11 @@ msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr "Allow terminal configuration"
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Allow token minting"
 
@@ -460,6 +465,8 @@ msgstr "Allow your V1 project token holders to swap their tokens for your V2 pro
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1053,6 +1060,8 @@ msgstr "Determines whether tokens will be minted from payments to this address."
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2025,8 +2034,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "Owner can mint tokens at any time."
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr "Owner can set the project's payment terminals."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Owner is not allowed to mint tokens."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr "Owner isn't allowed to set the project's payment terminals."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2845,6 +2862,10 @@ msgstr ""
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr "Terminal configuration"
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr "Text record is set"
@@ -2943,6 +2964,10 @@ msgstr "The onchain memo for each transaction made through the address. It will 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
+msgstr "The project owner can add and remove payment terminals."
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -3406,6 +3431,10 @@ msgstr "When distributing, payouts to Ethereum addresses incur a 2.5% JBX member
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "When enabled, the project owner can manually mint any amount of tokens to any address."
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr "When enabled, the project owner can set the project's payment terminals."
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -456,6 +456,11 @@ msgstr "Permitir tokens creados"
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr ""
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Permitir acuñación de tokens"
 
@@ -465,6 +470,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1058,6 +1065,8 @@ msgstr "Determinar si es que los tokens serán minteados desde pagos hacia esta 
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2030,8 +2039,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "El dueño puede acuñar tokens en cualquier momento."
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr ""
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "El dueño no está autorizado para emitir tokens."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2850,6 +2867,10 @@ msgstr "Objetivo"
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "La meta-ojetivo es 0: Todos los fondos serán considerados excedente y pueden ser canjeados al quemar tokens del proyecto."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
@@ -2948,6 +2969,10 @@ msgstr "El memo onchain para cada transacción hecha a través de la dirección.
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "El porcentaje que éste individuo recibe del {reservedRate}% total de asignación de tokens reservados"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
+msgstr ""
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -3411,6 +3436,10 @@ msgstr ""
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Cuando está habilitado, el dueño del proyecto puede acuñar manualmente cualquier cantidad de tokens a cualquier dirección."
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -456,6 +456,11 @@ msgstr "Permettre la frappe de tokens"
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr ""
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Autoriser la frappe de tokens"
 
@@ -465,6 +470,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1058,6 +1065,8 @@ msgstr "Détermine si les tokens seront frappés à partir des paiements effectu
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2030,8 +2039,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "Le propriétaire peut frapper des tokens à tout moment."
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr ""
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Le propriétaire n'est pas autorisé à frapper des tokens."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2850,6 +2867,10 @@ msgstr "Objectif"
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "L'objectif est de 0 : Tous les fonds seront considérés comme de l'overflow et pourront être récupérés en brûlant les tokens du projet."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
@@ -2948,6 +2969,10 @@ msgstr "Le mémo en chaîne pour chaque transaction réalisée par biais de l'ad
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "Le pourcentage que cet individu reçoit de l'allocation globale {reservedRate}% de tokens réservés"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
+msgstr ""
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -3411,6 +3436,10 @@ msgstr ""
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Lorsque cette option est activée, le propriétaire du projet peut frapper manuellement n'importe quelle quantité de tokens vers n'importe quelle adresse."
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -456,6 +456,11 @@ msgstr "Permitir a produção de tokens"
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr ""
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Permitir emissão de token"
 
@@ -465,6 +470,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1058,6 +1065,8 @@ msgstr "Determine se os tokens serão emitidos a partir de pagamentos neste ende
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2030,8 +2039,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "O proprietário é capaz de emitir tokens a qualquer momento."
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr ""
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "O proprietário não é capaz de emitir tokens."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2850,6 +2867,10 @@ msgstr "Objetivo"
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "O objetivo é 0: Todos os fundos serão considerados overflow e podem ser resgatados ao queimar os tokens do projeto."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
@@ -2948,6 +2969,10 @@ msgstr "A nota onchain para cada transação feita a partir do endereço. Isso i
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "A porcentagem que este indivíduo recebe do {reservedRate}% total de alocação de token reservado"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
+msgstr ""
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -3411,6 +3436,10 @@ msgstr ""
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Quando ativado, o dono do projeto pode manualmente emitir qualquer quantidade de tokens para qualquer endereço."
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -456,6 +456,11 @@ msgstr "Разрешить майнинг токенов"
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr ""
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Разрешить минтить токены"
 
@@ -465,6 +470,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1058,6 +1065,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2030,8 +2039,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "Владелец может минтить токены в любое время."
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr ""
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Владельцу не разрешается минтить токены."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2850,6 +2867,10 @@ msgstr "Цель"
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "Цель - 0: Все средства будут считаться переполненными и могут быть использованы при сжигании токенов."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
@@ -2947,6 +2968,10 @@ msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
+msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts
@@ -3411,6 +3436,10 @@ msgstr ""
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Если эта функция включена, владелец проекта может вручную минтить любое количество токенов на любой адрес."
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -456,6 +456,11 @@ msgstr "Token'ların basılmasına izin verin"
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr ""
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Token basmaya izin ver"
 
@@ -465,6 +470,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1058,6 +1065,8 @@ msgstr "Bu adrese yapılan ödemelerden token basılıp basılmayacağını beli
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2030,8 +2039,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "Proje sahibi, istediği zaman token basabilir."
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr ""
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Proje sahibinin token basmasına izin verilmez."
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2850,6 +2867,10 @@ msgstr "Hedef"
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "Hedef 0: Tüm fonlar taşma olarak kabul edilecek ve proje token'ları yakılarak kullanılabilecektir."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
@@ -2948,6 +2969,10 @@ msgstr "Adres aracılığıyla yapılan her işlem için zincir üstü not. Biri
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "Bu kişinin toplam %{reservedRate} rezerve token tahsisinden aldığı yüzde"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
+msgstr ""
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -3411,6 +3436,10 @@ msgstr ""
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Etkinleştirildiğinde, proje sahibi herhangi bir token miktarını herhangi bir adrese manuel olarak basabilir."
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -456,6 +456,11 @@ msgstr "允许铸造代币"
 
 #: src/pages/create/forms/RulesForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Allow terminal configuration"
+msgstr ""
+
+#: src/pages/create/forms/RulesForm/index.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "允许铸造代币"
 
@@ -465,6 +470,8 @@ msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
@@ -1058,6 +1065,8 @@ msgstr "决定了向这个地址付款是否会铸造代币。"
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
@@ -2030,8 +2039,16 @@ msgid "Owner can mint tokens at any time."
 msgstr "项目方可以随时铸造代币"
 
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner can set the project's payment terminals."
+msgstr ""
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "项目方不能够铸造代币。"
+
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+msgid "Owner isn't allowed to set the project's payment terminals."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
@@ -2850,6 +2867,10 @@ msgstr "目标"
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "目标为 0 ：所有资金将被视为溢出，可以通过燃烧项目代币来赎回。"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "Terminal configuration"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
@@ -2948,6 +2969,10 @@ msgstr "通过这个地址进行的每一笔交易的链上备注。如果有人
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "这个个体收到的全部 {reservedRate}% 保留代币分配方案中的百分比"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+msgid "The project owner can add and remove payment terminals."
+msgstr ""
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
@@ -3411,6 +3436,10 @@ msgstr ""
 #: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "启用此选项，项目拥有者就能够随时手动铸造任意数量的代币。"
+
+#: src/pages/create/forms/RulesForm/index.tsx
+msgid "When enabled, the project owner can set the project's payment terminals."
+msgstr ""
 
 #: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/pages/create/forms/RulesForm/index.tsx
+++ b/src/pages/create/forms/RulesForm/index.tsx
@@ -46,6 +46,7 @@ export default function RulesForm({
       ballotStrategy: getBallotStrategyByAddress(
         fundingCycleData.ballot ?? DEFAULT_BALLOT_STRATEGY.address,
       ),
+      allowSetTerminals: fundingCycleMetadata.global.allowSetTerminals,
     }),
     [fundingCycleData, fundingCycleMetadata],
   )
@@ -55,6 +56,9 @@ export default function RulesForm({
     initialValues.ballotStrategy,
   )
   const [pausePay, setPausePay] = useState<boolean>(initialValues.pausePay)
+  const [allowSetTerminals, setAllowSetTerminals] = useState<boolean>(
+    initialValues.allowSetTerminals,
+  )
   const [allowMinting, setAllowMinting] = useState<boolean>(
     initialValues.allowMinting,
   )
@@ -63,16 +67,33 @@ export default function RulesForm({
     const hasFormUpdated =
       initialValues.allowMinting !== allowMinting ||
       initialValues.pausePay !== pausePay ||
+      initialValues.allowSetTerminals !== allowSetTerminals ||
       !isEqual(initialValues.ballotStrategy, ballotStrategy)
+
     onFormUpdated?.(hasFormUpdated)
-  }, [onFormUpdated, initialValues, pausePay, allowMinting, ballotStrategy])
+  }, [
+    onFormUpdated,
+    initialValues,
+    pausePay,
+    allowMinting,
+    ballotStrategy,
+    allowSetTerminals,
+  ])
 
   const onFormSaved = useCallback(() => {
     dispatch(editingV2ProjectActions.setPausePay(pausePay))
     dispatch(editingV2ProjectActions.setAllowMinting(allowMinting))
+    dispatch(editingV2ProjectActions.setAllowSetTerminals(allowSetTerminals))
     dispatch(editingV2ProjectActions.setBallot(ballotStrategy.address))
     onFinish?.()
-  }, [dispatch, onFinish, ballotStrategy, pausePay, allowMinting])
+  }, [
+    dispatch,
+    onFinish,
+    ballotStrategy,
+    pausePay,
+    allowMinting,
+    allowSetTerminals,
+  ])
 
   const switchContainerStyle = {
     display: 'flex',
@@ -126,6 +147,30 @@ export default function RulesForm({
                 checked={allowMinting}
               />
               <Trans>Allow token minting</Trans>
+            </div>
+          </Form.Item>
+
+          <Form.Item
+            extra={
+              <Trans>
+                When enabled, the project owner can set the project's payment
+                terminals.
+              </Trans>
+            }
+          >
+            <div
+              style={{
+                ...switchContainerStyle,
+              }}
+            >
+              <Switch
+                onChange={checked => {
+                  setAllowSetTerminals(checked)
+                }}
+                style={{ marginRight: '0.5rem' }}
+                checked={allowSetTerminals}
+              />
+              <Trans>Allow terminal configuration</Trans>
             </div>
           </Form.Item>
         </div>

--- a/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -281,6 +281,28 @@ export function AllowMintingStatistic({
   )
 }
 
+export function AllowSetTerminalsStatistic({
+  allowSetTerminals,
+}: {
+  allowSetTerminals: boolean
+}) {
+  return (
+    <Statistic
+      title={
+        <TooltipLabel
+          label={t`Allow terminal configuration`}
+          tip={
+            allowSetTerminals
+              ? t`Owner can set the project's payment terminals.`
+              : t`Owner isn't allowed to set the project's payment terminals.`
+          }
+        />
+      }
+      valueRender={() => (allowSetTerminals ? t`Allowed` : t`Disabled`)}
+    />
+  )
+}
+
 export function ReconfigurationStatistic({
   ballotAddress,
 }: {

--- a/src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
@@ -192,14 +192,14 @@ export default function FundingSummarySection() {
             />
           </Col>
           <Col md={8} xs={24}>
-            {hasDuration && (
-              <ReconfigurationStatistic ballotAddress={fundingCycle.ballot} />
-            )}
-          </Col>
-          <Col md={8} xs={24}>
             <AllowSetTerminalsStatistic
               allowSetTerminals={fundingCycleMetadata.global.allowSetTerminals}
             />
+          </Col>
+          <Col md={8} xs={24}>
+            {hasDuration && (
+              <ReconfigurationStatistic ballotAddress={fundingCycle.ballot} />
+            )}
           </Col>
         </Row>
         <Row gutter={rowGutter} style={{ width: '100%' }}>

--- a/src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
@@ -42,6 +42,7 @@ import {
   DistributionSplitsStatistic,
   ReservedSplitsStatistic,
   InflationRateStatistic,
+  AllowSetTerminalsStatistic,
 } from './FundingAttributes'
 
 export default function FundingSummarySection() {
@@ -194,6 +195,11 @@ export default function FundingSummarySection() {
             {hasDuration && (
               <ReconfigurationStatistic ballotAddress={fundingCycle.ballot} />
             )}
+          </Col>
+          <Col md={8} xs={24}>
+            <AllowSetTerminalsStatistic
+              allowSetTerminals={fundingCycleMetadata.global.allowSetTerminals}
+            />
           </Col>
         </Row>
         <Row gutter={rowGutter} style={{ width: '100%' }}>

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -215,6 +215,9 @@ const editingV2ProjectSlice = createSlice({
     setNftRewardsCid: (state, action: PayloadAction<string>) => {
       state.nftRewardsCid = action.payload
     },
+    setAllowSetTerminals: (state, action: PayloadAction<boolean>) => {
+      state.fundingCycleMetadata.global.allowSetTerminals = action.payload
+    },
   },
 })
 

--- a/src/utils/v2/__tests__/fundingCycle.test.ts
+++ b/src/utils/v2/__tests__/fundingCycle.test.ts
@@ -19,8 +19,6 @@ import { decodeV2FundingCycleMetadata } from '../fundingCycle'
  * @note Passing in an empty obj will use default values below
  */
 function packFundingCycleMetadata(packedMetadata: V2FundingCycleMetadata) {
-  const one = BigNumber.from(1)
-
   const {
     version,
     global,
@@ -42,9 +40,11 @@ function packFundingCycleMetadata(packedMetadata: V2FundingCycleMetadata) {
     dataSource, // address
   } = packedMetadata
 
+  const one = BigNumber.from(1)
+
   let packed = BigNumber.from(version)
   if (global.allowSetTerminals) packed = packed.or(one.shl(8))
-  if (global.allowSetController) packed = packed.or(one.shl(16))
+  if (global.allowSetController) packed = packed.or(one.shl(9))
   packed = packed.or(reservedRate.shl(24))
   packed = packed.or(invertPermyriad(redemptionRate).shl(40))
   packed = packed.or(invertPermyriad(ballotRedemptionRate).shl(56))

--- a/src/utils/v2/fundingCycle.ts
+++ b/src/utils/v2/fundingCycle.ts
@@ -82,8 +82,10 @@ const parameters: {
     bits: 16,
     parser: val => {
       return {
-        allowSetTerminals: bigNumberToBoolean(BigNumber.from(val).shr(1)),
-        allowSetController: bigNumberToBoolean(BigNumber.from(val).shr(2)),
+        allowSetTerminals: bigNumberToBoolean(BigNumber.from(val).and(1)),
+        allowSetController: bigNumberToBoolean(
+          BigNumber.from(val).shr(1).and(1),
+        ),
       }
     },
   },


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/1333.

For the V1=>V2 token migration, projects need to have `allowSetTerminals` set to `true`.

This PR adds the configuration capability. The following UI updates are included:
- Add **Allow terminal configuration** to project creation and FC reconfiguration.
- Add **Terminal configuration** key-value element to the current/upcoming funding cycle cards.
- Fixes the FC metadata parser to parse `allowSetTerminals` correctly.

## Screenshots or screen recordings

See comments below for inline screenshots.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [-] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [-] I have tested this PR in dark mode and light mode (if applicable).
