### PR TITLE
Fix edit payouts amount precision

### DIFF
--- a/src/components/v1/shared/ProjectPayMods/ProjectModInput.tsx
+++ b/src/components/v1/shared/ProjectPayMods/ProjectModInput.tsx
@@ -67,7 +67,7 @@ const FormattedPercentageAmount = ({
             amountSubFee(parseWad(target), feePerbicent)
               ?.mul(percent)
               .div(10000),
-            { precision: 4, padEnd: true },
+            { precision: currencyName === 'USD' ? 2 : 4, padEnd: true },
           )}
         </span>
       )}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
@@ -20,6 +20,7 @@ import CurrencySymbol from 'components/CurrencySymbol'
 import { amountFromPercent } from 'utils/v2/distributions'
 import { t, Trans } from '@lingui/macro'
 import TooltipIcon from 'components/TooltipIcon'
+import { round } from 'lodash'
 
 import DistributionSplitModal from './DistributionSplitModal'
 import { CurrencyName } from 'constants/currency'
@@ -204,11 +205,12 @@ export default function DistributionSplitCard({
                   {!distributionLimitIsInfinite && (
                     <span>
                       <CurrencySymbol currency={currencyName} />
-                      {parseFloat(
+                      {round(
                         amountFromPercent({
                           percent: preciseFormatSplitPercent(split.percent),
                           amount: distributionLimit,
-                        }).toFixed(4),
+                        }),
+                        currencyName === 'USD' ? 4 : 2,
                       )}
                     </span>
                   )}


### PR DESCRIPTION
## What does this PR do and why?

Closes #873. We need to show decent precision on these, particularly in ETH amounts - since in V1 the split percent is only to 4dp, the amounts may be a bit off from what they were intended. In V2 this isn't much of a problem since the split percents are much more precise. 

Anyway, implemented lodash rounding to 2dp with USD amounts and 4dp with ETH amounts for V1 and V2.

## Screenshots or screen recordings

BEFORE:

<img width="691" alt="Screen Shot 2022-07-05 at 3 25 44 pm" src="https://user-images.githubusercontent.com/96150256/177257565-7067ba3c-d0b6-4594-8fbe-024ef30c634c.png">

AFTER:

<img width="605" alt="Screen Shot 2022-07-05 at 3 34 49 pm" src="https://user-images.githubusercontent.com/96150256/177257614-9cbd73aa-e987-4ce9-bd66-3fdb68a442f9.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
