### PR TITLE
fix latest transactions css

### DIFF
--- a/src/pages/home/TrendingSection.tsx
+++ b/src/pages/home/TrendingSection.tsx
@@ -81,7 +81,7 @@ export default function TrendingSection() {
         <Col xs={24} md={12}>
           <Space direction="vertical" style={{ width: '100%' }} size="middle">
             <SmallHeader text={<Trans>Latest payments</Trans>} />
-            <div style={{ maxHeight: 600, overflow: 'auto' }}>
+            <div style={{ maxHeight: 784, overflow: 'auto' }}>
               <Payments />
             </div>
           </Space>


### PR DESCRIPTION
## What does this PR do and why?

changed the max-height to 784px, the same height value as the 6-trending projects



## Screenshots or screen recordings
<img width="1304" alt="CleanShot 2022-07-08 at 09 33 11@2x" src="https://user-images.githubusercontent.com/2502947/178002439-beee4035-1353-4da3-96d7-04e5494ec496.png">

This fixes the problem on desktop but not on tablet. 


I can leave this as a fix for the moment and comeback and address the tablet viewport size in another diff.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
