### PR TITLE
Make upload button transparent

### DIFF
--- a/src/styles/antd-overrides/button.scss
+++ b/src/styles/antd-overrides/button.scss
@@ -133,7 +133,3 @@
   background-color: var(--background-l2);
   box-shadow: 0px 8px 12px 2px #000000;
 }
-
-.ant-upload.ant-upload-select-picture-card {
-  width: 100%
-}

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -239,9 +239,14 @@ textarea.ant-input::placeholder {
   box-shadow: none !important;
 }
 
+
 .ant-upload {
-  background-color: var(--background-l1);
   color: var(--text-primary)
+}
+
+.ant-upload.ant-upload-select-picture-card {
+  background: var(--background-l1);
+  width: 100%
 }
 
 .ant-upload-list,


### PR DESCRIPTION
## What does this PR do and why?

Closes #1326 - styles changed on upload button with new NFT form. This PR fixes the regression

## Screenshots or screen recordings

BEFORE:

<img width="279" alt="Screen Shot 2022-07-05 at 3 15 28 pm" src="https://user-images.githubusercontent.com/96150256/177254325-8354f778-c070-4eba-bf3f-4012e8a556dd.png">

AFTER:

<img width="545" alt="Screen Shot 2022-07-05 at 3 11 36 pm" src="https://user-images.githubusercontent.com/96150256/177254277-b9cf11c8-bc00-4d5c-a8dd-217d1b445043.png">

<img width="571" alt="Screen Shot 2022-07-05 at 3 11 40 pm" src="https://user-images.githubusercontent.com/96150256/177254267-b7bde091-ac69-4424-81c3-78e002faed76.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
