### PR TITLE
[4/6] Venft token ranges & carousel

### DIFF
--- a/src/components/veNft/VeNftCarouselItem.tsx
+++ b/src/components/veNft/VeNftCarouselItem.tsx
@@ -1,0 +1,68 @@
+import { Col, Image } from 'antd'
+import { VeNftTokenMetadata, VeNftVariant } from 'models/v2/veNft'
+import { getVeNftBaseImage } from 'utils/v2/veNft'
+
+interface VeNftCarouselItemProps {
+  variant?: VeNftVariant
+  tokenMetadata?: VeNftTokenMetadata
+  baseImagesHash: string
+  handleImageClick: (variant: VeNftVariant) => void
+  isActive: boolean
+  dims?: number
+}
+
+const VeNftCarouselItem = ({
+  variant,
+  tokenMetadata,
+  baseImagesHash,
+  handleImageClick,
+  isActive,
+  dims,
+}: VeNftCarouselItemProps) => {
+  const imgDims = dims || 150
+  const style = { opacity: isActive ? 1 : 0.3 }
+  const labelStyle = {
+    opacity: isActive ? 1 : 0.8,
+  }
+
+  const variantRangeInfo = (variant: VeNftVariant) => {
+    return (
+      <p style={{ textAlign: 'center', ...labelStyle }}>
+        {variant.tokensStakedMin}-
+        {variant.tokensStakedMax ? variant.tokensStakedMax : '+'}
+      </p>
+    )
+  }
+
+  const getCarouselImage = () => {
+    if (!variant) {
+      return undefined
+    }
+    if (isActive) {
+      return tokenMetadata
+        ? tokenMetadata.thumbnailUri
+        : getVeNftBaseImage(baseImagesHash, variant)
+    }
+    return getVeNftBaseImage(baseImagesHash, variant)
+  }
+
+  return (
+    <Col span={8}>
+      {variant && (
+        <>
+          <Image
+            src={getCarouselImage()}
+            preview={false}
+            style={style}
+            width={imgDims}
+            height={imgDims}
+            onClick={() => handleImageClick(variant)}
+          />
+          {variantRangeInfo(variant)}
+        </>
+      )}
+    </Col>
+  )
+}
+
+export default VeNftCarouselItem

