### PR TITLE
Hide 'add handle' button in project header during preview

### DIFF
--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -141,7 +141,9 @@ export default function V2Project({
         isArchived={isArchived}
         handle={handle}
         onClickSetHandle={
-          isOwner ? () => setHandleModalVisible(true) : undefined
+          isOwner && !isPreviewMode
+            ? () => setHandleModalVisible(true)
+            : undefined
         }
       />
       {!isPreviewMode &&

--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -107,6 +107,7 @@ export default function V2Project({
   const colSizeMd = singleColumnLayout ? 24 : 12
   const hasCurrentFundingCycle = fundingCycle?.number.gt(0)
   const hasQueuedFundingCycle = queuedFundingCycle?.number.gt(0)
+  const showAddHandle = isOwner && !isPreviewMode && !handle
 
   if (projectId === undefined) return null
 
@@ -141,9 +142,7 @@ export default function V2Project({
         isArchived={isArchived}
         handle={handle}
         onClickSetHandle={
-          isOwner && !isPreviewMode
-            ? () => setHandleModalVisible(true)
-            : undefined
+          showAddHandle ? () => setHandleModalVisible(true) : undefined
         }
       />
       {!isPreviewMode &&
@@ -211,7 +210,7 @@ export default function V2Project({
         onCancel={() => setBalancesModalVisible(false)}
         storeCidTx={editV2ProjectDetailsTx}
       />
-      {isOwner && !handle && (
+      {showAddHandle && (
         <V2ReconfigureProjectHandleDrawer
           visible={handleModalVisible}
           onFinish={() => setHandleModalVisible(false)}


### PR DESCRIPTION
## What does this PR do and why?

Hide 'add handle' button in project header during preview

## Screenshots or screen recordings

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/79433522/178052906-4886e011-c1d1-420a-9f88-05c6b7d4e36f.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
