### PR TITLE
Venft content

### DIFF
--- a/src/components/veNft/VeNftContent.tsx
+++ b/src/components/veNft/VeNftContent.tsx
@@ -1,7 +1,26 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import VeNftHeader from 'components/veNft/VeNftHeader'
+
+import { tokenSymbolText } from 'utils/tokenSymbolText'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { t } from '@lingui/macro'
 
 const VeNftContent = () => {
-  return <div>VeNftContent</div>
+  const { tokenSymbol, tokenName, projectMetadata } =
+    useContext(V2ProjectContext)
+
+  const tokenSymbolDisplayText = tokenSymbolText({ tokenSymbol })
+  const projectName = projectMetadata?.name ?? t`Unknown Project`
+
+  return (
+    <>
+      <VeNftHeader
+        tokenName={tokenName}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
+        projectName={projectName}
+      />
+    </>
+  )
 }
 
 export default VeNftContent

--- a/src/components/veNft/VeNftContent.tsx
+++ b/src/components/veNft/VeNftContent.tsx
@@ -1,9 +1,13 @@
 import React, { useContext } from 'react'
-import VeNftHeader from 'components/veNft/VeNftHeader'
 
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { t } from '@lingui/macro'
+
+import VeNftHeaderSection from 'components/veNft/VeNftHeaderSection'
+import VeNftStakingForm from 'components/veNft/VeNftStakingForm'
+import VeNftOwnedTokensSection from 'components/veNft/VeNftOwnedTokensSection'
+import VeNftSummaryStatsSection from 'components/veNft/VeNftSummaryStatsSection'
 
 const VeNftContent = () => {
   const { tokenSymbol, tokenName, projectMetadata } =
@@ -14,10 +18,15 @@ const VeNftContent = () => {
 
   return (
     <>
-      <VeNftHeader
+      <VeNftHeaderSection
         tokenName={tokenName}
         tokenSymbolDisplayText={tokenSymbolDisplayText}
         projectName={projectName}
+      />
+      <VeNftStakingForm />
+      <VeNftOwnedTokensSection />
+      <VeNftSummaryStatsSection
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
       />
     </>
   )

--- a/src/components/veNft/VeNftHeader.tsx
+++ b/src/components/veNft/VeNftHeader.tsx
@@ -1,0 +1,31 @@
+import { Trans } from '@lingui/macro'
+import React from 'react'
+
+interface VeNftHeaderProps {
+  tokenName: string | undefined
+  tokenSymbolDisplayText: string
+  projectName: string
+}
+
+const VeNftHeader = ({
+  tokenName,
+  tokenSymbolDisplayText,
+  projectName,
+}: VeNftHeaderProps) => {
+  return (
+    <>
+      <h1>
+        <Trans>Lock {tokenName} for Voting Power</Trans>
+      </h1>
+      <p>
+        <Trans>
+          Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for
+          voting weight. In return, you will impact {projectName} governance and
+          receive a choice governance NFT.
+        </Trans>
+      </p>
+    </>
+  )
+}
+
+export default VeNftHeader

--- a/src/components/veNft/VeNftHeaderSection.tsx
+++ b/src/components/veNft/VeNftHeaderSection.tsx
@@ -1,17 +1,17 @@
 import { Trans } from '@lingui/macro'
 import React from 'react'
 
-interface VeNftHeaderProps {
+interface VeNftHeaderSectionProps {
   tokenName: string | undefined
   tokenSymbolDisplayText: string
   projectName: string
 }
 
-const VeNftHeader = ({
+const VeNftHeaderSection = ({
   tokenName,
   tokenSymbolDisplayText,
   projectName,
-}: VeNftHeaderProps) => {
+}: VeNftHeaderSectionProps) => {
   return (
     <>
       <h1>
@@ -28,4 +28,4 @@ const VeNftHeader = ({
   )
 }
 
-export default VeNftHeader
+export default VeNftHeaderSection

--- a/src/components/veNft/VeNftHeaderSection.tsx
+++ b/src/components/veNft/VeNftHeaderSection.tsx
@@ -15,12 +15,12 @@ const VeNftHeaderSection = ({
   return (
     <>
       <h1>
-        <Trans>Lock {tokenName} for Voting Power</Trans>
+        <Trans>Lock ${tokenSymbolDisplayText} for Voting Power</Trans>
       </h1>
       <p>
         <Trans>
           Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for
-          voting weight. In return, you will impact {projectName} governance and
+          voting weight. In return, you'll impact {projectName} governance and
           receive a choice governance NFT.
         </Trans>
       </p>

--- a/src/components/veNft/VeNftOwnedTokensSection.tsx
+++ b/src/components/veNft/VeNftOwnedTokensSection.tsx
@@ -1,0 +1,19 @@
+import { Trans } from '@lingui/macro'
+
+import { ThemeContext } from 'contexts/themeContext'
+import React, { useContext } from 'react'
+
+import { shadowCard } from 'constants/styles/shadowCard'
+
+const VeNftOwnedTokensSection = () => {
+  const { theme } = useContext(ThemeContext)
+  return (
+    <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
+      <h3>
+        <Trans>You don't own any veNFTs!</Trans>
+      </h3>
+    </div>
+  )
+}
+
+export default VeNftOwnedTokensSection

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -1,0 +1,28 @@
+import { Trans } from '@lingui/macro'
+import { Form, Space } from 'antd'
+
+import { ThemeContext } from 'contexts/themeContext'
+import { useContext } from 'react'
+
+import { shadowCard } from 'constants/styles/shadowCard'
+
+const VeNftStakingForm = () => {
+  const { theme } = useContext(ThemeContext)
+
+  return (
+    <Form layout="vertical" style={{ width: '100%' }}>
+      <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
+        <Space size="middle" direction="vertical">
+          <h4>
+            <Trans>
+              Currently, only project tokens claimed as ERC-20 tokens can be
+              staked for NFTs.
+            </Trans>
+          </h4>
+        </Space>
+      </div>
+    </Form>
+  )
+}
+
+export default VeNftStakingForm

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -4,6 +4,8 @@ import { Form, Space } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
 
+import Callout from 'components/Callout'
+
 import { shadowCard } from 'constants/styles/shadowCard'
 
 const VeNftStakingForm = () => {
@@ -13,12 +15,12 @@ const VeNftStakingForm = () => {
     <Form layout="vertical" style={{ width: '100%' }}>
       <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
         <Space size="middle" direction="vertical">
-          <h4>
+          <Callout>
             <Trans>
-              Currently, only project tokens claimed as ERC-20 tokens can be
-              staked for NFTs.
+              Only project tokens claimed as ERC-20 tokens can be staked for
+              NFTs.
             </Trans>
-          </h4>
+          </Callout>
         </Space>
       </div>
     </Form>

--- a/src/components/veNft/VeNftSummaryStatsSection.tsx
+++ b/src/components/veNft/VeNftSummaryStatsSection.tsx
@@ -1,5 +1,5 @@
-import { Trans } from '@lingui/macro'
-import { Row, Col } from 'antd'
+import { t, Trans } from '@lingui/macro'
+import { Descriptions } from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
 import React, { useContext } from 'react'
@@ -17,7 +17,9 @@ const VeNftSummaryStatsSection = ({
 
   return (
     <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
-      <h3>Staking Summary:</h3>
+      {/* <h3>
+        <Trans>Staking Summary:</Trans>
+      </h3>
       <Row>
         <Col span={8}>
           <p>
@@ -31,8 +33,20 @@ const VeNftSummaryStatsSection = ({
           <p>0</p>
           <p>0</p>
         </Col>
-        <br />
-      </Row>
+      </Row> */}
+      <Descriptions
+        title={
+          <h3>
+            <Trans>Staking Summary:</Trans>
+          </h3>
+        }
+        column={1}
+      >
+        <Descriptions.Item label={t`Total staked ${tokenSymbolDisplayText}`}>
+          0
+        </Descriptions.Item>
+        <Descriptions.Item label={t`Total staked period`}>0</Descriptions.Item>
+      </Descriptions>
     </div>
   )
 }

--- a/src/components/veNft/VeNftSummaryStatsSection.tsx
+++ b/src/components/veNft/VeNftSummaryStatsSection.tsx
@@ -17,23 +17,6 @@ const VeNftSummaryStatsSection = ({
 
   return (
     <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
-      {/* <h3>
-        <Trans>Staking Summary:</Trans>
-      </h3>
-      <Row>
-        <Col span={8}>
-          <p>
-            <Trans>Total staked ${tokenSymbolDisplayText}:</Trans>
-          </p>
-          <p>
-            <Trans>Total staked period:</Trans>
-          </p>
-        </Col>
-        <Col span={16}>
-          <p>0</p>
-          <p>0</p>
-        </Col>
-      </Row> */}
       <Descriptions
         title={
           <h3>

--- a/src/components/veNft/VeNftSummaryStatsSection.tsx
+++ b/src/components/veNft/VeNftSummaryStatsSection.tsx
@@ -1,0 +1,40 @@
+import { Trans } from '@lingui/macro'
+import { Row, Col } from 'antd'
+
+import { ThemeContext } from 'contexts/themeContext'
+import React, { useContext } from 'react'
+
+import { shadowCard } from 'constants/styles/shadowCard'
+
+interface VeNftSummaryStatsSectionProps {
+  tokenSymbolDisplayText: string
+}
+
+const VeNftSummaryStatsSection = ({
+  tokenSymbolDisplayText,
+}: VeNftSummaryStatsSectionProps) => {
+  const { theme } = useContext(ThemeContext)
+
+  return (
+    <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
+      <h3>Staking Summary:</h3>
+      <Row>
+        <Col span={8}>
+          <p>
+            <Trans>Total staked ${tokenSymbolDisplayText}:</Trans>
+          </p>
+          <p>
+            <Trans>Total staked period:</Trans>
+          </p>
+        </Col>
+        <Col span={16}>
+          <p>0</p>
+          <p>0</p>
+        </Col>
+        <br />
+      </Row>
+    </div>
+  )
+}
+
+export default VeNftSummaryStatsSection

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -25,6 +25,7 @@ export type V2ProjectContextType = {
   projectMetadata: ProjectMetadataV4 | undefined
   tokenAddress: string | undefined
   tokenSymbol: string | undefined
+  tokenName: string | undefined
   terminals: string[] | undefined // array of terminal addresses, 0xABC...
   primaryTerminal: string | undefined
   ETHBalance: BigNumber | undefined
@@ -66,6 +67,7 @@ export const V2ProjectContext = createContext<V2ProjectContextType>({
   projectMetadata: undefined,
   tokenAddress: undefined,
   tokenSymbol: undefined,
+  tokenName: undefined,
   terminals: undefined,
   primaryTerminal: undefined,
   ETHBalance: undefined,

--- a/src/hooks/NameOfERC20.ts
+++ b/src/hooks/NameOfERC20.ts
@@ -1,0 +1,22 @@
+import { useErc20Contract } from 'hooks/Erc20Contract'
+import { useEffect, useState } from 'react'
+
+/** Returns name for ERC20 token with `address`. */
+export default function useNameOfERC20(address: string | undefined) {
+  const [data, setData] = useState<string>()
+
+  const contract = useErc20Contract(address)
+
+  useEffect(() => {
+    async function fetchName() {
+      if (!contract || !address) return
+
+      const name = await contract.name()
+      setData(name)
+    }
+
+    fetchName()
+  }, [address, contract])
+
+  return data
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1807,6 +1807,10 @@ msgstr ""
 msgid "Lock until"
 msgstr "Lock until"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr "Lock {tokenName} for Voting Power"
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Locked:"
@@ -2876,6 +2880,10 @@ msgstr ""
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
@@ -3367,6 +3375,10 @@ msgstr "Unarchive project"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Unavailable"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr "Unknown Project"
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -945,10 +945,6 @@ msgstr "Current owner: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Currently worth: <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Custom memo"
@@ -1805,15 +1801,15 @@ msgstr "Link Juicebox V1 project"
 msgid "Load more"
 msgstr ""
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr "Lock ${tokenSymbolDisplayText} for Voting Power"
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Lock until"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr "Lock {tokenName} for Voting Power"
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2063,6 +2059,10 @@ msgstr "Once launched, your first funding cycle <0>can't be changed</0>. You can
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr "Only lowercase letters"
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
@@ -2885,12 +2885,16 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
-msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
+msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
+msgstr "Staking Summary:"
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -3318,12 +3322,12 @@ msgid "Total raised"
 msgstr "Total raised"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
-msgstr "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
+msgstr "Total staked period"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
-msgstr "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
+msgstr "Total staked {tokenSymbolDisplayText}"
 
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -945,6 +945,10 @@ msgstr "Current owner: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Currently worth: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Custom memo"
@@ -1807,7 +1811,7 @@ msgstr ""
 msgid "Lock until"
 msgstr "Lock until"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr "Lock {tokenName} for Voting Power"
 
@@ -2880,7 +2884,7 @@ msgstr ""
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 
@@ -3313,6 +3317,14 @@ msgstr ""
 msgid "Total raised"
 msgstr "Total raised"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr "Total staked ${tokenSymbolDisplayText}:"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr "Total staked period:"
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3627,6 +3639,10 @@ msgstr "You don't have a funding cycle duration. Changes you make will take effe
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "You don't hold tokens for any Juicebox project."
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr "You don't own any veNFTs!"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1812,6 +1812,10 @@ msgstr "Cargar más"
 msgid "Lock until"
 msgstr "Bloquear hasta"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Bloqueado:"
@@ -2881,6 +2885,10 @@ msgstr "Gasto"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
@@ -3372,6 +3380,10 @@ msgstr "Desarchivar proyecto"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "No disponible"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -950,10 +950,6 @@ msgstr "Dueño actual: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Actualmente vale: <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr ""
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Memo personalizado"
@@ -1810,15 +1806,15 @@ msgstr ""
 msgid "Load more"
 msgstr "Cargar más"
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquear hasta"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2067,6 +2063,10 @@ msgstr "Una vez lanzado, tu primer ciclo de financiamiento <0>no se puede cambia
 
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -2890,11 +2890,15 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr ""
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
 msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -3323,11 +3327,11 @@ msgid "Total raised"
 msgstr "Total recaudado"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
 msgstr ""
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -950,6 +950,10 @@ msgstr "Dueño actual: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Actualmente vale: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Memo personalizado"
@@ -1812,7 +1816,7 @@ msgstr "Cargar más"
 msgid "Lock until"
 msgstr "Bloquear hasta"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr ""
 
@@ -2885,7 +2889,7 @@ msgstr "Gasto"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
@@ -3318,6 +3322,14 @@ msgstr "Fondos totales:"
 msgid "Total raised"
 msgstr "Total recaudado"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3632,6 +3644,10 @@ msgstr "No tienes una duración de ciclo de financiamiento. Los cambios que haga
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "No holdeas tokens para ningún proyecto de Juicebox."
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -950,10 +950,6 @@ msgstr "Propriétaire actuel: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Valeur actuelle : <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr ""
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Customiser le mémo"
@@ -1810,15 +1806,15 @@ msgstr ""
 msgid "Load more"
 msgstr "Télécharger d'avantage"
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquer jusqu'à"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2067,6 +2063,10 @@ msgstr "Une fois lancé, votre premier cycle de financement <0>ne peut plus êtr
 
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -2890,11 +2890,15 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr ""
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
 msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -3323,11 +3327,11 @@ msgid "Total raised"
 msgstr "Total collecté"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
 msgstr ""
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -950,6 +950,10 @@ msgstr "Propriétaire actuel: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Valeur actuelle : <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Customiser le mémo"
@@ -1812,7 +1816,7 @@ msgstr "Télécharger d'avantage"
 msgid "Lock until"
 msgstr "Bloquer jusqu'à"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr ""
 
@@ -2885,7 +2889,7 @@ msgstr "Dépenses"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
@@ -3318,6 +3322,14 @@ msgstr "Total de fonds :"
 msgid "Total raised"
 msgstr "Total collecté"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3632,6 +3644,10 @@ msgstr "Vous n'avez pas une durée de cycle de financement. Les modifications qu
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Vous ne détenez pas de tokens pour aucun projet Juicebox."
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1812,6 +1812,10 @@ msgstr "Télécharger d'avantage"
 msgid "Lock until"
 msgstr "Bloquer jusqu'à"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Bloqué :"
@@ -2881,6 +2885,10 @@ msgstr "Dépenses"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
@@ -3372,6 +3380,10 @@ msgstr "Désarchiver le projet"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Indisponible"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1812,6 +1812,10 @@ msgstr "Carregar mais"
 msgid "Lock until"
 msgstr "Trancar até"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Trancado:"
@@ -2881,6 +2885,10 @@ msgstr "Gastos"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
@@ -3372,6 +3380,10 @@ msgstr "Desarquivar projeto"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Indisponível"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -950,6 +950,10 @@ msgstr "Atual proprietário: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Atualmente vale: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Nota personalizada"
@@ -1812,7 +1816,7 @@ msgstr "Carregar mais"
 msgid "Lock until"
 msgstr "Trancar até"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr ""
 
@@ -2885,7 +2889,7 @@ msgstr "Gastos"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
@@ -3318,6 +3322,14 @@ msgstr "Total de fundos:"
 msgid "Total raised"
 msgstr "Total arrecadado"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3632,6 +3644,10 @@ msgstr "Você não possui uma duração de ciclo de financiamento. Mudanças que
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Você não possui token de nenhum projeto Juicebox."
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -950,10 +950,6 @@ msgstr "Atual proprietário: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Atualmente vale: <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr ""
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Nota personalizada"
@@ -1810,15 +1806,15 @@ msgstr ""
 msgid "Load more"
 msgstr "Carregar mais"
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Trancar até"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2067,6 +2063,10 @@ msgstr "Uma vez lançado, o seu primeiro ciclo de financiamento <0>não pode ser
 
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -2890,11 +2890,15 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr ""
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
 msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -3323,11 +3327,11 @@ msgid "Total raised"
 msgstr "Total arrecadado"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
 msgstr ""
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -950,10 +950,6 @@ msgstr "Текущий владелец: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "На данный момент стоит: <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr ""
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr ""
@@ -1810,15 +1806,15 @@ msgstr ""
 msgid "Load more"
 msgstr "Загрузить ещё"
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Заблокировать до"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2067,6 +2063,10 @@ msgstr ""
 
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -2890,11 +2890,15 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr ""
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
 msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -3323,11 +3327,11 @@ msgid "Total raised"
 msgstr "Итого собрано"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
 msgstr ""
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -950,6 +950,10 @@ msgstr "Текущий владелец: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "На данный момент стоит: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr ""
@@ -1812,7 +1816,7 @@ msgstr "Загрузить ещё"
 msgid "Lock until"
 msgstr "Заблокировать до"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr ""
 
@@ -2885,7 +2889,7 @@ msgstr "Расходы"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
@@ -3318,6 +3322,14 @@ msgstr "Всего средств:"
 msgid "Total raised"
 msgstr "Итого собрано"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3632,6 +3644,10 @@ msgstr "У вас нет продолжительности цикла фина�
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Вы не владеете токенами ни для одного проекта Juicebox."
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1812,6 +1812,10 @@ msgstr "Загрузить ещё"
 msgid "Lock until"
 msgstr "Заблокировать до"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr ""
@@ -2881,6 +2885,10 @@ msgstr "Расходы"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
@@ -3372,6 +3380,10 @@ msgstr "Разархивировать проект"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Недоступно"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -950,6 +950,10 @@ msgstr "Güncel sahibi: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Güncel değeri: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Özel not"
@@ -1812,7 +1816,7 @@ msgstr "Daha fazla yükle"
 msgid "Lock until"
 msgstr "Kilit süresi bitiş tarihi"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr ""
 
@@ -2885,7 +2889,7 @@ msgstr "Harcama"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
@@ -3318,6 +3322,14 @@ msgstr "Toplam fon:"
 msgid "Total raised"
 msgstr "Toplanan yekün"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3632,6 +3644,10 @@ msgstr "Bir finansman döngüsü süreniz yok. Yaptığınız değişiklikler he
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Herhangi bir Juicebox projesi için token tutmuyorsunuz."
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -950,10 +950,6 @@ msgstr "Güncel sahibi: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Güncel değeri: <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr ""
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Özel not"
@@ -1810,15 +1806,15 @@ msgstr ""
 msgid "Load more"
 msgstr "Daha fazla yükle"
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Kilit süresi bitiş tarihi"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2067,6 +2063,10 @@ msgstr "Bir kez başlatıldığında, ilk finansman döngünüz <0>değiştirile
 
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -2890,11 +2890,15 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr ""
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
 msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -3323,11 +3327,11 @@ msgid "Total raised"
 msgstr "Toplanan yekün"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
 msgstr ""
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1812,6 +1812,10 @@ msgstr "Daha fazla yükle"
 msgid "Lock until"
 msgstr "Kilit süresi bitiş tarihi"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Kilitlendi:"
@@ -2881,6 +2885,10 @@ msgstr "Harcama"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
@@ -3372,6 +3380,10 @@ msgstr "Projeyi arşivden kaldır"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Mevcut değil"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1812,6 +1812,10 @@ msgstr "加载更多"
 msgid "Lock until"
 msgstr "锁定至"
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Lock {tokenName} for Voting Power"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "锁定："
@@ -2881,6 +2885,10 @@ msgstr "资金分配"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
+#: src/components/veNft/VeNftHeader.tsx
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
@@ -3372,6 +3380,10 @@ msgstr "取消项目的存档状态"
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "不可用"
+
+#: src/components/veNft/VeNftContent.tsx
+msgid "Unknown Project"
+msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -950,10 +950,6 @@ msgstr "当前项目方：{ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "当前价值： <0><1/>{0}</0>"
 
-#: src/components/veNft/VeNftStakingForm.tsx
-msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
-msgstr ""
-
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "自定义备注"
@@ -1810,15 +1806,15 @@ msgstr ""
 msgid "Load more"
 msgstr "加载更多"
 
+#: src/components/veNft/VeNftHeaderSection.tsx
+msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "锁定至"
-
-#: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Lock {tokenName} for Voting Power"
-msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2067,6 +2063,10 @@ msgstr "一旦启动，你的第一个筹款周期 <0>不能再更改</0>。 你
 
 #: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -2890,11 +2890,15 @@ msgid "Stake your {tokensLabel} to increase your voting weight and claim Governa
 msgstr ""
 
 #: src/components/veNft/VeNftHeaderSection.tsx
-msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
+msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Staking Summary:"
 msgstr ""
 
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -3323,11 +3327,11 @@ msgid "Total raised"
 msgstr "总筹款"
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked ${tokenSymbolDisplayText}:"
+msgid "Total staked period"
 msgstr ""
 
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
-msgid "Total staked period:"
+msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
 #: src/components/v1/V1Project/Rewards/index.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -950,6 +950,10 @@ msgstr "当前项目方：{ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "当前价值： <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Currently, only project tokens claimed as ERC-20 tokens can be staked for NFTs."
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "自定义备注"
@@ -1812,7 +1816,7 @@ msgstr "加载更多"
 msgid "Lock until"
 msgstr "锁定至"
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock {tokenName} for Voting Power"
 msgstr ""
 
@@ -2885,7 +2889,7 @@ msgstr "资金分配"
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeader.tsx
+#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you will impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
@@ -3318,6 +3322,14 @@ msgstr "总资金："
 msgid "Total raised"
 msgstr "总筹款"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked ${tokenSymbolDisplayText}:"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "Total staked period:"
+msgstr ""
+
 #: src/components/v1/V1Project/Rewards/index.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
@@ -3632,6 +3644,10 @@ msgstr "你的项目未设置筹款周期时长。你做的更改将会立即生
 #: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "你目前未持有任何 Juicebox 项目的代币。"
+
+#: src/components/veNft/VeNftOwnedTokensSection.tsx
+msgid "You don't own any veNFTs!"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"

--- a/src/pages/create/ProjectPreview.tsx
+++ b/src/pages/create/ProjectPreview.tsx
@@ -83,6 +83,7 @@ export default function ProjectPreview({
     terminals: [],
     primaryTerminal: undefined,
     tokenSymbol: undefined,
+    tokenName: undefined,
     projectOwnerAddress: userAddress,
     ballotState: undefined,
     primaryTerminalCurrentOverflow: undefined,

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -34,6 +34,8 @@ import { useNftRewardTiersOf } from 'hooks/v2/contractReader/NftRewardTiersOf'
 import useNftRewards from 'hooks/v2/NftRewards'
 import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
 
+import useNameOfERC20 from 'hooks/NameOfERC20'
+
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
@@ -127,6 +129,7 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
   })
 
   const tokenSymbol = useSymbolOfERC20(tokenAddress)
+  const tokenName = useNameOfERC20(tokenAddress)
 
   const { data: primaryTerminalCurrentOverflow } = useTerminalCurrentOverflow({
     projectId,
@@ -212,6 +215,7 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
     distributionLimitCurrency,
     balanceInDistributionLimitCurrency,
     tokenSymbol,
+    tokenName,
     projectOwnerAddress,
     primaryTerminalCurrentOverflow,
     totalTokenSupply,


### PR DESCRIPTION
## What does this PR do and why?

Adds skeleton structure for the content of the veNft drawer. The drawer consists primarily of 4 sections:

The Header
The Staking Form
The Owned NFTs Section
The Staking Summary Section

Additionally, this PR adds additional hook to get the name of an ERC-20 token for display purposes.

## Screenshots or screen recordings

<img width="630" alt="image" src="https://user-images.githubusercontent.com/33093632/180449072-4e867a21-e2a4-4952-8092-3b232888e869.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
