### PR TITLE
[3/6] Venft approve and mint

### DIFF
--- a/src/components/v2/V2Project/V2ManageTokensSection/index.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/index.tsx
@@ -30,7 +30,7 @@ import { default as useV1HandleForProjectId } from 'hooks/v1/contractReader/Hand
 import { useHasV1TokenPaymentTerminal } from 'hooks/v2/hasV1TokenPaymentTerminal'
 import { featureFlagEnabled } from 'utils/featureFlags'
 
-import { useVeNftEnabled } from 'hooks/veNft/veNftEnabled'
+import { useVeNftEnabled } from 'hooks/veNft/VeNftEnabled'
 
 import V2RedeemModal from './V2RedeemModal'
 import V2ClaimTokensModal from './V2ClaimTokensModal'

--- a/src/components/veNft/VeNftContent.tsx
+++ b/src/components/veNft/VeNftContent.tsx
@@ -8,7 +8,6 @@ import VeNftHeaderSection from 'components/veNft/VeNftHeaderSection'
 import VeNftStakingForm from 'components/veNft/VeNftStakingForm'
 import VeNftOwnedTokensSection from 'components/veNft/VeNftOwnedTokensSection'
 import VeNftSummaryStatsSection from 'components/veNft/VeNftSummaryStatsSection'
