### PR TITLE
Validate FC mustStartAtOrAfter + duration

### DIFF
--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -16,5 +16,5 @@ export const MaxUint232 = constants.MaxUint256.add(1)
   .div(2 ** 24)
   .sub(1)
 export const MaxUint88 = 2 ** 88 - 1
-export const MaxUint54 = BigNumber.from(10).pow(54).sub(1)
+export const MaxUint54 = BigNumber.from(2).pow(54).sub(1)
 export const MaxUint48 = 2 ** 48 - 1

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -1,6 +1,20 @@
+import * as constants from '@ethersproject/constants'
+import { BigNumber } from '@ethersproject/bignumber'
+
 export const WAD_DECIMALS = 18
 
 export const SECONDS_IN_DAY = 24 * 60 * 60
 export const SECONDS_IN_HOUR = 60 * 60
 
 export const PROJECT_PAY_CHARACTER_LIMIT = 16
+
+export const TEN_THOUSAND = 10000
+export const ONE_MILLION = 1000000
+export const ONE_BILLION = 1000000000
+
+export const MaxUint232 = constants.MaxUint256.add(1)
+  .div(2 ** 24)
+  .sub(1)
+export const MaxUint88 = 2 ** 88 - 1
+export const MaxUint54 = BigNumber.from(10).pow(54).sub(1)
+export const MaxUint48 = 2 ** 48 - 1

--- a/src/hooks/v2/transactor/LaunchFundingCyclesTx.ts
+++ b/src/hooks/v2/transactor/LaunchFundingCyclesTx.ts
@@ -8,6 +8,7 @@ import {
 } from 'models/v2/fundingCycle'
 
 import { GroupedSplits, SplitGroup } from 'models/v2/splits'
+import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
 import { TransactorInstance } from '../../Transactor'
 
@@ -40,7 +41,8 @@ export function useLaunchFundingCyclesTx(): TransactorInstance<{
       !transactor ||
       !userAddress ||
       !contracts?.JBController ||
-      !contracts?.JBETHPaymentTerminal
+      !contracts?.JBETHPaymentTerminal ||
+      !isValidMustStartAtOrAfter(mustStartAtOrAfter, fundingCycleData.duration)
     ) {
       return Promise.resolve(false)
     }

--- a/src/hooks/v2/transactor/LaunchProjectTx.ts
+++ b/src/hooks/v2/transactor/LaunchProjectTx.ts
@@ -8,6 +8,7 @@ import {
 } from 'models/v2/fundingCycle'
 
 import { GroupedSplits, SplitGroup } from 'models/v2/splits'
+import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
 import { TransactorInstance } from '../../Transactor'
 import { JUICEBOX_MONEY_METADATA_DOMAIN } from 'constants/v2/metadataDomain'
