### PR TITLE
[5/6] Venft owned tokens and summary

### DIFF
--- a/src/components/veNft/VeNftContent.tsx
+++ b/src/components/veNft/VeNftContent.tsx
@@ -10,8 +10,12 @@ import VeNftOwnedTokensSection from 'components/veNft/VeNftOwnedTokensSection'
 import VeNftSummaryStatsSection from 'components/veNft/VeNftSummaryStatsSection'
 
 const VeNftContent = () => {
-  const { tokenSymbol, tokenName, projectMetadata } =
-    useContext(V2ProjectContext)
+  const {
+    tokenSymbol,
+    tokenName,
+    projectMetadata,
+    veNft: { userTokens },
+  } = useContext(V2ProjectContext)
 
   const tokenSymbolDisplayText = tokenSymbolText({ tokenSymbol })
   const projectName = projectMetadata?.name ?? t`Unknown Project`
@@ -24,8 +28,12 @@ const VeNftContent = () => {
         projectName={projectName}
       />
       <VeNftStakingForm tokenSymbolDisplayText={tokenSymbolDisplayText} />
-      <VeNftOwnedTokensSection />
+      <VeNftOwnedTokensSection
+        userTokens={userTokens}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
+      />
       <VeNftSummaryStatsSection
+        userTokens={userTokens}
         tokenSymbolDisplayText={tokenSymbolDisplayText}
       />
     </>

--- a/src/components/veNft/VeNftExtendLockModal.tsx
+++ b/src/components/veNft/VeNftExtendLockModal.tsx
@@ -1,0 +1,32 @@
+import { Trans, t } from '@lingui/macro'
+import { Modal } from 'antd'
+import React from 'react'
+
+interface VeNftExtendLockModalProps {
+  visible: boolean
+  onCancel: VoidFunction
+}
+
+const VeNftExtendLockModal = ({
+  visible,
+  onCancel,
+}: VeNftExtendLockModalProps) => {
+  const redeem = () => {
+    return
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onCancel}
+      onOk={redeem}
+      okText={t`Extend Lock`}
+    >
+      <h2>
+        <Trans>Extend Lock</Trans>
+      </h2>
+    </Modal>
+  )
+}
+
+export default VeNftExtendLockModal

--- a/src/components/veNft/VeNftExtendLockModal.tsx
+++ b/src/components/veNft/VeNftExtendLockModal.tsx
@@ -1,31 +1,127 @@
-import { Trans, t } from '@lingui/macro'
-import { Modal } from 'antd'
-import React from 'react'
+import { Form } from 'antd'
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+import { useExtendLockTx } from 'hooks/veNft/transactor/VeNftExtendLockTx'
+import { NetworkContext } from 'contexts/networkContext'
+import { t, Trans } from '@lingui/macro'
+import { emitSuccessNotification } from 'utils/notifications'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 
-interface VeNftExtendLockModalProps {
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+
+import TransactionModal from 'components/TransactionModal'
+import LockDurationSelectInput from 'components/veNft/formControls/LockDurationSelectInput'
+
+type VeNftExtendLockModalProps = {
   visible: boolean
+  token: VeNftToken
   onCancel: VoidFunction
+  onCompleted: VoidFunction
+}
+
+interface ExtendLockFormProps {
+  lockDuration: number
 }
 
 const VeNftExtendLockModal = ({
   visible,
+  token,
   onCancel,
+  onCompleted,
 }: VeNftExtendLockModalProps) => {
-  const redeem = () => {
-    return
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { tokenId } = token
+  const {
+    veNft: { lockDurationOptions },
+  } = useContext(V2ProjectContext)
+  const [form] = Form.useForm<ExtendLockFormProps>()
+  const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
+  const lockDurationOptionsInSeconds = useMemo(() => {
+    return lockDurationOptions
+      ? lockDurationOptions.map((option: BigNumber) => {
+          return option.toNumber()
+        })
+      : []
+  }, [lockDurationOptions])
+
+  useEffect(() => {
+    lockDurationOptionsInSeconds.length > 0 &&
+      form.setFieldsValue({ lockDuration: lockDurationOptionsInSeconds[0] })
+  }, [lockDurationOptionsInSeconds, form])
+
+  const initialValues = {
+    lockDuration: 0,
+  }
+
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const extendLockTx = useExtendLockTx()
+
+  const extendLock = async () => {
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const lockDuration = form.getFieldValue('lockDuration')
+
+    setLoading(true)
+
+    const txSuccess = await extendLockTx(
+      {
+        tokenId,
+        updatedDuration: lockDuration,
+      },
+      {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
+          setLoading(false)
+          emitSuccessNotification(
+            t`Extend lock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Extend Lock`}
       onCancel={onCancel}
-      onOk={redeem}
-      okText={t`Extend Lock`}
+      onOk={extendLock}
+      okText={`Extend Lock`}
+      confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Extend Lock</Trans>
-      </h2>
-    </Modal>
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>Update your veNFT's lock duration.</Trans>
+        </p>
+      </div>
+      <Form
+        layout="vertical"
+        style={{ width: '100%' }}
+        form={form}
+        initialValues={initialValues}
+      >
+        <LockDurationSelectInput
+          form={form}
+          lockDurationOptionsInSeconds={lockDurationOptionsInSeconds}
+        />
+      </Form>
+    </TransactionModal>
   )
 }
 

--- a/src/components/veNft/VeNftOwnedTokenCard.tsx
+++ b/src/components/veNft/VeNftOwnedTokenCard.tsx
@@ -129,14 +129,21 @@ export default function OwnedVeNftCard({
       <VeNftExtendLockModal
         visible={extendLockModalVisible}
         onCancel={() => setExtendLockModalVisible(false)}
+        token={token}
+        onCompleted={() => setExtendLockModalVisible(false)}
       />
       <VeNftRedeemModal
         visible={redeemModalVisible}
         onCancel={() => setRedeemModalVisible(false)}
+        token={token}
+        onCompleted={() => setRedeemModalVisible(false)}
       />
       <VeNftUnlockModal
         visible={unlockModalVisible}
         onCancel={() => setUnlockModalVisible(false)}
+        token={token}
+        onCompleted={() => setUnlockModalVisible(false)}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
       />
     </Card>
   )

--- a/src/components/veNft/VeNftOwnedTokenCard.tsx
+++ b/src/components/veNft/VeNftOwnedTokenCard.tsx
@@ -1,0 +1,146 @@
+import { Button, Card, Col, Row, Image, Space, Tooltip } from 'antd'
+
+import { ThemeContext } from 'contexts/themeContext'
+
+import { CSSProperties, useContext, useState } from 'react'
+import { formattedNum, fromWad } from 'utils/formatNumber'
+import { detailedTimeString } from 'utils/formatTime'
+
+import { useVeNftTokenMetadata } from 'hooks/veNft/VeNftTokenMetadata'
+import { Trans } from '@lingui/macro'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import VeNftExtendLockModal from './VeNftExtendLockModal'
+import VeNftRedeemModal from './VeNftRedeemModal'
+import VeNftUnlockModal from './VeNftUnlockModal'
+
+type OwnedVeNftCardProps = {
+  token: VeNftToken
+  tokenSymbolDisplayText: string
+  hasOverflow: boolean | undefined
+}
+
+export default function OwnedVeNftCard({
+  token,
+  tokenSymbolDisplayText,
+  hasOverflow,
+}: OwnedVeNftCardProps) {
+  const [extendLockModalVisible, setExtendLockModalVisible] = useState(false)
+  const [redeemModalVisible, setRedeemModalVisible] = useState(false)
+  const [unlockModalVisible, setUnlockModalVisible] = useState(false)
+
+  const { lockAmount, lockEnd, lockDuration } = token
+  const { data: metadata } = useVeNftTokenMetadata(token.tokenUri)
+  const thumbnailUri = metadata?.thumbnailUri
+
+  const remaining = Math.max(Math.round(lockEnd - Date.now() / 1000), 0)
+
+  const { colors, radii } = useContext(ThemeContext).theme
+
+  const cardStyles: CSSProperties = {
+    display: 'flex',
+    padding: '1rem',
+    borderRadius: radii.md,
+    background: colors.background.l0,
+  }
+
+  const renderRedeemButton = () => {
+    if (hasOverflow) {
+      return (
+        <Button block onClick={() => setRedeemModalVisible(true)}>
+          <Trans>REDEEM</Trans>
+        </Button>
+      )
+    } else {
+      return (
+        <Tooltip
+          trigger={['hover']}
+          title={
+            <Trans>
+              A veNft can only be redeemed if the project currently has
+              overflow.
+            </Trans>
+          }
+        >
+          <Button block disabled>
+            <Trans>REDEEM</Trans>
+          </Button>
+        </Tooltip>
+      )
+    }
+  }
+
+  return (
+    <Card style={cardStyles}>
+      <div style={{ color: colors.text.primary }}>
+        <Row>
+          <Col span={14}>
+            <Row align="top" gutter={0}>
+              <Col span={12}>
+                <p>
+                  <Trans>Staked ${tokenSymbolDisplayText}:</Trans>
+                </p>
+                <p>
+                  <Trans>Stake duration:</Trans>
+                </p>
+                <p>
+                  <Trans>Time remaining:</Trans>
+                </p>
+              </Col>
+              <Col span={12}>
+                <p>{formattedNum(fromWad(lockAmount))}</p>
+                <p>
+                  {detailedTimeString({
+                    timeSeconds: lockDuration,
+                    fullWords: true,
+                  })}
+                </p>
+                <p>
+                  {detailedTimeString({
+                    timeSeconds: remaining,
+                  })}{' '}
+                </p>
+              </Col>
+            </Row>
+            <Row align="top" gutter={0}></Row>
+          </Col>
+          <Col span={4} />
+          <Col span={6}>
+            <Image src={thumbnailUri} alt="nft" preview={false} />
+          </Col>
+        </Row>
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Row>
+            <Button block onClick={() => setExtendLockModalVisible(true)}>
+              <Trans>EXTEND LOCK</Trans>
+            </Button>
+          </Row>
+          <Row>{renderRedeemButton()}</Row>
+          {remaining === 0 && (
+            <Row>
+              <Button
+                block
+                disabled={remaining > 0}
+                onClick={() => setUnlockModalVisible(true)}
+              >
+                <Trans>UNLOCK</Trans>
+              </Button>
+            </Row>
+          )}
+        </Space>
+      </div>
+      <VeNftExtendLockModal
+        visible={extendLockModalVisible}
+        onCancel={() => setExtendLockModalVisible(false)}
+      />
+      <VeNftRedeemModal
+        visible={redeemModalVisible}
+        onCancel={() => setRedeemModalVisible(false)}
+      />
+      <VeNftUnlockModal
+        visible={unlockModalVisible}
+        onCancel={() => setUnlockModalVisible(false)}
+      />
+    </Card>
+  )
+}

--- a/src/components/veNft/VeNftOwnedTokenCard.tsx
+++ b/src/components/veNft/VeNftOwnedTokenCard.tsx
@@ -1,4 +1,13 @@
-import { Button, Card, Col, Row, Image, Space, Tooltip } from 'antd'
+import {
+  Button,
+  Card,
+  Col,
+  Row,
+  Image,
+  Space,
+  Tooltip,
+  Descriptions,
+} from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
 
@@ -7,7 +16,7 @@ import { formattedNum, fromWad } from 'utils/formatNumber'
 import { detailedTimeString } from 'utils/formatTime'
 
 import { useVeNftTokenMetadata } from 'hooks/veNft/VeNftTokenMetadata'
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 
 import VeNftExtendLockModal from './VeNftExtendLockModal'
@@ -48,7 +57,7 @@ export default function OwnedVeNftCard({
     if (hasOverflow) {
       return (
         <Button block onClick={() => setRedeemModalVisible(true)}>
-          <Trans>REDEEM</Trans>
+          <Trans>Redeem</Trans>
         </Button>
       )
     } else {
@@ -63,7 +72,7 @@ export default function OwnedVeNftCard({
           }
         >
           <Button block disabled>
-            <Trans>REDEEM</Trans>
+            <Trans>Redeem</Trans>
           </Button>
         </Tooltip>
       )
@@ -75,34 +84,22 @@ export default function OwnedVeNftCard({
       <div style={{ color: colors.text.primary }}>
         <Row>
           <Col span={14}>
-            <Row align="top" gutter={0}>
-              <Col span={12}>
-                <p>
-                  <Trans>Staked ${tokenSymbolDisplayText}:</Trans>
-                </p>
-                <p>
-                  <Trans>Stake duration:</Trans>
-                </p>
-                <p>
-                  <Trans>Time remaining:</Trans>
-                </p>
-              </Col>
-              <Col span={12}>
-                <p>{formattedNum(fromWad(lockAmount))}</p>
-                <p>
-                  {detailedTimeString({
-                    timeSeconds: lockDuration,
-                    fullWords: true,
-                  })}
-                </p>
-                <p>
-                  {detailedTimeString({
-                    timeSeconds: remaining,
-                  })}{' '}
-                </p>
-              </Col>
-            </Row>
-            <Row align="top" gutter={0}></Row>
+            <Descriptions column={1}>
+              <Descriptions.Item label={t`Locked ${tokenSymbolDisplayText}`}>
+                {formattedNum(fromWad(lockAmount))}
+              </Descriptions.Item>
+              <Descriptions.Item label={t`Lock Duration`}>
+                {detailedTimeString({
+                  timeSeconds: lockDuration,
+                  fullWords: true,
+                })}
+              </Descriptions.Item>
+              <Descriptions.Item label={t`Time Remaining`}>
+                {detailedTimeString({
+                  timeSeconds: remaining,
+                })}
+              </Descriptions.Item>
+            </Descriptions>
           </Col>
           <Col span={4} />
           <Col span={6}>
@@ -112,7 +109,7 @@ export default function OwnedVeNftCard({
         <Space direction="vertical" style={{ width: '100%' }}>
           <Row>
             <Button block onClick={() => setExtendLockModalVisible(true)}>
-              <Trans>EXTEND LOCK</Trans>
+              <Trans>Extend Lock</Trans>
             </Button>
           </Row>
           <Row>{renderRedeemButton()}</Row>
@@ -123,7 +120,7 @@ export default function OwnedVeNftCard({
                 disabled={remaining > 0}
                 onClick={() => setUnlockModalVisible(true)}
               >
-                <Trans>UNLOCK</Trans>
+                <Trans>Unlock</Trans>
               </Button>
             </Row>
           )}

--- a/src/components/veNft/VeNftOwnedTokensSection.tsx
+++ b/src/components/veNft/VeNftOwnedTokensSection.tsx
@@ -1,19 +1,52 @@
-import { Trans } from '@lingui/macro'
+import { Space } from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
+
+import { Trans } from '@lingui/macro'
+
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import OwnedVeNftCard from 'components/veNft/VeNftOwnedTokenCard'
+
+import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import { shadowCard } from 'constants/styles/shadowCard'
 
-const VeNftOwnedTokensSection = () => {
+type OwnedNFTsSectionProps = {
+  userTokens: VeNftToken[] | undefined
+  tokenSymbolDisplayText: string
+}
+
+export default function OwnedNFTSection({
+  userTokens,
+  tokenSymbolDisplayText,
+}: OwnedNFTsSectionProps) {
   const { theme } = useContext(ThemeContext)
+  const { primaryTerminalCurrentOverflow } = useContext(V2ProjectContext)
+  const hasOverflow = Boolean(primaryTerminalCurrentOverflow?.gt(0))
+
   return (
     <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
-      <h3>
-        <Trans>You don't own any veNFTs!</Trans>
-      </h3>
+      {userTokens && userTokens.length > 0 ? (
+        <>
+          <h3>$ve{tokenSymbolDisplayText} NFTs:</h3>
+          <Space direction="vertical">
+            {userTokens.map((token, i) => (
+              <OwnedVeNftCard
+                key={i}
+                token={token}
+                tokenSymbolDisplayText={tokenSymbolDisplayText}
+                hasOverflow={hasOverflow}
+              />
+            ))}
+          </Space>
+        </>
+      ) : (
+        <h3>
+          <Trans>You don't own any veNFTs!</Trans>
+        </h3>
+      )}
     </div>
   )
 }
-
-export default VeNftOwnedTokensSection

--- a/src/components/veNft/VeNftRedeemModal.tsx
+++ b/src/components/veNft/VeNftRedeemModal.tsx
@@ -1,28 +1,106 @@
-import { Trans, t } from '@lingui/macro'
-import { Modal } from 'antd'
-import React from 'react'
+import { t, Trans } from '@lingui/macro'
+import { Form } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import { useContext, useState } from 'react'
 
-interface VeNftRedeemModalProps {
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { useRedeemVeNftTx } from 'hooks/veNft/transactor/VeNftRedeemTx'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import { emitSuccessNotification } from 'utils/notifications'
+
+import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
+import TransactionModal from 'components/TransactionModal'
+import { MemoFormInput } from 'components/inputs/Pay/MemoFormInput'
+
+type VeNftRedeemModalProps = {
+  token: VeNftToken
   visible: boolean
   onCancel: VoidFunction
+  onCompleted: VoidFunction
 }
 
-const VeNftRedeemModal = ({ visible, onCancel }: VeNftRedeemModalProps) => {
-  const redeem = () => {
-    return
+const VeNftRedeemModal = ({
+  token,
+  visible,
+  onCancel,
+  onCompleted,
+}: VeNftRedeemModalProps) => {
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { primaryTerminal, tokenAddress } = useContext(V2ProjectContext)
+  const { tokenId } = token
+  const [form] = useForm<{ beneficiary: string }>()
+  const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
+  const [memo, setMemo] = useState('')
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const redeemTx = useRedeemVeNftTx()
+
+  const redeem = async () => {
+    const { beneficiary } = form.getFieldsValue()
+    await form.validateFields()
+
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const txBeneficiary = beneficiary ? beneficiary : userAddress!
+
+    setLoading(true)
+
+    const txSuccess = await redeemTx(
+      {
+        tokenId,
+        token: tokenAddress || '',
+        beneficiary: txBeneficiary,
+        memo,
+        terminal: primaryTerminal ? primaryTerminal : '',
+      },
+      {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
+          setLoading(false)
+          emitSuccessNotification(
+            t`Redeem successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      return
+    }
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Redeem veNFT`}
       onCancel={onCancel}
       onOk={redeem}
-      okText={t`Redeem`}
+      okText={`Redeem`}
+      confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Redeem Token</Trans>
-      </h2>
-    </Modal>
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>Redeeming this NFT will burn the token and return...</Trans>
+        </p>
+      </div>
+      <Form form={form} layout="vertical">
+        <MemoFormInput value={memo} onChange={setMemo} />
+        <CustomBeneficiaryInput form={form} />
+      </Form>
+    </TransactionModal>
   )
 }
 

--- a/src/components/veNft/VeNftRedeemModal.tsx
+++ b/src/components/veNft/VeNftRedeemModal.tsx
@@ -1,0 +1,29 @@
+import { Trans, t } from '@lingui/macro'
+import { Modal } from 'antd'
+import React from 'react'
+
+interface VeNftRedeemModalProps {
+  visible: boolean
+  onCancel: VoidFunction
+}
+
+const VeNftRedeemModal = ({ visible, onCancel }: VeNftRedeemModalProps) => {
+  const redeem = () => {
+    return
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onCancel}
+      onOk={redeem}
+      okText={t`Redeem`}
+    >
+      <h2>
+        <Trans>Redeem Token</Trans>
+      </h2>
+    </Modal>
+  )
+}
+
+export default VeNftRedeemModal

--- a/src/components/veNft/VeNftSummaryStatsSection.tsx
+++ b/src/components/veNft/VeNftSummaryStatsSection.tsx
@@ -1,19 +1,31 @@
-import { t, Trans } from '@lingui/macro'
+import { Plural, t, Trans } from '@lingui/macro'
 import { Descriptions } from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
 import React, { useContext } from 'react'
 
+import { useVeNftSummaryStats } from 'hooks/veNft/VeNftSummaryStats'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import { formattedNum } from 'utils/formatNumber'
+
 import { shadowCard } from 'constants/styles/shadowCard'
 
 interface VeNftSummaryStatsSectionProps {
   tokenSymbolDisplayText: string
+  userTokens: VeNftToken[] | undefined
 }
 
 const VeNftSummaryStatsSection = ({
   tokenSymbolDisplayText,
+  userTokens,
 }: VeNftSummaryStatsSectionProps) => {
   const { theme } = useContext(ThemeContext)
+  const { totalStaked, totalStakedPeriod } = useVeNftSummaryStats(userTokens)
+  const totalStakedPeriodInDays = totalStakedPeriod / (60 * 60 * 24)
+  const formattedTotalStakedPeriod = formattedNum(totalStakedPeriodInDays, {
+    precision: 2,
+  })
 
   return (
     <div style={{ ...shadowCard(theme), padding: 25, marginBottom: 10 }}>
@@ -26,9 +38,16 @@ const VeNftSummaryStatsSection = ({
         column={1}
       >
         <Descriptions.Item label={t`Total staked ${tokenSymbolDisplayText}`}>
-          0
+          {totalStaked}
         </Descriptions.Item>
-        <Descriptions.Item label={t`Total staked period`}>0</Descriptions.Item>
+        <Descriptions.Item label={t`Total staked period`}>
+          {`${formattedTotalStakedPeriod} `}
+          <Plural
+            value={totalStakedPeriodInDays}
+            one={t`day`}
+            other={t`days`}
+          />
+        </Descriptions.Item>
       </Descriptions>
     </div>
   )

--- a/src/components/veNft/VeNftUnlockModal.tsx
+++ b/src/components/veNft/VeNftUnlockModal.tsx
@@ -1,0 +1,29 @@
+import { Trans, t } from '@lingui/macro'
+import { Modal } from 'antd'
+import React from 'react'
+
+interface VeNftUnlockModalProps {
+  visible: boolean
+  onCancel: VoidFunction
+}
+
+const VeNftUnlockModal = ({ visible, onCancel }: VeNftUnlockModalProps) => {
+  const redeem = () => {
+    return
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onCancel}
+      onOk={redeem}
+      okText={t`Unlock`}
+    >
+      <h2>
+        <Trans>Unlock Token</Trans>
+      </h2>
+    </Modal>
+  )
+}
+
+export default VeNftUnlockModal

--- a/src/components/veNft/VeNftUnlockModal.tsx
+++ b/src/components/veNft/VeNftUnlockModal.tsx
@@ -1,29 +1,101 @@
-import { Trans, t } from '@lingui/macro'
-import { Modal } from 'antd'
-import React from 'react'
+import { t, Trans } from '@lingui/macro'
+import { Form } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { useUnlockTx } from 'hooks/veNft/transactor/VeNftUnlockTx'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+import { useContext, useState } from 'react'
+import { emitSuccessNotification } from 'utils/notifications'
 
-interface VeNftUnlockModalProps {
+import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
+import TransactionModal from 'components/TransactionModal'
+
+type UnlockModalProps = {
   visible: boolean
+  token: VeNftToken
+  tokenSymbolDisplayText: string
   onCancel: VoidFunction
+  onCompleted: VoidFunction
 }
 
-const VeNftUnlockModal = ({ visible, onCancel }: VeNftUnlockModalProps) => {
-  const redeem = () => {
-    return
+const UnlockModal = ({
+  visible,
+  token,
+  tokenSymbolDisplayText,
+  onCancel,
+  onCompleted,
+}: UnlockModalProps) => {
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { tokenId } = token
+  const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
+  const [form] = useForm<{ beneficiary: string }>()
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const unlockTx = useUnlockTx()
+
+  const unlock = async () => {
+    await form.validateFields()
+
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const beneficiary = form.getFieldValue('beneficiary')
+    const txBeneficiary = beneficiary ? beneficiary : userAddress
+    setLoading(true)
+
+    const txSuccess = await unlockTx(
+      {
+        tokenId,
+        beneficiary: txBeneficiary,
+      },
+      {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
+          setLoading(false)
+          emitSuccessNotification(
+            t`Unlock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Unlock veNFT`}
       onCancel={onCancel}
-      onOk={redeem}
-      okText={t`Unlock`}
+      onOk={unlock}
+      okText={`Unlock`}
+      confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Unlock Token</Trans>
-      </h2>
-    </Modal>
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>
+            Unlocking this staking position will burn your NFT and return $
+            {tokenSymbolDisplayText}.
+          </Trans>
+        </p>
+      </div>
+      <Form form={form} layout="vertical">
+        <CustomBeneficiaryInput form={form} />
+      </Form>
+    </TransactionModal>
   )
 }
 
-export default VeNftUnlockModal
+export default UnlockModal

--- a/src/components/veNft/veNftCarousel.tsx
+++ b/src/components/veNft/veNftCarousel.tsx
@@ -8,7 +8,7 @@ type StakingNFTCarouselProps = {
   variants: VeNftVariant[]
   baseImagesHash: string
   form: FormInstance
-  tokenMetadata: VeNftTokenMetadata
+  tokenMetadata: VeNftTokenMetadata | undefined
 }
 
 export default function StakingNFTCarousel({

--- a/src/components/veNft/veNftConfirmStakeModal.tsx
+++ b/src/components/veNft/veNftConfirmStakeModal.tsx
@@ -1,7 +1,8 @@
 import { t, Trans } from '@lingui/macro'
-import { Col, Modal, Row, Image, Descriptions } from 'antd'
+import { Col, Row, Image, Descriptions } from 'antd'
 import Callout from 'components/Callout'
 import FormattedAddress from 'components/FormattedAddress'
+import TransactionModal from 'components/TransactionModal'
 
 import { NetworkContext } from 'contexts/networkContext'
 import { useLockTx } from 'hooks/veNft/transactor/VeNftLockTx'
@@ -41,6 +42,7 @@ export default function ConfirmStakeModal({
 }: ConfirmStakeModalProps) {
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
   const recipient = beneficiary !== '' ? beneficiary : userAddress
 
   const tokensStakedInWad = parseWad(tokensStaked)
@@ -60,7 +62,6 @@ export default function ConfirmStakeModal({
       return
     }
 
-    // Prompt wallet connect if no wallet connected
     if (!userAddress && onSelectWallet) {
       onSelectWallet()
     }
@@ -77,7 +78,11 @@ export default function ConfirmStakeModal({
         allowPublicExtension: false,
       },
       {
-        onConfirmed() {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
           setLoading(false)
           emitSuccessNotification(
             t`Lock successful. Results will be indexed in a few moments.`,
@@ -93,16 +98,15 @@ export default function ConfirmStakeModal({
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Confirm Stake`}
       onCancel={onCancel}
       onOk={lock}
       okText={`Lock $${tokenSymbolDisplayText}`}
       confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Confirm Stake</Trans>
-      </h2>
       <Callout>
         <Trans>
           You are agreeing to IRREVOCABLY lock your tokens for{' '}
@@ -135,6 +139,6 @@ export default function ConfirmStakeModal({
           />
         </Col>
       </Row>
-    </Modal>
+    </TransactionModal>
   )
 }

--- a/src/hooks/veNft/VeNftSummaryStats.ts
+++ b/src/hooks/veNft/VeNftSummaryStats.ts
@@ -1,0 +1,27 @@
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+import { fromWad } from 'utils/formatNumber'
+
+export type VeNftSummaryStats = {
+  totalStaked: number
+  totalStakedPeriod: number
+}
+
+export function useVeNftSummaryStats(userTokens: VeNftToken[] | undefined) {
+  if (!userTokens) {
+    return {
+      totalStaked: 0,
+      totalStakedPeriod: 0,
+    }
+  }
+
+  const summaryStats: VeNftSummaryStats = {
+    totalStaked: userTokens.reduce((acc, token) => {
+      return acc + parseInt(fromWad(token.lockAmount))
+    }, 0),
+    totalStakedPeriod: userTokens.reduce((acc, token) => {
+      return acc + token.lockDuration
+    }, 0),
+  }
+
+  return summaryStats
+}

--- a/src/hooks/veNft/VeNftUserTokens.ts
+++ b/src/hooks/veNft/VeNftUserTokens.ts
@@ -1,0 +1,29 @@
+import { NetworkContext } from 'contexts/networkContext'
+import useSubgraphQuery from 'hooks/SubgraphQuery'
+import { useContext } from 'react'
+
+export const useVeNftUserTokens = () => {
+  const { userAddress } = useContext(NetworkContext)
+  return useSubgraphQuery({
+    entity: 'veNftToken',
+    keys: [
+      'tokenId',
+      'tokenUri',
+      'owner',
+      'lockAmount',
+      'lockDuration',
+      'lockEnd',
+      'lockUseJbToken',
+      'lockAllowPublicExtension',
+      'createdAt',
+      'unlockedAt',
+      'redeemedAt',
+    ],
+    where: [
+      {
+        key: 'owner',
+        value: userAddress || '',
+      },
+    ],
+  })
+}

--- a/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
@@ -1,0 +1,33 @@
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type ExtendLockTx = TransactorInstance<{
+  tokenId: number
+  updatedDuration: number
+}>
+
+export function useExtendLockTx(): ExtendLockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+
+  return ({ tokenId, updatedDuration }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'extendLock',
+      [[{ tokenId, updatedDuration }]],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftRedeemTx.ts
+++ b/src/hooks/veNft/transactor/VeNftRedeemTx.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type RedeemVeNftTx = TransactorInstance<{
+  tokenId: number
+  token: string
+  beneficiary: string
+  memo: string
+  terminal: string
+}>
+
+export function useRedeemVeNftTx(): RedeemVeNftTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+  const minReturnedTokens = BigNumber.from(0) // TODO will need a field for this in V2ConfirmPayOwnerModal
+  const metadata: string[] = [] //randomBytes(1)
+
+  return ({ tokenId, token, beneficiary, memo, terminal }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'redeem',
+      [
+        [
+          {
+            tokenId,
+            token,
+            minReturnedTokens,
+            beneficiary,
+            memo,
+            metadata,
+            terminal,
+          },
+        ],
+      ],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftUnlockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftUnlockTx.ts
@@ -1,0 +1,28 @@
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type UnlockTx = TransactorInstance<{
+  tokenId: number
+  beneficiary: string
+}>
+
+export function useUnlockTx(): UnlockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+
+  return ({ tokenId, beneficiary }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(nftContract, 'unlock', [[{ tokenId, beneficiary }]], {
+      ...txOpts,
+    })
+  }
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -305,6 +305,10 @@ msgstr ""
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr "A veNft can only be redeemed if the project currently has overflow."
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVED"
@@ -1325,6 +1329,10 @@ msgstr "ERC20 Deployed"
 msgid "ETH-ERC20 Address Created"
 msgstr "ETH-ERC20 Address Created"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr "EXTEND LOCK"
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
@@ -1423,6 +1431,11 @@ msgstr "Error uploading file"
 #: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explore projects"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
+msgstr "Extend Lock"
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2497,6 +2510,11 @@ msgstr "Projects with a handle:<0/><1/>1. Are included in search results on the 
 msgid "Provide a link to additional information about this NFT."
 msgstr "Provide a link to additional information about this NFT."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr "REDEEM"
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr "Raised on Juicebox"
@@ -2605,6 +2623,14 @@ msgstr "Reconfigure upcoming funding"
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigure upcoming funding cycles"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr "Redeem"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr "Redeem Token"
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2934,6 +2960,10 @@ msgstr "Spaces are not allowed"
 msgid "Spending"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr "Stake duration:"
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
@@ -2945,6 +2975,10 @@ msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voti
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
+msgstr "Staked ${tokenSymbolDisplayText}:"
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
@@ -3235,6 +3269,10 @@ msgstr "This will erase all of your changes."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "This will reset the data for your new project. All changes will be lost."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr "Time remaining:"
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
@@ -3445,6 +3483,10 @@ msgstr ""
 msgid "Twitter handle"
 msgstr "Twitter handle"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr "UNLOCK"
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3461,6 +3503,14 @@ msgstr "Unknown Project"
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr "Unlock"
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
+msgstr "Unlock Token"
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
@@ -3877,6 +3927,11 @@ msgstr ""
 msgid "called by <0/>"
 msgstr "called by <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr "day"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4136,6 +4191,10 @@ msgstr "{tokensText} reserved"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} amount"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1429,10 +1429,13 @@ msgid "Explore projects"
 msgstr "Explore projects"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr "Extend Lock"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr "Extend lock successful. Results will be indexed in a few moments."
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2627,13 +2630,16 @@ msgstr "Reconfigure upcoming funding cycles"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr "Redeem"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
-msgstr "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr "Redeem successful. Results will be indexed in a few moments."
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr "Redeem veNFT"
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2657,6 +2663,10 @@ msgstr "Redeem {tokensTextLong} for ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Redeemed"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr "Redeeming this NFT will burn the token and return..."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3496,13 +3506,20 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr "Unlock"
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
-msgstr "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr "Unlock successful. Results will be indexed in a few moments."
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr "Unlock veNFT"
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
@@ -3520,6 +3537,10 @@ msgstr "Untrack token"
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr "Update your veNFT's lock duration."
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1329,10 +1329,6 @@ msgstr "ERC20 Deployed"
 msgid "ETH-ERC20 Address Created"
 msgstr "ETH-ERC20 Address Created"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr "EXTEND LOCK"
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
@@ -1434,6 +1430,7 @@ msgstr "Explore projects"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr "Extend Lock"
 
@@ -1848,6 +1845,7 @@ msgstr ""
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr "Lock ${tokenSymbolDisplayText} for Voting Power"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr "Lock Duration"
@@ -1865,6 +1863,10 @@ msgstr "Lock successful. Results will be indexed in a few moments."
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Lock until"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr "Locked {tokenSymbolDisplayText}"
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2514,11 +2516,6 @@ msgstr "Projects with a handle:<0/><1/>1. Are included in search results on the 
 msgid "Provide a link to additional information about this NFT."
 msgstr "Provide a link to additional information about this NFT."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr "REDEEM"
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr "Raised on Juicebox"
@@ -2628,6 +2625,8 @@ msgstr "Reconfigure upcoming funding"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigure upcoming funding cycles"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr "Redeem"
@@ -2964,10 +2963,6 @@ msgstr "Spaces are not allowed"
 msgid "Spending"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr "Stake duration:"
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
@@ -2979,10 +2974,6 @@ msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voti
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
-msgstr "Staked ${tokenSymbolDisplayText}:"
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
@@ -3274,8 +3265,8 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "This will reset the data for your new project. All changes will be lost."
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
-msgstr "Time remaining:"
+msgid "Time Remaining"
+msgstr "Time Remaining"
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
@@ -3487,10 +3478,6 @@ msgstr ""
 msgid "Twitter handle"
 msgstr "Twitter handle"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr "UNLOCK"
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3508,6 +3495,7 @@ msgstr "Unknown Project"
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr "Unlock"
@@ -4215,5 +4203,4 @@ msgstr "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% of total supply"
-
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -310,6 +310,10 @@ msgstr "Una reconfiguración para el siguiente ciclo de financiación debe ser p
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Un porcentaje reservado de más del 90% es riesgoso para los contribuidores. Los contribuidores no recibirán suficientes tokens por su contribución."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVADO"
@@ -1330,6 +1334,10 @@ msgstr "ERC20 Desplegado"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Cada pago recibirá su porcentaje de este total cada ciclo de financiamiento si hay suficiente en el tesoro. En caso contrario, recibirán el porcentaje de lo que haya en el tesoro."
@@ -1428,6 +1436,11 @@ msgstr ""
 #: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explorar proyectos"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
+msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2502,6 +2515,11 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr ""
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2610,6 +2628,14 @@ msgstr "Reconfigurar financiamientos próximos"
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamiento próximos"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2939,6 +2965,10 @@ msgstr ""
 msgid "Spending"
 msgstr "Gasto"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2949,6 +2979,10 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
@@ -3240,6 +3274,10 @@ msgstr "Esto borrará todos tus cambios."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "Esto reiniciará los datos para tu nuevo proyecto. Todos los cambios se perderán."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3450,6 +3488,10 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "Identificador de Twitter"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr ""
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3466,6 +3508,14 @@ msgstr ""
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A menos que los pagos estén en pausa en la configuración del ciclo de financiamiento, tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo de Juicebox."
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
+msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
@@ -3882,6 +3932,11 @@ msgstr "{0}% después de la comisión de JBX"
 msgid "called by <0/>"
 msgstr "llamado por <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4141,6 +4196,10 @@ msgstr "{tokensText} reservados"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "cantidad de {tokensTokenUpper}"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1434,9 +1434,12 @@ msgid "Explore projects"
 msgstr "Explorar proyectos"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2632,12 +2635,15 @@ msgstr "Reconfigurar ciclos de financiamiento próximos"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2662,6 +2668,10 @@ msgstr "Canjear {tokensTextLong} por ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Canjeado"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3501,12 +3511,19 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "A menos que los pagos estén en pausa en la configuración del ciclo de financiamiento, tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo de Juicebox."
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3525,6 +3542,10 @@ msgstr "Dejar de seguir token"
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Próximos"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1334,10 +1334,6 @@ msgstr "ERC20 Desplegado"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr ""
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Cada pago recibirá su porcentaje de este total cada ciclo de financiamiento si hay suficiente en el tesoro. En caso contrario, recibirán el porcentaje de lo que haya en el tesoro."
@@ -1439,6 +1435,7 @@ msgstr "Explorar proyectos"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
@@ -1853,6 +1850,7 @@ msgstr "Cargar más"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1870,6 +1868,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquear hasta"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2519,11 +2521,6 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr ""
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2633,6 +2630,8 @@ msgstr "Reconfigurar financiamientos próximos"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamiento próximos"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
@@ -2969,10 +2968,6 @@ msgstr ""
 msgid "Spending"
 msgstr "Gasto"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr ""
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2983,10 +2978,6 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
-msgstr ""
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
@@ -3279,7 +3270,7 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "Esto reiniciará los datos para tu nuevo proyecto. Todos los cambios se perderán."
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
+msgid "Time Remaining"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
@@ -3492,10 +3483,6 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "Identificador de Twitter"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr ""
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3513,6 +3500,7 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A menos que los pagos estén en pausa en la configuración del ciclo de financiamiento, tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo de Juicebox."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
@@ -4220,5 +4208,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage} % de suministro total"
-
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -310,6 +310,10 @@ msgstr "Le reparamétrage d'un cycle de financement à venir doit être soumis a
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Un taux réservé supérieur à 90% est risqué pour les contributeurs. Les contributeurs ne recevront pas beaucoup de tokens pour leur contribution."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVÉ"
@@ -1330,6 +1334,10 @@ msgstr "ERC20 Déployé"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Chaque paiement recevra son pourcentage de ce total à chaque cycle de financement s'il y en a assez dans la trésorerie. Sinon, ils recevront leur pourcentage de tout ce que dispose la trésorerie."
@@ -1428,6 +1436,11 @@ msgstr ""
 #: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explorer des projets"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
+msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2502,6 +2515,11 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr ""
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2610,6 +2628,14 @@ msgstr "Modifier les prochains financements"
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurer les prochains cycles de financement"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2939,6 +2965,10 @@ msgstr ""
 msgid "Spending"
 msgstr "Dépenses"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2949,6 +2979,10 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
@@ -3240,6 +3274,10 @@ msgstr "Cela effacera toutes vos modifications."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3450,6 +3488,10 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr ""
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3465,6 +3507,14 @@ msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3882,6 +3932,11 @@ msgstr "après {0}% de frais JBX"
 msgid "called by <0/>"
 msgstr "appelé par <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4141,6 +4196,10 @@ msgstr "{tokensText} réservés"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} montant"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1334,10 +1334,6 @@ msgstr "ERC20 Déployé"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr ""
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Chaque paiement recevra son pourcentage de ce total à chaque cycle de financement s'il y en a assez dans la trésorerie. Sinon, ils recevront leur pourcentage de tout ce que dispose la trésorerie."
@@ -1439,6 +1435,7 @@ msgstr "Explorer des projets"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
@@ -1853,6 +1850,7 @@ msgstr "Télécharger d'avantage"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1870,6 +1868,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquer jusqu'à"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2519,11 +2521,6 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr ""
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2633,6 +2630,8 @@ msgstr "Modifier les prochains financements"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurer les prochains cycles de financement"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
@@ -2969,10 +2968,6 @@ msgstr ""
 msgid "Spending"
 msgstr "Dépenses"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr ""
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2983,10 +2978,6 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
-msgstr ""
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
@@ -3279,7 +3270,7 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
+msgid "Time Remaining"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
@@ -3492,10 +3483,6 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr ""
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3513,6 +3500,7 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
@@ -4220,5 +4208,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de l'offre totale"
-
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1434,9 +1434,12 @@ msgid "Explore projects"
 msgstr "Explorer des projets"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2632,12 +2635,15 @@ msgstr "Reconfigurer les prochains cycles de financement"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2662,6 +2668,10 @@ msgstr "Récupérer {tokensTextLong} pour ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Récupéré"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3501,12 +3511,19 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3525,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "À venir"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1334,10 +1334,6 @@ msgstr "ERC20 Implementado"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr ""
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Cada pagamento você receberá a porcentagem deste total a cada ciclo de financiamento, caso haja o suficiente na tesouraria. Caso contrário, eles receberão a porcentagem de qualquer coisa que estiver na tesouraria."
@@ -1439,6 +1435,7 @@ msgstr "Explore projetos"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
@@ -1853,6 +1850,7 @@ msgstr "Carregar mais"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1870,6 +1868,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Trancar até"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2519,11 +2521,6 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr ""
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2633,6 +2630,8 @@ msgstr "Reconfigurar financiamento futuro"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamento futuros"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
@@ -2969,10 +2968,6 @@ msgstr ""
 msgid "Spending"
 msgstr "Gastos"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr ""
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2983,10 +2978,6 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
-msgstr ""
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
@@ -3279,7 +3270,7 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
+msgid "Time Remaining"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
@@ -3492,10 +3483,6 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "Nick do Twitter"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr ""
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3513,6 +3500,7 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A não ser que os pagamentos estejam pausados nas suas configurações de ciclo de financiamento, o seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
@@ -4220,5 +4208,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de fornecimento total"
-
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -310,6 +310,10 @@ msgstr "Uma reconfiguração de um ciclo de financiamento deve ser submetida pel
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Uma tava de reserva de mais de 90% é um risco para os contribuidores. Os contribuidores não receberão muitos tokens por sua contribuição."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARQUIVADO"
@@ -1330,6 +1334,10 @@ msgstr "ERC20 Implementado"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Cada pagamento você receberá a porcentagem deste total a cada ciclo de financiamento, caso haja o suficiente na tesouraria. Caso contrário, eles receberão a porcentagem de qualquer coisa que estiver na tesouraria."
@@ -1428,6 +1436,11 @@ msgstr ""
 #: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explore projetos"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
+msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2502,6 +2515,11 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr ""
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2610,6 +2628,14 @@ msgstr "Reconfigurar financiamento futuro"
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamento futuros"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2939,6 +2965,10 @@ msgstr ""
 msgid "Spending"
 msgstr "Gastos"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2949,6 +2979,10 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
@@ -3240,6 +3274,10 @@ msgstr "Isso vai apagar todas as suas mudanças."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3450,6 +3488,10 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "Nick do Twitter"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr ""
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3466,6 +3508,14 @@ msgstr ""
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A não ser que os pagamentos estejam pausados nas suas configurações de ciclo de financiamento, o seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
+msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
@@ -3882,6 +3932,11 @@ msgstr "depois da taxa de {0}% de JBX"
 msgid "called by <0/>"
 msgstr "chamado por <0/>"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4141,6 +4196,10 @@ msgstr "{tokensText} reservados"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "quantidade de {tokensTokenUpper}"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1434,9 +1434,12 @@ msgid "Explore projects"
 msgstr "Explore projetos"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2632,12 +2635,15 @@ msgstr "Reconfigurar ciclos de financiamento futuros"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2662,6 +2668,10 @@ msgstr "Resgatar {tokensTextLong} por ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Resgatado"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3501,12 +3511,19 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "A não ser que os pagamentos estejam pausados nas suas configurações de ciclo de financiamento, o seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3525,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Futuro"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1334,10 +1334,6 @@ msgstr ""
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr ""
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr ""
@@ -1439,6 +1435,7 @@ msgstr ""
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
@@ -1853,6 +1850,7 @@ msgstr "Загрузить ещё"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1870,6 +1868,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Заблокировать до"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2519,11 +2521,6 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr ""
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2633,6 +2630,8 @@ msgstr "Перенастроить предстоящие финансирова
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Перенастроить предстоящие циклы финансирования"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
@@ -2969,10 +2968,6 @@ msgstr ""
 msgid "Spending"
 msgstr "Расходы"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr ""
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2983,10 +2978,6 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
-msgstr ""
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
@@ -3279,7 +3270,7 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
+msgid "Time Remaining"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
@@ -3492,10 +3483,6 @@ msgstr "Твиттер"
 msgid "Twitter handle"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr ""
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3513,6 +3500,7 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
@@ -4220,5 +4208,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% от общего объема предложения"
-
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -310,6 +310,10 @@ msgstr "Реконфигурацию/план изменений для пред
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Резервная ставка более 90% является рискованной для вкладчиков. Вкладчики не получат много токенов за свой вклад."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "АРХИВИРОВАНО"
@@ -1330,6 +1334,10 @@ msgstr ""
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr ""
@@ -1427,6 +1435,11 @@ msgstr ""
 
 #: src/pages/index.page.tsx
 msgid "Explore projects"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2502,6 +2515,11 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr ""
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2610,6 +2628,14 @@ msgstr "Перенастроить предстоящие финансирова
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Перенастроить предстоящие циклы финансирования"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2939,6 +2965,10 @@ msgstr ""
 msgid "Spending"
 msgstr "Расходы"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2949,6 +2979,10 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
@@ -3240,6 +3274,10 @@ msgstr "Это удалит все ваши изменения."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3450,6 +3488,10 @@ msgstr "Твиттер"
 msgid "Twitter handle"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr ""
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3465,6 +3507,14 @@ msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3882,6 +3932,11 @@ msgstr "после  {0}% комиссии JBX"
 msgid "called by <0/>"
 msgstr ""
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4141,6 +4196,10 @@ msgstr "{tokensText} зарезервировано"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} количество"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1434,9 +1434,12 @@ msgid "Explore projects"
 msgstr ""
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2632,12 +2635,15 @@ msgstr "Перенастроить предстоящие циклы финан�
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2661,6 +2667,10 @@ msgstr "Обменять {tokensTextLong} за ETH"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -3501,12 +3511,19 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3525,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Предстоящие"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1334,10 +1334,6 @@ msgstr ""
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr ""
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Her ödeme, finansman döngülerinin her birinde, hazinede yeterli tutar mevcutsa bu toplamdan ona ait olan yüzdeyi alacaktır. Aksi halde, hazinede bulunan tutar ne kadarsa bu tutar üzerinden yüzde alacaktır."
@@ -1439,6 +1435,7 @@ msgstr "Projeleri keşfedin"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
@@ -1853,6 +1850,7 @@ msgstr "Daha fazla yükle"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1870,6 +1868,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Kilit süresi bitiş tarihi"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2519,11 +2521,6 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr ""
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2633,6 +2630,8 @@ msgstr "Yaklaşan finansmanı yeniden yapılandır"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Yaklaşan finansman döngülerini yeniden yapılandır"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
@@ -2969,10 +2968,6 @@ msgstr ""
 msgid "Spending"
 msgstr "Harcama"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr ""
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2983,10 +2978,6 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
-msgstr ""
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
@@ -3279,7 +3270,7 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
+msgid "Time Remaining"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
@@ -3492,10 +3483,6 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "Twitter tanıtıcısı"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr ""
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3513,6 +3500,7 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
@@ -4220,5 +4208,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "Toplam arzın %{userOwnershipPercentage} kadarı"
-
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -310,6 +310,10 @@ msgstr "Yaklaşan bir finansman döngüsü için yeniden yapılandırma, döngü
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "%90'ın üzerindeki rezerv oranları, katkıda bulunanlar için risklidir. Katkıda bulunanlar, katkıları karşılığında çok fazla token almazlar."
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARŞİVLENDİ"
@@ -1330,6 +1334,10 @@ msgstr ""
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Her ödeme, finansman döngülerinin her birinde, hazinede yeterli tutar mevcutsa bu toplamdan ona ait olan yüzdeyi alacaktır. Aksi halde, hazinede bulunan tutar ne kadarsa bu tutar üzerinden yüzde alacaktır."
@@ -1428,6 +1436,11 @@ msgstr ""
 #: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Projeleri keşfedin"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
+msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2502,6 +2515,11 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr ""
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2610,6 +2628,14 @@ msgstr "Yaklaşan finansmanı yeniden yapılandır"
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Yaklaşan finansman döngülerini yeniden yapılandır"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2939,6 +2965,10 @@ msgstr ""
 msgid "Spending"
 msgstr "Harcama"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2949,6 +2979,10 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
@@ -3240,6 +3274,10 @@ msgstr "Yaptığınız tüm değişiklikler silinecektir."
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3450,6 +3488,10 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "Twitter tanıtıcısı"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr ""
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3465,6 +3507,14 @@ msgstr ""
 
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3882,6 +3932,11 @@ msgstr "%{0} JBX ücretinden sonra"
 msgid "called by <0/>"
 msgstr ""
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4141,6 +4196,10 @@ msgstr "Rezerve {tokensText} token'ları"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} token miktarı"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1434,9 +1434,12 @@ msgid "Explore projects"
 msgstr "Projeleri keşfedin"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2632,12 +2635,15 @@ msgstr "Yaklaşan finansman döngülerini yeniden yapılandır"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2662,6 +2668,10 @@ msgstr "{tokensTextLong} token'larını ETH için kullan"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Kullanılan"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3501,12 +3511,19 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3525,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Yaklaşan"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -310,6 +310,10 @@ msgstr "对之后筹款周期的重新配置，至少得提前七天提交。"
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "代币保留率超过90%对捐款人是有风险的。捐款人能获得的代币数量不多。"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "A veNft can only be redeemed if the project currently has overflow."
+msgstr ""
+
 #: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "已存档"
@@ -1330,6 +1334,10 @@ msgstr "部署 ERC-20 标准代币"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "EXTEND LOCK"
+msgstr ""
+
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "如果金库资金足够，每个支出对象将在每个筹款周期收到自己在这个总额里的对应份额。否则，他们将按各自的占比来分配金库剩余的资金。"
@@ -1428,6 +1436,11 @@ msgstr ""
 #: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "探索项目"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend Lock"
+msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -2502,6 +2515,11 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "REDEEM"
+msgstr ""
+
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2610,6 +2628,14 @@ msgstr "重新配置之后的筹款"
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "重新配置以后的筹款周期"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem Token"
+msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2939,6 +2965,10 @@ msgstr ""
 msgid "Spending"
 msgstr "资金分配"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Stake duration:"
+msgstr ""
+
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2949,6 +2979,10 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
+msgstr ""
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/VeNftConfirmStakeModal.tsx
@@ -3240,6 +3274,10 @@ msgstr "这将删除你所有的更改。"
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Time remaining:"
+msgstr ""
+
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
@@ -3450,6 +3488,10 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "推特名"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "UNLOCK"
+msgstr ""
+
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3466,6 +3508,14 @@ msgstr ""
 #: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "除非在项目筹款周期设置中将付款暂停，否则项目仍能通过 Juicebox 协议的合约直接收到付款。"
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock Token"
+msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
@@ -3882,6 +3932,11 @@ msgstr "计算 {0}% JBX 费用之后"
 msgid "called by <0/>"
 msgstr "由 <0/> 调用"
 
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "day"
+msgstr ""
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 #: src/utils/formatTime.ts
 msgid "days"
@@ -4141,6 +4196,10 @@ msgstr "{tokensText} 已保留"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} 数量"
+
+#: src/components/veNft/VeNftSummaryStatsSection.tsx
+msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1434,9 +1434,12 @@ msgid "Explore projects"
 msgstr "探索项目"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -2632,12 +2635,15 @@ msgstr "重新配置以后的筹款周期"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2662,6 +2668,10 @@ msgstr "燃烧 {tokensTextLong} 来赎回 ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "赎回"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -3501,12 +3511,19 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "除非在项目筹款周期设置中将付款暂停，否则项目仍能通过 Juicebox 协议的合约直接收到付款。"
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
@@ -3525,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "未来"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1334,10 +1334,6 @@ msgstr "部署 ERC-20 标准代币"
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "EXTEND LOCK"
-msgstr ""
-
 #: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "如果金库资金足够，每个支出对象将在每个筹款周期收到自己在这个总额里的对应份额。否则，他们将按各自的占比来分配金库剩余的资金。"
@@ -1439,6 +1435,7 @@ msgstr "探索项目"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
 #: src/components/veNft/VeNftExtendLockModal.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
@@ -1853,6 +1850,7 @@ msgstr "加载更多"
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/veNftConfirmStakeModal.tsx
 msgid "Lock Duration"
 msgstr ""
@@ -1870,6 +1868,10 @@ msgstr ""
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "锁定至"
+
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+msgid "Locked {tokenSymbolDisplayText}"
+msgstr ""
 
 #: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
@@ -2519,11 +2521,6 @@ msgstr ""
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "REDEEM"
-msgstr ""
-
 #: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
@@ -2633,6 +2630,8 @@ msgstr "重新配置之后的筹款"
 msgid "Reconfigure upcoming funding cycles"
 msgstr "重新配置以后的筹款周期"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem"
 msgstr ""
@@ -2969,10 +2968,6 @@ msgstr ""
 msgid "Spending"
 msgstr "资金分配"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Stake duration:"
-msgstr ""
-
 #: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
@@ -2983,10 +2978,6 @@ msgstr ""
 
 #: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
-msgstr ""
-
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Staked ${tokenSymbolDisplayText}:"
 msgstr ""
 
 #: src/components/veNft/veNftConfirmStakeModal.tsx
@@ -3279,7 +3270,7 @@ msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
 #: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "Time remaining:"
+msgid "Time Remaining"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
@@ -3492,10 +3483,6 @@ msgstr "Twitter"
 msgid "Twitter handle"
 msgstr "推特名"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-msgid "UNLOCK"
-msgstr ""
-
 #: src/components/ArchiveProject/index.tsx
 #: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
@@ -3513,6 +3500,7 @@ msgstr ""
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "除非在项目筹款周期设置中将付款暂停，否则项目仍能通过 Juicebox 协议的合约直接收到付款。"
 
+#: src/components/veNft/VeNftOwnedTokenCard.tsx
 #: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock"
 msgstr ""
@@ -4220,5 +4208,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "总供应量的 {userOwnershipPercentage}%"
-
 

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -37,12 +37,10 @@ import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
 import useNameOfERC20 from 'hooks/NameOfERC20'
 
 import { useVeNftLockDurationOptions } from 'hooks/veNft/VeNftLockDurationOptions'
-
 import { useVeNftBaseImagesHash } from 'hooks/veNft/VeNftBaseImagesHash'
-
 import { useVeNftVariants } from 'hooks/veNft/VeNftVariants'
-
 import { useVeNftResolverAddress } from 'hooks/veNft/VeNftResolverAddress'
+import { useVeNftUserTokens } from 'hooks/veNft/VeNftUserTokens'
 
 import {
   ETH_PAYOUT_SPLIT_GROUP,
@@ -191,6 +189,7 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
   const { data: lockDurationOptions } = useVeNftLockDurationOptions()
   const { data: resolverAddress } = useVeNftResolverAddress()
   const { data: variants } = useVeNftVariants()
+  const { data: userTokens } = useVeNftUserTokens()
   const baseImagesHash = useVeNftBaseImagesHash()
 
   const isArchived = projectId
@@ -244,11 +243,11 @@ export default function V2Dashboard({ projectId }: { projectId: number }) {
 
     veNft: {
       name: veNftProjectName,
-      lockDurationOptions: lockDurationOptions,
-      baseImagesHash: baseImagesHash,
-      resolverAddress: resolverAddress,
-      variants: variants,
-      userTokens: undefined,
+      lockDurationOptions,
+      baseImagesHash,
+      resolverAddress,
+      variants,
+      userTokens,
     },
 
     loading: {

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -55,6 +55,7 @@ import {
 import {
   VeNftToken,
   VeNftTokenJson,
+  parseVeNftTokenJson,
 } from 'models/subgraph-entities/v2/venft-token'
 import {
   DeployedERC20Event,


### PR DESCRIPTION
## What does this PR do and why?

Adds fetching for the user's open veNft positions, displays them in the Owned NFTs section, and calculates summary stats based on them.

You will need the following subgraph URL in order to enable this functionality:
`https://api.studio.thegraph.com/query/26890/jbx-rinkeby-w-vebanny/0.0.1`

Also note that the token images do not match the locked durations due to new options being set on the deployed contract. This will be resolved contract-side.

## Screenshots or screen recordings

<img width="555" alt="Screen Shot 2022-07-23 at 9 36 15 AM" src="https://user-images.githubusercontent.com/33093632/180607508-1dbf6376-8332-4c9b-8f0b-eb418aba0fd9.png">

<img width="594" alt="Screen Shot 2022-07-23 at 9 36 19 AM" src="https://user-images.githubusercontent.com/33093632/180607510-5e0a83d6-52fa-42d0-90f3-39e3ba29b366.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
