### PR TITLE
Bump @jbx-protocol/contracts-v1 to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@jbx-protocol/contracts-v1": "^1.1.5",
+    "@jbx-protocol/contracts-v1": "2.0.0",
     "@jbx-protocol/contracts-v2-4.0.0": "npm:@jbx-protocol/contracts-v2@4.0.0",
     "@jbx-protocol/contracts-v2-latest": "npm:@jbx-protocol/contracts-v2@8.0.0",
     "@jbx-protocol/juice-v1-token-terminal": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,20 +3350,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jbx-protocol/contracts-v1@^1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v1/-/contracts-v1-1.1.5.tgz#9f4c5f584be598346aca3e9e06e8a207ed4d74f3"
-  integrity sha512-YfR4SWLO5EsAvA3hBTQVo9QdH2mwXh9DxDhOAkCTwoYtiI3EIhxQpVEXdzeEhI60c/mxWOrAuFGTl5B+aoPKAA==
-  dependencies:
-    "@chainlink/contracts" "^0.1.6"
-    "@nomiclabs/hardhat-etherscan" "^2.1.4"
-    "@openzeppelin/contracts" "4.2.0"
-    "@paulrberg/contracts" "3.4.0"
-    dotenv "^10.0.0"
-    esm "^3.2.25"
-    glob "^7.2.0"
-    hardhat-deploy-ethers "^0.3.0-beta.10"
-    prettier "^2.4.0"
+"@jbx-protocol/contracts-v1@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v1/-/contracts-v1-2.0.0.tgz#616dd2adb8603dd1067d29fa613e704737adc243"
+  integrity sha512-70BvKKor6iM8eBTa4klH7iOA5+/oa0J5gMpazK5nECrn8U0xeKTB19v+jXmTu+26JYruZHzCKZVdV5aH+c8qnA==
 
 "@jbx-protocol/contracts-v2-4.0.0@npm:@jbx-protocol/contracts-v2@4.0.0":
   version "4.0.0"
@@ -3970,22 +3960,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@openzeppelin/contracts@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.2.0.tgz#260d921d99356e48013d9d760caaa6cea35dc642"
-  integrity sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ==
-
 "@openzeppelin/contracts@^4.5.0-rc.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
-
-"@paulrberg/contracts@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@paulrberg/contracts/-/contracts-3.4.0.tgz#ce6bb7c1b425f5a3a60258aef96e573537f9c608"
-  integrity sha512-wh9mKkEZ1nZ9T7/ymxEUHVQcunfybl3kP/u63RBrwYqASK6cB+pU+aCBvb1X2Yfde461L4LkJpC7Z3BIbFUvfA==
-  dependencies:
-    prb-math "^2.2.0"
 
 "@paulrberg/contracts@^3.4.0":
   version "3.7.0"
@@ -16974,11 +16952,6 @@ postcss@^8.1.0:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
-
-prb-math@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prb-math/-/prb-math-2.3.0.tgz#cc35252c729b441afb3948da18861f0d2d53fc20"
-  integrity sha512-WmC5G5snavrPcoqcI6D5Rd+6dY+wwrtJWo2bkfJ7eWFaBIqbTr/4n7QUgc5GDSsH+w2tATg4qfmnFsUoac/QyA==
 
 prb-math@^2.4.1:
   version "2.4.3"


### PR DESCRIPTION
What it says on the tin!

This PR upgrades the V1 contract package version. This new version is itself a reshuffling of dependencies. See https://github.com/jbx-protocol/juice-contracts-v1/pull/20 for the diff.