### PR TITLE
[6/6] VeNft - Add unlock, extend, redeem modals and functionality

### DIFF
--- a/src/components/veNft/VeNftExtendLockModal.tsx
+++ b/src/components/veNft/VeNftExtendLockModal.tsx
@@ -1,4 +1,4 @@
-import { Form, Modal } from 'antd'
+import { Form } from 'antd'
 import { BigNumber } from '@ethersproject/bignumber'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { ThemeContext } from 'contexts/themeContext'
@@ -9,9 +9,9 @@ import { emitSuccessNotification } from 'utils/notifications'
 import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { useForm } from 'antd/lib/form/Form'
 
-import LockDurationSelectInput from './formControls/LockDurationSelectInput'
+import TransactionModal from 'components/TransactionModal'
+import LockDurationSelectInput from 'components/veNft/formControls/LockDurationSelectInput'
 
 type VeNftExtendLockModalProps = {
   visible: boolean
@@ -35,8 +35,9 @@ const VeNftExtendLockModal = ({
   const {
     veNft: { lockDurationOptions },
   } = useContext(V2ProjectContext)
-  const [form] = useForm<ExtendLockFormProps>()
+  const [form] = Form.useForm<ExtendLockFormProps>()
   const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
   const lockDurationOptionsInSeconds = useMemo(() => {
     return lockDurationOptions
       ? lockDurationOptions.map((option: BigNumber) => {
@@ -75,7 +76,11 @@ const VeNftExtendLockModal = ({
         updatedDuration: lockDuration,
       },
       {
-        onConfirmed() {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
           setLoading(false)
           emitSuccessNotification(
             t`Extend lock successful. Results will be indexed in a few moments.`,
@@ -91,19 +96,18 @@ const VeNftExtendLockModal = ({
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Extend Lock`}
       onCancel={onCancel}
       onOk={extendLock}
       okText={`Extend Lock`}
       confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Extend Lock</Trans>
-      </h2>
       <div style={{ color: colors.text.secondary }}>
         <p>
-          <Trans>Set an updated duration for your staking position.</Trans>
+          <Trans>Update your veNFT's lock duration.</Trans>
         </p>
       </div>
       <Form
@@ -117,7 +121,7 @@ const VeNftExtendLockModal = ({
           lockDurationOptionsInSeconds={lockDurationOptionsInSeconds}
         />
       </Form>
-    </Modal>
+    </TransactionModal>
   )
 }
 

--- a/src/components/veNft/VeNftExtendLockModal.tsx
+++ b/src/components/veNft/VeNftExtendLockModal.tsx
@@ -1,30 +1,122 @@
-import { Trans, t } from '@lingui/macro'
-import { Modal } from 'antd'
-import React from 'react'
+import { Form, Modal } from 'antd'
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+import { useExtendLockTx } from 'hooks/veNft/transactor/VeNftExtendLockTx'
+import { NetworkContext } from 'contexts/networkContext'
+import { t, Trans } from '@lingui/macro'
+import { emitSuccessNotification } from 'utils/notifications'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 
-interface VeNftExtendLockModalProps {
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { useForm } from 'antd/lib/form/Form'
+
+import LockDurationSelectInput from './formControls/LockDurationSelectInput'
+
+type VeNftExtendLockModalProps = {
   visible: boolean
+  token: VeNftToken
   onCancel: VoidFunction
+  onCompleted: VoidFunction
+}
+
+interface ExtendLockFormProps {
+  lockDuration: number
 }
 
 const VeNftExtendLockModal = ({
   visible,
+  token,
   onCancel,
+  onCompleted,
 }: VeNftExtendLockModalProps) => {
-  const redeem = () => {
-    return
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { tokenId } = token
+  const {
+    veNft: { lockDurationOptions },
+  } = useContext(V2ProjectContext)
+  const [form] = useForm<ExtendLockFormProps>()
+  const [loading, setLoading] = useState(false)
+  const lockDurationOptionsInSeconds = useMemo(() => {
+    return lockDurationOptions
+      ? lockDurationOptions.map((option: BigNumber) => {
+          return option.toNumber()
+        })
+      : []
+  }, [lockDurationOptions])
+
+  useEffect(() => {
+    lockDurationOptionsInSeconds.length > 0 &&
+      form.setFieldsValue({ lockDuration: lockDurationOptionsInSeconds[0] })
+  }, [lockDurationOptionsInSeconds, form])
+
+  const initialValues = {
+    lockDuration: 0,
+  }
+
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const extendLockTx = useExtendLockTx()
+
+  const extendLock = async () => {
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const lockDuration = form.getFieldValue('lockDuration')
+
+    setLoading(true)
+
+    const txSuccess = await extendLockTx(
+      {
+        tokenId,
+        updatedDuration: lockDuration,
+      },
+      {
+        onConfirmed() {
+          setLoading(false)
+          emitSuccessNotification(
+            t`Extend lock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
   }
 
   return (
     <Modal
       visible={visible}
       onCancel={onCancel}
-      onOk={redeem}
-      okText={t`Extend Lock`}
+      onOk={extendLock}
+      okText={`Extend Lock`}
+      confirmLoading={loading}
     >
       <h2>
         <Trans>Extend Lock</Trans>
       </h2>
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>Set an updated duration for your staking position.</Trans>
+        </p>
+      </div>
+      <Form
+        layout="vertical"
+        style={{ width: '100%' }}
+        form={form}
+        initialValues={initialValues}
+      >
+        <LockDurationSelectInput
+          form={form}
+          lockDurationOptionsInSeconds={lockDurationOptionsInSeconds}
+        />
+      </Form>
     </Modal>
   )
 }

--- a/src/components/veNft/VeNftOwnedTokenCard.tsx
+++ b/src/components/veNft/VeNftOwnedTokenCard.tsx
@@ -132,14 +132,21 @@ export default function OwnedVeNftCard({
       <VeNftExtendLockModal
         visible={extendLockModalVisible}
         onCancel={() => setExtendLockModalVisible(false)}
+        token={token}
+        onCompleted={() => setExtendLockModalVisible(false)}
       />
       <VeNftRedeemModal
         visible={redeemModalVisible}
         onCancel={() => setRedeemModalVisible(false)}
+        token={token}
+        onCompleted={() => setRedeemModalVisible(false)}
       />
       <VeNftUnlockModal
         visible={unlockModalVisible}
         onCancel={() => setUnlockModalVisible(false)}
+        token={token}
+        onCompleted={() => setUnlockModalVisible(false)}
+        tokenSymbolDisplayText={tokenSymbolDisplayText}
       />
     </Card>
   )

--- a/src/components/veNft/VeNftRedeemModal.tsx
+++ b/src/components/veNft/VeNftRedeemModal.tsx
@@ -1,20 +1,18 @@
 import { t, Trans } from '@lingui/macro'
-import { Form, Modal, Switch } from 'antd'
+import { Form, Modal } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import { MemoFormInput } from 'components/inputs/Pay/MemoFormInput'
 
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
-import { isAddress } from 'ethers/lib/utils'
 import { useRedeemVeNftTx } from 'hooks/veNft/transactor/VeNftRedeemTx'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 import { useContext, useState } from 'react'
 
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-
-import { EthAddressInput } from 'components/inputs/EthAddressInput'
-
 import { emitSuccessNotification } from 'utils/notifications'
-import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+
+import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 type VeNftRedeemModalProps = {
   token: VeNftToken
@@ -32,8 +30,6 @@ const VeNftRedeemModal = ({
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const { primaryTerminal, tokenAddress } = useContext(V2ProjectContext)
   const { tokenId } = token
-  const [customBeneficiaryEnabled, setCustomBeneficiaryEnabled] =
-    useState(false)
   const [form] = useForm<{ beneficiary: string }>()
   const [memo, setMemo] = useState('')
   const {
@@ -41,16 +37,6 @@ const VeNftRedeemModal = ({
   } = useContext(ThemeContext)
 
   const redeemTx = useRedeemVeNftTx()
-
-  const validateCustomBeneficiary = () => {
-    const beneficiary = form.getFieldValue('beneficiary')
-    if (!beneficiary) {
-      return Promise.reject(t`Address required`)
-    } else if (!isAddress(beneficiary)) {
-      return Promise.reject(t`Invalid address`)
-    }
-    return Promise.resolve()
-  }
 
   const redeem = async () => {
     const { beneficiary } = form.getFieldsValue()
@@ -103,34 +89,7 @@ const VeNftRedeemModal = ({
       </div>
       <Form form={form} layout="vertical">
         <MemoFormInput value={memo} onChange={setMemo} />
-        <Form.Item
-          label={
-            <>
-              <Trans>Custom beneficiary</Trans>
-              <Switch
-                checked={customBeneficiaryEnabled}
-                onChange={setCustomBeneficiaryEnabled}
-                style={{ marginLeft: 10 }}
-              />
-            </>
-          }
-          extra={<Trans>Send unlocked tokens to a custom address.</Trans>}
-          style={{ marginBottom: '1rem' }}
-        />
-
-        {customBeneficiaryEnabled && (
-          <Form.Item
-            name="beneficiary"
-            label="Beneficiary"
-            rules={[
-              {
-                validator: validateCustomBeneficiary,
-              },
-            ]}
-          >
-            <EthAddressInput />
-          </Form.Item>
-        )}
+        <CustomBeneficiaryInput form={form} />
       </Form>
     </Modal>
   )

--- a/src/components/veNft/VeNftUnlockModal.tsx
+++ b/src/components/veNft/VeNftUnlockModal.tsx
@@ -1,29 +1,134 @@
-import { Trans, t } from '@lingui/macro'
-import { Modal } from 'antd'
-import React from 'react'
+import { isAddress } from '@ethersproject/address'
+import { t, Trans } from '@lingui/macro'
+import { Form, Modal, Switch } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import { EthAddressInput } from 'components/inputs/EthAddressInput'
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { useUnlockTx } from 'hooks/veNft/transactor/VeNftUnlockTx'
+import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
+import { useContext, useState } from 'react'
+import { emitSuccessNotification } from 'utils/notifications'
 
-interface VeNftUnlockModalProps {
+type UnlockModalProps = {
   visible: boolean
+  token: VeNftToken
+  tokenSymbolDisplayText: string
   onCancel: VoidFunction
+  onCompleted: VoidFunction
 }
 
-const VeNftUnlockModal = ({ visible, onCancel }: VeNftUnlockModalProps) => {
-  const redeem = () => {
-    return
+const UnlockModal = ({
+  visible,
+  token,
+  tokenSymbolDisplayText,
+  onCancel,
+  onCompleted,
+}: UnlockModalProps) => {
+  const { userAddress, onSelectWallet } = useContext(NetworkContext)
+  const { tokenId } = token
+  const [customBeneficiaryEnabled, setCustomBeneficiaryEnabled] =
+    useState(false)
+  const [loading, setLoading] = useState(false)
+  const [form] = useForm<{ beneficiary: string }>()
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const unlockTx = useUnlockTx()
+
+  const validateCustomBeneficiary = () => {
+    const beneficiary = form.getFieldValue('beneficiary')
+    if (!beneficiary) {
+      return Promise.reject(t`Address required`)
+    } else if (!isAddress(beneficiary)) {
+      return Promise.reject(t`Invalid address`)
+    }
+    return Promise.resolve()
+  }
+
+  const unlock = async () => {
+    await form.validateFields()
+
+    // Prompt wallet connect if no wallet connected
+    if (!userAddress && onSelectWallet) {
+      onSelectWallet()
+    }
+
+    const beneficiary = form.getFieldValue('beneficiary')
+    const txBeneficiary = beneficiary ? beneficiary : userAddress
+    setLoading(true)
+
+    const txSuccess = await unlockTx(
+      {
+        tokenId,
+        beneficiary: txBeneficiary,
+      },
+      {
+        onConfirmed() {
+          setLoading(false)
+          emitSuccessNotification(
+            t`Unlock successful. Results will be indexed in a few moments.`,
+          )
+          onCompleted()
+        },
+      },
+    )
+
+    if (!txSuccess) {
+      setLoading(false)
+    }
   }
 
   return (
     <Modal
       visible={visible}
       onCancel={onCancel}
-      onOk={redeem}
-      okText={t`Unlock`}
+      onOk={unlock}
+      okText={`Unlock`}
+      confirmLoading={loading}
     >
-      <h2>
-        <Trans>Unlock Token</Trans>
-      </h2>
+      <h2>Unlock Token</h2>
+      <div style={{ color: colors.text.secondary }}>
+        <p>
+          <Trans>
+            Unlocking this staking position will burn your NFT and return $
+            {tokenSymbolDisplayText}.
+          </Trans>
+        </p>
+      </div>
+      <Form form={form} layout="vertical">
+        <Form.Item
+          label={
+            <>
+              <Trans>Custom beneficiary</Trans>
+              <Switch
+                checked={customBeneficiaryEnabled}
+                onChange={setCustomBeneficiaryEnabled}
+                style={{ marginLeft: 10 }}
+              />
+            </>
+          }
+          extra={<Trans>Send unlocked tokens to a custom address.</Trans>}
+          style={{ marginBottom: '1rem' }}
+        />
+
+        {customBeneficiaryEnabled && (
+          <Form.Item
+            name="beneficiary"
+            label="Beneficiary"
+            rules={[
+              {
+                validator: validateCustomBeneficiary,
+              },
+            ]}
+          >
+            <EthAddressInput />
+          </Form.Item>
+        )}
+      </Form>
     </Modal>
   )
 }
 
-export default VeNftUnlockModal
+export default UnlockModal

--- a/src/components/veNft/VeNftUnlockModal.tsx
+++ b/src/components/veNft/VeNftUnlockModal.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Form, Modal } from 'antd'
+import { Form } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
@@ -9,6 +9,7 @@ import { useContext, useState } from 'react'
 import { emitSuccessNotification } from 'utils/notifications'
 
 import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
+import TransactionModal from 'components/TransactionModal'
 
 type UnlockModalProps = {
   visible: boolean
@@ -28,6 +29,7 @@ const UnlockModal = ({
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const { tokenId } = token
   const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
   const [form] = useForm<{ beneficiary: string }>()
   const {
     theme: { colors },
@@ -38,7 +40,6 @@ const UnlockModal = ({
   const unlock = async () => {
     await form.validateFields()
 
-    // Prompt wallet connect if no wallet connected
     if (!userAddress && onSelectWallet) {
       onSelectWallet()
     }
@@ -53,7 +54,11 @@ const UnlockModal = ({
         beneficiary: txBeneficiary,
       },
       {
-        onConfirmed() {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
           setLoading(false)
           emitSuccessNotification(
             t`Unlock successful. Results will be indexed in a few moments.`,
@@ -69,14 +74,15 @@ const UnlockModal = ({
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Unlock veNFT`}
       onCancel={onCancel}
       onOk={unlock}
       okText={`Unlock`}
       confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>Unlock Token</h2>
       <div style={{ color: colors.text.secondary }}>
         <p>
           <Trans>
@@ -88,7 +94,7 @@ const UnlockModal = ({
       <Form form={form} layout="vertical">
         <CustomBeneficiaryInput form={form} />
       </Form>
-    </Modal>
+    </TransactionModal>
   )
 }
 

--- a/src/components/veNft/VeNftUnlockModal.tsx
+++ b/src/components/veNft/VeNftUnlockModal.tsx
@@ -1,14 +1,14 @@
-import { isAddress } from '@ethersproject/address'
 import { t, Trans } from '@lingui/macro'
-import { Form, Modal, Switch } from 'antd'
+import { Form, Modal } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
-import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useUnlockTx } from 'hooks/veNft/transactor/VeNftUnlockTx'
 import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'
 import { useContext, useState } from 'react'
 import { emitSuccessNotification } from 'utils/notifications'
+
+import CustomBeneficiaryInput from 'components/veNft/formControls/CustomBeneficiaryInput'
 
 type UnlockModalProps = {
   visible: boolean
@@ -27,8 +27,6 @@ const UnlockModal = ({
 }: UnlockModalProps) => {
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const { tokenId } = token
-  const [customBeneficiaryEnabled, setCustomBeneficiaryEnabled] =
-    useState(false)
   const [loading, setLoading] = useState(false)
   const [form] = useForm<{ beneficiary: string }>()
   const {
@@ -36,16 +34,6 @@ const UnlockModal = ({
   } = useContext(ThemeContext)
 
   const unlockTx = useUnlockTx()
-
-  const validateCustomBeneficiary = () => {
-    const beneficiary = form.getFieldValue('beneficiary')
-    if (!beneficiary) {
-      return Promise.reject(t`Address required`)
-    } else if (!isAddress(beneficiary)) {
-      return Promise.reject(t`Invalid address`)
-    }
-    return Promise.resolve()
-  }
 
   const unlock = async () => {
     await form.validateFields()
@@ -98,34 +86,7 @@ const UnlockModal = ({
         </p>
       </div>
       <Form form={form} layout="vertical">
-        <Form.Item
-          label={
-            <>
-              <Trans>Custom beneficiary</Trans>
-              <Switch
-                checked={customBeneficiaryEnabled}
-                onChange={setCustomBeneficiaryEnabled}
-                style={{ marginLeft: 10 }}
-              />
-            </>
-          }
-          extra={<Trans>Send unlocked tokens to a custom address.</Trans>}
-          style={{ marginBottom: '1rem' }}
-        />
-
-        {customBeneficiaryEnabled && (
-          <Form.Item
-            name="beneficiary"
-            label="Beneficiary"
-            rules={[
-              {
-                validator: validateCustomBeneficiary,
-              },
-            ]}
-          >
-            <EthAddressInput />
-          </Form.Item>
-        )}
+        <CustomBeneficiaryInput form={form} />
       </Form>
     </Modal>
   )

--- a/src/components/veNft/veNftCarousel.tsx
+++ b/src/components/veNft/veNftCarousel.tsx
@@ -8,7 +8,7 @@ type StakingNFTCarouselProps = {
   variants: VeNftVariant[]
   baseImagesHash: string
   form: FormInstance
-  tokenMetadata: VeNftTokenMetadata
+  tokenMetadata: VeNftTokenMetadata | undefined
 }
 
 export default function StakingNFTCarousel({

--- a/src/components/veNft/veNftConfirmStakeModal.tsx
+++ b/src/components/veNft/veNftConfirmStakeModal.tsx
@@ -1,7 +1,8 @@
 import { t, Trans } from '@lingui/macro'
-import { Col, Modal, Row, Image, Descriptions } from 'antd'
+import { Col, Row, Image, Descriptions } from 'antd'
 import Callout from 'components/Callout'
 import FormattedAddress from 'components/FormattedAddress'
+import TransactionModal from 'components/TransactionModal'
 
 import { NetworkContext } from 'contexts/networkContext'
 import { useLockTx } from 'hooks/veNft/transactor/VeNftLockTx'
@@ -41,6 +42,7 @@ export default function ConfirmStakeModal({
 }: ConfirmStakeModalProps) {
   const { userAddress, onSelectWallet } = useContext(NetworkContext)
   const [loading, setLoading] = useState(false)
+  const [transactionPending, setTransactionPending] = useState(false)
   const recipient = beneficiary !== '' ? beneficiary : userAddress
 
   const tokensStakedInWad = parseWad(tokensStaked)
@@ -60,7 +62,6 @@ export default function ConfirmStakeModal({
       return
     }
 
-    // Prompt wallet connect if no wallet connected
     if (!userAddress && onSelectWallet) {
       onSelectWallet()
     }
@@ -77,7 +78,11 @@ export default function ConfirmStakeModal({
         allowPublicExtension: false,
       },
       {
-        onConfirmed() {
+        onDone: () => {
+          setTransactionPending(true)
+        },
+        onConfirmed: () => {
+          setTransactionPending(false)
           setLoading(false)
           emitSuccessNotification(
             t`Lock successful. Results will be indexed in a few moments.`,
@@ -93,16 +98,15 @@ export default function ConfirmStakeModal({
   }
 
   return (
-    <Modal
+    <TransactionModal
       visible={visible}
+      title={t`Confirm Stake`}
       onCancel={onCancel}
       onOk={lock}
       okText={`Lock $${tokenSymbolDisplayText}`}
       confirmLoading={loading}
+      transactionPending={transactionPending}
     >
-      <h2>
-        <Trans>Confirm Stake</Trans>
-      </h2>
       <Callout>
         <Trans>
           You are agreeing to IRREVOCABLY lock your tokens for{' '}
@@ -135,6 +139,6 @@ export default function ConfirmStakeModal({
           />
         </Col>
       </Row>
-    </Modal>
+    </TransactionModal>
   )
 }

--- a/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
@@ -1,0 +1,33 @@
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type ExtendLockTx = TransactorInstance<{
+  tokenId: number
+  updatedDuration: number
+}>
+
+export function useExtendLockTx(): ExtendLockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+
+  return ({ tokenId, updatedDuration }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'extendLock',
+      [[{ tokenId, updatedDuration }]],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftRedeemTx.ts
+++ b/src/hooks/veNft/transactor/VeNftRedeemTx.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type RedeemVeNftTx = TransactorInstance<{
+  tokenId: number
+  token: string
+  beneficiary: string
+  memo: string
+  terminal: string
+}>
+
+export function useRedeemVeNftTx(): RedeemVeNftTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+  const minReturnedTokens = BigNumber.from(0) // TODO will need a field for this in V2ConfirmPayOwnerModal
+  const metadata: string[] = [] //randomBytes(1)
+
+  return ({ tokenId, token, beneficiary, memo, terminal }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(
+      nftContract,
+      'redeem',
+      [
+        [
+          {
+            tokenId,
+            token,
+            minReturnedTokens,
+            beneficiary,
+            memo,
+            metadata,
+            terminal,
+          },
+        ],
+      ],
+      {
+        ...txOpts,
+      },
+    )
+  }
+}

--- a/src/hooks/veNft/transactor/VeNftUnlockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftUnlockTx.ts
@@ -1,0 +1,28 @@
+import { useContext } from 'react'
+import { V2UserContext } from 'contexts/v2/userContext'
+
+import { TransactorInstance } from 'hooks/Transactor'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export type UnlockTx = TransactorInstance<{
+  tokenId: number
+  beneficiary: string
+}>
+
+export function useUnlockTx(): UnlockTx {
+  const { transactor } = useContext(V2UserContext)
+  const nftContract = useVeNftContract(VENFT_CONTRACT_ADDRESS)
+
+  return ({ tokenId, beneficiary }, txOpts) => {
+    if (!transactor || !nftContract) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    return transactor(nftContract, 'unlock', [[{ tokenId, beneficiary }]], {
+      ...txOpts,
+    })
+  }
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -397,6 +397,8 @@ msgstr "Add token allocation"
 msgid "Address"
 msgstr ""
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr "Address required"
@@ -970,6 +972,11 @@ msgstr "Current owner: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Currently worth: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr "Custom beneficiary"
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Custom memo"
@@ -1433,9 +1440,12 @@ msgid "Explore projects"
 msgstr "Explore projects"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
 msgstr "Extend Lock"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
+msgstr "Extend lock successful. Results will be indexed in a few moments."
 
 #: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
@@ -1719,6 +1729,8 @@ msgstr "Initial issuance rate"
 msgid "Initial mint rate"
 msgstr "Initial mint rate"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr "Invalid address"
@@ -2625,12 +2637,12 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigure upcoming funding cycles"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
-msgstr "Redeem"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem Token"
 msgstr "Redeem Token"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem successful. Results will be indexed in a few moments."
+msgstr "Redeem successful. Results will be indexed in a few moments."
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2654,6 +2666,10 @@ msgstr "Redeem {tokensTextLong} for ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Redeemed"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr "Redeeming this NFT will burn the token and return..."
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -2870,6 +2886,11 @@ msgstr "Seconds"
 msgid "See transaction"
 msgstr "See transaction"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr "Send unlocked tokens to a custom address."
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr "Set ENS name"
@@ -2897,6 +2918,10 @@ msgstr "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordK
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
+msgstr "Set an updated duration for your staking position."
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
@@ -3505,12 +3530,12 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
-msgstr "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
+msgstr "Unlock successful. Results will be indexed in a few moments."
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
-msgstr "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
+msgstr "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -397,8 +397,6 @@ msgstr "Add token allocation"
 msgid "Address"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr "Address required"
@@ -971,11 +969,6 @@ msgstr "Current owner: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Currently worth: <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr "Custom beneficiary"
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1729,8 +1722,6 @@ msgstr "Initial issuance rate"
 msgid "Initial mint rate"
 msgstr "Initial mint rate"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr "Invalid address"
@@ -2885,11 +2876,6 @@ msgstr "Seconds"
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "See transaction"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr "Send unlocked tokens to a custom address."
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2634,12 +2634,12 @@ msgid "Redeem"
 msgstr "Redeem"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
-msgstr "Redeem Token"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr "Redeem successful. Results will be indexed in a few moments."
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeem veNFT"
+msgstr "Redeem veNFT"
 
 #: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
@@ -2910,10 +2910,6 @@ msgstr "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordK
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
-msgstr "Set an updated duration for your staking position."
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
@@ -3518,6 +3514,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr "Unlock successful. Results will be indexed in a few moments."
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr "Unlock veNFT"
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 
@@ -3537,6 +3537,10 @@ msgstr "Untrack token"
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr "Update your veNFT's lock duration."
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4220,5 +4224,4 @@ msgstr "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% of total supply"
-
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -402,6 +402,8 @@ msgstr "Añadir distribución de token"
 msgid "Address"
 msgstr "Dirección"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -975,6 +977,11 @@ msgstr "Dueño actual: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Actualmente vale: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Memo personalizado"
@@ -1438,8 +1445,11 @@ msgid "Explore projects"
 msgstr "Explorar proyectos"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1724,6 +1734,8 @@ msgstr "Tasa de emisión inicial"
 msgid "Initial mint rate"
 msgstr "Tasa inicial de acuñación"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2630,11 +2642,11 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamiento próximos"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
+msgid "Redeem Token"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2659,6 +2671,10 @@ msgstr "Canjear {tokensTextLong} por ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Canjeado"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -2875,6 +2891,11 @@ msgstr "Segundos"
 msgid "See transaction"
 msgstr "Ver transacción"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
@@ -2901,6 +2922,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3510,11 +3535,11 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "A menos que los pagos estén en pausa en la configuración del ciclo de financiamiento, tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo de Juicebox."
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2639,11 +2639,11 @@ msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem successful. Results will be indexed in a few moments."
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2914,10 +2914,6 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-msgstr ""
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3523,6 +3519,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
@@ -3542,6 +3542,10 @@ msgstr "Dejar de seguir token"
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Próximos"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4225,5 +4229,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage} % de suministro total"
-
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -402,8 +402,6 @@ msgstr "Añadir distribución de token"
 msgid "Address"
 msgstr "Dirección"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -976,11 +974,6 @@ msgstr "Dueño actual: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Actualmente vale: <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1734,8 +1727,6 @@ msgstr "Tasa de emisión inicial"
 msgid "Initial mint rate"
 msgstr "Tasa inicial de acuñación"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2890,11 +2881,6 @@ msgstr "Segundos"
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Ver transacción"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -402,6 +402,8 @@ msgstr "Ajouter l'allocation de token"
 msgid "Address"
 msgstr "Adresse"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -975,6 +977,11 @@ msgstr "Propriétaire actuel: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Valeur actuelle : <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Customiser le mémo"
@@ -1438,8 +1445,11 @@ msgid "Explore projects"
 msgstr "Explorer des projets"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1724,6 +1734,8 @@ msgstr "Taux d'émission initiale"
 msgid "Initial mint rate"
 msgstr "Taux de frappe initial"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2630,11 +2642,11 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurer les prochains cycles de financement"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
+msgid "Redeem Token"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2659,6 +2671,10 @@ msgstr "Récupérer {tokensTextLong} pour ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Récupéré"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -2875,6 +2891,11 @@ msgstr "Secondes"
 msgid "See transaction"
 msgstr "Voir la transaction"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
@@ -2901,6 +2922,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3510,11 +3535,11 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2639,11 +2639,11 @@ msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem successful. Results will be indexed in a few moments."
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2914,10 +2914,6 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-msgstr ""
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3523,6 +3519,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
@@ -3542,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "À venir"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4225,5 +4229,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de l'offre totale"
-
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -402,8 +402,6 @@ msgstr "Ajouter l'allocation de token"
 msgid "Address"
 msgstr "Adresse"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -976,11 +974,6 @@ msgstr "Propriétaire actuel: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Valeur actuelle : <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1734,8 +1727,6 @@ msgstr "Taux d'émission initiale"
 msgid "Initial mint rate"
 msgstr "Taux de frappe initial"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2890,11 +2881,6 @@ msgstr "Secondes"
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Voir la transaction"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2639,11 +2639,11 @@ msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem successful. Results will be indexed in a few moments."
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2914,10 +2914,6 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-msgstr ""
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3523,6 +3519,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
@@ -3542,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Futuro"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4225,5 +4229,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de fornecimento total"
-
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -402,6 +402,8 @@ msgstr "Adicionar alocação de token"
 msgid "Address"
 msgstr "Endereço"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -975,6 +977,11 @@ msgstr "Atual proprietário: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Atualmente vale: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Nota personalizada"
@@ -1438,8 +1445,11 @@ msgid "Explore projects"
 msgstr "Explore projetos"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1724,6 +1734,8 @@ msgstr "Taxa de emissão inicial"
 msgid "Initial mint rate"
 msgstr "A taxa inicial de emissão"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2630,11 +2642,11 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamento futuros"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
+msgid "Redeem Token"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2659,6 +2671,10 @@ msgstr "Resgatar {tokensTextLong} por ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Resgatado"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -2875,6 +2891,11 @@ msgstr "Segundos"
 msgid "See transaction"
 msgstr "Ver transação"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
@@ -2901,6 +2922,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3510,11 +3535,11 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "A não ser que os pagamentos estejam pausados nas suas configurações de ciclo de financiamento, o seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -402,8 +402,6 @@ msgstr "Adicionar alocação de token"
 msgid "Address"
 msgstr "Endereço"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -976,11 +974,6 @@ msgstr "Atual proprietário: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Atualmente vale: <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1734,8 +1727,6 @@ msgstr "Taxa de emissão inicial"
 msgid "Initial mint rate"
 msgstr "A taxa inicial de emissão"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2890,11 +2881,6 @@ msgstr "Segundos"
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Ver transação"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2639,11 +2639,11 @@ msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem successful. Results will be indexed in a few moments."
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2914,10 +2914,6 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-msgstr ""
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3523,6 +3519,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
@@ -3542,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Предстоящие"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4225,5 +4229,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% от общего объема предложения"
-
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -402,6 +402,8 @@ msgstr ""
 msgid "Address"
 msgstr "Адрес"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -975,6 +977,11 @@ msgstr "Текущий владелец: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "На данный момент стоит: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr ""
@@ -1438,8 +1445,11 @@ msgid "Explore projects"
 msgstr ""
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1724,6 +1734,8 @@ msgstr "Первоначальная ставка эмиссии"
 msgid "Initial mint rate"
 msgstr ""
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2630,11 +2642,11 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "Перенастроить предстоящие циклы финансирования"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
+msgid "Redeem Token"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2658,6 +2670,10 @@ msgstr "Обменять {tokensTextLong} за ETH"
 #: src/components/v1/V1Project/ProjectActivity/index.tsx
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
+msgstr ""
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -2875,6 +2891,11 @@ msgstr ""
 msgid "See transaction"
 msgstr "Увидить трансакцию"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
@@ -2901,6 +2922,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3510,11 +3535,11 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -402,8 +402,6 @@ msgstr ""
 msgid "Address"
 msgstr "Адрес"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -976,11 +974,6 @@ msgstr "Текущий владелец: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "На данный момент стоит: <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1734,8 +1727,6 @@ msgstr "Первоначальная ставка эмиссии"
 msgid "Initial mint rate"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2890,11 +2881,6 @@ msgstr ""
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Увидить трансакцию"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -402,8 +402,6 @@ msgstr "Token tahsisi ekle"
 msgid "Address"
 msgstr "Adres"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -976,11 +974,6 @@ msgstr "Güncel sahibi: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Güncel değeri: <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1734,8 +1727,6 @@ msgstr "İlk token çıkarma oranı"
 msgid "Initial mint rate"
 msgstr "İlk basım oranı"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2890,11 +2881,6 @@ msgstr "Saniye"
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "İşlemi gör"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2639,11 +2639,11 @@ msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem successful. Results will be indexed in a few moments."
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2914,10 +2914,6 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-msgstr ""
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3523,6 +3519,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
@@ -3542,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Yaklaşan"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4225,5 +4229,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "Toplam arzın %{userOwnershipPercentage} kadarı"
-
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -402,6 +402,8 @@ msgstr "Token tahsisi ekle"
 msgid "Address"
 msgstr "Adres"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -975,6 +977,11 @@ msgstr "Güncel sahibi: {ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Güncel değeri: <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "Özel not"
@@ -1438,8 +1445,11 @@ msgid "Explore projects"
 msgstr "Projeleri keşfedin"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1724,6 +1734,8 @@ msgstr "İlk token çıkarma oranı"
 msgid "Initial mint rate"
 msgstr "İlk basım oranı"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2630,11 +2642,11 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "Yaklaşan finansman döngülerini yeniden yapılandır"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
+msgid "Redeem Token"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2659,6 +2671,10 @@ msgstr "{tokensTextLong} token'larını ETH için kullan"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Kullanılan"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -2875,6 +2891,11 @@ msgstr "Saniye"
 msgid "See transaction"
 msgstr "İşlemi gör"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
@@ -2901,6 +2922,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3510,11 +3535,11 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2639,11 +2639,11 @@ msgid "Redeem"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem successful. Results will be indexed in a few moments."
+msgid "Redeem veNFT"
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2914,10 +2914,6 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
-msgstr ""
-
-#: src/components/veNft/VeNftExtendLockModal.tsx
-msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3523,6 +3519,10 @@ msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Unlock veNFT"
+msgstr ""
+
+#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
@@ -3542,6 +3542,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "未来"
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Update your veNFT's lock duration."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
@@ -4225,5 +4229,4 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "总供应量的 {userOwnershipPercentage}%"
-
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -402,6 +402,8 @@ msgstr "添加代币的分配方案"
 msgid "Address"
 msgstr "地址"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -975,6 +977,11 @@ msgstr "当前项目方：{ownerAddress}"
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "当前价值： <0><1/>{0}</0>"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Custom beneficiary"
+msgstr ""
+
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
 msgstr "自定义备注"
@@ -1438,8 +1445,11 @@ msgid "Explore projects"
 msgstr "探索项目"
 
 #: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend Lock"
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/Navbar/MenuItems.tsx
@@ -1724,6 +1734,8 @@ msgstr "初始发行比率"
 msgid "Initial mint rate"
 msgstr "最初铸造比率"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2630,11 +2642,11 @@ msgid "Reconfigure upcoming funding cycles"
 msgstr "重新配置以后的筹款周期"
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem"
+msgid "Redeem Token"
 msgstr ""
 
 #: src/components/veNft/VeNftRedeemModal.tsx
-msgid "Redeem Token"
+msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/ManageTokensModal.tsx
@@ -2659,6 +2671,10 @@ msgstr "燃烧 {tokensTextLong} 来赎回 ETH"
 #: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "赎回"
+
+#: src/components/veNft/VeNftRedeemModal.tsx
+msgid "Redeeming this NFT will burn the token and return..."
+msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
@@ -2875,6 +2891,11 @@ msgstr "秒"
 msgid "See transaction"
 msgstr "查看交易"
 
+#: src/components/veNft/VeNftRedeemModal.tsx
+#: src/components/veNft/VeNftUnlockModal.tsx
+msgid "Send unlocked tokens to a custom address."
+msgstr ""
+
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
@@ -2901,6 +2922,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+#: src/components/veNft/VeNftExtendLockModal.tsx
+msgid "Set an updated duration for your staking position."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
@@ -3510,11 +3535,11 @@ msgid "Unless payments are paused in your funding cycle settings, your project c
 msgstr "除非在项目筹款周期设置中将付款暂停，否则项目仍能通过 Juicebox 协议的合约直接收到付款。"
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock"
+msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
 #: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Unlock Token"
+msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
 #: src/components/v2/shared/UnsavedChangesModal.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -402,8 +402,6 @@ msgstr "添加代币的分配方案"
 msgid "Address"
 msgstr "地址"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
@@ -976,11 +974,6 @@ msgstr "当前项目方：{ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "当前价值： <0><1/>{0}</0>"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Custom beneficiary"
-msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Custom memo"
@@ -1734,8 +1727,6 @@ msgstr "初始发行比率"
 msgid "Initial mint rate"
 msgstr "最初铸造比率"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
 #: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
@@ -2890,11 +2881,6 @@ msgstr "秒"
 #: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "查看交易"
-
-#: src/components/veNft/VeNftRedeemModal.tsx
-#: src/components/veNft/VeNftUnlockModal.tsx
-msgid "Send unlocked tokens to a custom address."
-msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"


### PR DESCRIPTION
## What does this PR do and why?

Adds functionality for the Unlock, Redeem, and Extend Lock modals on user tokens.

## Screenshots or screen recordings

<img width="517" alt="image" src="https://user-images.githubusercontent.com/33093632/180608764-ab268fd2-f2f9-4639-88b1-39bb572f7a86.png">

<img width="510" alt="image" src="https://user-images.githubusercontent.com/33093632/180608776-9c61b834-609c-4b47-a2a6-f2f84e573a41.png">

<img width="506" alt="image" src="https://user-images.githubusercontent.com/33093632/180608961-79a83c60-a69f-4a20-bdaf-db955dd327c5.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
