### PR TITLE
remove tooltip v2 payment modal sticker

### DIFF
--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -1,6 +1,6 @@
 import * as constants from '@ethersproject/constants'
 import { t, Trans } from '@lingui/macro'
-import { Checkbox, Form, Input, Modal, Space, Switch, Tooltip } from 'antd'
+import { Checkbox, Form, Input, Modal, Space, Switch } from 'antd'
 import { FormInstance, FormProps, useWatch } from 'antd/lib/form/Form'
 import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import { FormImageUploader } from 'components/inputs/FormImageUploader'
@@ -95,15 +95,13 @@ export const V2PayForm = ({
                 }}
               >
                 {canAddMoreStickers ? (
-                  <Tooltip title={t`Attach a sticker`}>
-                    <Sticker
-                      style={{ color: colors.text.secondary }}
-                      size={20}
-                      onClick={() => {
-                        setAttachStickerModalVisible(true)
-                      }}
-                    />
-                  </Tooltip>
+                  <Sticker
+                    style={{ color: colors.text.secondary }}
+                    size={20}
+                    onClick={() => {
+                      setAttachStickerModalVisible(true)
+                    }}
+                  />
                 ) : (
                   <Sticker
                     size={20}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -539,7 +539,6 @@ msgid "Assets"
 msgstr "Assets"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr "Attach a sticker"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -544,7 +544,6 @@ msgid "Assets"
 msgstr "Activos"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr "Adjuntar un sticker"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -544,7 +544,6 @@ msgid "Assets"
 msgstr "Actifs"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr "Ajouter un autocollant"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -544,7 +544,6 @@ msgid "Assets"
 msgstr "Ativos"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr "Anexar um sticker"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -544,7 +544,6 @@ msgid "Assets"
 msgstr "Активы"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -544,7 +544,6 @@ msgid "Assets"
 msgstr "Varlıklar"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -544,7 +544,6 @@ msgid "Assets"
 msgstr "资产"
 
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Attach a sticker"
 msgstr "上传一张贴图"
 


### PR DESCRIPTION
## What does this PR do and why?
removes the tooltip in v2 to match v1 functionality addressed down the pr stack

hover sticker icon, tool tip doesn't show anymore 
## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
