### PR TITLE
clean up terinary

### DIFF
--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -94,23 +94,20 @@ export const V2PayForm = ({
                   top: 7,
                 }}
               >
-                {canAddMoreStickers ? (
+                {
                   <Sticker
-                    style={{ color: colors.text.secondary }}
+                    style={{
+                      color: colors.text.secondary,
+                      cursor: canAddMoreStickers ? 'pointer' : 'not-allowed',
+                    }}
                     size={20}
                     onClick={() => {
-                      setAttachStickerModalVisible(true)
+                      canAddMoreStickers
+                        ? setAttachStickerModalVisible(true)
+                        : undefined
                     }}
                   />
-                ) : (
-                  <Sticker
-                    size={20}
-                    style={{
-                      color: colors.text.disabled,
-                      cursor: 'not-allowed',
-                    }}
-                  />
-                )}
+                }
               </div>
               <Form.Item name="stickerUrls">
                 <StickerSelection />


### PR DESCRIPTION
## What does this PR do and why?

After cleaning up the sticker div stuff it seemed like just having these two ternaries would be easier to read than rendering two different components. Not sure if we have a strong style guide on stuff like this, it just felt logical. If the previous code style was better feel free to just close this diff.

That's one of the nice things about stacked diffs. Because changes are so small we don't have to wait on this one style nit here or there. It can just be broken up into different PRs and we can isolate the single change, giving it the thumbs up or down.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