-import { BigNumber } from '@ethersproject/bignumber'
 
 const VeNftContent = () => {
   const { tokenSymbol, tokenName, projectMetadata } =
@@ -17,12 +16,6 @@ const VeNftContent = () => {
   const tokenSymbolDisplayText = tokenSymbolText({ tokenSymbol })
   const projectName = projectMetadata?.name ?? t`Unknown Project`
 
-  const lockDurationOptions = [
-    BigNumber.from(1),
-    BigNumber.from(7),
-    BigNumber.from(30),
-  ]
-
   return (
     <>
       <VeNftHeaderSection
@@ -30,10 +23,7 @@ const VeNftContent = () => {
         tokenSymbolDisplayText={tokenSymbolDisplayText}
         projectName={projectName}
       />
-      <VeNftStakingForm
-        tokenSymbolDisplayText={tokenSymbolDisplayText}
-        lockDurationOptions={lockDurationOptions}
-      />
+      <VeNftStakingForm tokenSymbolDisplayText={tokenSymbolDisplayText} />
       <VeNftOwnedTokensSection />
       <VeNftSummaryStatsSection
         tokenSymbolDisplayText={tokenSymbolDisplayText}

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -39,15 +39,16 @@ interface StakingFormProps {
 
 interface VeNftStakingFormProps {
   tokenSymbolDisplayText: string
-  lockDurationOptions: BigNumber[]
 }
 
 const VeNftStakingForm = ({
-  lockDurationOptions,
   tokenSymbolDisplayText,
 }: VeNftStakingFormProps) => {
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
-  const { tokenAddress } = useContext(V2ProjectContext)
+  const {
+    tokenAddress,
+    veNft: { lockDurationOptions },
+  } = useContext(V2ProjectContext)
   const { theme } = useContext(ThemeContext)
 
   const [form] = useForm<StakingFormProps>()

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -15,9 +15,9 @@ import LockDurationSelectInput from 'components/veNft/formControls/LockDurationS
 import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
 import StakingFormActionButton from 'components/veNft/formControls/StakingFormActionButton'
 import VotingPowerDisplayInput from 'components/veNft/formControls/VotingPowerDisplayInput'
-import VeNftCarousel from 'components/veNft/veNftCarousel'
+import VeNftCarousel from 'components/veNft/VeNftCarousel'
 import StakingTokenRangesModal from 'components/veNft/veNftStakingTokenRangesModal'
-import ConfirmStakeModal from 'components/veNft/veNftConfirmStakeModal'
+import ConfirmStakeModal from 'components/veNft/VeNftConfirmStakeModal'
 
 import Callout from 'components/Callout'
 
@@ -50,6 +50,7 @@ const VeNftStakingForm = ({
 
   const tokensStaked = useWatch('tokensStaked', form) || '1'
   const lockDuration = useWatch('lockDuration', form) || 0
+  const beneficiary = useWatch('beneficiary', form) || ''
 
   const lockDurationOptionsInSeconds = useMemo(() => {
     return lockDurationOptions
@@ -145,8 +146,13 @@ const VeNftStakingForm = ({
       />
       <ConfirmStakeModal
         visible={confirmStakeModalVisible}
-        onCancel={() => setConfirmStakeModalVisible(false)}
         tokenSymbolDisplayText={tokenSymbolDisplayText}
+        tokensStaked={parseInt(tokensStaked)}
+        lockDuration={lockDuration}
+        beneficiary={beneficiary}
+        votingPower={votingPower}
+        onCancel={() => setConfirmStakeModalVisible(false)}
+        onCompleted={() => setConfirmStakeModalVisible(false)}
       />
     </>
   )

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -1,16 +1,19 @@
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { Button, Col, Form, Row, Space } from 'antd'
-
+import { MaxUint256 } from '@ethersproject/constants'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext, useMemo, useState, useEffect } from 'react'
-
 import { useForm, useWatch } from 'antd/lib/form/Form'
 import { BigNumber } from '@ethersproject/bignumber'
-import { NetworkContext } from 'contexts/networkContext'
-import useERC20BalanceOf from 'hooks/v2/contractReader/ERC20BalanceOf'
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-import TokensStakedInput from 'components/veNft/formControls/TokensStakedInput'
 
+import { NetworkContext } from 'contexts/networkContext'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+
+import useERC20BalanceOf from 'hooks/v2/contractReader/ERC20BalanceOf'
+import useERC20Approve from 'hooks/veNft/transactor/ERC20ApproveTx'
+import useERC20Allowance from 'hooks/ERC20Allowance'
+
+import TokensStakedInput from 'components/veNft/formControls/TokensStakedInput'
 import LockDurationSelectInput from 'components/veNft/formControls/LockDurationSelectInput'
 import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
 import StakingFormActionButton from 'components/veNft/formControls/StakingFormActionButton'
@@ -18,10 +21,15 @@ import VotingPowerDisplayInput from 'components/veNft/formControls/VotingPowerDi
 import VeNftCarousel from 'components/veNft/VeNftCarousel'
 import StakingTokenRangesModal from 'components/veNft/veNftStakingTokenRangesModal'
 import ConfirmStakeModal from 'components/veNft/VeNftConfirmStakeModal'
-
 import Callout from 'components/Callout'
 
+import { reloadWindow } from 'utils/windowUtils'
+import { parseWad } from 'utils/formatNumber'
+
+import { emitSuccessNotification } from 'utils/notifications'
+
 import { shadowCard } from 'constants/styles/shadowCard'
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
 interface StakingFormProps {
   tokensStaked: string
@@ -38,7 +46,7 @@ const VeNftStakingForm = ({
   lockDurationOptions,
   tokenSymbolDisplayText,
 }: VeNftStakingFormProps) => {
-  const { userAddress } = useContext(NetworkContext)
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const { tokenAddress } = useContext(V2ProjectContext)
   const { theme } = useContext(ThemeContext)
 
@@ -47,6 +55,7 @@ const VeNftStakingForm = ({
   const [tokenRangesModalVisible, setTokenRangesModalVisible] = useState(false)
   const [confirmStakeModalVisible, setConfirmStakeModalVisible] =
     useState(false)
+  const [tokenApprovalLoading, setTokenApprovalLoading] = useState(false)
 
   const tokensStaked = useWatch('tokensStaked', form) || '1'
   const lockDuration = useWatch('lockDuration', form) || 0
@@ -68,9 +77,44 @@ const VeNftStakingForm = ({
   const { data: claimedBalance } = useERC20BalanceOf(tokenAddress, userAddress)
 
   const minTokensAllowedToStake = 1 //TODO: get this from the contract
-  const hasAdequateApproval = true //TODO: get this from the contract
+
+  const { data: allowance } = useERC20Allowance(
+    tokenAddress,
+    userAddress,
+    VENFT_CONTRACT_ADDRESS,
+  )
+  const hasAdequateApproval = allowance
+    ? allowance.gte(parseWad(tokensStaked))
+    : false
 
   const votingPower = parseInt(tokensStaked) * (lockDuration / maxLockDuration)
+
+  const approveTx = useERC20Approve(tokenAddress)
+  const approve = async () => {
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    setTokenApprovalLoading(true)
+
+    const txSuccess = await approveTx(
+      {
+        spender: VENFT_CONTRACT_ADDRESS,
+        amount: MaxUint256,
+      },
+      {
+        onConfirmed() {
+          setTokenApprovalLoading(false)
+          emitSuccessNotification(t`Successfully approved ERC-20 spending.`)
+          reloadWindow()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setTokenApprovalLoading(false)
+    }
+  }
 
   const handleReviewButtonClick = async () => {
     await form.validateFields()
@@ -135,6 +179,8 @@ const VeNftStakingForm = ({
             </Button>
             <StakingFormActionButton
               hasAdequateApproval={hasAdequateApproval}
+              tokenApprovalLoading={tokenApprovalLoading}
+              onApproveButtonClick={approve}
               onReviewButtonClick={handleReviewButtonClick}
             />
           </Space>

--- a/src/components/veNft/formControls/StakingFormActionButton.tsx
+++ b/src/components/veNft/formControls/StakingFormActionButton.tsx
@@ -4,18 +4,18 @@ import { useContext } from 'react'
 
 interface StakingFormActionButtonProps {
   hasAdequateApproval: boolean
+  tokenApprovalLoading: boolean
+  onApproveButtonClick: () => void
   onReviewButtonClick: () => void
 }
 
 const StakingFormActionButton = ({
   hasAdequateApproval,
+  tokenApprovalLoading,
+  onApproveButtonClick,
   onReviewButtonClick,
 }: StakingFormActionButtonProps) => {
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
-
-  const approve = () => {
-    return
-  }
 
   const renderActionButton = () => {
     if (!userAddress && onSelectWallet) {
@@ -31,7 +31,12 @@ const StakingFormActionButton = ({
     }
     if (!hasAdequateApproval) {
       return (
-        <Button block style={{ whiteSpace: 'pre' }} onClick={approve}>
+        <Button
+          block
+          style={{ whiteSpace: 'pre' }}
+          onClick={onApproveButtonClick}
+          loading={tokenApprovalLoading}
+        >
           Approve Token for Transaction
         </Button>
       )

--- a/src/components/veNft/veNftConfirmStakeModal.tsx
+++ b/src/components/veNft/veNftConfirmStakeModal.tsx
@@ -1,28 +1,156 @@
-import { Trans } from '@lingui/macro'
-import { Modal } from 'antd'
+import { t, Trans } from '@lingui/macro'
+import { Col, Divider, Modal, Row, Image } from 'antd'
+import FormattedAddress from 'components/FormattedAddress'
 
-interface ConfirmStakeModalProps {
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { useLockTx } from 'hooks/veNft/transactor/LockTx'
+
+import { useContext, useState } from 'react'
+import { formattedNum, parseWad } from 'utils/formatNumber'
+
+import { detailedTimeString } from 'utils/formatTime'
+import { emitSuccessNotification } from 'utils/notifications'
+
+type ConfirmStakeModalProps = {
   visible: boolean
+  tokenSymbol: string
+  tokensStaked: number
+  votingPower: number
+  lockDuration: number
+  beneficiary: string
+  maxLockDuration: number
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tokenMetadata: any
   onCancel: VoidFunction
-  tokenSymbolDisplayText: string
+  onCompleted: VoidFunction
 }
 
-const ConfirmStakeModal = ({
+export default function ConfirmStakeModal({
   visible,
+  tokenSymbol,
+  tokensStaked,
+  votingPower,
+  lockDuration,
+  beneficiary,
+  maxLockDuration,
+  tokenMetadata,
   onCancel,
-  tokenSymbolDisplayText,
-}: ConfirmStakeModalProps) => {
+  onCompleted,
+}: ConfirmStakeModalProps) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const [loading, setLoading] = useState(false)
+  const recipient = beneficiary !== '' ? beneficiary : userAddress!
+
+  const tokensStakedInWad = parseWad(tokensStaked)
+
+  const formattedLockDuration = detailedTimeString({
+    timeSeconds: lockDuration,
+    fullWords: true,
+  })
+  const formattedMaxLockDuration = detailedTimeString({
+    timeSeconds: maxLockDuration,
+    fullWords: true,
+  })
+
+  const lockTx = useLockTx()
+
+  async function lock() {
+    // Prompt wallet connect if no wallet connected
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    setLoading(true)
+
+    const txSuccess = await lockTx(
+      {
+        account: userAddress!,
+        value: tokensStakedInWad,
+        lockDuration: lockDuration,
+        beneficiary: recipient,
+        useJbToken: true,
+        allowPublicExtension: false,
+      },
+      {
+        onConfirmed() {
+          setLoading(false)
+          emitSuccessNotification(
+            t`Lock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
+  }
+
   return (
     <Modal
       visible={visible}
       onCancel={onCancel}
-      okText={`Lock $${tokenSymbolDisplayText}`}
+      onOk={lock}
+      okText={`Lock $${tokenSymbol}`}
+      confirmLoading={loading}
     >
       <h2>
         <Trans>Confirm Stake</Trans>
       </h2>
+      <div style={{ color: colors.text.secondary, textAlign: 'center' }}>
+        <p>
+          {votingPower} = {tokensStaked} ${tokenSymbol} * ({' '}
+          {formattedLockDuration} / {formattedMaxLockDuration} )
+        </p>
+      </div>
+      <h4>
+        <Trans>
+          You are agreeing to IRREVOCABLY lock your tokens for{' '}
+          {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbol}
+        </Trans>
+      </h4>
+      <Divider />
+      <h4>
+        <Trans>$ve{tokenSymbol} NFT summary:</Trans>
+      </h4>
+      <Row>
+        <Col span={14}>
+          <Row align="top" gutter={0}>
+            <Col span={12}>
+              <p>
+                <Trans>Staked ${tokenSymbol}:</Trans>
+              </p>
+              <p>
+                <Trans>Lock Duration:</Trans>
+              </p>
+              <p>
+                <Trans>$ve{tokenSymbol} Received:</Trans>
+              </p>
+              <p>
+                <Trans>Beneficiary:</Trans>
+              </p>
+            </Col>
+            <Col span={12}>
+              <p>{formattedNum(tokensStaked)}</p>
+              <p>{formattedLockDuration}</p>
+              <p>{formattedNum(votingPower)}</p>
+              <FormattedAddress address={recipient} />
+            </Col>
+          </Row>
+        </Col>
+        <Col span={4} />
+        <Col span={6}>
+          <Image
+            src={tokenMetadata && tokenMetadata.thumbnailUri}
+            preview={false}
+          ></Image>
+        </Col>
+      </Row>
     </Modal>
   )
 }
-
-export default ConfirmStakeModal

--- a/src/hooks/ERC20Allowance.ts
+++ b/src/hooks/ERC20Allowance.ts
@@ -1,0 +1,16 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { useErc20Contract } from 'hooks/Erc20Contract'
+
+import useContractReader from 'hooks/v2/contractReader/V2ContractReader'
+
+export default function useERC20Allowance(
+  tokenAddress: string | undefined,
+  owner: string | undefined,
+  spender: string | undefined,
+) {
+  return useContractReader<BigNumber>({
+    contract: useErc20Contract(tokenAddress),
+    functionName: 'allowance',
+    args: owner && spender ? [owner, spender] : null,
+  })
+}

--- a/src/hooks/veNft/VeNftContract.ts
+++ b/src/hooks/veNft/VeNftContract.ts
@@ -1,0 +1,36 @@
+import { isAddress } from '@ethersproject/address'
+import { Contract } from '@ethersproject/contracts'
+
+import { NetworkContext } from 'contexts/networkContext'
+
+import * as constants from '@ethersproject/constants'
+import { useContext, useEffect, useState } from 'react'
+
+import { veNftAbi } from 'constants/veNft/veNftAbi'
+
+import { readProvider } from 'constants/readProvider'
+
+export function useNFTContract(address: string | undefined) {
+  const [contract, setContract] = useState<Contract>()
+  const { signingProvider } = useContext(NetworkContext)
+
+  useEffect(() => {
+    const provider = signingProvider ?? readProvider
+
+    provider.listAccounts().then(accounts => {
+      if (
+        !address ||
+        !isAddress(address) ||
+        address === constants.AddressZero
+      ) {
+        setContract(undefined)
+      } else if (!accounts.length) {
+        setContract(new Contract(address, veNftAbi, readProvider))
+      } else {
+        setContract(new Contract(address, veNftAbi, provider.getSigner()))
+      }
+    })
+  }, [address, signingProvider])
+
+  return contract
+}

--- a/src/hooks/veNft/VeNftContract.ts
+++ b/src/hooks/veNft/VeNftContract.ts
@@ -1,36 +1,17 @@
-import { isAddress } from '@ethersproject/address'
 import { Contract } from '@ethersproject/contracts'
 
-import { NetworkContext } from 'contexts/networkContext'
-
-import * as constants from '@ethersproject/constants'
-import { useContext, useEffect, useState } from 'react'
+import { useMemo } from 'react'
 
 import { veNftAbi } from 'constants/veNft/veNftAbi'
 
 import { readProvider } from 'constants/readProvider'
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
-export function useNFTContract(address: string | undefined) {
-  const [contract, setContract] = useState<Contract>()
-  const { signingProvider } = useContext(NetworkContext)
-
-  useEffect(() => {
-    const provider = signingProvider ?? readProvider
-
-    provider.listAccounts().then(accounts => {
-      if (
-        !address ||
-        !isAddress(address) ||
-        address === constants.AddressZero
-      ) {
-        setContract(undefined)
-      } else if (!accounts.length) {
-        setContract(new Contract(address, veNftAbi, readProvider))
-      } else {
-        setContract(new Contract(address, veNftAbi, provider.getSigner()))
-      }
-    })
-  }, [address, signingProvider])
+export function useVeNftContract() {
+  const contract = useMemo(
+    () => new Contract(VENFT_CONTRACT_ADDRESS, veNftAbi, readProvider),
+    [],
+  )
 
   return contract
 }

--- a/src/hooks/veNft/VeNftContract.ts
+++ b/src/hooks/veNft/VeNftContract.ts
@@ -1,17 +1,36 @@
+import { isAddress } from '@ethersproject/address'
 import { Contract } from '@ethersproject/contracts'
 
-import { useMemo } from 'react'
+import { NetworkContext } from 'contexts/networkContext'
+
+import * as constants from '@ethersproject/constants'
+import { useContext, useEffect, useState } from 'react'
 
 import { veNftAbi } from 'constants/veNft/veNftAbi'
 
 import { readProvider } from 'constants/readProvider'
-import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
-export function useVeNftContract() {
-  const contract = useMemo(
-    () => new Contract(VENFT_CONTRACT_ADDRESS, veNftAbi, readProvider),
-    [],
-  )
+export function useVeNftContract(address: string | undefined) {
+  const [contract, setContract] = useState<Contract>()
+  const { signingProvider } = useContext(NetworkContext)
+
+  useEffect(() => {
+    const provider = signingProvider ?? readProvider
+
+    provider.listAccounts().then(accounts => {
+      if (
+        !address ||
+        !isAddress(address) ||
+        address === constants.AddressZero
+      ) {
+        setContract(undefined)
+      } else if (!accounts.length) {
+        setContract(new Contract(address, veNftAbi, readProvider))
+      } else {
+        setContract(new Contract(address, veNftAbi, provider.getSigner()))
+      }
+    })
+  }, [address, signingProvider])
 
   return contract
 }

--- a/src/hooks/veNft/VeNftLockDurationOptions.ts
+++ b/src/hooks/veNft/VeNftLockDurationOptions.ts
@@ -1,0 +1,13 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+import useV2ContractReader from '../v2/contractReader/V2ContractReader'
+import { useNFTContract } from './VeNftContract'
+
+export function useNFTLockDurationOptions() {
+  return useV2ContractReader<BigNumber[]>({
+    contract: useNFTContract(VENFT_CONTRACT_ADDRESS),
+    functionName: 'lockDurationOptions',
+  })
+}

--- a/src/hooks/veNft/VeNftLockDurationOptions.ts
+++ b/src/hooks/veNft/VeNftLockDurationOptions.ts
@@ -3,9 +3,11 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { useVeNftContract } from 'hooks/veNft/VeNftContract'
 import useV2ContractReader from 'hooks/v2/contractReader/V2ContractReader'
 
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
 export function useVeNftLockDurationOptions() {
   return useV2ContractReader<BigNumber[]>({
-    contract: useVeNftContract(),
+    contract: useVeNftContract(VENFT_CONTRACT_ADDRESS),
     functionName: 'lockDurationOptions',
   })
 }

--- a/src/hooks/veNft/VeNftLockDurationOptions.ts
+++ b/src/hooks/veNft/VeNftLockDurationOptions.ts
@@ -1,13 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
 
-import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+import useV2ContractReader from 'hooks/v2/contractReader/V2ContractReader'
 
-import useV2ContractReader from '../v2/contractReader/V2ContractReader'
-import { useNFTContract } from './VeNftContract'
-
-export function useNFTLockDurationOptions() {
+export function useVeNftLockDurationOptions() {
   return useV2ContractReader<BigNumber[]>({
-    contract: useNFTContract(VENFT_CONTRACT_ADDRESS),
+    contract: useVeNftContract(),
     functionName: 'lockDurationOptions',
   })
 }

--- a/src/hooks/veNft/transactor/ERC20ApproveTx.ts
+++ b/src/hooks/veNft/transactor/ERC20ApproveTx.ts
@@ -12,7 +12,7 @@ export type ERC20ApproveArgs = {
 }
 
 export default function useERC20Approve(
-  erc20address: string,
+  erc20address: string | undefined,
 ): TransactorInstance<ERC20ApproveArgs> {
   const { transactor } = useContext(V2UserContext)
   const contract = useErc20Contract(erc20address)

--- a/src/hooks/veNft/transactor/ERC20ApproveTx.ts
+++ b/src/hooks/veNft/transactor/ERC20ApproveTx.ts
@@ -1,0 +1,30 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
+import { V2UserContext } from 'contexts/v2/userContext'
+import { useErc20Contract } from 'hooks/Erc20Contract'
+import { TransactorInstance } from 'hooks/Transactor'
+
+import { useContext } from 'react'
+
+export type ERC20ApproveArgs = {
+  spender: string
+  amount: BigNumber
+}
+
+export default function useERC20Approve(
+  erc20address: string,
+): TransactorInstance<ERC20ApproveArgs> {
+  const { transactor } = useContext(V2UserContext)
+  const contract = useErc20Contract(erc20address)
+
+  return ({ spender, amount }, txOpts) => {
+    if (!transactor || !contract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(contract, 'approve', [spender, amount], {
+      ...txOpts,
+    })
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftLockTx.ts
@@ -3,7 +3,7 @@ import { useContext } from 'react'
 import { V2UserContext } from 'contexts/v2/userContext'
 
 import { TransactorInstance } from 'hooks/Transactor'
-import { useNFTContract } from 'hooks/veNft/VeNftContract'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
 
 import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
@@ -18,7 +18,7 @@ export type LockTx = TransactorInstance<{
 
 export function useLockTx(): LockTx {
   const { transactor } = useContext(V2UserContext)
-  const nftContract = useNFTContract(VENFT_CONTRACT_ADDRESS)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
 
   return (
     {

--- a/src/hooks/veNft/transactor/VeNftLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftLockTx.ts
@@ -1,0 +1,55 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useNFTContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type LockTx = TransactorInstance<{
+  account: string
+  value: BigNumber
+  lockDuration: BigNumberish
+  beneficiary: string
+  useJbToken: boolean
+  allowPublicExtension: boolean
+}>
+
+export function useLockTx(): LockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useNFTContract(VENFT_CONTRACT_ADDRESS)
+
+  return (
+    {
+      account,
+      value,
+      lockDuration,
+      beneficiary,
+      useJbToken,
+      allowPublicExtension,
+    },
+    txOpts,
+  ) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'lock',
+      [
+        account,
+        value,
+        lockDuration,
+        beneficiary,
+        useJbToken,
+        allowPublicExtension,
+      ],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,6 +13,14 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr "$ve{tokenSymbolDisplayText} NFT summary:"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr "$ve{tokenSymbolDisplayText} Received"
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
@@ -593,6 +601,7 @@ msgstr "Balance of the project owner's wallet."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiary"
 
@@ -790,7 +799,7 @@ msgstr "Configure the dynamics of your project's token."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr "Confirm Stake"
 
@@ -1822,6 +1831,14 @@ msgstr ""
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr "Lock ${tokenSymbolDisplayText} for Voting Power"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr "Lock Duration"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr "Lock successful. Results will be indexed in a few moments."
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2001,6 +2018,10 @@ msgstr "No active funding cycle."
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr "No beneficiary selected. Is your wallet connected?"
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2917,6 +2938,10 @@ msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voti
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr "Staked {tokenSymbolDisplayText}"
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr "Staking Summary:"
@@ -2951,6 +2976,10 @@ msgstr "Step 1. Add V1 token payment terminal"
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr "Step 2. Link your Juicebox V1 project"
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
+msgstr "Successfully approved ERC-20 spending."
 
 #: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
@@ -3660,6 +3689,10 @@ msgstr "Would you like to issue an ERC-20 token to be used as this project's tok
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Yes"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr "$ve{tokenSymbolDisplayText} NFT summary:"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr "$ve{tokenSymbolDisplayText} Received"
 
@@ -601,7 +601,7 @@ msgstr "Balance of the project owner's wallet."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiary"
 
@@ -799,7 +799,7 @@ msgstr "Configure the dynamics of your project's token."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr "Confirm Stake"
 
@@ -1831,11 +1831,11 @@ msgstr ""
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr "Lock ${tokenSymbolDisplayText} for Voting Power"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr "Lock Duration"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr "Lock successful. Results will be indexed in a few moments."
 
@@ -2019,7 +2019,7 @@ msgstr "No active funding cycle."
 msgid "No activity yet"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr "No beneficiary selected. Is your wallet connected?"
 
@@ -2938,7 +2938,7 @@ msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voti
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr "Staked {tokenSymbolDisplayText}"
 
@@ -3690,7 +3690,7 @@ msgstr "Would you like to issue an ERC-20 token to be used as this project's tok
 msgid "Yes"
 msgstr "Yes"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "Balance en la cartera del dueño del proyecto."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiario"
 
@@ -804,7 +804,7 @@ msgstr "Configura la dinámica del token de tu proyecto."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr "Cargar más"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgstr "No hay ciclo de financiamiento activo."
 msgid "No activity yet"
 msgstr "Sin actividad, todavía"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr "¿Deseas emitir un token ERC-20 para ser usado como token de este proyec
 msgid "Yes"
 msgstr "Sí"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,6 +18,14 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr ""
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
@@ -598,6 +606,7 @@ msgstr "Balance en la cartera del dueño del proyecto."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiario"
 
@@ -795,7 +804,7 @@ msgstr "Configura la dinámica del token de tu proyecto."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1827,6 +1836,14 @@ msgstr "Cargar más"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2006,6 +2023,10 @@ msgstr "No hay ciclo de financiamiento activo."
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Sin actividad, todavía"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2922,6 +2943,10 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
@@ -2955,6 +2980,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
 #: src/components/v1/shared/PayoutModsList.tsx
@@ -3665,6 +3694,10 @@ msgstr "¿Deseas emitir un token ERC-20 para ser usado como token de este proyec
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Sí"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "Solde du portefeuille du propriétaire du projet."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Bénéficiaire"
 
@@ -804,7 +804,7 @@ msgstr "Configurer la dynamique du token de votre projet."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr "Télécharger d'avantage"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgstr "Aucun cycle de financement actif."
 msgid "No activity yet"
 msgstr "Aucune activité"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr "Souhaitez-vous émettre un token ERC-20 à utiliser comme token de ce pr
 msgid "Yes"
 msgstr "Oui"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -18,6 +18,14 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr ""
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
@@ -598,6 +606,7 @@ msgstr "Solde du portefeuille du propriétaire du projet."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Bénéficiaire"
 
@@ -795,7 +804,7 @@ msgstr "Configurer la dynamique du token de votre projet."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1827,6 +1836,14 @@ msgstr "Télécharger d'avantage"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2006,6 +2023,10 @@ msgstr "Aucun cycle de financement actif."
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Aucune activité"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2922,6 +2943,10 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
@@ -2955,6 +2980,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
 #: src/components/v1/shared/PayoutModsList.tsx
@@ -3665,6 +3694,10 @@ msgstr "Souhaitez-vous émettre un token ERC-20 à utiliser comme token de ce pr
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Oui"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "Saldo da carteira do dono do projeto."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiário"
 
@@ -804,7 +804,7 @@ msgstr "Configurar as dinâmicas de seu token de projeto."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr "Carregar mais"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgstr "Nenhum ciclo de financiamento ativo."
 msgid "No activity yet"
 msgstr "Nenhuma atividade ainda"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr "Você desejaria emitir um token ERC-20 para que seja usado como um token
 msgid "Yes"
 msgstr "Sim"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -18,6 +18,14 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr ""
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
@@ -598,6 +606,7 @@ msgstr "Saldo da carteira do dono do projeto."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiário"
 
@@ -795,7 +804,7 @@ msgstr "Configurar as dinâmicas de seu token de projeto."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1827,6 +1836,14 @@ msgstr "Carregar mais"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2006,6 +2023,10 @@ msgstr "Nenhum ciclo de financiamento ativo."
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Nenhuma atividade ainda"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2922,6 +2943,10 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
@@ -2955,6 +2980,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
 #: src/components/v1/shared/PayoutModsList.tsx
@@ -3665,6 +3694,10 @@ msgstr "Você desejaria emitir um token ERC-20 para que seja usado como um token
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Sim"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -18,6 +18,14 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr ""
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
@@ -598,6 +606,7 @@ msgstr "Баланс кошелька владельца проекта."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Получатель"
 
@@ -795,7 +804,7 @@ msgstr "Настройте динамику токена вашего проек
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1827,6 +1836,14 @@ msgstr "Загрузить ещё"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2006,6 +2023,10 @@ msgstr ""
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Нет активности"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2922,6 +2943,10 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
@@ -2955,6 +2980,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
 #: src/components/v1/shared/PayoutModsList.tsx
@@ -3665,6 +3694,10 @@ msgstr "Хотите ли вы выпустить токен ERC-20, котор�
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Да"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "Баланс кошелька владельца проекта."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Получатель"
 
@@ -804,7 +804,7 @@ msgstr "Настройте динамику токена вашего проек
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr "Загрузить ещё"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgstr ""
 msgid "No activity yet"
 msgstr "Нет активности"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr "Хотите ли вы выпустить токен ERC-20, котор�
 msgid "Yes"
 msgstr "Да"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "Proje sahibinin cüzdan bakiyesi."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Faydalanıcı"
 
@@ -804,7 +804,7 @@ msgstr "Proje token'ınızın dinamiklerini yapılandırın."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr "Daha fazla yükle"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgstr "Aktif finansman döngüsü yok."
 msgid "No activity yet"
 msgstr "Henüz etkinlik yok"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr "Bu projenin token'ı olarak kullanılmak üzere bir ERC-20 token'ı çı
 msgid "Yes"
 msgstr "Evet"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -18,6 +18,14 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr ""
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "(%{0})"
@@ -598,6 +606,7 @@ msgstr "Proje sahibinin cüzdan bakiyesi."
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Faydalanıcı"
 
@@ -795,7 +804,7 @@ msgstr "Proje token'ınızın dinamiklerini yapılandırın."
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1827,6 +1836,14 @@ msgstr "Daha fazla yükle"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2006,6 +2023,10 @@ msgstr "Aktif finansman döngüsü yok."
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Henüz etkinlik yok"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2922,6 +2943,10 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
@@ -2955,6 +2980,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
 #: src/components/v1/shared/PayoutModsList.tsx
@@ -3665,6 +3694,10 @@ msgstr "Bu projenin token'ı olarak kullanılmak üzere bir ERC-20 token'ı çı
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Evet"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -18,6 +18,14 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} NFT summary:"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "$ve{tokenSymbolDisplayText} Received"
+msgstr ""
+
 #: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
@@ -598,6 +606,7 @@ msgstr "项目拥有者钱包的余额"
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "受益人"
 
@@ -795,7 +804,7 @@ msgstr "设置项目代币的各项动能指标。"
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/veNftConfirmStakeModal.tsx
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1827,6 +1836,14 @@ msgstr "加载更多"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock Duration"
+msgstr ""
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 #: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -2006,6 +2023,10 @@ msgstr "没有活跃的筹款周期。"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "暂无动态"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
 
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
@@ -2922,6 +2943,10 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
 #: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
@@ -2955,6 +2980,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
+msgstr ""
+
+#: src/components/veNft/VeNftStakingForm.tsx
+msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
 #: src/components/v1/shared/PayoutModsList.tsx
@@ -3665,6 +3694,10 @@ msgstr "你是否要签发一个 ERC-20 标准代币来作为项目代币？"
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "确定"
+
+#: src/components/veNft/VeNftConfirmStakeModal.tsx
+msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} NFT summary:"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "项目拥有者钱包的余额"
 
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "受益人"
 
@@ -804,7 +804,7 @@ msgstr "设置项目代币的各项动能指标。"
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr "加载更多"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgstr "没有活跃的筹款周期。"
 msgid "No activity yet"
 msgstr "暂无动态"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr "你是否要签发一个 ERC-20 标准代币来作为项目代币？"
 msgid "Yes"
 msgstr "确定"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
+#: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -36,7 +36,7 @@ import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
 
 import useNameOfERC20 from 'hooks/NameOfERC20'
 
-import { BigNumber } from '@ethersproject/bignumber'
+import { useVeNftLockDurationOptions } from 'hooks/veNft/VeNftLockDurationOptions'
 
 import {
   ETH_PAYOUT_SPLIT_GROUP,
@@ -181,6 +181,8 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
   const { data: nftRewardTiers, isLoading: nftRewardTiersLoading } =
     useNftRewards(nftRewardsCIDs)
 
+  const { data: lockDurationOptions } = useVeNftLockDurationOptions()
+
   const isArchived = projectId
     ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived
     : false
@@ -196,9 +198,6 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
   }
 
   const nftsLoading = nftRewardTiersLoading || nftRewardsCIDsLoading
-
-  // const { data: lockDurationOptions2 } = useVeNftLockDurationOptions()
-  const lockDurationOptions = [BigNumber.from(1)]
 
   const project: V2ProjectContextType = {
     cv: '2',

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -36,6 +36,8 @@ import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
 
 import useNameOfERC20 from 'hooks/NameOfERC20'
 
+import { useVeNftLockDurationOptions } from 'hooks/veNft/VeNftLockDurationOptions'
+
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
@@ -195,6 +197,8 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
 
   const nftsLoading = nftRewardTiersLoading || nftRewardsCIDsLoading
 
+  const { data: lockDurationOptions } = useVeNftLockDurationOptions()
+
   const project: V2ProjectContextType = {
     cv: '2',
     handle,
@@ -230,7 +234,7 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
 
     veNft: {
       name: undefined,
-      lockDurationOptions: undefined,
+      lockDurationOptions: lockDurationOptions,
       baseImagesHash: undefined,
       resolverAddress: undefined,
       variants: undefined,

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -36,7 +36,7 @@ import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
 
 import useNameOfERC20 from 'hooks/NameOfERC20'
 
-import { useVeNftLockDurationOptions } from 'hooks/veNft/VeNftLockDurationOptions'
+import { BigNumber } from '@ethersproject/bignumber'
 
 import {
   ETH_PAYOUT_SPLIT_GROUP,
@@ -197,7 +197,8 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
 
   const nftsLoading = nftRewardTiersLoading || nftRewardsCIDsLoading
 
-  const { data: lockDurationOptions } = useVeNftLockDurationOptions()
+  // const { data: lockDurationOptions2 } = useVeNftLockDurationOptions()
+  const lockDurationOptions = [BigNumber.from(1)]
 
   const project: V2ProjectContextType = {
     cv: '2',


### PR DESCRIPTION
## What does this PR do and why?

Adds the token approval and minting flow to the staking form.

To mint a veNft and stake tokens a user has to:
- Approve the veNft contract to spend their project ERC-20
- Call the `lock` transaction using the parameters from the staking form.

## Screenshots or screen recordings

<img width="606" alt="image" src="https://user-images.githubusercontent.com/33093632/180577738-749762be-3017-491c-a09e-083fce3c737c.png">

The form when a user has not yet approved the veNft contract as a spender

<img width="517" alt="image" src="https://user-images.githubusercontent.com/33093632/180577773-83ce3b76-c3fa-48e0-b07c-b8f6da28c756.png">

The staking modal to confirm and call the `lock` transaction

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
