### PR TITLE
Format fee payments to V2 Juicebox project

### DIFF
--- a/src/components/activityEventElems/PayEventElem.tsx
+++ b/src/components/activityEventElems/PayEventElem.tsx
@@ -9,6 +9,8 @@ import { PayEvent } from 'models/subgraph-entities/vX/pay-event'
 import { useCallback, useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
 
+import V2ProjectHandle from '../v2/shared/V2ProjectHandle'
+
 import {
   contentLineHeight,
   primaryContentFontSize,
@@ -31,7 +33,13 @@ export default function PayEventElem({
   event:
     | Pick<
         PayEvent,
-        'amount' | 'timestamp' | 'beneficiary' | 'note' | 'id' | 'txHash'
+        | 'amount'
+        | 'timestamp'
+        | 'beneficiary'
+        | 'note'
+        | 'id'
+        | 'txHash'
+        | 'feeFromV2Project'
       >
     | undefined
 }) {
@@ -107,15 +115,26 @@ export default function PayEventElem({
         </div>
       </div>
 
-      <div style={{ marginTop: 5 }}>
-        <RichNote
-          note={
-            (usePayEventOverrides
-              ? formatPayEventOverride(event)
-              : event.note) ?? ''
-          }
-        />
-      </div>
+      {event.feeFromV2Project ? (
+        <div style={{ marginTop: 5 }}>
+          <Trans>
+            Fee from{' '}
+            <span>
+              <V2ProjectHandle projectId={event.feeFromV2Project} />
+            </span>
+          </Trans>
+        </div>
+      ) : (
+        <div style={{ marginTop: 5 }}>
+          <RichNote
+            note={
+              (usePayEventOverrides
+                ? formatPayEventOverride(event)
+                : event.note) ?? ''
+            }
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/v2/V2Project/ProjectActivity/index.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/index.tsx
@@ -117,7 +117,15 @@ export default function ProjectActivity() {
       'id',
       {
         entity: 'payEvent',
-        keys: ['amount', 'timestamp', 'beneficiary', 'note', 'id', 'txHash'],
+        keys: [
+          'amount',
+          'timestamp',
+          'beneficiary',
+          'note',
+          'id',
+          'txHash',
+          'feeFromV2Project',
+        ],
       },
       {
         entity: 'deployedERC20Event',

--- a/src/components/v2/shared/V2ProjectHandle.tsx
+++ b/src/components/v2/shared/V2ProjectHandle.tsx
@@ -1,31 +1,27 @@
-import { BigNumberish } from '@ethersproject/bignumber'
 import { Trans } from '@lingui/macro'
-import ProjectVersionBadge from 'components/ProjectVersionBadge'
+import useProjectHandle from 'hooks/v2/contractReader/ProjectHandle'
 import { CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { v2ProjectRoute } from 'utils/routes'
 
 export default function V2ProjectHandle({
   projectId,
-  handle,
   style,
 }: {
-  projectId: BigNumberish
-  handle: string | null | undefined
+  projectId: number
   style?: CSSProperties
 }) {
+  const { data: handle } = useProjectHandle({ projectId })
+
   return (
-    <div style={{ display: 'flex', alignItems: 'center' }}>
-      <Link
-        to={v2ProjectRoute({ projectId, handle })}
-        style={{ fontWeight: 500, ...style }}
-        className="text-primary hover-text-action-primary hover-text-decoration-underline"
-      >
-        <span style={{ marginRight: '0.5rem' }}>
-          {handle ? `@${handle}` : <Trans>Project {projectId}</Trans>}
-        </span>
-      </Link>
-      <ProjectVersionBadge versionText="V2" size="small" />
-    </div>
+    <Link
+      to={v2ProjectRoute({ projectId, handle })}
+      style={{ fontWeight: 500, ...style }}
+      className="text-primary hover-text-action-primary hover-text-decoration-underline"
+    >
+      <span style={{ marginRight: '0.5rem' }}>
+        {handle ? `@${handle}` : <Trans>Project {projectId}</Trans>}
+      </span>
+    </Link>
   )
 }

--- a/src/components/v2/shared/V2ProjectTokenBalance/V2ProjectTokenBalance.tsx
+++ b/src/components/v2/shared/V2ProjectTokenBalance/V2ProjectTokenBalance.tsx
@@ -1,6 +1,4 @@
-import V2ProjectHandle from 'components/v2/shared/V2ProjectHandle'
 import { NetworkContext } from 'contexts/networkContext'
-import { ThemeContext } from 'contexts/themeContext'
 import useSymbolOfERC20 from 'hooks/SymbolOfERC20'
 import useProjectToken from 'hooks/v2/contractReader/ProjectToken'
 import useTotalBalanceOf from 'hooks/v2/contractReader/TotalBalanceOf'
@@ -10,42 +8,27 @@ import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 export const V2ProjectTokenBalance = ({
   projectId,
-  handle,
   style,
   precision,
 }: {
   projectId: number
-  handle?: string
   style?: CSSProperties
   precision?: number
 }) => {
-  const {
-    theme: { colors },
-  } = useContext(ThemeContext)
   const { data: tokenAddress } = useProjectToken({ projectId })
   const tokenSymbol = useSymbolOfERC20(tokenAddress)
   const { userAddress } = useContext(NetworkContext)
   const { data: balance } = useTotalBalanceOf(userAddress, projectId)
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', ...style }}>
-      <span>
-        {tokenSymbol !== undefined ? (
-          <>
-            {formatWad(balance, { precision: precision ?? 0 })}{' '}
-            {tokenSymbolText({ tokenSymbol, plural: true })}
-          </>
-        ) : (
-          '--'
-        )}
-      </span>
-
-      {handle && (
-        <V2ProjectHandle
-          style={{ color: colors.text.tertiary }}
-          projectId={projectId}
-          handle={handle}
-        />
+    <div style={{ ...style }}>
+      {tokenSymbol !== undefined ? (
+        <>
+          {formatWad(balance, { precision: precision ?? 0 })}{' '}
+          {tokenSymbolText({ tokenSymbol, plural: true })}
+        </>
+      ) : (
+        '--'
       )}
     </div>
   )

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1392,6 +1392,10 @@ msgstr ""
 msgid "Failed to update project metadata"
 msgstr "Failed to update project metadata"
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr "Fee from <0><1/></0>"
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "File must be less than {formattedSize}{unit}"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1397,6 +1397,10 @@ msgstr "Preguntas frecuentes"
 msgid "Failed to update project metadata"
 msgstr "No se ha podido actualizar la metadata del proyecto"
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr ""
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "El archivo debe ser menor que {formattedSize}{unit}"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1397,6 +1397,10 @@ msgstr "FAQs"
 msgid "Failed to update project metadata"
 msgstr "Échec de la mise à jour des métadonnées du projet"
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr ""
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "Le fichier doit être inférieur à {formattedSize}{unit}"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1397,6 +1397,10 @@ msgstr "FAQs"
 msgid "Failed to update project metadata"
 msgstr "Houve falha na atualização do metadado do projeto"
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr ""
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "O arquivo deve ter menos que {formattedSize}{unit}"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1397,6 +1397,10 @@ msgstr "FAQ (Вопросы)"
 msgid "Failed to update project metadata"
 msgstr ""
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr ""
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr ""

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1397,6 +1397,10 @@ msgstr "SSS"
 msgid "Failed to update project metadata"
 msgstr "Proje meta verileri güncellenemedi"
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr ""
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "Dosya {formattedSize}{unit} değerinden küçük olmalıdır"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1397,6 +1397,10 @@ msgstr "常见问题解答"
 msgid "Failed to update project metadata"
 msgstr "更新项目元数据失败"
 
+#: src/components/activityEventElems/PayEventElem.tsx
+msgid "Fee from <0><1/></0>"
+msgstr ""
+
 #: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "文件大小必须小于 {formattedSize}{unit}"

--- a/src/models/subgraph-entities/vX/pay-event.ts
+++ b/src/models/subgraph-entities/vX/pay-event.ts
@@ -16,6 +16,7 @@ export interface PayEvent extends BaseProjectEntity, BaseEventEntity {
   beneficiary: string
   amount: BigNumber
   note: string
+  feeFromV2Project?: number
 }
 
 export type PayEventJson = Partial<
@@ -31,4 +32,7 @@ export const parsePayEventJson = (j: PayEventJson): Partial<PayEvent> => ({
   beneficiary: j.beneficiary,
   amount: j.amount ? BigNumber.from(j.amount) : undefined,
   note: j.note,
+  feeFromV2Project: j.feeFromV2Project
+    ? parseInt(j.feeFromV2Project)
+    : undefined,
 })

--- a/src/pages/home/Payments.tsx
+++ b/src/pages/home/Payments.tsx
@@ -1,16 +1,15 @@
-import RichNote from 'components/RichNote'
+import ETHAmount from 'components/currency/ETHAmount'
 import FormattedAddress from 'components/FormattedAddress'
 import Loading from 'components/Loading'
+import ProjectVersionBadge from 'components/ProjectVersionBadge'
+import RichNote from 'components/RichNote'
 import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
-
+import V2ProjectHandle from 'components/v2/shared/V2ProjectHandle'
 import { ThemeContext } from 'contexts/themeContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
+import { Project } from 'models/subgraph-entities/vX/project'
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/formatDate'
-
-import ETHAmount from 'components/currency/ETHAmount'
-import { Project } from 'models/subgraph-entities/vX/project'
-import V2ProjectHandle from 'components/v2/shared/V2ProjectHandle'
 
 export default function Payments() {
   const {
@@ -38,10 +37,10 @@ export default function Payments() {
     return (
       <div style={{ color: colors.text.action.primary, fontWeight: 500 }}>
         {project.cv === '2' ? (
-          <V2ProjectHandle
-            projectId={project.projectId}
-            handle={project.handle}
-          />
+          <div style={{ display: 'flex', alignItems: 'baseline' }}>
+            <V2ProjectHandle projectId={project.projectId} />
+            <ProjectVersionBadge versionText="V2" size="small" />
+          </div>
         ) : (
           <V1ProjectHandle projectId={project.projectId} />
         )}


### PR DESCRIPTION
## What does this PR do and why?

Displays "Fee from <project>" in memo of payments to Juicebox V2 project. Includes a bit of redesign to the V2ProjectHandle element—makes it more similar to V1ProjectHandle, and better accommodates us now having proper handles for V2 projects.

## Screenshots or screen recordings

<img width="557" alt="image" src="https://user-images.githubusercontent.com/79433522/177591769-032dfa35-00d5-45b3-b318-161ef49fbabf.png">
<img width="535" alt="image" src="https://user-images.githubusercontent.com/79433522/177591810-3131f0d2-204c-4781-b3c3-dc1d34c28abd.png">
<img width="531" alt="image" src="https://user-images.githubusercontent.com/79433522/177591844-f49060a4-7b83-4534-99ab-c74e050aedc2.png">

Closes https://github.com/jbx-protocol/juice-interface/issues/1066
Closes https://github.com/jbx-protocol/juice-interface/issues/402

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
