### PR TITLE
Enable useDataSourceForPay when NFT projects reconfigure FC

### DIFF
--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/reconfigureFundingCycle.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/reconfigureFundingCycle.ts
@@ -1,5 +1,7 @@
+import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { useReconfigureV2FundingCycleTx } from 'hooks/v2/transactor/ReconfigureV2FundingCycleTx'
-import { useCallback, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
+import { NFT_FUNDING_CYCLE_METADATA_OVERRIDES } from 'pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton'
 
 import { EditingProjectData } from './editingProjectData'
 
@@ -17,6 +19,11 @@ export const useReconfigureFundingCycle = ({
     editingFundingCycleData,
     editingFundAccessConstraints,
   } = editingProjectData
+
+  const {
+    nftRewards: { CIDs: nftRewardsCids },
+  } = useContext(V2ProjectContext)
+
   const reconfigureV2FundingCycleTx = useReconfigureV2FundingCycleTx()
   const [reconfigureTxLoading, setReconfigureTxLoading] =
     useState<boolean>(false)
@@ -34,10 +41,18 @@ export const useReconfigureFundingCycle = ({
       throw new Error('Error deploying project.')
     }
 
+    // Projects with NFT rewards need useDataSourceForPay to be true for NFT rewards to work
+    const fundingCycleMetadata = nftRewardsCids?.length
+      ? {
+          ...editingFundingCycleMetadata,
+          ...NFT_FUNDING_CYCLE_METADATA_OVERRIDES,
+        }
+      : editingFundingCycleMetadata
+
     const txSuccessful = await reconfigureV2FundingCycleTx(
       {
         fundingCycleData: editingFundingCycleData,
-        fundingCycleMetadata: editingFundingCycleMetadata,
+        fundingCycleMetadata,
         fundAccessConstraints: editingFundAccessConstraints,
         groupedSplits: [
           editingPayoutGroupedSplits,
@@ -66,6 +81,7 @@ export const useReconfigureFundingCycle = ({
     editingFundingCycleMetadata,
     editingPayoutGroupedSplits,
     editingReservedTokensGroupedSplits,
+    nftRewardsCids,
     exit,
     reconfigureV2FundingCycleTx,
   ])

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -11,6 +11,7 @@ import FundingDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers
 import TokenDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer'
 
 import RulesDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import { V2ReconfigureProjectDetailsDrawer } from './drawers/V2ReconfigureProjectDetailsDrawer'
 import V2ReconfigureUpcomingMessage from './V2ReconfigureUpcomingMessage'
@@ -88,6 +89,11 @@ export default function V2ProjectReconfigureModal({
     editingProjectData,
     initialEditingData,
   })
+  const {
+    fundingCycleMetadata,
+    nftRewards: { CIDs: nftRewardsCids },
+  } = useContext(V2ProjectContext)
+
   const { reconfigureLoading, reconfigureFundingCycle } =
     useReconfigureFundingCycle({ editingProjectData, exit })
 
@@ -124,6 +130,10 @@ export default function V2ProjectReconfigureModal({
     openUnsavedChangesModal()
   }, [fundingHasSavedChanges, onCancel])
 
+  const nftsWithFalseDataSourceForPay = Boolean(
+    nftRewardsCids?.length && !fundingCycleMetadata?.useDataSourceForPay,
+  )
+
   return (
     <Modal
       title={<Trans>Project configuration</Trans>}
@@ -132,7 +142,7 @@ export default function V2ProjectReconfigureModal({
       onCancel={handleGlobalModalClose}
       okText={t`Deploy funding cycle configuration`}
       okButtonProps={{
-        disabled: !fundingHasSavedChanges,
+        disabled: !fundingHasSavedChanges && !nftsWithFalseDataSourceForPay,
         style: { marginBottom: '15px' },
       }}
       confirmLoading={reconfigureLoading}
@@ -166,14 +176,15 @@ export default function V2ProjectReconfigureModal({
           />
         )}
         {!hideProjectDetails && (
-          <ReconfigureButton
-            reconfigureHasChanges={false}
-            title={t`Other details`}
-            onClick={() => setProjectDetailsDrawerVisible(true)}
-          />
+          <>
+            <ReconfigureButton
+              reconfigureHasChanges={false}
+              title={t`Other details`}
+              onClick={() => setProjectDetailsDrawerVisible(true)}
+            />
+            <Divider />
+          </>
         )}
-
-        <Divider />
 
         <h4 style={{ marginBottom: 0 }}>
           <Trans>Reconfigure upcoming funding cycles</Trans>

--- a/src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
@@ -32,7 +32,9 @@ import { findTransactionReceipt } from './utils'
 
 const NFT_CREATE_EVENT_IDX = 2
 const NFT_PROJECT_ID_TOPIC_IDX = 1
-const FUNDING_CYCLE_METADATA_OVERRIDES = {
+
+// Projects with NFT rewards need useDataSourceForPay to be true for NFT rewards to work
+export const NFT_FUNDING_CYCLE_METADATA_OVERRIDES = {
   useDataSourceForPay: true,
 }
 
@@ -158,7 +160,7 @@ export function DeployProjectWithNftsButton() {
             fundingCycleData,
             fundingCycleMetadata: {
               ...fundingCycleMetadata,
-              ...FUNDING_CYCLE_METADATA_OVERRIDES,
+              ...NFT_FUNDING_CYCLE_METADATA_OVERRIDES,
             },
             fundAccessConstraints,
             groupedSplits,


### PR DESCRIPTION
## What does this PR do and why?

There were a few hours where newly deployed NFT projects had `useDataSourceForPay` set to `false`. 

- In these specific cases, I've enabled the reconfigure modal confirm button even when no changes have occured
- Then, on reconfigure, the `useDataSourceForPay` is set to `true`. 

- Also closes #1357 (weird divider thing):

<img width="626" alt="Screen Shot 2022-07-23 at 9 10 30 am" src="https://user-images.githubusercontent.com/96150256/180579356-137628e4-0f53-4e88-9d23-44d5dc0eed1a.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
