### PR TITLE
remove tool tip

### DIFF
--- a/src/components/inputs/Pay/MemoFormInput.tsx
+++ b/src/components/inputs/Pay/MemoFormInput.tsx
@@ -35,7 +35,9 @@ export function MemoFormInput({
           showCount
           autoSize
         />
-        <div
+        <Sticker
+          onClick={() => setAttachStickerModalVisible(true)}
+          size={20}
           style={{
             color: colors.text.secondary,
             fontSize: '.8rem',
@@ -43,11 +45,7 @@ export function MemoFormInput({
             right: 5,
             top: 7,
           }}
-        >
-          <div onClick={() => setAttachStickerModalVisible(true)}>
-            <Sticker size={20} />
-          </div>
-        </div>
+        />
       </div>
       <AttachStickerModal
         visible={attachStickerModalVisible}

--- a/src/components/inputs/Pay/MemoFormInput.tsx
+++ b/src/components/inputs/Pay/MemoFormInput.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import { Input, Tooltip } from 'antd'
+import { Input } from 'antd'
 
 import { useContext, useState } from 'react'
 import { ThemeContext } from 'contexts/themeContext'
@@ -44,13 +44,9 @@ export function MemoFormInput({
             top: 7,
           }}
         >
-          <Tooltip title={t`Attach a sticker`}>
-            <Sticker
-              role="button"
-              onClick={() => setAttachStickerModalVisible(true)}
-              size={20}
-            />
-          </Tooltip>
+          <div onClick={() => setAttachStickerModalVisible(true)}>
+            <Sticker size={20} />
+          </div>
         </div>
       </div>
       <AttachStickerModal

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -538,7 +538,6 @@ msgstr "Are you sure you want to start over?"
 msgid "Assets"
 msgstr "Assets"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -543,7 +543,6 @@ msgstr "¿Estás seguro de que quieres volver a empezar?"
 msgid "Assets"
 msgstr "Activos"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -543,7 +543,6 @@ msgstr "Êtes-vous sûr de vouloir recommencer ?"
 msgid "Assets"
 msgstr "Actifs"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -543,7 +543,6 @@ msgstr "Você tem certeza que quer começar novamente?"
 msgid "Assets"
 msgstr "Ativos"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -543,7 +543,6 @@ msgstr "Вы уверены, что хотите начать все снача�
 msgid "Assets"
 msgstr "Активы"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -543,7 +543,6 @@ msgstr "Baştan başlamak istediğinizden emin misiniz?"
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -543,7 +543,6 @@ msgstr "你确定要重新开始吗？"
 msgid "Assets"
 msgstr "资产"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"


### PR DESCRIPTION
## What does this PR do and why?

Remove Tooltip from MemoFormInput, this was an unrelated comment in https://github.com/jbx-protocol/juice-interface/pull/1297/files/2ade91865d8ebdece5355eb373fb9f6ebc3be033#r925329483.


I'm addressing this change in another diff because it's unrelated to the sticker icon change in the previous diff.


## Screenshots or screen recordings
It's hard to screen shot, if you go to http://localhost:3000/p/ganggangdao, go to payment, hover sticker icon, it will not longer show tooltip


- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
