### PR TITLE
Match sticker to v1 sticker

### DIFF
--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -1,4 +1,3 @@
-import { SmileOutlined } from '@ant-design/icons'
 import * as constants from '@ethersproject/constants'
 import { t, Trans } from '@lingui/macro'
 import { Checkbox, Form, Input, Modal, Space, Switch, Tooltip } from 'antd'
@@ -17,6 +16,8 @@ import {
   getUnsafeV2FundingCycleProperties,
   V2FundingCycleRiskCount,
 } from 'utils/v2/fundingCycle'
+
+import Sticker from 'components/icons/Sticker'
 
 import { ProjectPreferences } from 'constants/v2/projectPreferences'
 import { StickerSelection } from './StickerSelection'
@@ -95,20 +96,24 @@ export const V2PayForm = ({
               >
                 {canAddMoreStickers ? (
                   <Tooltip title={t`Attach a sticker`}>
-                    <SmileOutlined
-                      style={{ color: colors.text.secondary }}
+                    <div
                       onClick={() => {
                         setAttachStickerModalVisible(true)
                       }}
-                    />
+                      style={{ color: colors.text.secondary }}
+                    >
+                      <Sticker size={20} />
+                    </div>
                   </Tooltip>
                 ) : (
-                  <SmileOutlined
+                  <div
                     style={{
                       color: colors.text.disabled,
                       cursor: 'not-allowed',
                     }}
-                  />
+                  >
+                    <Sticker size={20} />
+                  </div>
                 )}
               </div>
               <Form.Item name="stickerUrls">

--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -96,14 +96,13 @@ export const V2PayForm = ({
               >
                 {canAddMoreStickers ? (
                   <Tooltip title={t`Attach a sticker`}>
-                    <div
+                    <Sticker
+                      style={{ color: colors.text.secondary }}
+                      size={20}
                       onClick={() => {
                         setAttachStickerModalVisible(true)
                       }}
-                      style={{ color: colors.text.secondary }}
-                    >
-                      <Sticker size={20} />
-                    </div>
+                    />
                   </Tooltip>
                 ) : (
                   <div

--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -105,14 +105,13 @@ export const V2PayForm = ({
                     />
                   </Tooltip>
                 ) : (
-                  <div
+                  <Sticker
+                    size={20}
                     style={{
                       color: colors.text.disabled,
                       cursor: 'not-allowed',
                     }}
-                  >
-                    <Sticker size={20} />
-                  </div>
+                  />
                 )}
               </div>
               <Form.Item name="stickerUrls">


### PR DESCRIPTION
## What does this PR do and why?
Updates v2 payment modal sticker icon. Note, there will be more stack changes both up and down stack to addess the:

- Lack of types for `style` on the sticker component
- remove additional divs
- remove tooltip


Follow up: Changes have been addressed
this is just the smallest and easiest to check change. Literally just changing the icon here.

_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

## Screenshots or screen recordings
v1 on left, v2 on right
<img width="1523" alt="CleanShot 2022-07-23 at 12 01 14@2x" src="https://user-images.githubusercontent.com/2502947/180613079-a3036065-f8ec-4b7c-8967-ce1089e3839b.png">

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
