### PR TITLE
Distribute buttons improvements

### DIFF
--- a/src/components/FormattedAddress.tsx
+++ b/src/components/FormattedAddress.tsx
@@ -32,10 +32,12 @@ export default function FormattedAddress({
   address,
   label,
   tooltipDisabled,
+  truncateTo,
 }: {
   address: string | undefined
   label?: string
   tooltipDisabled?: boolean
+  truncateTo?: number
 }) {
   const [ensName, setEnsName] = useState<string | null>()
 
@@ -90,11 +92,19 @@ export default function FormattedAddress({
 
   if (!address) return null
 
+  const effectiveTruncateTo = truncateTo ?? 6
+  const frontTruncate = effectiveTruncateTo + 2 // account for 0x
+
   const formatted =
     ensName ??
     label ??
     (address
-      ? address.substring(0, 6) + '...' + address.substr(address.length - 6, 6)
+      ? address.substring(0, frontTruncate) +
+        '...' +
+        address.substr(
+          address.length - effectiveTruncateTo,
+          effectiveTruncateTo,
+        )
       : '')
 
   if (tooltipDisabled) {

--- a/src/components/Project/SpendingStats.tsx
+++ b/src/components/Project/SpendingStats.tsx
@@ -17,7 +17,7 @@ export default function SpendingStats({
   currency,
   targetAmount,
   distributedAmount,
-  projectBalanceInCurrency,
+  distributableAmount,
   ownerAddress,
   feePercentage,
   hasFundingTarget,
@@ -25,7 +25,7 @@ export default function SpendingStats({
   currency: CurrencyName | undefined
   targetAmount: BigNumber
   distributedAmount: BigNumber
-  projectBalanceInCurrency: BigNumber | undefined
+  distributableAmount: BigNumber | undefined
   ownerAddress: string | undefined
   feePercentage: string | undefined
   hasFundingTarget: boolean | undefined
@@ -33,12 +33,6 @@ export default function SpendingStats({
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-
-  const untapped = targetAmount.sub(distributedAmount)
-
-  const distributableAmount = projectBalanceInCurrency?.gt(untapped)
-    ? untapped
-    : projectBalanceInCurrency
 
   const smallHeaderStyle: CSSProperties = {
     fontSize: '.7rem',

--- a/src/components/v1/shared/FundingCycle/Spending.tsx
+++ b/src/components/v1/shared/FundingCycle/Spending.tsx
@@ -26,6 +26,15 @@ export default function Spending({
 
   if (!currentFC) return null
 
+  const target = currentFC.target
+  const distributedAmount = currentFC.tapped
+
+  const distributable = target.sub(distributedAmount)
+
+  const distributableAmount = balanceInCurrency?.gt(distributable)
+    ? distributable
+    : balanceInCurrency
+
   return (
     <div>
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
@@ -41,9 +50,9 @@ export default function Spending({
             currency={V1CurrencyName(
               currentFC.currency.toNumber() as V1CurrencyOption,
             )}
-            projectBalanceInCurrency={balanceInCurrency}
-            targetAmount={currentFC.target}
-            distributedAmount={currentFC.tapped}
+            distributableAmount={distributableAmount}
+            targetAmount={target}
+            distributedAmount={distributedAmount}
             feePercentage={perbicentToPercent(currentFC.fee)}
             ownerAddress={owner}
           />

--- a/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
@@ -1,10 +1,8 @@
 import { SettingOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
-import * as constants from '@ethersproject/constants'
 import { t, Trans } from '@lingui/macro'
 import { Button, Skeleton, Space, Tooltip } from 'antd'
 import { CardSection } from 'components/CardSection'
-import FormattedAddress from 'components/FormattedAddress'
 import TooltipLabel from 'components/TooltipLabel'
 import SplitList from 'components/v2/shared/SplitList'
 import { ThemeContext } from 'contexts/themeContext'
@@ -32,13 +30,8 @@ export default function ReservedTokensSplitsCard({
   reservedTokensSplits: Split[] | undefined
   reservedRate: BigNumber | undefined
 }) {
-  const {
-    tokenSymbol,
-    tokenAddress,
-    projectOwnerAddress,
-    projectId,
-    isPreviewMode,
-  } = useContext(V2ProjectContext)
+  const { tokenSymbol, projectOwnerAddress, projectId, isPreviewMode } =
+    useContext(V2ProjectContext)
   const {
     theme: { colors },
   } = useContext(ThemeContext)
@@ -67,12 +60,6 @@ export default function ReservedTokensSplitsCard({
     tokenSymbol,
     capitalize: false,
     plural: true,
-  })
-
-  const tokensTextSingular = tokenSymbolText({
-    tokenSymbol,
-    capitalize: true,
-    plural: false,
   })
 
   const distributeButtonDisabled = isPreviewMode || reservedTokens?.eq(0)
@@ -136,12 +123,6 @@ export default function ReservedTokensSplitsCard({
                   </Trans>
                 }
               />
-              {tokenAddress && tokenAddress !== constants.AddressZero ? (
-                <div style={smallHeaderStyle}>
-                  {tokensTextSingular} contract address:{' '}
-                  <FormattedAddress address={tokenAddress} truncateTo={3} />
-                </div>
-              ) : null}
             </div>
             {reservedTokens?.eq(0) ? (
               <Tooltip title={t`No reserved tokens available to distribute.`}>

--- a/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
@@ -1,8 +1,8 @@
 import { SettingOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import * as constants from '@ethersproject/constants'
-import { Trans } from '@lingui/macro'
-import { Button, Skeleton, Space } from 'antd'
+import { t, Trans } from '@lingui/macro'
+import { Button, Skeleton, Space, Tooltip } from 'antd'
 import { CardSection } from 'components/CardSection'
 import FormattedAddress from 'components/FormattedAddress'
 import TooltipLabel from 'components/TooltipLabel'
@@ -75,6 +75,21 @@ export default function ReservedTokensSplitsCard({
     plural: false,
   })
 
+  const distributeButtonDisabled = isPreviewMode || reservedTokens?.eq(0)
+
+  function DistributeButton(): JSX.Element {
+    return (
+      <Button
+        type="ghost"
+        size="small"
+        onClick={() => setDistributeReservedTokensModalVisible(true)}
+        disabled={distributeButtonDisabled}
+      >
+        <Trans>Distribute {tokensText}</Trans>
+      </Button>
+    )
+  }
+
   return (
     <CardSection>
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
@@ -124,18 +139,19 @@ export default function ReservedTokensSplitsCard({
               {tokenAddress && tokenAddress !== constants.AddressZero ? (
                 <div style={smallHeaderStyle}>
                   {tokensTextSingular} contract address:{' '}
-                  <FormattedAddress address={tokenAddress} />
+                  <FormattedAddress address={tokenAddress} truncateTo={3} />
                 </div>
               ) : null}
             </div>
-            <Button
-              type="ghost"
-              size="small"
-              onClick={() => setDistributeReservedTokensModalVisible(true)}
-              disabled={isPreviewMode}
-            >
-              <Trans>Distribute {tokensText}</Trans>
-            </Button>
+            {reservedTokens?.eq(0) ? (
+              <Tooltip title={t`No reserved tokens available to distribute.`}>
+                <div>
+                  <DistributeButton />
+                </div>
+              </Tooltip>
+            ) : (
+              <DistributeButton />
+            )}
           </div>
         )}
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1948,6 +1948,10 @@ msgstr ""
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr ""
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr "No funds available to distribute."
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
@@ -1965,6 +1969,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr ""
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr "No reserved tokens available to distribute."
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1953,6 +1953,10 @@ msgstr "Sin actividad, todavía"
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Sin meta-objetivo de financiamiento: Este proyecto va a controlar cómo serán distribuidos todos los fondos, y ninguno podrá ser canjeado por los tenedores de los tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr ""
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "No se pueden distribuir fondos afuera del tesoro. Solo los poseedores de tokens pueden acceder a los fondos canjeando sus tokens."
@@ -1970,6 +1974,10 @@ msgstr "No más que el objetivo del ciclo de financiación puede ser distribuido
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Sin ciclos de financiamiento pasados"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr ""
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1953,6 +1953,10 @@ msgstr "Aucune activité"
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Aucun objectif de financement : le projet contrôlera la manière dont tous les fonds sont distribués, et rien ne pourra être récupéré par les titulaires de tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr ""
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "Aucun fonds ne peut être distribué en dehors de la trésorerie. Les fonds ne sont accessibles qu'aux détenteurs de tokens qui échangent leurs tokens."
@@ -1970,6 +1974,10 @@ msgstr "Seulement l'objectif du cycle de financement peut être distribué par l
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Aucun cycle de financement précédent"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr ""
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1953,6 +1953,10 @@ msgstr "Nenhuma atividade ainda"
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Sem meta de financiamento: Este projeto irá controlar como serão distribuídos todos os fundos e nada poderá ser resgatado pelos titulares de tokens."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr ""
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "Os fundos não podem ser distribuídos para fora da tesouraria. Os fundos podem ser acessados apenas por titulares de token ao resgatarem os tokens."
@@ -1970,6 +1974,10 @@ msgstr "Apenas o objetivo do ciclo de financiamento pode ser distribuído pelo p
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Nenhum ciclo de financiamento passado"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr ""
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1953,6 +1953,10 @@ msgstr "Нет активности"
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Нет цели финансирования: проект будет контролировать, как распределяются все средства, и ничего не может быть обменяно владельцами токенов."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr ""
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr ""
@@ -1970,6 +1974,10 @@ msgstr "Не более одного целевого показателя ци�
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Нет прошлых циклов финансирования"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr ""
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1953,6 +1953,10 @@ msgstr "Henüz etkinlik yok"
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Finansman hedefi yok: Proje, tüm fonların nasıl dağıtılacağını kontrol eder ve hiçbiri token sahipleri tarafından talep edilemez."
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr ""
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "Hazineden para dağıtılamaz. Fonlara yalnızca token'larını kullanan token sahipleri erişebilir."
@@ -1970,6 +1974,10 @@ msgstr "Tek bir finansman döngüsünde proje, finansman döngüsü hedefinden d
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Geçmiş finansman döngüsü yok"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr ""
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1953,6 +1953,10 @@ msgstr "暂无动态"
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "不设定筹款目标：所有的资金如何分发都由此项目决定，代币持有者无法赎回。"
 
+#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+msgid "No funds available to distribute."
+msgstr ""
+
 #: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "资金不能从金库分配出去。资金只能由代币持有人通过赎回代币来获得。"
@@ -1970,6 +1974,10 @@ msgstr "在单个筹款周期中，项目无法提取超出筹款目标的资金
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "没有历史筹款周期"
+
+#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+msgid "No reserved tokens available to distribute."
+msgstr ""
 
 #: src/constants/v1/ballotStrategies/index.ts
 #: src/constants/v2/ballotStrategies/index.ts


### PR DESCRIPTION
## What does this PR do and why?

Closes #1312 
Closes #1311

- Disables and ads tooltips to distribute funds and distributed reserved tokens buttons. 

<img width="554" alt="Screen Shot 2022-07-05 at 10 48 41 pm" src="https://user-images.githubusercontent.com/96150256/177335355-8d5f1503-c15f-439b-8640-1a027724634e.png">

<img width="546" alt="Screen Shot 2022-07-05 at 11 10 20 pm" src="https://user-images.githubusercontent.com/96150256/177335483-eb157ad8-5783-4fb0-93f2-29c96f42f54c.png">

- Also adds a little more truncation to the token address so the distribute button can fit:
BEFORE:
<img width="508" alt="Screen Shot 2022-07-05 at 11 02 28 pm" src="https://user-images.githubusercontent.com/96150256/177335636-92407278-2e1c-4019-8f86-d6051cd81abb.png">

AFTER:
<img width="546" alt="Screen Shot 2022-07-05 at 11 10 20 pm" src="https://user-images.githubusercontent.com/96150256/177335662-7f0a89e0-3394-40ce-87b7-a12ba360fc4b.png">


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
