### PR TITLE
Various redemption rate and redeem tokens improvements

### DIFF
--- a/src/components/formItems/ProjectRedemptionRate.tsx
+++ b/src/components/formItems/ProjectRedemptionRate.tsx
@@ -221,11 +221,11 @@ export function ProjectRedemptionRate({
                   }}
                   disabled={disabled}
                 >
-                  {label ?? <Trans>Bonding curve rate</Trans>}
+                  {label ?? <Trans>Redemption rate</Trans>}
                 </SwitchHeading>
               ) : (
                 <FormItemLabel>
-                  {label ?? <Trans>Bonding curve rate</Trans>}
+                  {label ?? <Trans>Redemption rate</Trans>}
                 </FormItemLabel>
               )}
             </div>

--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -5,6 +5,7 @@ import { formattedNum } from 'utils/formatNumber'
 import { FormItemExt } from 'components/formItems/formItemExt'
 
 export default function FormattedNumberInput({
+  name,
   style,
   min,
   max,
@@ -19,6 +20,7 @@ export default function FormattedNumberInput({
   onChange,
   isInteger,
 }: {
+  name?: string
   style?: CSSProperties
   min?: number
   max?: number
@@ -54,63 +56,65 @@ export default function FormattedNumberInput({
   }
 
   return (
-    <div className="formatted-number-input">
-      <Form.Item {...formItemProps}>
+    <Form.Item
+      name={name}
+      {...formItemProps}
+      className="formatted-number-input"
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          position: 'relative',
+          ...style,
+        }}
+      >
+        <InputNumber
+          className={accessory ? 'antd-no-number-handler' : ''}
+          min={min}
+          max={max}
+          style={{ width: '100%' }}
+          value={value !== undefined ? parseFloat(value) : undefined}
+          step={step ?? 1}
+          stringMode={true}
+          placeholder={placeholder}
+          formatter={(val?: string | number | undefined) =>
+            _prefix +
+            (val
+              ? formattedNum(val, {
+                  thousandsSeparator,
+                  decimalSeparator,
+                })
+              : '') +
+            _suffix
+          }
+          parser={(val?: string) =>
+            parseFloat(
+              (val !== undefined ? val : '0')
+                .replace(new RegExp(thousandsSeparator, 'g'), '')
+                .replace(_prefix, '')
+                .replace(_suffix, '')
+                .split('')
+                .filter(char => allowedValueChars.includes(char))
+                .join('') || '0',
+            )
+          }
+          disabled={disabled}
+          onChange={_value => {
+            onChange?.(_value?.toString())
+          }}
+        />
         <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            position: 'relative',
-            ...style,
+            zIndex: 1,
+            fontSize: '.8rem',
+            position: 'absolute',
+            right: 5,
           }}
         >
-          <InputNumber
-            className={accessory ? 'antd-no-number-handler' : ''}
-            min={min}
-            max={max}
-            style={{ width: '100%' }}
-            value={value !== undefined ? parseFloat(value) : undefined}
-            step={step ?? 1}
-            stringMode={true}
-            placeholder={placeholder}
-            formatter={(val?: string | number | undefined) =>
-              _prefix +
-              (val
-                ? formattedNum(val, {
-                    thousandsSeparator,
-                    decimalSeparator,
-                  })
-                : '') +
-              _suffix
-            }
-            parser={(val?: string) =>
-              parseFloat(
-                (val !== undefined ? val : '0')
-                  .replace(new RegExp(thousandsSeparator, 'g'), '')
-                  .replace(_prefix, '')
-                  .replace(_suffix, '')
-                  .split('')
-                  .filter(char => allowedValueChars.includes(char))
-                  .join('') || '0',
-              )
-            }
-            disabled={disabled}
-            onChange={_value => {
-              onChange?.(_value?.toString())
-            }}
-          />
-          <div
-            style={{
-              zIndex: 1,
-              fontSize: '.8rem',
-              position: 'absolute',
-              right: 5,
-            }}
-          >
-            {accessory && <div>{accessory}</div>}
-          </div>
+          {accessory && <div>{accessory}</div>}
         </div>
-      </Form.Item>
-    </div>
+      </div>
+    </Form.Item>
   )
 }