@@ -41,7 +42,8 @@ export function useLaunchProjectTx(): TransactorInstance<{
       !transactor ||
       !userAddress ||
       !contracts?.JBController ||
-      !contracts.JBETHPaymentTerminal
+      !contracts.JBETHPaymentTerminal ||
+      !isValidMustStartAtOrAfter(mustStartAtOrAfter, fundingCycleData.duration)
     ) {
       txOpts?.onDone?.()
       return Promise.resolve(false)

--- a/src/hooks/v2/transactor/LaunchProjectWithNftsTx.ts
+++ b/src/hooks/v2/transactor/LaunchProjectWithNftsTx.ts
@@ -12,13 +12,14 @@ import {
 import { GroupedSplits, SplitGroup } from 'models/v2/splits'
 
 import { BigNumber } from '@ethersproject/bignumber'
-import { MaxUint48 } from 'utils/v2/math'
 import { parseEther } from '@ethersproject/units'
+import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 import { IPFS_GATEWAY_HOSTNAME } from 'constants/ipfs'
 import { TransactorInstance } from '../../Transactor'
 import { JUICEBOX_MONEY_METADATA_DOMAIN } from 'constants/v2/metadataDomain'
+import { MaxUint48 } from 'constants/numbers'
 
 const DEFAULT_MUST_START_AT_OR_AFTER = '1' // start immediately
 const DEFAULT_MEMO = ''
@@ -101,7 +102,8 @@ export function useLaunchProjectWithNftsTx(): TransactorInstance<{
       !transactor ||
       !userAddress ||
       !contracts?.JBController ||
-      !contracts.JBETHPaymentTerminal
+      !contracts.JBETHPaymentTerminal ||
+      !isValidMustStartAtOrAfter(mustStartAtOrAfter, fundingCycleData.duration)
     ) {
       txOpts?.onDone?.()
       return Promise.resolve(false)

--- a/src/hooks/v2/transactor/ReconfigureV2FundingCycleTx.ts
+++ b/src/hooks/v2/transactor/ReconfigureV2FundingCycleTx.ts
@@ -9,6 +9,7 @@ import { GroupedSplits, SplitGroup } from 'models/v2/splits'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { V2UserContext } from 'contexts/v2/userContext'
 import { TransactorInstance } from 'hooks/Transactor'
+import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
 const DEFAULT_MUST_START_AT_OR_AFTER = '1'
 const DEFAULT_MEMO = ''
@@ -33,7 +34,12 @@ export function useReconfigureV2FundingCycleTx(): TransactorInstance<{
     },
     txOpts,
   ) => {
-    if (!transactor || !projectId || !contracts?.JBController) {
+    if (
+      !transactor ||
+      !projectId ||
+      !contracts?.JBController ||
+      !isValidMustStartAtOrAfter(mustStartAtOrAfter, fundingCycleData.duration)
+    ) {
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }

--- a/src/pages/create/forms/FundingForm/index.tsx
+++ b/src/pages/create/forms/FundingForm/index.tsx
@@ -38,10 +38,7 @@ import ExternalLink from 'components/ExternalLink'
 
 import { Split } from 'models/v2/splits'
 
-import {
-  DEFAULT_FUNDING_CYCLE_DURATION,
-  MAX_DISTRIBUTION_LIMIT,
-} from 'utils/v2/math'
+import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2/math'
 
 import {
   deriveDurationUnit,
@@ -76,6 +73,8 @@ type FundingFormFields = {
   durationEnabled?: boolean
   totalSplitsPercentage?: number
 }
+
+const DEFAULT_FUNDING_CYCLE_DURATION = 14
 
 export default function FundingForm({
   onFormUpdated,

--- a/src/utils/v2/__tests__/fundingCycle.test.ts
+++ b/src/utils/v2/__tests__/fundingCycle.test.ts
@@ -8,7 +8,11 @@ import { Wallet } from '@ethersproject/wallet'
 
 import { invertPermyriad } from 'utils/bigNumbers'
 
-import { decodeV2FundingCycleMetadata } from '../fundingCycle'
+import {
+  decodeV2FundingCycleMetadata,
+  isValidMustStartAtOrAfter,
+} from '../fundingCycle'
+import { MaxUint54 } from 'constants/numbers'
 
 /**
  * Returns a mock FundingCyleMetadata packed into a BigNumber
@@ -101,7 +105,7 @@ const createMetadata = ({
   }
 }
 
-describe('fundingCycle', () => {
+describe('fundingCycle utils', () => {
   describe('decodeV2FundingCycleMetadata', () => {
     it.each`
       flagsEnabled
@@ -121,5 +125,23 @@ describe('fundingCycle', () => {
         expect(decodeV2FundingCycleMetadata(packedMetadata)).toEqual(metadata)
       },
     )
+  })
+
+  describe('isValidMustStartAtOrAfter', () => {
+    it.each`
+      mustStartAtOrAfter  | duration            | isValid
+      ${0}                | ${0}                | ${true}
+      ${1}                | ${1}                | ${true}
+      ${MaxUint54.sub(1)} | ${0}                | ${true}
+      ${0}                | ${MaxUint54.sub(1)} | ${true}
+      ${0}                | ${MaxUint54}        | ${false}
+      ${MaxUint54}        | ${0}                | ${false}
+      ${0}                | ${MaxUint54.add(1)} | ${false}
+      ${MaxUint54.add(1)} | ${0}                | ${false}
+    `('returns correct result', ({ mustStartAtOrAfter, duration, isValid }) => {
+      expect(isValidMustStartAtOrAfter(mustStartAtOrAfter, duration)).toBe(
+        isValid,
+      )
+    })
   })
 })

--- a/src/utils/v2/fundingCycle.ts
+++ b/src/utils/v2/fundingCycle.ts
@@ -19,6 +19,7 @@ import {
 import { FundingCycleRiskFlags } from 'constants/fundingWarningText'
 import { getBallotStrategyByAddress } from 'constants/v2/ballotStrategies/getBallotStrategiesByAddress'
 import { MAX_DISTRIBUTION_LIMIT } from './math'
+import { MaxUint54 } from 'constants/numbers'
 
 export const hasDistributionLimit = (
   fundAccessConstraint: SerializedV2FundAccessConstraint | undefined,
@@ -211,4 +212,17 @@ export const V2FundingCycleRiskCount = (
   return Object.values(getUnsafeV2FundingCycleProperties(fundingCycle)).filter(
     v => v === true,
   ).length
+}
+
+/**
+ * _mustStartAtOrAfter + _duration > type(uint54).max
+ * @param mustStartAtOrAfter
+ */
+export const isValidMustStartAtOrAfter = (
+  mustStartAtOrAfter: string,
+  fundingCycleDuration: BigNumber,
+): boolean => {
+  return BigNumber.from(mustStartAtOrAfter)
+    .add(fundingCycleDuration)
+    .lt(MaxUint54)
 }

--- a/src/utils/v2/math.ts
+++ b/src/utils/v2/math.ts
@@ -4,26 +4,24 @@ import { invertPermyriad } from 'utils/bigNumbers'
 import { fromWad, percentToPermyriad } from 'utils/formatNumber'
 import { WeightFunction } from 'utils/math'
 
-const TEN_THOUSAND = 10000
-const ONE_BILLION = 1000000000
-
-const MaxUint232 = constants.MaxUint256.add(1)
-  .div(2 ** 24)
-  .sub(1)
-const MaxUint88 = 2 ** 88 - 1
-export const MaxUint48 = 2 ** 48 - 1
+import {
+  MaxUint232,
+  MaxUint88,
+  ONE_BILLION,
+  ONE_MILLION,
+  TEN_THOUSAND,
+} from 'constants/numbers'
 
 export const MAX_RESERVED_RATE = TEN_THOUSAND
 export const MAX_REDEMPTION_RATE = TEN_THOUSAND
 export const MAX_DISCOUNT_RATE = ONE_BILLION
 export const SPLITS_TOTAL_PERCENT = ONE_BILLION
-const MAX_FEE = ONE_BILLION
 export const MAX_DISTRIBUTION_LIMIT = MaxUint232
 
-export const DEFAULT_MINT_RATE = 10 ** 6
+export const DEFAULT_MINT_RATE = ONE_MILLION
 export const MAX_MINT_RATE = Math.floor(MaxUint88 / 10 ** 18)
 
-export const DEFAULT_FUNDING_CYCLE_DURATION = 14
+const MAX_FEE = ONE_BILLION
 
 /**
  * Express a given discount rate (parts-per-billion) as a percentage.


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/1420

Part of remediation for a contract bug. The specific remediation recommendation was:

```
- Web clients should prevent projects from being launched or reconfigured with `_mustStartAtOrAfter + _duration > type(uint54).max. This prevents the proposed start time and that of the upcoming cycle from overflowing a uint54, which has a max value of 2ˆ54 - 1.
```

This PR implements the above.

source: https://juicebox.notion.site/Code4rena-discoveries-d036b810eade4bec98523e01bdf62752

Discord discussion: https://discord.com/channels/775859454780244028/997096039758708776/997441281506676856

## Screenshots or screen recordings

No user-facing changes.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
