### PR TITLE
Fix FC number not showing

### DIFF
--- a/src/components/Project/BallotStateBadge.tsx
+++ b/src/components/Project/BallotStateBadge.tsx
@@ -1,0 +1,55 @@
+import { ClockCircleOutlined } from '@ant-design/icons'
+import { BallotState } from 'models/v2/fundingCycle'
+import { Tooltip } from 'antd'
+import { t } from '@lingui/macro'
+
+import { Badge, BadgeVariant } from '../Badge'
+import { getBallotStrategyByAddress } from 'constants/v2/ballotStrategies/getBallotStrategiesByAddress'
+
+export function BallotStateBadge({
+  ballotState,
+  ballotStrategyAddress,
+}: {
+  ballotState: BallotState
+  ballotStrategyAddress?: string
+}) {
+  const ballotStrategy = ballotStrategyAddress
+    ? getBallotStrategyByAddress(ballotStrategyAddress)
+    : undefined
+
+  // only show badge for ballot states 0 and 2 (don't show if ballot is 'approved'.)
+  const ballotStateVariantMap: { [k in BallotState]?: BadgeVariant } = {
+    0: 'warning',
+  }
+
+  const ballotStateLabelMap: { [k in BallotState]?: string } = {
+    0: 'Pending',
+  }
+
+  const ballotStateTooltips: { [k in BallotState]?: string } = {
+    0: t`This proposed reconfiguration hasn't passed the ${
+      ballotStrategy?.durationSeconds && ballotStrategy?.name
+        ? ballotStrategy.name
+        : 'delay'
+    } period. It's not guaranteed to take effect in the upcoming funding cycle.`,
+  }
+
+  const ballotStateIcons: { [k in BallotState]?: JSX.Element } = {
+    0: <ClockCircleOutlined />,
+  }
+
+  const variant = ballotStateVariantMap[ballotState]
+
+  if (!variant) return null
+
+  return (
+    <Badge
+      variant={variant}
+      style={{ marginLeft: '0.5rem', textTransform: 'capitalize' }}
+    >
+      <Tooltip title={ballotStateTooltips[ballotState]}>
+        {ballotStateIcons[ballotState]} {ballotStateLabelMap[ballotState]}
+      </Tooltip>
+    </Badge>
+  )
+}