--- a/src/components/veNft/VeNftContent.tsx
+++ b/src/components/veNft/VeNftContent.tsx
@@ -11,8 +11,12 @@ import VeNftOwnedTokensSection from 'components/veNft/VeNftOwnedTokensSection'
 import VeNftSummaryStatsSection from 'components/veNft/VeNftSummaryStatsSection'
 
 const VeNftContent = () => {
-  const { tokenSymbol, tokenName, projectMetadata } =
-    useContext(V2ProjectContext)
+  const {
+    tokenSymbol,
+    tokenName,
+    projectMetadata,
+    veNft: { userTokens },
+  } = useContext(V2ProjectContext)
 
   const tokenSymbolDisplayText = tokenSymbolText({ tokenSymbol })
   const projectName = projectMetadata?.name ?? t`Unknown Project`
@@ -25,8 +29,12 @@ const VeNftContent = () => {
         projectName={projectName}
       />
       <VeNftStakingForm tokenSymbolDisplayText={tokenSymbolDisplayText} />
-      <VeNftOwnedTokensSection />
+      <VeNftOwnedTokensSection
+        userTokens={userTokens}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
+      />
       <VeNftSummaryStatsSection
+        userTokens={userTokens}
         tokenSymbolDisplayText={tokenSymbolDisplayText}
       />
     </Space>

--- a/src/components/veNft/VeNftExtendLockModal.tsx
+++ b/src/components/veNft/VeNftExtendLockModal.tsx
@@ -1,0 +1,128 @@
+import { Form } from 'antd'
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+import { useExtendLockTx } from 'hooks/veNft/transactor/VeNftExtendLockTx'
+import { NetworkContext } from 'contexts/networkContext'
+import { t, Trans } from '@lingui/macro'
+import { emitSuccessNotification } from 'utils/notifications'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+
+import TransactionModal from 'components/TransactionModal'
+import LockDurationSelectInput from 'components/veNft/formControls/LockDurationSelectInput'
+
+type VeNftExtendLockModalProps = {
+  visible: boolean
+  token: VeNftToken
+  onCancel: VoidFunction
+  onCompleted: VoidFunction
+}
+
+interface ExtendLockFormProps {
+  lockDuration: number
+}
+
+const VeNftExtendLockModal = ({
+  visible,
+  token,
+  onCancel,
+  onCompleted,
+}: VeNftExtendLockModalProps) => {
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { tokenId } = token
+  const {
+    veNft: { lockDurationOptions },
+  } = useContext(V2ProjectContext)
+  const [form] = Form.useForm<ExtendLockFormProps>()
+  const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
+  const lockDurationOptionsInSeconds = useMemo(() => {
+    return lockDurationOptions
+      ? lockDurationOptions.map((option: BigNumber) => {
+          return option.toNumber()
+        })
+      : []
+  }, [lockDurationOptions])
+
+  useEffect(() => {
+    lockDurationOptionsInSeconds.length > 0 &&
+      form.setFieldsValue({ lockDuration: lockDurationOptionsInSeconds[0] })
+  }, [lockDurationOptionsInSeconds, form])
+
+  const initialValues = {
+    lockDuration: 0,
+  }
+
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const extendLockTx = useExtendLockTx()
+
+  const extendLock = async () => {
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const lockDuration = form.getFieldValue('lockDuration')
+
+    setLoading(true)
+
+    const txSuccess = await extendLockTx(
+      {
+        tokenId,
+        updatedDuration: lockDuration,
+      },
+      {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
+          setLoading(false)
+          emitSuccessNotification(
+            t`Extend lock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <TransactionModal
+      visible={visible}
+      title={t`Extend Lock`}
+      onCancel={onCancel}
+      onOk={extendLock}
+      okText={`Extend Lock`}
+      confirmLoading={loading}
+      transactionPending={transactionPending}
+    >
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>Update your veNFT's lock duration.</Trans>
+        </p>
+      </div>
+      <Form
+        layout="vertical"
+        style={{ width: '100%' }}
+        form={form}
+        initialValues={initialValues}
+      >
+        <LockDurationSelectInput
+          form={form}
+          lockDurationOptionsInSeconds={lockDurationOptionsInSeconds}
+        />
+      </Form>
+    </TransactionModal>
+  )
+}
+
+export default VeNftExtendLockModal

--- a/src/components/veNft/VeNftOwnedTokenCard.tsx
+++ b/src/components/veNft/VeNftOwnedTokenCard.tsx
@@ -1,0 +1,150 @@
+import {
+  Button,
+  Card,
+  Col,
+  Row,
+  Image,
+  Space,
+  Tooltip,
+  Descriptions,
+} from 'antd'
+
+import { ThemeContext } from 'contexts/themeContext'
+
+import { CSSProperties, useContext, useState } from 'react'
+import { formattedNum, fromWad } from 'utils/formatNumber'
+import { detailedTimeString } from 'utils/formatTime'
+
+import { useVeNftTokenMetadata } from 'hooks/veNft/VeNftTokenMetadata'
+import { t, Trans } from '@lingui/macro'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import VeNftExtendLockModal from './VeNftExtendLockModal'
+import VeNftRedeemModal from './VeNftRedeemModal'
+import VeNftUnlockModal from './VeNftUnlockModal'
+
+type OwnedVeNftCardProps = {
+  token: VeNftToken
+  tokenSymbolDisplayText: string
+  hasOverflow: boolean | undefined
+}
+
+export default function OwnedVeNftCard({
+  token,
+  tokenSymbolDisplayText,
+  hasOverflow,
+}: OwnedVeNftCardProps) {
+  const [extendLockModalVisible, setExtendLockModalVisible] = useState(false)
+  const [redeemModalVisible, setRedeemModalVisible] = useState(false)
+  const [unlockModalVisible, setUnlockModalVisible] = useState(false)
+
+  const { lockAmount, lockEnd, lockDuration } = token
+  const { data: metadata } = useVeNftTokenMetadata(token.tokenUri)
+  const thumbnailUri = metadata?.thumbnailUri
+
+  const remaining = Math.max(Math.round(lockEnd - Date.now() / 1000), 0)
+
+  const { colors, radii } = useContext(ThemeContext).theme
+
+  const cardStyles: CSSProperties = {
+    display: 'flex',
+    padding: '1rem',
+    borderRadius: radii.md,
+    background: colors.background.l0,
+  }
+
+  const renderRedeemButton = () => {
+    if (hasOverflow) {
+      return (
+        <Button block onClick={() => setRedeemModalVisible(true)}>
+          <Trans>Redeem</Trans>
+        </Button>
+      )
+    } else {
+      return (
+        <Tooltip
+          trigger={['hover']}
+          title={
+            <Trans>
+              A veNft can only be redeemed if the project currently has
+              overflow.
+            </Trans>
+          }
+        >
+          <Button block disabled>
+            <Trans>Redeem</Trans>
+          </Button>
+        </Tooltip>
+      )
+    }
+  }
+
+  return (
+    <Card style={cardStyles}>
+      <div style={{ color: colors.text.primary }}>
+        <Row>
+          <Col span={14}>
+            <Descriptions column={1}>
+              <Descriptions.Item label={t`Locked ${tokenSymbolDisplayText}`}>
+                {formattedNum(fromWad(lockAmount))}
+              </Descriptions.Item>
+              <Descriptions.Item label={t`Lock Duration`}>
+                {detailedTimeString({
+                  timeSeconds: lockDuration,
+                  fullWords: true,
+                })}
+              </Descriptions.Item>
+              <Descriptions.Item label={t`Time Remaining`}>
+                {detailedTimeString({
+                  timeSeconds: remaining,
+                })}
+              </Descriptions.Item>
+            </Descriptions>
+          </Col>
+          <Col span={4} />
+          <Col span={6}>
+            <Image src={thumbnailUri} alt="nft" preview={false} />
+          </Col>
+        </Row>
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Row>
+            <Button block onClick={() => setExtendLockModalVisible(true)}>
+              <Trans>Extend Lock</Trans>
+            </Button>
+          </Row>
+          <Row>{renderRedeemButton()}</Row>
+          {remaining === 0 && (
+            <Row>
+              <Button
+                block
+                disabled={remaining > 0}
+                onClick={() => setUnlockModalVisible(true)}
+              >
+                <Trans>Unlock</Trans>
+              </Button>
+            </Row>
+          )}
+        </Space>
+      </div>
+      <VeNftExtendLockModal
+        visible={extendLockModalVisible}
+        onCancel={() => setExtendLockModalVisible(false)}
+        token={token}
+        onCompleted={() => setExtendLockModalVisible(false)}
+      />
+      <VeNftRedeemModal
+        visible={redeemModalVisible}
+        onCancel={() => setRedeemModalVisible(false)}
+        token={token}
+        onCompleted={() => setRedeemModalVisible(false)}
+      />
+      <VeNftUnlockModal
+        visible={unlockModalVisible}
+        onCancel={() => setUnlockModalVisible(false)}
+        token={token}
+        onCompleted={() => setUnlockModalVisible(false)}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
+      />
+    </Card>
+  )
+}

--- a/src/components/veNft/VeNftOwnedTokensSection.tsx
+++ b/src/components/veNft/VeNftOwnedTokensSection.tsx
@@ -1,19 +1,52 @@
-import { Trans } from '@lingui/macro'
+import { Space } from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
+
+import { Trans } from '@lingui/macro'
+
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import OwnedVeNftCard from 'components/veNft/VeNftOwnedTokenCard'
+
+import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import { shadowCard } from 'constants/styles/shadowCard'
 
-const VeNftOwnedTokensSection = () => {
+type OwnedNFTsSectionProps = {
+  userTokens: VeNftToken[] | undefined
+  tokenSymbolDisplayText: string
+}
+
+export default function OwnedNFTSection({
+  userTokens,
+  tokenSymbolDisplayText,
+}: OwnedNFTsSectionProps) {
   const { theme } = useContext(ThemeContext)
+  const { primaryTerminalCurrentOverflow } = useContext(V2ProjectContext)
+  const hasOverflow = Boolean(primaryTerminalCurrentOverflow?.gt(0))
+
   return (
     <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
-      <h3>
-        <Trans>You don't own any veNFTs!</Trans>
-      </h3>
+      {userTokens && userTokens.length > 0 ? (
+        <>
+          <h3>$ve{tokenSymbolDisplayText} NFTs:</h3>
+          <Space direction="vertical">
+            {userTokens.map((token, i) => (
+              <OwnedVeNftCard
+                key={i}
+                token={token}
+                tokenSymbolDisplayText={tokenSymbolDisplayText}
+                hasOverflow={hasOverflow}
+              />
+            ))}
+          </Space>
+        </>
+      ) : (
+        <h3>
+          <Trans>You don't own any veNFTs!</Trans>
+        </h3>
+      )}
     </div>
   )
 }
-
-export default VeNftOwnedTokensSection

--- a/src/components/veNft/VeNftRedeemModal.tsx
+++ b/src/components/veNft/VeNftRedeemModal.tsx
@@ -1,0 +1,107 @@
+import { t, Trans } from '@lingui/macro'
+import { Form } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import { useContext, useState } from 'react'
+
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { useRedeemVeNftTx } from 'hooks/veNft/transactor/VeNftRedeemTx'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import { emitSuccessNotification } from 'utils/notifications'
+
+import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
+import TransactionModal from 'components/TransactionModal'
+import { MemoFormInput } from 'components/inputs/Pay/MemoFormInput'
+
+type VeNftRedeemModalProps = {
+  token: VeNftToken
+  visible: boolean
+  onCancel: VoidFunction
+  onCompleted: VoidFunction
+}
+
+const VeNftRedeemModal = ({
+  token,
+  visible,
+  onCancel,
+  onCompleted,
+}: VeNftRedeemModalProps) => {
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { primaryTerminal, tokenAddress } = useContext(V2ProjectContext)
+  const { tokenId } = token
+  const [form] = useForm<{ beneficiary: string }>()
+  const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
+  const [memo, setMemo] = useState('')
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const redeemTx = useRedeemVeNftTx()
+
+  const redeem = async () => {
+    const { beneficiary } = form.getFieldsValue()
+    await form.validateFields()
+
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const txBeneficiary = beneficiary ? beneficiary : userAddress!
+
+    setLoading(true)
+
+    const txSuccess = await redeemTx(
+      {
+        tokenId,
+        token: tokenAddress || '',
+        beneficiary: txBeneficiary,
+        memo,
+        terminal: primaryTerminal ? primaryTerminal : '',
+      },
+      {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
+          setLoading(false)
+          emitSuccessNotification(
+            t`Redeem successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      return
+    }
+  }
+
+  return (
+    <TransactionModal
+      visible={visible}
+      title={t`Redeem veNFT`}
+      onCancel={onCancel}
+      onOk={redeem}
+      okText={`Redeem`}
+      confirmLoading={loading}
+      transactionPending={transactionPending}
+    >
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>Redeeming this NFT will burn the token and return...</Trans>
+        </p>
+      </div>
+      <Form form={form} layout="vertical">
+        <MemoFormInput value={memo} onChange={setMemo} />
+        <CustomBeneficiaryInput form={form} />
+      </Form>
+    </TransactionModal>
+  )
+}
+
+export default VeNftRedeemModal

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -28,6 +28,10 @@ import { parseWad } from 'utils/formatNumber'
 
 import { emitSuccessNotification } from 'utils/notifications'
 
+import { useVeNftTokenMetadata } from 'hooks/veNft/VeNftTokenMetadata'
+
+import { useVeNftResolverTokenUri } from 'hooks/veNft/VeNftResolverTokenUri'
+
 import { shadowCard } from 'constants/styles/shadowCard'
 import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
@@ -47,7 +51,7 @@ const VeNftStakingForm = ({
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const {
     tokenAddress,
-    veNft: { lockDurationOptions },
+    veNft: { lockDurationOptions, resolverAddress, baseImagesHash, variants },
   } = useContext(V2ProjectContext)
   const { theme } = useContext(ThemeContext)
 
@@ -61,6 +65,14 @@ const VeNftStakingForm = ({
   const tokensStaked = useWatch('tokensStaked', form) || '1'
   const lockDuration = useWatch('lockDuration', form) || 0
   const beneficiary = useWatch('beneficiary', form) || ''
+
+  const { data: nftTokenUri } = useVeNftResolverTokenUri(
+    resolverAddress,
+    parseWad(tokensStaked),
+    lockDuration,
+    lockDurationOptions,
+  )
+  const { data: tokenMetadata, refetch } = useVeNftTokenMetadata(nftTokenUri)
 
   const lockDurationOptionsInSeconds = useMemo(() => {
     return lockDurationOptions
@@ -119,7 +131,7 @@ const VeNftStakingForm = ({
 
   const handleReviewButtonClick = async () => {
     await form.validateFields()
-    // refetch()
+    refetch()
     setConfirmStakeModalVisible(true)
   }
 
@@ -173,7 +185,15 @@ const VeNftStakingForm = ({
             </Col>
           </Row>
           <CustomBeneficiaryInput form={form} />
-          <VeNftCarousel />
+          {variants && baseImagesHash && (
+            <VeNftCarousel
+              tokensStaked={tokensStaked}
+              baseImagesHash={baseImagesHash}
+              variants={variants}
+              form={form}
+              tokenMetadata={tokenMetadata}
+            />
+          )}
           <Space size="middle" direction="vertical" style={{ width: '100%' }}>
             <Button block onClick={() => setTokenRangesModalVisible(true)}>
               <Trans>View Token Ranges</Trans>
@@ -199,6 +219,7 @@ const VeNftStakingForm = ({
         lockDuration={lockDuration}
         beneficiary={beneficiary}
         votingPower={votingPower}
+        tokenMetadata={tokenMetadata}
         onCancel={() => setConfirmStakeModalVisible(false)}
         onCompleted={() => setConfirmStakeModalVisible(false)}
       />

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -189,6 +189,7 @@ const VeNftStakingForm = ({
       </Form>
       <StakingTokenRangesModal
         visible={tokenRangesModalVisible}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
         onCancel={() => setTokenRangesModalVisible(false)}
       />
       <ConfirmStakeModal

--- a/src/components/veNft/VeNftSummaryStatsSection.tsx
+++ b/src/components/veNft/VeNftSummaryStatsSection.tsx
@@ -1,19 +1,31 @@
-import { t, Trans } from '@lingui/macro'
+import { Plural, t, Trans } from '@lingui/macro'
 import { Descriptions } from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
 import React, { useContext } from 'react'
 
+import { useVeNftSummaryStats } from 'hooks/veNft/VeNftSummaryStats'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import { formattedNum } from 'utils/formatNumber'
+
 import { shadowCard } from 'constants/styles/shadowCard'
 
 interface VeNftSummaryStatsSectionProps {
   tokenSymbolDisplayText: string
+  userTokens: VeNftToken[] | undefined
 }
 
 const VeNftSummaryStatsSection = ({
   tokenSymbolDisplayText,
+  userTokens,
 }: VeNftSummaryStatsSectionProps) => {
   const { theme } = useContext(ThemeContext)
+  const { totalStaked, totalStakedPeriod } = useVeNftSummaryStats(userTokens)
+  const totalStakedPeriodInDays = totalStakedPeriod / (60 * 60 * 24)
+  const formattedTotalStakedPeriod = formattedNum(totalStakedPeriodInDays, {
+    precision: 2,
+  })
 
   return (
     <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
@@ -26,9 +38,16 @@ const VeNftSummaryStatsSection = ({
         column={1}
       >
         <Descriptions.Item label={t`Total staked ${tokenSymbolDisplayText}`}>
-          0
+          {totalStaked}
         </Descriptions.Item>
-        <Descriptions.Item label={t`Total staked period`}>0</Descriptions.Item>
+        <Descriptions.Item label={t`Total staked period`}>
+          {`${formattedTotalStakedPeriod} `}
+          <Plural
+            value={totalStakedPeriodInDays}
+            one={t`day`}
+            other={t`days`}
+          />
+        </Descriptions.Item>
       </Descriptions>
     </div>
   )

--- a/src/components/veNft/VeNftUnlockModal.tsx
+++ b/src/components/veNft/VeNftUnlockModal.tsx
@@ -1,0 +1,101 @@
+import { t, Trans } from '@lingui/macro'
+import { Form } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { useUnlockTx } from 'hooks/veNft/transactor/VeNftUnlockTx'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+import { useContext, useState } from 'react'
+import { emitSuccessNotification } from 'utils/notifications'
+
+import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
+import TransactionModal from 'components/TransactionModal'
+
+type UnlockModalProps = {
+  visible: boolean
+  token: VeNftToken
+  tokenSymbolDisplayText: string
+  onCancel: VoidFunction
+  onCompleted: VoidFunction
+}
+
+const UnlockModal = ({
+  visible,
+  token,
+  tokenSymbolDisplayText,
+  onCancel,
+  onCompleted,
+}: UnlockModalProps) => {
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { tokenId } = token
+  const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
+  const [form] = useForm<{ beneficiary: string }>()
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const unlockTx = useUnlockTx()
+
+  const unlock = async () => {
+    await form.validateFields()
+
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const beneficiary = form.getFieldValue('beneficiary')
+    const txBeneficiary = beneficiary ? beneficiary : userAddress
+    setLoading(true)
+
+    const txSuccess = await unlockTx(
+      {
+        tokenId,
+        beneficiary: txBeneficiary,
+      },
+      {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
+          setLoading(false)
+          emitSuccessNotification(
+            t`Unlock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <TransactionModal
+      visible={visible}
+      title={t`Unlock veNFT`}
+      onCancel={onCancel}
+      onOk={unlock}
+      okText={`Unlock`}
+      confirmLoading={loading}
+      transactionPending={transactionPending}
+    >
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>
+            Unlocking this staking position will burn your NFT and return $
+            {tokenSymbolDisplayText}.
+          </Trans>
+        </p>
+      </div>
+      <Form form={form} layout="vertical">
+        <CustomBeneficiaryInput form={form} />
+      </Form>
+    </TransactionModal>
+  )
+}
+
+export default UnlockModal

--- a/src/components/veNft/veNftCarousel.tsx
+++ b/src/components/veNft/veNftCarousel.tsx
@@ -1,5 +1,114 @@
-const veNftCarousel = () => {
-  return <div>veNftCarousel</div>
+import { Row, Col, Image, FormInstance } from 'antd'
+import { VeNftVariant } from 'models/v2/veNft'
+import { getVeNftBaseImage } from 'utils/v2/veNft'
+
+type StakingNFTCarouselProps = {
+  tokensStaked: string
+  variants: VeNftVariant[]
+  baseImagesHash: string
+  form: FormInstance
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tokenMetadata: any
 }
 
-export default veNftCarousel
+export default function StakingNFTCarousel({
+  form,
+  tokensStaked,
+  variants,
+  baseImagesHash,
+  tokenMetadata,
+}: StakingNFTCarouselProps) {
+  const activeIdx = variants
+    ? Math.max(
+        variants.findIndex(variant => {
+          const curTokens = parseInt(tokensStaked)
+          return (
+            variant.tokensStakedMin <= curTokens &&
+            (variant.tokensStakedMax
+              ? variant.tokensStakedMax > curTokens
+              : true)
+          )
+        }),
+        0,
+      )
+    : 0
+
+  const prevVariant = activeIdx - 1 < 0 ? undefined : variants[activeIdx - 1]
+  const prevVariantImage = prevVariant
+    ? getVeNftBaseImage(baseImagesHash, prevVariant)
+    : undefined
+  const currentVariant = variants[activeIdx]
+  const currentImage = tokenMetadata
+    ? tokenMetadata.thumbnailUri
+    : getVeNftBaseImage(baseImagesHash, currentVariant)
+  const nextVariant =
+    activeIdx + 1 >= variants.length ? undefined : variants[activeIdx + 1]
+  const nextVariantImage = nextVariant
+    ? getVeNftBaseImage(baseImagesHash, nextVariant)
+    : undefined
+
+  const nonActiveStyle = { opacity: 0.3 }
+
+  const handleImageClick = (variant: VeNftVariant) => {
+    form.setFieldsValue({ tokensStaked: variant.tokensStakedMin })
+  }
+
+  const dims = 150
+
+  const variantRangeInfo = (variant: VeNftVariant, opacity?: number) => {
+    return (
+      <p style={{ textAlign: 'center', opacity: opacity }}>
+        {variant.tokensStakedMin}-
+        {variant.tokensStakedMax ? variant.tokensStakedMax : '+'}
+      </p>
+    )
+  }
+
+  return (
+    <Row>
+      <Col span={8}>
+        {prevVariant && (
+          <>
+            <div onClick={() => handleImageClick(prevVariant)}>
+              <Image
+                src={prevVariantImage}
+                preview={false}
+                style={nonActiveStyle}
+                width={dims}
+                height={dims}
+              />
+            </div>
+            {variantRangeInfo(prevVariant, 0.8)}
+          </>
+        )}
+      </Col>
+      <Col span={8}>
+        <div onClick={() => handleImageClick(currentVariant)}>
+          <Image
+            src={currentImage}
+            preview={false}
+            width={dims}
+            height={dims}
+          />
+        </div>
+        {variantRangeInfo(currentVariant)}
+      </Col>
+      <Col span={8}>
+        {nextVariant && (
+          <>
+            <div onClick={() => handleImageClick(nextVariant)}>
+              <Image
+                src={nextVariantImage}
+                preview={false}
+                style={nonActiveStyle}
+                width={dims}
+                height={dims}
+              />
+            </div>
+            {variantRangeInfo(nextVariant, 0.8)}
+          </>
+        )}
+      </Col>
+    </Row>
+  )
+}

--- a/src/components/veNft/veNftCarousel.tsx
+++ b/src/components/veNft/veNftCarousel.tsx
@@ -8,7 +8,7 @@ type StakingNFTCarouselProps = {
   variants: VeNftVariant[]
   baseImagesHash: string
   form: FormInstance
-  tokenMetadata: VeNftTokenMetadata
+  tokenMetadata: VeNftTokenMetadata | undefined
 }
 
 export default function StakingNFTCarousel({

--- a/src/components/veNft/veNftCarousel.tsx
+++ b/src/components/veNft/veNftCarousel.tsx
@@ -1,14 +1,14 @@
-import { Row, Col, Image, FormInstance } from 'antd'
-import { VeNftVariant } from 'models/v2/veNft'
-import { getVeNftBaseImage } from 'utils/v2/veNft'
+import { Row, FormInstance } from 'antd'
+import { VeNftTokenMetadata, VeNftVariant } from 'models/v2/veNft'
+
+import VeNftCarouselItem from 'components/veNft/VeNftCarouselItem'
 
 type StakingNFTCarouselProps = {
   tokensStaked: string
   variants: VeNftVariant[]
   baseImagesHash: string
   form: FormInstance
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tokenMetadata: any
+  tokenMetadata: VeNftTokenMetadata
 }
 
 export default function StakingNFTCarousel({
@@ -34,81 +34,35 @@ export default function StakingNFTCarousel({
     : 0
 
   const prevVariant = activeIdx - 1 < 0 ? undefined : variants[activeIdx - 1]
-  const prevVariantImage = prevVariant
-    ? getVeNftBaseImage(baseImagesHash, prevVariant)
-    : undefined
   const currentVariant = variants[activeIdx]
-  const currentImage = tokenMetadata
-    ? tokenMetadata.thumbnailUri
-    : getVeNftBaseImage(baseImagesHash, currentVariant)
   const nextVariant =
     activeIdx + 1 >= variants.length ? undefined : variants[activeIdx + 1]
-  const nextVariantImage = nextVariant
-    ? getVeNftBaseImage(baseImagesHash, nextVariant)
-    : undefined
-
-  const nonActiveStyle = { opacity: 0.3 }
 
   const handleImageClick = (variant: VeNftVariant) => {
     form.setFieldsValue({ tokensStaked: variant.tokensStakedMin })
   }
 
-  const dims = 150
-
-  const variantRangeInfo = (variant: VeNftVariant, opacity?: number) => {
-    return (
-      <p style={{ textAlign: 'center', opacity: opacity }}>
-        {variant.tokensStakedMin}-
-        {variant.tokensStakedMax ? variant.tokensStakedMax : '+'}
-      </p>
-    )
-  }
-
   return (
     <Row>
-      <Col span={8}>
-        {prevVariant && (
-          <>
-            <div onClick={() => handleImageClick(prevVariant)}>
-              <Image
-                src={prevVariantImage}
-                preview={false}
-                style={nonActiveStyle}
-                width={dims}
-                height={dims}
-              />
-            </div>
-            {variantRangeInfo(prevVariant, 0.8)}
-          </>
-        )}
-      </Col>
-      <Col span={8}>
-        <div onClick={() => handleImageClick(currentVariant)}>
-          <Image
-            src={currentImage}
-            preview={false}
-            width={dims}
-            height={dims}
-          />
-        </div>
-        {variantRangeInfo(currentVariant)}
-      </Col>
-      <Col span={8}>
-        {nextVariant && (
-          <>
-            <div onClick={() => handleImageClick(nextVariant)}>
-              <Image
-                src={nextVariantImage}
-                preview={false}
-                style={nonActiveStyle}
-                width={dims}
-                height={dims}
-              />
-            </div>
-            {variantRangeInfo(nextVariant, 0.8)}
-          </>
-        )}
-      </Col>
+      <VeNftCarouselItem
+        variant={prevVariant}
+        baseImagesHash={baseImagesHash}
+        isActive={false}
+        handleImageClick={handleImageClick}
+      />
+      <VeNftCarouselItem
+        variant={currentVariant}
+        tokenMetadata={tokenMetadata}
+        baseImagesHash={baseImagesHash}
+        isActive={true}
+        handleImageClick={handleImageClick}
+      />
+      <VeNftCarouselItem
+        variant={nextVariant}
+        baseImagesHash={baseImagesHash}
+        isActive={false}
+        handleImageClick={handleImageClick}
+      />
     </Row>
   )
 }

--- a/src/components/veNft/veNftConfirmStakeModal.tsx
+++ b/src/components/veNft/veNftConfirmStakeModal.tsx
@@ -5,6 +5,7 @@ import FormattedAddress from 'components/FormattedAddress'
 
 import { NetworkContext } from 'contexts/networkContext'
 import { useLockTx } from 'hooks/veNft/transactor/VeNftLockTx'
+import { VeNftTokenMetadata } from 'models/v2/veNft'
 
 import { useContext, useState } from 'react'
 import { formattedNum, parseWad } from 'utils/formatNumber'
@@ -22,6 +23,7 @@ type ConfirmStakeModalProps = {
   votingPower: number
   lockDuration: number
   beneficiary: string
+  tokenMetadata: VeNftTokenMetadata | undefined
   onCancel: VoidFunction
   onCompleted: VoidFunction
 }
@@ -33,6 +35,7 @@ export default function ConfirmStakeModal({
   votingPower,
   lockDuration,
   beneficiary,
+  tokenMetadata,
   onCancel,
   onCompleted,
 }: ConfirmStakeModalProps) {
@@ -134,7 +137,7 @@ export default function ConfirmStakeModal({
         <Col span={4} />
         <Col span={6}>
           <Image
-            src={``} //TODO: add image
+            src={tokenMetadata ? tokenMetadata.thumbnailUri : ''}
             preview={false}
           />
         </Col>

--- a/src/components/veNft/veNftConfirmStakeModal.tsx
+++ b/src/components/veNft/veNftConfirmStakeModal.tsx
@@ -1,7 +1,8 @@
 import { t, Trans } from '@lingui/macro'
-import { Col, Modal, Row, Image, Descriptions } from 'antd'
+import { Col, Row, Image, Descriptions } from 'antd'
 import Callout from 'components/Callout'
 import FormattedAddress from 'components/FormattedAddress'
+import TransactionModal from 'components/TransactionModal'
 
 import { NetworkContext } from 'contexts/networkContext'
 import { useLockTx } from 'hooks/veNft/transactor/VeNftLockTx'
@@ -41,6 +42,7 @@ export default function ConfirmStakeModal({
 }: ConfirmStakeModalProps) {
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
   const recipient = beneficiary !== '' ? beneficiary : userAddress
 
   const tokensStakedInWad = parseWad(tokensStaked)
@@ -60,7 +62,6 @@ export default function ConfirmStakeModal({
       return
     }
 
-    // Prompt wallet connect if no wallet connected
     if (!userAddress && onSelectWallet) {
       onSelectWallet()
     }
@@ -77,7 +78,11 @@ export default function ConfirmStakeModal({
         allowPublicExtension: false,
       },
       {
-        onConfirmed() {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
           setLoading(false)
           emitSuccessNotification(
             t`Lock successful. Results will be indexed in a few moments.`,
@@ -93,16 +98,15 @@ export default function ConfirmStakeModal({
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Confirm Stake`}
       onCancel={onCancel}
       onOk={lock}
       okText={`Lock $${tokenSymbolDisplayText}`}
       confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Confirm Stake</Trans>
-      </h2>
       <Callout>
         <Trans>
           You are agreeing to IRREVOCABLY lock your tokens for{' '}
@@ -135,6 +139,6 @@ export default function ConfirmStakeModal({
           />
         </Col>
       </Row>
-    </Modal>
+    </TransactionModal>
   )
 }

--- a/src/components/veNft/veNftStakingTokenRangesModal.tsx
+++ b/src/components/veNft/veNftStakingTokenRangesModal.tsx
@@ -1,22 +1,64 @@
 import { Trans } from '@lingui/macro'
-import { Modal } from 'antd'
+import { Col, Modal, Row, Image } from 'antd'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { useContext } from 'react'
+import { getVeNftBaseImage } from 'utils/v2/veNft'
 
-interface StakingTokenRangesModalProps {
+type StakingTokenRangesModalProps = {
   visible: boolean
+  tokenSymbolDisplayText: string
   onCancel: VoidFunction
 }
 
-const StakingTokenRangesModal = ({
+export default function StakingTokenRangesModal({
   visible,
+  tokenSymbolDisplayText,
   onCancel,
-}: StakingTokenRangesModalProps) => {
+}: StakingTokenRangesModalProps) {
+  const {
+    veNft: { baseImagesHash, variants },
+  } = useContext(V2ProjectContext)
+
   return (
-    <Modal visible={visible} onCancel={onCancel}>
-      <h2>
-        <Trans>Token Ranges</Trans>
-      </h2>
+    <Modal
+      visible={visible}
+      onCancel={onCancel}
+      cancelText="Close"
+      okButtonProps={{ style: { display: 'none' } }}
+    >
+      <Row>
+        <Col span={6}>
+          <Trans>{tokenSymbolDisplayText} range</Trans>
+        </Col>
+        <Col span={8}>NFT</Col>
+        <Col span={6}>
+          <Trans>Range</Trans>
+        </Col>
+        <Col span={4}>
+          <Trans>Character</Trans>
+        </Col>
+      </Row>
+      {variants &&
+        baseImagesHash &&
+        variants.map(variant => {
+          const image = getVeNftBaseImage(baseImagesHash, variant)
+          const nftRange = `${variant.tokensStakedMin}${
+            variant.tokensStakedMax ? `-${variant.tokensStakedMax}` : '+'
+          }`
+          const nftRangeDifference = variant.tokensStakedMax
+            ? variant.tokensStakedMax - variant.tokensStakedMin + 1
+            : '+'
+          return (
+            <Row key={variant.id}>
+              <Col span={6}>{nftRange}</Col>
+              <Col span={8}>{variant.name}</Col>
+              <Col span={6}>{nftRangeDifference}</Col>
+              <Col span={4}>
+                <Image src={image} preview={false} />
+              </Col>
+            </Row>
+          )
+        })}
     </Modal>
   )
 }
-
-export default StakingTokenRangesModal

--- a/src/contexts/v2/projectContext.ts
+++ b/src/contexts/v2/projectContext.ts
@@ -6,7 +6,7 @@ import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 import { V2FundingCycle, V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 import { NftRewardTier } from 'models/v2/nftRewardTier'
 import { Split } from 'models/v2/splits'
-import { VeNftVariant } from 'models/v2/veNftVariant'
+import { VeNftVariant } from 'models/v2/veNft'
 import { createContext } from 'react'
 
 type V2ProjectLoadingStates = {

--- a/src/hooks/veNft/VeNftBaseImagesHash.ts
+++ b/src/hooks/veNft/VeNftBaseImagesHash.ts
@@ -1,0 +1,5 @@
+import { VARIANTS_HASH } from 'constants/veNft/veNftProject'
+
+export function useVeNftBaseImagesHash() {
+  return VARIANTS_HASH
+}

--- a/src/hooks/veNft/VeNftResolverAddress.ts
+++ b/src/hooks/veNft/VeNftResolverAddress.ts
@@ -1,0 +1,11 @@
+import useV2ContractReader from 'hooks/v2/contractReader/V2ContractReader'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export function useVeNftResolverAddress() {
+  return useV2ContractReader<string>({
+    contract: useVeNftContract(VENFT_CONTRACT_ADDRESS),
+    functionName: 'uriResolver',
+  })
+}

--- a/src/hooks/veNft/VeNftResolverContract.ts
+++ b/src/hooks/veNft/VeNftResolverContract.ts
@@ -1,0 +1,37 @@
+import { isAddress } from '@ethersproject/address'
+import { Contract } from '@ethersproject/contracts'
+
+import { NetworkContext } from 'contexts/networkContext'
+
+import * as constants from '@ethersproject/constants'
+import { useContext, useEffect, useState } from 'react'
+
+import { readProvider } from 'constants/readProvider'
+import { veNftResolverAbi } from 'constants/veNft/veNftResolverAbi'
+
+export function useVeNftResolverContract(address: string | undefined) {
+  const [contract, setContract] = useState<Contract>()
+  const { signingProvider } = useContext(NetworkContext)
+
+  useEffect(() => {
+    const provider = signingProvider ?? readProvider
+
+    provider.listAccounts().then(accounts => {
+      if (
+        !address ||
+        !isAddress(address) ||
+        address === constants.AddressZero
+      ) {
+        setContract(undefined)
+      } else if (!accounts.length) {
+        setContract(new Contract(address, veNftResolverAbi, readProvider))
+      } else {
+        setContract(
+          new Contract(address, veNftResolverAbi, provider.getSigner()),
+        )
+      }
+    })
+  }, [address, signingProvider])
+
+  return contract
+}

--- a/src/hooks/veNft/VeNftResolverTokenUri.ts
+++ b/src/hooks/veNft/VeNftResolverTokenUri.ts
@@ -1,0 +1,18 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
+
+import { useVeNftResolverContract } from 'hooks/veNft/VeNftResolverContract'
+
+import useV2ContractReader from '../v2/contractReader/V2ContractReader'
+
+export function useVeNftResolverTokenUri(
+  resolverAddress: string | undefined,
+  amount: BigNumber,
+  duration: BigNumberish,
+  lockDurationOptions: BigNumber[] | undefined,
+) {
+  return useV2ContractReader<string>({
+    contract: useVeNftResolverContract(resolverAddress),
+    functionName: 'tokenURI',
+    args: [1, amount, duration, 1, lockDurationOptions],
+  })
+}

--- a/src/hooks/veNft/VeNftResolverTokenUri.ts
+++ b/src/hooks/veNft/VeNftResolverTokenUri.ts
@@ -13,6 +13,12 @@ export function useVeNftResolverTokenUri(
   return useV2ContractReader<string>({
     contract: useVeNftResolverContract(resolverAddress),
     functionName: 'tokenURI',
-    args: [1, amount, duration, 1, lockDurationOptions],
+    args: [
+      1, // _tokenId
+      amount, // _amount
+      duration, // _duration
+      1, // _lockEndTime
+      lockDurationOptions, // _lockDurationOptions
+    ],
   })
 }

--- a/src/hooks/veNft/VeNftSummaryStats.ts
+++ b/src/hooks/veNft/VeNftSummaryStats.ts
@@ -1,0 +1,27 @@
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+import { fromWad } from 'utils/formatNumber'
+
+export type VeNftSummaryStats = {
+  totalStaked: number
+  totalStakedPeriod: number
+}
+
+export function useVeNftSummaryStats(userTokens: VeNftToken[] | undefined) {
+  if (!userTokens) {
+    return {
+      totalStaked: 0,
+      totalStakedPeriod: 0,
+    }
+  }
+
+  const summaryStats: VeNftSummaryStats = {
+    totalStaked: userTokens.reduce((acc, token) => {
+      return acc + parseInt(fromWad(token.lockAmount))
+    }, 0),
+    totalStakedPeriod: userTokens.reduce((acc, token) => {
+      return acc + token.lockDuration
+    }, 0),
+  }
+
+  return summaryStats
+}

--- a/src/hooks/veNft/VeNftTokenMetadata.ts
+++ b/src/hooks/veNft/VeNftTokenMetadata.ts
@@ -1,0 +1,26 @@
+import axios from 'axios'
+import { VeNftTokenMetadata } from 'models/v2/veNft'
+import { useQuery } from 'react-query'
+import { ipfsCidUrl } from 'utils/ipfs'
+
+export function useVeNftTokenMetadata(tokenUri: string | undefined) {
+  const hash = tokenUri ? tokenUri.split('ipfs://')[1] : undefined
+  return useQuery(
+    ['nft-metadata', hash],
+    async () => {
+      if (!hash) {
+        throw new Error('NFT hash not specified.')
+      }
+      const url = ipfsCidUrl(hash)
+      const response = await axios.get(url)
+      const metadata: VeNftTokenMetadata = {
+        thumbnailUri: response.data.thumbnailUri,
+      }
+      return metadata
+    },
+    {
+      enabled: !!tokenUri,
+      staleTime: 60000,
+    },
+  )
+}

--- a/src/hooks/veNft/VeNftUserTokens.ts
+++ b/src/hooks/veNft/VeNftUserTokens.ts
@@ -1,0 +1,29 @@
+import { NetworkContext } from 'contexts/networkContext'
+import useSubgraphQuery from 'hooks/SubgraphQuery'
+import { useContext } from 'react'
+
+export const useVeNftUserTokens = () => {
+  const { userAddress } = useContext(NetworkContext)
+  return useSubgraphQuery({
+    entity: 'veNftToken',
+    keys: [
+      'tokenId',
+      'tokenUri',
+      'owner',
+      'lockAmount',
+      'lockDuration',
+      'lockEnd',
+      'lockUseJbToken',
+      'lockAllowPublicExtension',
+      'createdAt',
+      'unlockedAt',
+      'redeemedAt',
+    ],
+    where: [
+      {
+        key: 'owner',
+        value: userAddress || '',
+      },
+    ],
+  })
+}

--- a/src/hooks/veNft/VeNftVariants.ts
+++ b/src/hooks/veNft/VeNftVariants.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { VeNftVariant } from 'models/v2/veNftVariant'
+import { VeNftVariant } from 'models/v2/veNft'
 import { useQuery } from 'react-query'
 import { ipfsCidUrl } from 'utils/ipfs'
 

--- a/src/hooks/veNft/VeNftVariants.ts
+++ b/src/hooks/veNft/VeNftVariants.ts
@@ -1,0 +1,52 @@
+import axios from 'axios'
+
+import { VeNftVariant } from 'models/v2/veNftVariant'
+import { useQuery } from 'react-query'
+import { ipfsCidUrl } from 'utils/ipfs'
+
+import { VARIANTS_HASH } from 'constants/veNft/veNftProject'
+
+type VeNftMetadataResponse = {
+  metadata: {
+    name: string
+    jbx_range: string
+  }
+}
+
+export function useVeNftVariants() {
+  const hash = VARIANTS_HASH
+  return useQuery(
+    ['nft-variants', hash],
+    async () => {
+      if (!hash) {
+        throw new Error('Variants hash not specified.')
+      }
+      const file = hash + '/characters.json'
+      const url = ipfsCidUrl(file)
+      const response = await axios.get(url)
+      const data: Record<string, VeNftMetadataResponse> = response.data
+      const variants: VeNftVariant[] = Object.entries(data).map(
+        ([id, variant]) => {
+          const { name, jbx_range } = variant.metadata
+          const split = jbx_range.split('-')
+          const tokensStakedMin = parseInt(split[0].replaceAll(',', ''))
+          const tokensStakedMax =
+            split.length > 1
+              ? parseInt(split[1].replaceAll(',', ''))
+              : undefined
+          return {
+            id: parseInt(id),
+            name: name.replaceAll('_', ' '),
+            tokensStakedMin,
+            tokensStakedMax,
+          }
+        },
+      )
+      return variants
+    },
+    {
+      enabled: !!hash,
+      staleTime: 60000,
+    },
+  )
+}

--- a/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
@@ -1,0 +1,33 @@
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type ExtendLockTx = TransactorInstance<{
+  tokenId: number
+  updatedDuration: number
+}>
+
+export function useExtendLockTx(): ExtendLockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+
+  return ({ tokenId, updatedDuration }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'extendLock',
+      [[{ tokenId, updatedDuration }]],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftRedeemTx.ts
+++ b/src/hooks/veNft/transactor/VeNftRedeemTx.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type RedeemVeNftTx = TransactorInstance<{
+  tokenId: number
+  token: string
+  beneficiary: string
+  memo: string
+  terminal: string
+}>
+
+export function useRedeemVeNftTx(): RedeemVeNftTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+  const minReturnedTokens = BigNumber.from(0) // TODO will need a field for this in V2ConfirmPayOwnerModal
+  const metadata: string[] = [] //randomBytes(1)
+
+  return ({ tokenId, token, beneficiary, memo, terminal }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'redeem',
+      [
+        [
+          {
+            tokenId,
+            token,
+            minReturnedTokens,
+            beneficiary,
+            memo,
+            metadata,
+            terminal,
+          },
+        ],
+      ],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftUnlockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftUnlockTx.ts
@@ -1,0 +1,28 @@
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type UnlockTx = TransactorInstance<{
+  tokenId: number
+  beneficiary: string
+}>
+
+export function useUnlockTx(): UnlockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+
+  return ({ tokenId, beneficiary }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(nftContract, 'unlock', [[{ tokenId, beneficiary }]], {
+      ...txOpts,
+    })
+  }
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -4157,4 +4157,3 @@ msgstr "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% of total supply"
 
-

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -301,6 +301,10 @@ msgstr ""
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr "A veNft can only be redeemed if the project currently has overflow."
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVED"
@@ -1424,6 +1428,15 @@ msgstr "Error uploading file"
 msgid "Explore projects"
 msgstr "Explore projects"
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr "Extend Lock"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr "Extend lock successful. Results will be indexed in a few moments."
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr ""
@@ -1835,6 +1848,7 @@ msgstr ""
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr "Lock ${tokenSymbolDisplayText} for Voting Power"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr "Lock Duration"
@@ -1852,6 +1866,10 @@ msgstr "Lock successful. Results will be indexed in a few moments."
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Lock until"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr "Locked {tokenSymbolDisplayText}"
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2610,6 +2628,19 @@ msgstr "Reconfigure upcoming funding"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigure upcoming funding cycles"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr "Redeem"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr "Redeem successful. Results will be indexed in a few moments."
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr "Redeem veNFT"
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2632,6 +2663,10 @@ msgstr "Redeem {tokensTextLong} for ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Redeemed"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr "Redeeming this NFT will burn the token and return..."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3239,6 +3274,10 @@ msgstr "This will erase all of your changes."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "This will reset the data for your new project. All changes will be lost."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr "Time Remaining"
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
@@ -3466,6 +3505,22 @@ msgstr "Unknown Project"
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr "Unlock"
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr "Unlock successful. Results will be indexed in a few moments."
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr "Unlock veNFT"
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
@@ -3482,6 +3537,10 @@ msgstr "Untrack token"
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr "Update your veNFT's lock duration."
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3881,6 +3940,11 @@ msgstr ""
 msgid "called by <0/>"
 msgstr "called by <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr "day"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4144,6 +4208,10 @@ msgstr "{tokensText} reserved"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} amount"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -723,7 +723,7 @@ msgstr "Changes will take effect according to the project's custom ballot contra
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr "Character"
 
@@ -2501,7 +2501,7 @@ msgstr "Provide a link to additional information about this NFT."
 msgid "Raised on Juicebox"
 msgstr "Raised on Juicebox"
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr "Range"
 
@@ -4101,6 +4101,10 @@ msgstr "{paymentCount, plural, one {# payment} other {# payments}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr "{tokenSymbolDisplayText} range"
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr "{tokenSymbolDisplayText} to lock"
@@ -4112,10 +4116,6 @@ msgstr "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can c
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 address"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr "{tokenSymbol} range"
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -723,6 +723,10 @@ msgstr "Changes will take effect according to the project's custom ballot contra
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr "Character"
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
@@ -2497,6 +2501,10 @@ msgstr "Provide a link to additional information about this NFT."
 msgid "Raised on Juicebox"
 msgstr "Raised on Juicebox"
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr "Range"
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
@@ -3241,10 +3249,6 @@ msgstr ""
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr "Token Ranges"
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4108,6 +4112,10 @@ msgstr "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can c
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 address"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr "{tokenSymbol} range"
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -728,7 +728,7 @@ msgstr "Los cambios surtirán efecto de acuerdo al contrato personalizado de vot
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Los cambios que hagas surtirán efecto de acuerdo a tu <0>{0}</0> regla de reconfiguración (primer ciclo de financiamiento siguiente <1>{1}</1> desde ahora)."
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
@@ -4106,6 +4106,10 @@ msgstr "{paymentCount, plural, one {# pago} other {# pagos}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr ""
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
@@ -4117,10 +4121,6 @@ msgstr "{tokenSymbolPluralCap} recibidos por cada ETH pagado al tesoro. Esto pue
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} dirección ERC-20"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -306,6 +306,10 @@ msgstr "Una reconfiguración para el siguiente ciclo de financiación debe ser p
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Un porcentaje reservado de más del 90% es riesgoso para los contribuidores. Los contribuidores no recibirán suficientes tokens por su contribución."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVADO"
@@ -1429,6 +1433,15 @@ msgstr ""
 msgid "Explore projects"
 msgstr "Explorar proyectos"
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "Preguntas frecuentes"
@@ -1840,6 +1853,7 @@ msgstr "Cargar más"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1857,6 +1871,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquear hasta"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2615,6 +2633,19 @@ msgstr "Reconfigurar financiamientos próximos"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamiento próximos"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Canjea tus {tokensLabel} por una porción del excedente del proyecto. Cualquier {tokensLabel} que canjees será quemado."
@@ -2637,6 +2668,10 @@ msgstr "Canjear {tokensTextLong} por ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Canjeado"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3244,6 +3279,10 @@ msgstr "Esto borrará todos tus cambios."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "Esto reiniciará los datos para tu nuevo proyecto. Todos los cambios se perderán."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3471,6 +3510,22 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A menos que los pagos estén en pausa en la configuración del ciclo de financiamiento, tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo de Juicebox."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr ""
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
@@ -3487,6 +3542,10 @@ msgstr "Dejar de seguir token"
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Próximos"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3886,6 +3945,11 @@ msgstr "{0}% después de la comisión de JBX"
 msgid "called by <0/>"
 msgstr "llamado por <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4149,6 +4213,10 @@ msgstr "{tokensText} reservados"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "cantidad de {tokensTokenUpper}"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -4162,4 +4162,3 @@ msgstr ""
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage} % de suministro total"
 
-

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -728,6 +728,10 @@ msgstr "Los cambios surtirán efecto de acuerdo al contrato personalizado de vot
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Los cambios que hagas surtirán efecto de acuerdo a tu <0>{0}</0> regla de reconfiguración (primer ciclo de financiamiento siguiente <1>{1}</1> desde ahora)."
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Marca esto para acuñar {tokenSymbol} ERC-20 a tu cartera. Deja desmarcado para que tu balance de tokens sea registrado por Juicebox, ahorrando gas en está transacción. Siempre puedes reclamar tus tokens ERC-20 después."
@@ -2502,6 +2506,10 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr ""
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Clasificaciones basadas en el número de contribuciones y volumen obtenido en los últimos {trendingWindow} días. <0>Ver código</0>"
@@ -3246,10 +3254,6 @@ msgstr "Para: <0/>"
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr ""
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4113,6 +4117,10 @@ msgstr "{tokenSymbolPluralCap} recibidos por cada ETH pagado al tesoro. Esto pue
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} dirección ERC-20"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -728,6 +728,10 @@ msgstr "Les modifications prendront effet selon les choix de projet du contrat a
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Les modifications que vous apportez prendront effet selon votre <0>{0}</0> règle de reconfiguration (le prochain cycle de financement à compter<1>{1}</1> de cette date)."
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Cochez ceci pour frapper {tokenSymbol} ERC-20 vers votre portefeuille. Laissez décoché pour que votre solde soit suivi par Juicebox, tout en économisant du gaz dans cette transaction. Vous pouvez toujours réclamer vos tokens ERC-20 plus tard."
@@ -2502,6 +2506,10 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr ""
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Classements basés sur le nombre de contributions et le volume gagné au cours des derniers {trendingWindow} jours. <0>Voir le code</0>"
@@ -3246,10 +3254,6 @@ msgstr "À : <0/>"
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr ""
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4113,6 +4117,10 @@ msgstr "{tokenSymbolPluralCap} reçu par ETH payé à la trésorerie. Cela peut 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} adresse ERC-20"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -306,6 +306,10 @@ msgstr "Le reparamétrage d'un cycle de financement à venir doit être soumis a
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Un taux réservé supérieur à 90% est risqué pour les contributeurs. Les contributeurs ne recevront pas beaucoup de tokens pour leur contribution."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVÉ"
@@ -1429,6 +1433,15 @@ msgstr ""
 msgid "Explore projects"
 msgstr "Explorer des projets"
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "FAQ"
@@ -1840,6 +1853,7 @@ msgstr "Télécharger d'avantage"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1857,6 +1871,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquer jusqu'à"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2615,6 +2633,19 @@ msgstr "Modifier les prochains financements"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurer les prochains cycles de financement"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Récupérer vos {tokensLabel} d'une portion de l'overflow du projet. Aucun {tokensLabel} récupéré sera brûlé."
@@ -2637,6 +2668,10 @@ msgstr "Récupérer {tokensTextLong} pour ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Récupéré"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3244,6 +3279,10 @@ msgstr "Cela effacera toutes vos modifications."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3471,6 +3510,22 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr ""
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Modifications non sauvegardées"
@@ -3487,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "À venir"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3886,6 +3945,11 @@ msgstr "après {0}% de frais JBX"
 msgid "called by <0/>"
 msgstr "appelé par <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4149,6 +4213,10 @@ msgstr "{tokensText} réservés"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} montant"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -728,7 +728,7 @@ msgstr "Les modifications prendront effet selon les choix de projet du contrat a
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Les modifications que vous apportez prendront effet selon votre <0>{0}</0> règle de reconfiguration (le prochain cycle de financement à compter<1>{1}</1> de cette date)."
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
@@ -4106,6 +4106,10 @@ msgstr "{paymentCount, plural, one {# paiement} other {# paiements}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr ""
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
@@ -4117,10 +4121,6 @@ msgstr "{tokenSymbolPluralCap} reçu par ETH payé à la trésorerie. Cela peut 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} adresse ERC-20"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -4162,4 +4162,3 @@ msgstr ""
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de l'offre totale"
 
-

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -4162,4 +4162,3 @@ msgstr ""
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de fornecimento total"
 
-

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -728,7 +728,7 @@ msgstr ""
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Mudanças que você fizer terão efeito de acordo com sua regra de reconfiguração <0>{0}</0> (o primeiro ciclo de financiamento após o <1>{1}</1> a partir de agora)."
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
@@ -4106,6 +4106,10 @@ msgstr "{paymentCount, plural, one {# pagamento} other {# pagamentos}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr ""
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
@@ -4117,10 +4121,6 @@ msgstr "{tokenSymbolPluralCap} recebido por ETH pagos para o tesouro. Isto pode 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} Endereço ERC-20"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -306,6 +306,10 @@ msgstr "Uma reconfiguração de um ciclo de financiamento deve ser submetida pel
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Uma tava de reserva de mais de 90% é um risco para os contribuidores. Os contribuidores não receberão muitos tokens por sua contribuição."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARQUIVADO"
@@ -1429,6 +1433,15 @@ msgstr ""
 msgid "Explore projects"
 msgstr "Explore projetos"
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "FAQ"
@@ -1840,6 +1853,7 @@ msgstr "Carregar mais"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1857,6 +1871,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Trancar até"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2615,6 +2633,19 @@ msgstr "Reconfigurar financiamento futuro"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamento futuros"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Resgate seus {tokensLabel} por uma porção do overflow do projeto. Qualquer {tokensLabel} que você resgatar será queimado."
@@ -2637,6 +2668,10 @@ msgstr "Resgatar {tokensTextLong} por ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Resgatado"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3244,6 +3279,10 @@ msgstr "Isso vai apagar todas as suas mudanças."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3471,6 +3510,22 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A não ser que os pagamentos estejam pausados nas suas configurações de ciclo de financiamento, o seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr ""
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Mudanças não salvas"
@@ -3487,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Futuro"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3886,6 +3945,11 @@ msgstr "depois da taxa de {0}% de JBX"
 msgid "called by <0/>"
 msgstr "chamado por <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4149,6 +4213,10 @@ msgstr "{tokensText} reservados"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "quantidade de {tokensTokenUpper}"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -728,6 +728,10 @@ msgstr ""
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Mudanças que você fizer terão efeito de acordo com sua regra de reconfiguração <0>{0}</0> (o primeiro ciclo de financiamento após o <1>{1}</1> a partir de agora)."
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Marque isso para emitir os tokens {tokenSymbol} ERC-20 do projeto para sua carteira. Deixe desmarcados para deixar que o Juicebox monitore o seu saldo de tokens, economizando o gás da transação. Você sempre pode reivindicar seus tokens posteriormente."
@@ -2502,6 +2506,10 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr ""
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Rankings baseados em número de contribuições e volume ganho nos últimos {trendingWindow} dias. <0>Ver código</0>"
@@ -3246,10 +3254,6 @@ msgstr "Para: <0/>"
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr ""
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4113,6 +4117,10 @@ msgstr "{tokenSymbolPluralCap} recebido por ETH pagos para o tesouro. Isto pode 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} Endereço ERC-20"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -728,7 +728,7 @@ msgstr "Изменения вступят в силу в соответстви�
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
@@ -4106,6 +4106,10 @@ msgstr "{paymentCount, plural, one {# платеж} other {# платежи}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr ""
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr ""
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
@@ -4117,10 +4121,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC20 адрес"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -306,6 +306,10 @@ msgstr "Реконфигурацию/план изменений для пред
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Резервная ставка более 90% является рискованной для вкладчиков. Вкладчики не получат много токенов за свой вклад."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "АРХИВИРОВАНО"
@@ -1429,6 +1433,15 @@ msgstr ""
 msgid "Explore projects"
 msgstr ""
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "FAQ (Вопросы)"
@@ -1840,6 +1853,7 @@ msgstr "Загрузить ещё"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1857,6 +1871,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Заблокировать до"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2615,6 +2633,19 @@ msgstr "Перенастроить предстоящие финансирова
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Перенастроить предстоящие циклы финансирования"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Обменяйте свои {tokensLabel} на часть перелива проекта. Все {tokensLabel}, которые вы выкупите, будут сожжены."
@@ -2636,6 +2667,10 @@ msgstr "Обменять {tokensTextLong} за ETH"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -3244,6 +3279,10 @@ msgstr "Это удалит все ваши изменения."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3471,6 +3510,22 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr ""
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Несохраненные изменения"
@@ -3487,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Предстоящие"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3886,6 +3945,11 @@ msgstr "после  {0}% комиссии JBX"
 msgid "called by <0/>"
 msgstr ""
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4149,6 +4213,10 @@ msgstr "{tokensText} зарезервировано"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} количество"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -728,6 +728,10 @@ msgstr "Изменения вступят в силу в соответстви�
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Проверьте это, чтобы минтить {tokenSymbol} ERC-20 на ваш кошелек. Оставьте флажок не отмеченным, чтобы ваш баланс токенов отслеживался Juicebox, экономя газ на этой транзакции. Вы всегда можете потребовать свои токены ERC-20 позже."
@@ -2502,6 +2506,10 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr ""
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Рейтинг, основанный на количестве вкладов и объеме, полученном за последние {trendingWindow} дней. <0>Увидеть код</0>"
@@ -3246,10 +3254,6 @@ msgstr "Кому: <0/>"
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Токен"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr ""
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4113,6 +4117,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC20 адрес"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -4162,4 +4162,3 @@ msgstr ""
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% от общего объема предложения"
 
-

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -728,7 +728,7 @@ msgstr "Değişiklikler, projenin özel oylama sözleşmesine göre yürürlüğ
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Yaptığınız değişiklikler, <0>{0}</0> yeniden yapılandırma kuralınıza göre geçerlilik kazanacaktır (şu andan itibaren <1>{1}</1>'den sonraki ilk finansman döngüsü)."
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
@@ -4106,6 +4106,10 @@ msgstr "{paymentCount, plural, one {# ödeme} other {# ödeme}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH (%{0})"
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr ""
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
@@ -4117,10 +4121,6 @@ msgstr "Hazineye ödenen ETH başına alınan {tokenSymbolPluralCap} token'ı. B
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 addresi"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -4162,4 +4162,3 @@ msgstr ""
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "Toplam arzın %{userOwnershipPercentage} kadarı"
 
-

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -728,6 +728,10 @@ msgstr "Değişiklikler, projenin özel oylama sözleşmesine göre yürürlüğ
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Yaptığınız değişiklikler, <0>{0}</0> yeniden yapılandırma kuralınıza göre geçerlilik kazanacaktır (şu andan itibaren <1>{1}</1>'den sonraki ilk finansman döngüsü)."
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Cüzdanınıza {tokenSymbol} ERC-20 basmak için burayı işaretleyin. Token bakiyenizin Juicebox tarafından takip edilmesini sağlamak için işaretlemeden bırakın ve bu işlemde gazdan tasarruf edin. ERC-20 token'larınızı daha sonra her zaman talep edebilirsiniz."
@@ -2502,6 +2506,10 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr ""
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Katkı sayısına ve son {trendingWindow} gün içinde kazanılan hacme dayalı sıralamalar. <0>Kodu gör</0>"
@@ -3246,10 +3254,6 @@ msgstr "Kime: <0/>"
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr ""
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4113,6 +4117,10 @@ msgstr "Hazineye ödenen ETH başına alınan {tokenSymbolPluralCap} token'ı. B
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 addresi"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -306,6 +306,10 @@ msgstr "Yaklaşan bir finansman döngüsü için yeniden yapılandırma, döngü
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "%90'ın üzerindeki rezerv oranları, katkıda bulunanlar için risklidir. Katkıda bulunanlar, katkıları karşılığında çok fazla token almazlar."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARŞİVLENDİ"
@@ -1429,6 +1433,15 @@ msgstr ""
 msgid "Explore projects"
 msgstr "Projeleri keşfedin"
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "SSS"
@@ -1840,6 +1853,7 @@ msgstr "Daha fazla yükle"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1857,6 +1871,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Kilit süresi bitiş tarihi"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2615,6 +2633,19 @@ msgstr "Yaklaşan finansmanı yeniden yapılandır"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Yaklaşan finansman döngülerini yeniden yapılandır"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "{tokensLabel} token'larınızı, projenin taşmasının bir kısmını talep etmek için kullanın. Kullanılan her {tokensLabel} token'ı yakılacaktır."
@@ -2637,6 +2668,10 @@ msgstr "{tokensTextLong} token'larını ETH için kullan"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Kullanılan"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3244,6 +3279,10 @@ msgstr "Yaptığınız tüm değişiklikler silinecektir."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3471,6 +3510,22 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr ""
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Kaydedilmeyen değişiklikler"
@@ -3487,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Yaklaşan"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3886,6 +3945,11 @@ msgstr "%{0} JBX ücretinden sonra"
 msgid "called by <0/>"
 msgstr ""
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4149,6 +4213,10 @@ msgstr "Rezerve {tokensText} token'ları"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} token miktarı"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -306,6 +306,10 @@ msgstr "对之后筹款周期的重新配置，至少得提前七天提交。"
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "代币保留率超过90%对捐款人是有风险的。捐款人能获得的代币数量不多。"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "已存档"
@@ -1429,6 +1433,15 @@ msgstr ""
 msgid "Explore projects"
 msgstr "探索项目"
 
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr ""
+
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "常见问题解答"
@@ -1840,6 +1853,7 @@ msgstr "加载更多"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1857,6 +1871,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "锁定至"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2615,6 +2633,19 @@ msgstr "重新配置之后的筹款"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "重新配置以后的筹款周期"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "赎回你的 {tokensLabel} 来获取一部分项目的溢出资金。用于赎回的 {tokensLabel} 将会被燃烧掉。"
@@ -2637,6 +2668,10 @@ msgstr "燃烧 {tokensTextLong} 来赎回 ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "赎回"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3244,6 +3279,10 @@ msgstr "这将删除你所有的更改。"
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time Remaining"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3471,6 +3510,22 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "除非在项目筹款周期设置中将付款暂停，否则项目仍能通过 Juicebox 协议的合约直接收到付款。"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr ""
+
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "未保存更改"
@@ -3487,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "未来"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -3886,6 +3945,11 @@ msgstr "计算 {0}% JBX 费用之后"
 msgid "called by <0/>"
 msgstr "由 <0/> 调用"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4149,6 +4213,10 @@ msgstr "{tokensText} 已保留"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} 数量"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -728,6 +728,10 @@ msgstr "变更的生效将照按项目自定义的选票合约来执行。"
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "你作出的变更将按照你的 <0>{0}</0> 重新配置规则生效 (从现在开始<1>{1}</1> 后的第一个完整周期生效)。"
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Character"
+msgstr ""
+
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "勾选此项来铸造{tokenSymbol} ERC-20 代币并领取到你的钱包。不勾选可以降低本次交易的 gas 费用，你的代币余额将交由 Juicebox 托管。 你以后可以随时再来领取你的 ERC-20 代币。"
@@ -2502,6 +2506,10 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "Range"
+msgstr ""
+
 #: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "按最近 {trendingWindow} 天的支付次数与数额排行。<0>查看代码</0>"
@@ -3246,10 +3254,6 @@ msgstr "分配给：<0/>"
 #: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "代币"
-
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
-msgid "Token Ranges"
-msgstr ""
 
 #: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
@@ -4113,6 +4117,10 @@ msgstr "每向金库捐款 1 ETH 获得的 {tokenSymbolPluralCap} 代币。 这�
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 地址"
+
+#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbol} range"
+msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -4162,4 +4162,3 @@ msgstr ""
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "总供应量的 {userOwnershipPercentage}%"
 
-

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -728,7 +728,7 @@ msgstr "变更的生效将照按项目自定义的选票合约来执行。"
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "你作出的变更将按照你的 <0>{0}</0> 重新配置规则生效 (从现在开始<1>{1}</1> 后的第一个完整周期生效)。"
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
@@ -4106,6 +4106,10 @@ msgstr "{paymentCount, plural, one {# 笔付款} other {# 笔付款}}"
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
+#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
+msgid "{tokenSymbolDisplayText} range"
+msgstr ""
+
 #: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
@@ -4117,10 +4121,6 @@ msgstr "每向金库捐款 1 ETH 获得的 {tokenSymbolPluralCap} 代币。 这�
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 地址"
-
-#: src/components/veNft/veNftStakingTokenRangesModal.tsx
-msgid "{tokenSymbol} range"
-msgstr ""
 
 #: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."

--- a/src/models/subgraph-entities/v2/venft-token.ts
+++ b/src/models/subgraph-entities/v2/venft-token.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { VeNftVariant } from 'models/v2/veNftVariant'
+import { VeNftVariant } from 'models/v2/veNft'
 
 export interface VeNftToken {
   tokenId: number

--- a/src/models/v2/veNft.ts
+++ b/src/models/v2/veNft.ts
@@ -4,3 +4,7 @@ export type VeNftVariant = {
   tokensStakedMin: number
   tokensStakedMax?: number
 }
+
+export type VeNftTokenMetadata = {
+  thumbnailUri: string
+}

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -37,12 +37,10 @@ import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
 import useNameOfERC20 from 'hooks/NameOfERC20'
 
 import { useVeNftLockDurationOptions } from 'hooks/veNft/VeNftLockDurationOptions'
-
 import { useVeNftBaseImagesHash } from 'hooks/veNft/VeNftBaseImagesHash'
-
 import { useVeNftVariants } from 'hooks/veNft/VeNftVariants'
-
 import { useVeNftResolverAddress } from 'hooks/veNft/VeNftResolverAddress'
+import { useVeNftUserTokens } from 'hooks/veNft/VeNftUserTokens'
 
 import {
   ETH_PAYOUT_SPLIT_GROUP,
@@ -191,6 +189,7 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
   const { data: lockDurationOptions } = useVeNftLockDurationOptions()
   const { data: resolverAddress } = useVeNftResolverAddress()
   const { data: variants } = useVeNftVariants()
+  const { data: userTokens } = useVeNftUserTokens()
   const baseImagesHash = useVeNftBaseImagesHash()
 
   const isArchived = projectId
@@ -244,11 +243,11 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
 
     veNft: {
       name: veNftProjectName,
-      lockDurationOptions: lockDurationOptions,
-      baseImagesHash: baseImagesHash,
-      resolverAddress: resolverAddress,
-      variants: variants,
-      userTokens: undefined,
+      lockDurationOptions,
+      baseImagesHash,
+      resolverAddress,
+      variants,
+      userTokens,
     },
 
     loading: {

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -38,6 +38,12 @@ import useNameOfERC20 from 'hooks/NameOfERC20'
 
 import { useVeNftLockDurationOptions } from 'hooks/veNft/VeNftLockDurationOptions'
 
+import { useVeNftBaseImagesHash } from 'hooks/veNft/VeNftBaseImagesHash'
+
+import { useVeNftVariants } from 'hooks/veNft/VeNftVariants'
+
+import { useVeNftResolverAddress } from 'hooks/veNft/VeNftResolverAddress'
+
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
@@ -181,7 +187,11 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
   const { data: nftRewardTiers, isLoading: nftRewardTiersLoading } =
     useNftRewards(nftRewardsCIDs)
 
+  const veNftProjectName = 'veBanny'
   const { data: lockDurationOptions } = useVeNftLockDurationOptions()
+  const { data: resolverAddress } = useVeNftResolverAddress()
+  const { data: variants } = useVeNftVariants()
+  const baseImagesHash = useVeNftBaseImagesHash()
 
   const isArchived = projectId
     ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived
@@ -233,11 +243,11 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
     },
 
     veNft: {
-      name: undefined,
+      name: veNftProjectName,
       lockDurationOptions: lockDurationOptions,
-      baseImagesHash: undefined,
-      resolverAddress: undefined,
-      variants: undefined,
+      baseImagesHash: baseImagesHash,
+      resolverAddress: resolverAddress,
+      variants: variants,
       userTokens: undefined,
     },
 

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -55,6 +55,7 @@ import {
 import {
   VeNftToken,
   VeNftTokenJson,
+  parseVeNftTokenJson,
 } from 'models/subgraph-entities/v2/venft-token'
 import {
   DeployedERC20Event,

--- a/src/utils/v2/veNft.ts
+++ b/src/utils/v2/veNft.ts
@@ -1,9 +1,9 @@
 import { VeNftVariant } from 'models/v2/veNftVariant'
 
-export const getNFTBaseImage = (
+export const getVeNftBaseImage = (
   baseImagesHash: string,
   variant: VeNftVariant,
 ): string => {
   const padded = variant.id.toString().padStart(2, '0')
-  return `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/${baseImagesHash}/${padded}.png`
+  return `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/${baseImagesHash}/characters/${padded}.png`
 }

--- a/src/utils/v2/veNft.ts
+++ b/src/utils/v2/veNft.ts
@@ -1,4 +1,4 @@
-import { VeNftVariant } from 'models/v2/veNftVariant'
+import { VeNftVariant } from 'models/v2/veNft'
 
 export const getVeNftBaseImage = (
   baseImagesHash: string,


### PR DESCRIPTION
## What does this PR do and why?

Adds the functionality to fetch veNFT variant data and token metadata. Builds out functionality for the Staking Token Ranges Modal and Carousel. Displays the image of the NFT you will receive on the confirm stake modal.

Note that right now our variants are hardcoded to the IPFS hash of a one-time deploy Tank did, and that in the future it will be an action item to add deployment of variant metadata to the contract deployer.

Also note that loading these images does not currently work with the Juicebox dedicated pinata gateway, and you will need to use the public `gateway.pinata.cloud` instead.

## Screenshots or screen recordings

<img width="522" alt="Screen Shot 2022-07-23 at 8 22 17 AM" src="https://user-images.githubusercontent.com/33093632/180605913-65140dcd-4855-45f8-8e79-2d03dde16c8e.png">

<img width="511" alt="Screen Shot 2022-07-23 at 8 49 29 AM" src="https://user-images.githubusercontent.com/33093632/180605918-bc495e75-dc7e-48bf-9053-08983b4b32a3.png">

<img width="582" alt="Screen Shot 2022-07-23 at 8 49 37 AM" src="https://user-images.githubusercontent.com/33093632/180605924-e724555e-e731-4b2b-87ea-ff5331fb0d1c.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
