### PR TITLE
Fixes large space under image upload

### DIFF
--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -243,6 +243,9 @@ textarea.ant-input::placeholder {
 
 .ant-upload {
   color: var(--text-primary);
+}
+
+.ant-upload-select-picture-card .ant-upload {
   min-height: 101px;
 }
 


### PR DESCRIPTION
## What does this PR do and why?

Closes #1451. Fixes regression under project logo upload and maintains style of NFT upload box. 

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