--- a/src/components/v1/V1Project/modals/PrintPreminedModal.tsx
+++ b/src/components/v1/V1Project/modals/PrintPreminedModal.tsx
@@ -69,7 +69,6 @@ export default function PrintPreminedModal({
       if (!terminal?.version) return
 
       const amountValidator = () => {
-        console.info('amountValidator: ', value)
         if (!value || value === '0') {
           return Promise.reject(t`Amount required`)
         }

--- a/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
@@ -457,7 +457,7 @@ export default function ReconfigureFCModal({
               isRecurring(editingFC) &&
               hasFundingTarget(editingFC) && (
                 <Statistic
-                  title={t`Bonding curve rate`}
+                  title={t`Redemption rate`}
                   value={perbicentToPercent(editingFC.bondingCurveRate)}
                   suffix="%"
                 />

--- a/src/components/v1/V1Project/modals/RedeemModal.tsx
+++ b/src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -155,7 +155,7 @@ export default function RedeemModal({
       <Space direction="vertical" style={{ width: '100%' }}>
         <div>
           <p style={statsStyle}>
-            <Trans>Bonding curve:</Trans>{' '}
+            <Trans>Redemption rate:</Trans>{' '}
             <span>
               {fcMetadata?.bondingCurveRate !== undefined
                 ? fcMetadata.bondingCurveRate / 2

--- a/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -187,7 +187,7 @@ export default function FundingCycleDetails({
             span={2}
             label={
               <TooltipLabel
-                label={<Trans>Bonding curve rate</Trans>}
+                label={<Trans>Redemption rate</Trans>}
                 tip={
                   <Trans>
                     This rate determines the amount of overflow that each token

--- a/src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -104,7 +104,7 @@ export default function V2RedeemModal({
     if (redeemBN.eq(0)) {
       return Promise.reject(t`Required`)
     } else if (redeemBN.gt(totalBalance ?? 0)) {
-      return Promise.reject(t`Your balance exceeded`)
+      return Promise.reject(t`Insufficient token balance`)
     } else if (redeemBN.gt(totalTokenSupply ?? 0)) {
       // Error message already showing for this case
       return Promise.reject()
@@ -268,11 +268,13 @@ export default function V2RedeemModal({
           minReturnedTokens?.gt(0) ? (
             <div style={{ fontWeight: 500, marginTop: 20 }}>
               <>
+                {/* If USD denominated, can only define the lower limit (not exact amount), hence 'at least' */}
+                {/* Using 4 full sentences for translation purposes */}
                 {!personalBalanceExceeded ? (
                   <>
                     {inUSD ? (
                       <Trans>
-                        You will receive minimum {minReturnedTokensFormatted}{' '}
+                        You will receive at least {minReturnedTokensFormatted}{' '}
                         ETH
                       </Trans>
                     ) : (
@@ -285,7 +287,7 @@ export default function V2RedeemModal({
                   <>
                     {inUSD ? (
                       <Trans>
-                        You would receive minimum {minReturnedTokensFormatted}{' '}
+                        You would receive at least {minReturnedTokensFormatted}{' '}
                         ETH
                       </Trans>
                     ) : (

--- a/src/locales/bg/messages.po
+++ b/src/locales/bg/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -579,7 +579,6 @@ msgid "Back to top"
 msgstr "Back to top"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Balance exceeded"
 
@@ -610,18 +609,6 @@ msgstr "Block number"
 msgid "Blog"
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr ""
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr ""
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr ""
@@ -633,6 +620,10 @@ msgstr "Burn project tokens"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -673,6 +664,10 @@ msgstr "Cancel"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Cannot redeem tokens for ETH because this project has no overflow."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2579,11 +2574,20 @@ msgstr "Redeem {tokensTextLong} for ETH"
 msgid "Redeemed"
 msgstr "Redeemed"
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Redemption rate"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr "Redemption rate:"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3656,6 +3660,10 @@ msgstr "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr "You have exceeded the total token supply of <0>{0}</0>"
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr ""
@@ -3696,6 +3704,14 @@ msgstr "You will receive {0}{1} ETH"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "You will receive {minReturnedTokensFormatted} ETH"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr "You would receive minimum {minReturnedTokensFormatted} ETH"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr "You would receive {minReturnedTokensFormatted} ETH"
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr ""
@@ -3728,6 +3744,10 @@ msgstr "Your V1 {tokenSymbolFormatted} balance"
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr "Your balance exceeded"
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1675,6 +1675,10 @@ msgstr "Initial issuance rate"
 msgid "Initial mint rate"
 msgstr "Initial mint rate"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr "Insufficient token balance"
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Issue ERC-20"
@@ -3693,8 +3697,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr "You receive an NFT for contributing over <0>{0} ETH</0>."
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "You will receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr "You will receive at least {minReturnedTokensFormatted} ETH"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3705,8 +3709,8 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "You will receive {minReturnedTokensFormatted} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
+msgstr "You would receive at least {minReturnedTokensFormatted} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
@@ -3744,10 +3748,6 @@ msgstr "Your V1 {tokenSymbolFormatted} balance"
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr ""
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr "Your balance exceeded"
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -584,7 +584,6 @@ msgid "Back to top"
 msgstr "Regresa arriba"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Balance excedido"
 
@@ -615,18 +614,6 @@ msgstr "Número de bloque"
 msgid "Blog"
 msgstr "Blog"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr "Tasa de curva de adhesión"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr "Curva de adhesión:"
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Construido para:"
@@ -638,6 +625,10 @@ msgstr "Quemar tokens del proyecto"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Quema tus {tokensLabel}. No recibirás ETH de regreso porque este proyecto no tiene excedente."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -678,6 +669,10 @@ msgstr "Cancelar"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "No se pueden canjear tokens por ETH porque este proyecto no tiene excedente."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2584,11 +2579,20 @@ msgstr "Canjear {tokensTextLong} por ETH"
 msgid "Redeemed"
 msgstr "Canjeado"
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Porcentaje de canje"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3661,6 +3665,10 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Has configurado que todos los fondos sean distribuidos desde el tesoro. La suma de tus pagos actuales no es 100%, así que el remanente irá al dueño del proyecto."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr ""
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Has establecido un objetivo del ciclo de financiamiento."
@@ -3701,6 +3709,14 @@ msgstr "Vas a recibir {0}{1} ETH"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Recibirás {minReturnedTokensFormatted} ETH"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Podrás emitir tokens ERC-20 una vez el contrato de tu proyecto haya sido desplegado. Hasta entonces, el protocolo rastreará mientras tanto los balances de los tokens, permitiendo a tus seguidores ganar tokens y canjearlos por el excedente."
@@ -3733,6 +3749,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Tu balance"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1680,6 +1680,10 @@ msgstr "Tasa de emisión inicial"
 msgid "Initial mint rate"
 msgstr "Tasa inicial de acuñación"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr ""
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Emitir ERC-20"
@@ -3698,8 +3702,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "Recibirás al menos {minReturnedTokensFormatted} ETH"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3710,7 +3714,7 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Recibirás {minReturnedTokensFormatted} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -3749,10 +3753,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Tu balance"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1680,6 +1680,10 @@ msgstr "Taux d'émission initiale"
 msgid "Initial mint rate"
 msgstr "Taux de frappe initial"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr ""
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Émettre ERC-20"
@@ -3698,8 +3702,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "Vous recevrez un minimum {minReturnedTokensFormatted} d'ETH"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3710,7 +3714,7 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Vous recevrez {minReturnedTokensFormatted} d'ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -3749,10 +3753,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Votre solde"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -584,7 +584,6 @@ msgid "Back to top"
 msgstr "Haut de page"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Solde dépassé"
 
@@ -615,18 +614,6 @@ msgstr "Numéro de blocage"
 msgid "Blog"
 msgstr "Blog"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr "Taux de la courbe de liaison"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr "Courbe de liaison :"
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Construit pour :"
@@ -638,6 +625,10 @@ msgstr "Brûler les tokens du projet"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Brûler vos {tokensLabel}. Vous ne recevrez pas d'ETH en retour car ce projet n'a pas d'overflow."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -678,6 +669,10 @@ msgstr "Annuler"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Il n'est pas possible de récupérer des tokens pour ETH car ce projet n'a pas d'overflow."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2584,11 +2579,20 @@ msgstr "Récupérer {tokensTextLong} pour ETH"
 msgid "Redeemed"
 msgstr "Récupéré"
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Taux de récupération"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3661,6 +3665,10 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Vous avez configuré pour que tous les fonds soient distribués à partir de la trésorerie. Vos paiements actuels ne totalisent pas 100%, le reste ira donc au propriétaire du projet."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr ""
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Vous avez défini un objectif du cycle de financement."
@@ -3701,6 +3709,14 @@ msgstr "Vous recevrez {0}{1} ETH"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Vous recevrez {minReturnedTokensFormatted} d'ETH"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Vous pourrez émettre des tokens ERC-20 une fois votre contrat de projet déployé. Jusque-là, le protocole suivra les soldes de tokens, permettant à vos financeurs de gagner des tokens et de les récupérer de l'overflow entre-temps."
@@ -3733,6 +3749,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Votre solde"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/hi/messages.po
+++ b/src/locales/hi/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/id/messages.po
+++ b/src/locales/id/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -584,7 +584,6 @@ msgid "Back to top"
 msgstr "De volta ao início"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Saldo excedido"
 
@@ -615,18 +614,6 @@ msgstr "Número de Blockchain"
 msgid "Blog"
 msgstr "Blog"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr "Taxa da curva de vínculo"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr "Curva de vínculo:"
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Construído para:"
@@ -638,6 +625,10 @@ msgstr "Queimar os tokens do projeto"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Queime seus {tokensLabel}. Você não receberá ETH em retorno porque este projeto não tem overflow."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -678,6 +669,10 @@ msgstr "Cancelar"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Não é possível reivindicar tokens por ETH, porque este projeto não tem overflow."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2584,11 +2579,20 @@ msgstr "Resgatar {tokensTextLong} por ETH"
 msgid "Redeemed"
 msgstr "Resgatado"
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Taxa de resgate"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3661,6 +3665,10 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Você configurou para que todos os fundos sejam distribuídos a partir de sua tesouraria. Os seus pagamentos atuais não somam até 100%, então, o restante irá para o proprietário do projeto."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr ""
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Você definiu a meta do ciclo de financiamento."
@@ -3701,6 +3709,14 @@ msgstr "Você receberá {0}{1} ETH"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Você receberá {minReturnedTokensFormatted} ETH"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Você poderá emitir tokens ERC-20 uma vez que o contrato de seu projeto tenha sido lançado. Até lá, o protocolo rastreará os saldos de tokens, permitindo, enquanto isso, que os seus apoiadores ganhem tokens e os resgatem por overflow."
@@ -3733,6 +3749,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Seu saldo"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1680,6 +1680,10 @@ msgstr "Taxa de emissão inicial"
 msgid "Initial mint rate"
 msgstr "A taxa inicial de emissão"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr ""
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Emitir ERC-20"
@@ -3698,8 +3702,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "Você receberá um mínimo de {minReturnedTokensFormatted} ETH"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3710,7 +3714,7 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Você receberá {minReturnedTokensFormatted} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -3749,10 +3753,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Seu saldo"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -584,7 +584,6 @@ msgid "Back to top"
 msgstr "Вернуться наверх"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Баланс превышен"
 
@@ -615,18 +614,6 @@ msgstr "Номер блока"
 msgid "Blog"
 msgstr "Блог"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr "Ставка скорости кривой по облигациям"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr "Ставка скорости кривой по облигациям:"
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Создан для:"
@@ -638,6 +625,10 @@ msgstr "Сжечь токены проекта"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Сожгите свой {tokensLabel}. Вы не получите ETH взамен, потому что у этого проекта нет перетока."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -678,6 +669,10 @@ msgstr "Отменить"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Невозможно обменять токены на ETH, так как в этом проекте нет переполнения."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2584,11 +2579,20 @@ msgstr "Обменять {tokensTextLong} за ETH"
 msgid "Redeemed"
 msgstr ""
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Коэффициент выкупа"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3661,6 +3665,10 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr ""
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr ""
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Вы установили цель цикла финансирования."
@@ -3701,6 +3709,14 @@ msgstr "Вы получите {0}{1} ETH"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Вы получите {minReturnedTokensFormatted} ETH"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Вы сможете выпускать ERC-20 токены после того, как ваш контракт по проекту будет установлен. До тех пор протокол будет отслеживать балансы токенов, позволяя вашим сторонникам заработать токены и использовать их для переполнения."
@@ -3733,6 +3749,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Ваш баланс"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1680,6 +1680,10 @@ msgstr "Первоначальная ставка эмиссии"
 msgid "Initial mint rate"
 msgstr ""
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr ""
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Выпуск ERC-20"
@@ -3698,8 +3702,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "Вы будете получать минимум {minReturnedTokensFormatted} ETH"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3710,7 +3714,7 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Вы получите {minReturnedTokensFormatted} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -3749,10 +3753,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Ваш баланс"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -584,7 +584,6 @@ msgid "Back to top"
 msgstr "Başa dön"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Bakiye aşıldı"
 
@@ -615,18 +614,6 @@ msgstr "Blok numarası"
 msgid "Blog"
 msgstr "Blog"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr "Bağlılık eğrisi oranı"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr "Bağlılık eğrisi:"
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Şunlar için üretildi:"
@@ -638,6 +625,10 @@ msgstr "Proje token'larını yakın"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "{tokensLabel} token'larınızı yakın. Karşılığında ETH almayacaksınız çünkü bu projede taşma bulunmuyor."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -678,6 +669,10 @@ msgstr "İptal"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Bu projede taşma bulunmadığından ETH için token talep edilemez."
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2584,11 +2579,20 @@ msgstr "{tokensTextLong} token'larını ETH için kullan"
 msgid "Redeemed"
 msgstr "Kullanılan"
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Kullanım oranı"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3661,6 +3665,10 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Tüm fonları hazineden dağıtılacak şekilde yapılandırdınız. Mevcut ödemeleriniz %100'e ulaşmıyor, bu nedenle geri kalan miktar proje sahibine gidecek."
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr ""
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Bir finansman döngüsü hedefi belirlediniz."
@@ -3701,6 +3709,14 @@ msgstr "{0}{1} ETH alacaksınız"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "{minReturnedTokensFormatted} ETH alacaksınız"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Proje sözleşmeniz dağıtıldıktan sonra ERC-20 token'larını çıkarabileceksiniz. O zamana kadar protokol, token bakiyelerini takip ederek destekçilerinizin bu arada token kazanmasına ve onları taşma için kullanmasına izin verecektir."
@@ -3733,6 +3749,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Bakiyeniz"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -1680,6 +1680,10 @@ msgstr "İlk token çıkarma oranı"
 msgid "Initial mint rate"
 msgstr "İlk basım oranı"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr ""
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "ERC-20 çıkart"
@@ -3698,8 +3702,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "En az {minReturnedTokensFormatted} ETH alacaksınız"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3710,7 +3714,7 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "{minReturnedTokensFormatted} ETH alacaksınız"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -3749,10 +3753,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Bakiyeniz"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/uk/messages.po
+++ b/src/locales/uk/messages.po
@@ -620,11 +620,11 @@ msgstr ""
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
+msgid "Redemption rate"
 msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
+msgid "Redemption:"
 msgstr ""
 
 #: src/pages/index.page.tsx
@@ -4059,4 +4059,5 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr ""
+
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -584,7 +584,6 @@ msgid "Back to top"
 msgstr "回到顶部"
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "超出余额"
 
@@ -615,18 +614,6 @@ msgstr "区块数"
 msgid "Blog"
 msgstr "博客"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-msgid "Bonding curve rate"
-msgstr "联合曲线比率"
-
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-msgid "Bonding curve:"
-msgstr "联合曲线："
-
 #: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "服务的对象:"
@@ -638,6 +625,10 @@ msgstr "燃烧项目代币"
 #: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "燃烧你的 {tokensLabel}。你不会收到 ETH 作为回报，因为这个项目没有溢出的资金。"
+
+#: src/components/ManageTokensModal.tsx
+msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
@@ -678,6 +669,10 @@ msgstr "取消"
 #: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "这个项目的筹款没有溢出，无法用代币赎回 ETH"
+
+#: src/components/ManageTokensModal.tsx
+msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
+msgstr ""
 
 #: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
@@ -2584,11 +2579,20 @@ msgstr "燃烧 {tokensTextLong} 来赎回 ETH"
 msgid "Redeemed"
 msgstr "赎回"
 
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/formItems/ProjectRedemptionRate.tsx
+#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 #: src/pages/create/forms/TokenForm/index.tsx
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "赎回率"
+
+#: src/components/v1/V1Project/modals/RedeemModal.tsx
+msgid "Redemption rate:"
+msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
@@ -3661,6 +3665,10 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "你已经配置把金库的所有资金分配出去。你当前的支出总额没有达到所有资金的100%，因此剩余部分将会分配给项目方。"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You have exceeded the total token supply of <0>{0}</0>"
+msgstr ""
+
 #: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "您设定了一个筹款周期目标。"
@@ -3701,6 +3709,14 @@ msgstr "你会收到 {0}{1} ETH"
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "你将会收到 {minReturnedTokensFormatted} ETH"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgstr ""
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgstr ""
+
 #: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "项目合约部署上线后，你就可以铸造ERC-20代币了。在此之后，协议就会开始追踪代币余额，同时允许你的支持者获得代币以及赎回代币取得项目溢出资金。"
@@ -3733,6 +3749,10 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "你的余额"
+
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Your balance exceeded"
+msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1680,6 +1680,10 @@ msgstr "初始发行比率"
 msgid "Initial mint rate"
 msgstr "最初铸造比率"
 
+#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+msgid "Insufficient token balance"
+msgstr ""
+
 #: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "签发 ERC-20"
@@ -3698,8 +3702,8 @@ msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You will receive minimum {minReturnedTokensFormatted} ETH"
-msgstr "你将会收到最低额度 {minReturnedTokensFormatted} ETH"
+msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgstr ""
 
 #: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
@@ -3710,7 +3714,7 @@ msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "你将会收到 {minReturnedTokensFormatted} ETH"
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "You would receive minimum {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -3749,10 +3753,6 @@ msgstr ""
 #: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "你的余额"
-
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
-msgid "Your balance exceeded"
-msgstr ""
 
 #: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/pages/v1/create/ConfirmDeployProject.tsx
+++ b/src/pages/v1/create/ConfirmDeployProject.tsx
@@ -277,7 +277,7 @@ export default function ConfirmDeployProject() {
               hasFundingTarget(editingFC) && (
                 <Col md={8} xs={24}>
                   <Statistic
-                    title={t`Bonding curve rate`}
+                    title={t`Redemption rate`}
                     value={perbicentToPercent(editingFC?.bondingCurveRate)}
                     suffix="%"
                   />

--- a/src/utils/v2/fundingCycle.ts
+++ b/src/utils/v2/fundingCycle.ts
@@ -23,11 +23,13 @@ import { MAX_DISTRIBUTION_LIMIT } from './math'
 export const hasDistributionLimit = (
   fundAccessConstraint: SerializedV2FundAccessConstraint | undefined,
 ): boolean => {
+  // Distribution limit defaults to Zero (which is a distribution limit)
+  if (!fundAccessConstraint) return true
+
   return Boolean(
-    fundAccessConstraint?.distributionLimit &&
-      !parseWad(fundAccessConstraint.distributionLimit).eq(
-        MAX_DISTRIBUTION_LIMIT,
-      ),
+    !parseWad(fundAccessConstraint.distributionLimit).eq(
+      MAX_DISTRIBUTION_LIMIT,
+    ),
   )
 }
 


### PR DESCRIPTION
## What does this PR do and why?

Sorry could have split this one up a bit more, but most points are linked. 

- Fixes bug where redemption rate was disabled with distribution limit is **Zero** (Closes #1466)

- Disables redeem button (shows 'Burn' button) when redemption rate is **Zero** (Closes #251)
<img width="790" alt="Screen Shot 2022-07-25 at 3 05 47 pm" src="https://user-images.githubusercontent.com/96150256/180711827-d5ad9f4f-f794-45d3-8d7b-b95067e851e9.png">

- Changes all V1 `Bonding curve rate`s to `Redemption rate`s (Closes #1523)

- Various redeem modal improvements (Closes #652):
     - Show when total token supply exceeded
     - Hide 'You will receive 0 ETH'
     - Change 'will' to 'would' when personal token balance exceeded
     - Make validation actually work

https://user-images.githubusercontent.com/96150256/180712644-de9d41f3-477b-434d-8723-2bcd45abcee2.mp4




## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
