### PR TITLE
Force set useDataSourceForPay to false

### DIFF
--- a/src/hooks/AppSelector.ts
+++ b/src/hooks/AppSelector.ts
@@ -35,6 +35,10 @@ export const useEditingV2FundingCycleMetadataSelector = () => {
     [serializedFundingCycleMetadata],
   )
 
+  // force useDataSourceForPay to false, for safety.
+  // https://github.com/jbx-protocol/juice-interface/issues/1473
+  fundingCycleMetadata.useDataSourceForPay = false
+
   return fundingCycleMetadata
 }
 


### PR DESCRIPTION
Remediation for https://github.com/jbx-protocol/juice-interface/issues/1467

Affected projects can reconfig their project with no modifications, and `useDataSourceForPay` will revert from `true` to `false. 

This means their project's payments will work again.