--- a/src/components/Project/FundingCycleDetailsCard.tsx
+++ b/src/components/Project/FundingCycleDetailsCard.tsx
@@ -1,8 +1,5 @@
-import {
-  ExclamationCircleOutlined,
-  ClockCircleOutlined,
-} from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
+import { ExclamationCircleOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
 import { Collapse, Tooltip } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
 import { ThemeContext } from 'contexts/themeContext'
@@ -11,58 +8,9 @@ import { useContext } from 'react'
 import { detailedTimeUntil } from 'utils/formatTime'
 import { BallotState } from 'models/v2/fundingCycle'
 
-import { Badge, BadgeVariant } from '../Badge'
-import { getBallotStrategyByAddress } from 'constants/v2/ballotStrategies/getBallotStrategiesByAddress'
+import { BallotStateBadge } from './BallotStateBadge'
 
 const COLLAPSE_PANEL_KEY = 'funding-cycle-details'
-
-function BallotStateBadge({
-  ballotState,
-  ballotStrategyAddress,
-}: {
-  ballotState: BallotState
-  ballotStrategyAddress?: string
-}) {
-  const ballotStrategy = ballotStrategyAddress
-    ? getBallotStrategyByAddress(ballotStrategyAddress)
-    : undefined
-
-  // only show badge for ballot states 0 and 2 (don't show if ballot is 'approved'.)
-  const ballotStateVariantMap: { [k in BallotState]?: BadgeVariant } = {
-    0: 'warning',
-  }
-
-  const ballotStateLabelMap: { [k in BallotState]?: string } = {
-    0: 'Pending',
-  }
-
-  const ballotStateTooltips: { [k in BallotState]?: string } = {
-    0: t`This proposed reconfiguration hasn't passed the ${
-      ballotStrategy?.durationSeconds && ballotStrategy?.name
-        ? ballotStrategy.name
-        : 'delay'
-    } period. It's not guaranteed to take effect in the upcoming funding cycle.`,
-  }
-
-  const ballotStateIcons: { [k in BallotState]?: JSX.Element } = {
-    0: <ClockCircleOutlined />,
-  }
-
-  const variant = ballotStateVariantMap[ballotState]
-
-  if (!variant) return null
-
-  return (
-    <Badge
-      variant={variant}
-      style={{ marginLeft: '0.5rem', textTransform: 'capitalize' }}
-    >
-      <Tooltip title={ballotStateTooltips[ballotState]}>
-        {ballotStateIcons[ballotState]} {ballotStateLabelMap[ballotState]}
-      </Tooltip>
-    </Badge>
-  )
-}
 
 export default function FundingCycleDetailsCard({
   fundingCycleNumber,
@@ -145,26 +93,25 @@ export default function FundingCycleDetailsCard({
             }}
           >
             <div>
-              <span>
-                {fundingCycleDurationSeconds.gt(0) ? (
-                  <Trans>Cycle #{fundingCycleNumber.toString()}</Trans>
-                ) : (
-                  <Trans>Details</Trans>
-                )}
-              </span>
+              {fundingCycleDurationSeconds.gt(0) ||
+              (fundingCycleDurationSeconds.eq(0) &&
+                fundingCycleNumber.gt(0)) ? (
+                <Trans>Cycle #{fundingCycleNumber.toString()}</Trans>
+              ) : (
+                <Trans>Details</Trans>
+              )}
 
               {fundingCycleRiskCount > 0 && (
                 <span style={{ marginLeft: 10, color: colors.text.secondary }}>
                   <Tooltip
                     title={
                       <Trans>
-                        Some funding cycle properties may indicate risk for
-                        project contributors.
+                        Some funding cycle settings may put project contributors
+                        at risk.
                       </Trans>
                     }
                   >
-                    <ExclamationCircleOutlined style={{ marginRight: 6 }} />
-                    {fundingCycleRiskCount}
+                    <ExclamationCircleOutlined />
                   </Tooltip>
                 </span>
               )}

--- a/src/components/Project/SpendingStats.tsx
+++ b/src/components/Project/SpendingStats.tsx
@@ -62,10 +62,10 @@ export default function SpendingStats({
           label={<Trans>AVAILABLE</Trans>}
           tip={
             <Trans>
-              The funds available to distribution for this funding cycle (before
-              the {feePercentage}% JBX fee is subtracted). This number won't
-              roll over to the next funding cycle, so funds should be
-              distributed before this funding cycle ends.
+              Funds available to distribute in this funding cycle (before the{' '}
+              {feePercentage}% JBX fee). This amount won't roll over to the next
+              funding cycle, so funds should be distributed before this funding
+              cycle ends.
             </Trans>
           }
         />

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1472,6 +1472,10 @@ msgstr "Funding distribution"
 msgid "Funding target"
 msgstr "Funding target"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2838,8 +2842,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Since you have not set a funding duration, changes to these settings will be applied immediately."
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "Some funding cycle properties may indicate risk for project contributors."
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr "Some funding cycle settings may put project contributors at risk."
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2984,10 +2988,6 @@ msgstr "The balance of this project in the Juicebox contract."
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr ""
@@ -3123,7 +3123,7 @@ msgstr "This project uses the V2 version of the Juicebox contracts."
 msgid "This project's balance in the Juicebox contract."
 msgstr "This project's balance in the Juicebox contract."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1477,6 +1477,10 @@ msgstr "Distribución de fondos"
 msgid "Funding target"
 msgstr "Objetivo de financiamiento"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr ""
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2843,8 +2847,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Como no has establecido una duración de financiamiento, los cambios a estos ajustes serán aplicados de inmediato."
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "Algunas propiedades de los ciclos de financiamiento pueden indicar riesgo para los contribuyentes de proyectos."
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr ""
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2989,10 +2993,6 @@ msgstr "El balance de este proyecto en el contrato de Juicebox."
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "El límite de distribución para el ciclo es 0, lo que significa que todos los fondos en Juicebox actualmente son considerados excedente. El excedente puede ser redimido por los poseedores de tokens, pero no distribuidos."
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "Los fondos disponibles para distribuir en este ciclo de financiamiento (antes que la comisión de {feePercentage}% JBX sea sustraída). Este número no va a mantenerse para el siguiente ciclo de financiamiento, así que los fondos deben ser distribuidos antes que acabe el ciclo de financiamiento."
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "El futuro será liderado por creadores y las comunidades serán los dueños."
@@ -3128,7 +3128,7 @@ msgstr "Este proyecto usa la versión V2 de los contratos de Juicebox."
 msgid "This project's balance in the Juicebox contract."
 msgstr "El balance de este proyecto en el contrato de Juicebox."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1477,6 +1477,10 @@ msgstr "Distribution des fonds"
 msgid "Funding target"
 msgstr "Objectif de financement"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr ""
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2843,8 +2847,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Vous n'avez pas défini une durée de financement, les modifications apportées à ces paramètres seront appliquées immédiatement."
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "Certaines propriétés du cycle de financement peuvent indiquer un risque pour les contributeurs du projet."
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr ""
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2989,10 +2993,6 @@ msgstr "Le solde de ce projet dans le contrat Juicebox."
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "La limite de distribution pour ce cycle de financement est de 0, ce qui signifie que tous les fonds dans Juicebox sont actuellement considérés comme overflow. L'overflow peut être échangé par les holders de tokens, mais pas distribué."
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "Les fonds disponibles pour la distribution pour ce cycle de financement (avant que les {feePercentage}% de frais JBX soient soustraits). Ce nombre ne sera pas reporté sur le cycle de financement suivant, les fonds doivent donc être distribués avant la fin de ce cycle de financement."
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "L'avenir sera dirigé par des créateurs et appartiendra aux communautés."
@@ -3128,7 +3128,7 @@ msgstr "Ce projet utilise la version V2 des contrats Juicebox."
 msgid "This project's balance in the Juicebox contract."
 msgstr "Le solde de ce projet dans le contrat Juicebox."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1477,6 +1477,10 @@ msgstr "Distribuição de fundos"
 msgid "Funding target"
 msgstr "Objetivo de financiamento"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr ""
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2843,8 +2847,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Como você não colocou uma duração de financiamento, as mudanças para essas configurações serão aplicadas imediatamente."
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "Algumas propriedades do ciclo de financiamento podem indicar risco para os contribuidores do projeto."
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr ""
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2989,10 +2993,6 @@ msgstr "O saldo deste projeto no contrato do Juicebox."
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "O limite de distribuição deste ciclo de financiamento é 0, o que significa que todos os fundos no Juicebox são atualmente considerados overflow. Overflow pode ser resgatado por detentores de tokens, mas não distribuído."
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "Os fundos disponíveis para distribuição para este ciclo de financiamento (antes da taxa {feePercentage}% JBX ser subtraída). Esse valor não será mantido para o próximo ciclo de financiamento, portanto, fundos devem ser distribuídos antes do fim do ciclo de financiamento."
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "O futuro será liderado pelos criadores, e pertencente às comunidades."
@@ -3128,7 +3128,7 @@ msgstr "Este projeto usa a versão V2 dos contratos do Juicebox."
 msgid "This project's balance in the Juicebox contract."
 msgstr "Este saldo do projeto no contrato Juicebox."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1477,6 +1477,10 @@ msgstr "Распределение финансирования"
 msgid "Funding target"
 msgstr "Цель финансирования"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr ""
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2843,8 +2847,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Поскольку вы не установили срок финансирования, изменения в этих настройках будут применены немедленно."
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "Некоторые свойства цикла финансирования могут указывать на риск для участников проекта."
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr ""
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2989,10 +2993,6 @@ msgstr "Баланс этого проекта в контракте Juicebox."
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Лимит распределения для этого цикла финансирования равен 0, то есть все средства в Juicebox в настоящее время считаются переполнением. Переполнение может быть выкуплено держателями токенов, но не распределено."
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "Средства, доступные для распределения в этом цикле финансирования (до вычитания {feePercentage}% комиссии JBX). Это число не переносится на следующий цикл финансирования, поэтому средства должны быть распределены до окончания этого цикла финансирования."
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "Будущее будет возглавляться создателями и принадлежать сообществам."
@@ -3128,7 +3128,7 @@ msgstr "В этом проекте используется версия V2 ко
 msgid "This project's balance in the Juicebox contract."
 msgstr ""
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1477,6 +1477,10 @@ msgstr "Finansman dağılımı"
 msgid "Funding target"
 msgstr "Finansman hedefi"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr ""
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2843,8 +2847,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "Bir finansman süresi belirlemediğiniz için bu ayarlarda yapılan değişiklikler hemen uygulanacaktır."
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "Bazı finansman döngüsü özellikleri projeye katkıda bulunanlar için risk oluşturabilir."
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr ""
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2989,10 +2993,6 @@ msgstr "Bu projenin Juicebox sözleşmesindeki bakiyesi."
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Bu finansman döngüsü için dağıtım limiti 0'dır, yani Juicebox'taki tüm fonlar şu anda taşma olarak kabul edilir. Taşma, token sahipleri tarafından kullanılabilir, ancak dağıtılamaz."
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "Bu finansman döngüsü için dağıtılmaya uygun fonlar (%{feePercentage} JBX ücreti düşülmeden önce). Bu sayı bir sonraki finansman döngüsüne aktarılmayacaktır, bu nedenle fonlar bu finansman döngüsü sona ermeden dağıtılmalıdır."
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "Gelecek, içerik üreticileri tarafından yönetilecek ve topluluklara ait olacak."
@@ -3128,7 +3128,7 @@ msgstr "Bu proje, Juicebox sözleşmelerinin V2 sürümünü kullanır."
 msgid "This project's balance in the Juicebox contract."
 msgstr "Bu projenin Juicebox sözleşmesindeki bakiyesi."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1477,6 +1477,10 @@ msgstr "资金分发"
 msgid "Funding target"
 msgstr "筹款目标"
 
+#: src/components/Project/SpendingStats.tsx
+msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
+msgstr ""
+
 #: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 #: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
@@ -2843,8 +2847,8 @@ msgid "Since you have not set a funding duration, changes to these settings will
 msgstr "鉴于你并未设置筹款持续时间，对这些设置的修改将会立即生效。"
 
 #: src/components/Project/FundingCycleDetailsCard.tsx
-msgid "Some funding cycle properties may indicate risk for project contributors."
-msgstr "一些筹款周期的配置可能会给项目贡献者们造成一些风险。"
+msgid "Some funding cycle settings may put project contributors at risk."
+msgstr ""
 
 #: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
@@ -2989,10 +2993,6 @@ msgstr "该项目在Juicebox合约中的余额。"
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "当前筹款周期的分配限额为 0, 也就是说 Juicebox 里的所有资金都被视为溢出。溢出可供持币人赎回代币来换取，但不能用于分配。"
 
-#: src/components/Project/SpendingStats.tsx
-msgid "The funds available to distribution for this funding cycle (before the {feePercentage}% JBX fee is subtracted). This number won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
-msgstr "当前筹款周期的可分配资金(未扣除 {feePercentage}% JBX 费用)。这一金额将不会滚动至下个筹款周期，所以应该在本筹款周期结束完成分配。"
-
 #: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "创造者将引领未来, 而社区会拥有未来."
@@ -3128,7 +3128,7 @@ msgstr "这个项目使用的是 V2 版本的 Juicebox 合约。"
 msgid "This project's balance in the Juicebox contract."
 msgstr "这个项目在 Juicebox 合约内的余额。"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
+#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

We currently dont show the FC number if there is no duration. But if it's not the project's first funding cycle, we should.

This PR:
- show FC number if duration is 0 but its not the first cycle
- Remove the number of risks from the FC header. I don't think that's necessary info to put up-front.
- move BallotStateBadge to own file
- minor copy updates

## Screenshots or screen recordings

Project: https://www.juicebox.money/@ownthesebones


| before | after |
| --- | --- |
| <img width="512" alt="Screen Shot 2022-07-20 at 8 09 52 AM" src="https://user-images.githubusercontent.com/12551741/179860315-e7240b60-42ff-4045-adfe-2735c4fff4f7.png"> | <img width="525" alt="Screen Shot 2022-07-20 at 7 45 14 AM" src="https://user-images.githubusercontent.com/12551741/179857987-80696aad-d50f-48b5-867d-b67f775ac5aa.png"> |
 


## Acceptance checklist


- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
