### PR TITLE
add disabled prop to v1 payment button

### DIFF
--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -18,6 +18,7 @@ export default function FormattedNumberInput({
   accessory,
   formItemProps,
   onChange,
+  onBlur,
   isInteger,
 }: {
   name?: string
@@ -32,6 +33,7 @@ export default function FormattedNumberInput({
   prefix?: string
   accessory?: JSX.Element
   onChange?: (val?: string) => void
+  onBlur?: (val?: string) => void
   isInteger?: boolean
 } & FormItemExt) {
   const thousandsSeparator = ','
@@ -100,6 +102,9 @@ export default function FormattedNumberInput({
             )
           }
           disabled={disabled}
+          onBlur={_value => {
+            onBlur?.(_value?.toString())
+          }}
           onChange={_value => {
             onChange?.(_value?.toString())
           }}

--- a/src/components/v1/V1Project/V1PayButton.tsx
+++ b/src/components/v1/V1Project/V1PayButton.tsx
@@ -21,6 +21,7 @@ export default function V1PayButton({
   payInCurrency,
   onError,
   wrapperStyle,
+  disabled,
 }: PayButtonProps) {
   const { projectId, currentFC, metadata, isArchived, terminal } =
     useContext(V1ProjectContext)
@@ -59,7 +60,8 @@ export default function V1PayButton({
       isV1AndMaxRR || // v1 projects who still use 100% RR to disable pay
       currentFC.configured.eq(0) || // Edge case, see sequoiacapitaldao
       isMoonAndMaxRR || // Edge case for MoonDAO
-      isArchived) ??
+      isArchived ||
+      disabled) ??
     false
 
   let disabledMessage: string | undefined = shouldDisableButton


### PR DESCRIPTION
## What does this PR do and why?
I've been looking into input field bugs and the bug where the pay button is enabled by default with no value on `/p/[project]` bugs me the most.

I started to look through the code and noticed that `disabled` is on the button prop type but never added in the argument or in the button disabled logic in the `V1PayButton` and it's clearly used in the code 


Call site: https://github.com/jbx-protocol/juice-interface/blob/add-disable-prop-to-payment-button/src/components/inputs/Pay/PayInputGroup.tsx#L117

Import where button is imported and past to PayInputGroup: 
https://github.com/jbx-protocol/juice-interface/blob/add-disable-prop-to-payment-button/src/components/v1/V1Project/index.tsx#L83


@tomquirk This PR is going to be apart of a larger stack fixing an input and button enabled bug. Could we hold off on merging this, and add the graphite app to the repo?


https://docs.graphite.dev/guides/graphite-cli/authenticating-the-cli/using-a-github-personal-access-token - is here. Additionally, happy to do it myself if you're okay handing me permissions.




_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
