### PR TITLE
Disable download when no activity

### DIFF
--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -295,14 +295,13 @@ export default function ProjectActivity() {
         <SectionHeader text={t`Activity`} style={{ margin: 0 }} />
 
         <Space direction="horizontal" align="center" size="small">
-          <Button
-            type="text"
-            icon={<DownloadOutlined />}
-            onClick={() => setDownloadModalVisible(true)}
-            style={{
-              display: count > 0 ? 'inline-block' : 'none',
-            }}
-          />
+          {count > 0 && (
+            <Button
+              type="text"
+              icon={<DownloadOutlined />}
+              onClick={() => setDownloadModalVisible(true)}
+            />
+          )}
 
           <Select
             className="small"

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -172,6 +172,9 @@ export default function ProjectActivity() {
     where,
   })
 
+  const count =
+    projectEvents?.pages?.reduce((prev, cur) => prev + cur.length, 0) ?? 0
+
   const list = useMemo(
     () =>
       projectEvents?.pages.map(group =>
@@ -229,9 +232,6 @@ export default function ProjectActivity() {
   )
 
   const listStatus = useMemo(() => {
-    const count =
-      projectEvents?.pages?.reduce((prev, cur) => prev + cur.length, 0) ?? 0
-
     if (isLoading || isFetchingNextPage) {
       return (
         <div>
@@ -280,14 +280,7 @@ export default function ProjectActivity() {
         <Trans>{count} total</Trans>
       </div>
     )
-  }, [
-    projectEvents,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    colors,
-  ])
+  }, [isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, colors, count])
 
   return (
     <div>
@@ -306,6 +299,9 @@ export default function ProjectActivity() {
             type="text"
             icon={<DownloadOutlined />}
             onClick={() => setDownloadModalVisible(true)}
+            style={{
+              display: count > 0 ? 'inline-block' : 'none',
+            }}
           />
 
           <Select

--- a/src/components/v2/V2Project/ProjectActivity/index.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/index.tsx
@@ -345,14 +345,13 @@ export default function ProjectActivity() {
         <SectionHeader text={t`Activity`} style={{ margin: 0 }} />
 
         <Space direction="horizontal" align="center" size="small">
-          <Button
-            type="text"
-            icon={<DownloadOutlined />}
-            onClick={() => setDownloadModalVisible(true)}
-            style={{
-              display: count > 0 ? 'inline-block' : 'none',
-            }}
-          />
+          {count > 0 && (
+            <Button
+              type="text"
+              icon={<DownloadOutlined />}
+              onClick={() => setDownloadModalVisible(true)}
+            />
+          )}
 
           <Select
             className="small"

--- a/src/components/v2/V2Project/ProjectActivity/index.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/index.tsx
@@ -199,6 +199,9 @@ export default function ProjectActivity() {
     where,
   })
 
+  const count =
+    projectEvents?.pages?.reduce((prev, cur) => prev + cur.length, 0) ?? 0
+
   const list = useMemo(
     () =>
       projectEvents?.pages.map(group =>
@@ -279,9 +282,6 @@ export default function ProjectActivity() {
   )
 
   const listStatus = useMemo(() => {
-    const count =
-      projectEvents?.pages?.reduce((prev, cur) => prev + cur.length, 0) ?? 0
-
     if (isLoading || isFetchingNextPage) {
       return (
         <div>
@@ -330,14 +330,7 @@ export default function ProjectActivity() {
         <Trans>{count} total</Trans>
       </div>
     )
-  }, [
-    projectEvents,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    colors,
-  ])
+  }, [isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, colors, count])
 
   return (
     <div>
@@ -356,6 +349,9 @@ export default function ProjectActivity() {
             type="text"
             icon={<DownloadOutlined />}
             onClick={() => setDownloadModalVisible(true)}
+            style={{
+              display: count > 0 ? 'inline-block' : 'none',
+            }}
           />
 
           <Select


### PR DESCRIPTION
## What does this PR do and why?

Closes #1379.

I am not sure what you mean by "disable the select sorter when there is no project activity" @tomquirk ? At minimum, all projects will have a 'Project Created' event, right? Do you want to disable the select option if there is no event of that type? Regardless, I disabled the download button when there are no events of a given type

## Screenshots or screen recordings

V1

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/33093632/179864239-51b4aea2-a275-44c6-b018-231a1bf1383d.png">

V2

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/33093632/179864301-8cbb5a5b-dfc2-4b35-9fe0-2a04a4114210.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
