### PR TITLE
add owner field to v2 project header

### DIFF
--- a/src/components/Project/ProjectHeader/index.tsx
+++ b/src/components/Project/ProjectHeader/index.tsx
@@ -7,7 +7,6 @@ import { ProjectMetadataV4 } from 'models/project-metadata'
 import Paragraph from 'components/Paragraph'
 import FormattedAddress from 'components/FormattedAddress'
 
-import { useProjectOwner } from 'hooks/v1/contractReader/ProjectOwner'
 import { Button, Tooltip } from 'antd'
 
 import SocialLinks from './SocialLinks'
@@ -18,17 +17,18 @@ export default function ProjectHeader({
   isArchived,
   actions,
   onClickSetHandle,
+  owner,
 }: {
   metadata?: ProjectMetadataV4
   isArchived?: boolean
   handle?: string
   actions?: JSX.Element
   onClickSetHandle?: VoidFunction
+  owner?: string
 }) {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const { owner } = useProjectOwner()
 
   const headerHeight = 120
 

--- a/src/components/v1/V1Project/index.tsx
+++ b/src/components/v1/V1Project/index.tsx
@@ -40,6 +40,7 @@ export default function V1Project({
     tokenSymbol,
     tokenAddress,
     isPreviewMode,
+    owner,
     cv,
   } = useContext(V1ProjectContext)
 
@@ -56,6 +57,7 @@ export default function V1Project({
         metadata={metadata}
         handle={handle}
         isArchived={isArchived}
+        owner={owner}
         actions={<V1ProjectHeaderActions />}
       />
 

--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -141,6 +141,7 @@ export default function V2Project({
         actions={!isPreviewMode ? <V2ProjectHeaderActions /> : undefined}
         isArchived={isArchived}
         handle={handle}
+        owner={projectOwnerAddress}
         onClickSetHandle={
           showAddHandle ? () => setHandleModalVisible(true) : undefined
         }


### PR DESCRIPTION
## What does this PR do and why?
fixes #1377
### v2
[v2 localhost](http://localhost:3000/#/v2/p/4313)
<img width="1106" alt="CleanShot 2022-07-11 at 15 49 21@2x" src="https://user-images.githubusercontent.com/2502947/178348249-e7322c9c-da9d-42c8-9be8-512128d8703d.png">


### v1
[v1 localhost](http://localhost:3000/#/p/slicev2)
<img width="855" alt="CleanShot 2022-07-11 at 16 12 18@2x" src="https://user-images.githubusercontent.com/2502947/178349922-4128e2ab-64ee-441b-beb1-457f0c386caf.png">



- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
