### PR TITLE
Add loading state for stats section and Make Distribute activity element consistent with Pay event design

### DIFF
--- a/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
@@ -55,17 +55,35 @@ export default function ReservesEventElem({
         style={{
           display: 'flex',
           justifyContent: 'space-between',
+          alignContent: 'space-between',
         }}
       >
-        <div style={smallHeaderStyle(colors)}>
-          <Trans>
-            Distributed reserved{' '}
-            {tokenSymbolText({
-              tokenSymbol: tokenSymbol,
-              capitalize: false,
-              plural: true,
-            })}
-          </Trans>
+        <div>
+          <div style={smallHeaderStyle(colors)}>
+            <Trans>
+              Distributed reserved{' '}
+              {tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })}
+            </Trans>
+          </div>
+          {distributeEvents?.length ? (
+            <div
+              style={{
+                color: colors.text.primary,
+                fontWeight: 500,
+              }}
+            >
+              {formatWad(event.count, { precision: 0 })}{' '}
+              {tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })}
+            </div>
+          ) : null}
         </div>
 
         <div style={{ textAlign: 'right' }}>
@@ -128,18 +146,6 @@ export default function ReservesEventElem({
           </div>
         )}
       </div>
-
-      {distributeEvents?.length && distributeEvents?.length > 1 ? (
-        <div
-          style={{
-            color: colors.text.primary,
-            fontWeight: 500,
-            textAlign: 'right',
-          }}
-        >
-          {formatWad(event.count, { precision: 0 })}
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
@@ -80,7 +80,7 @@ export default function ReservesEventElem({
               {tokenSymbolText({
                 tokenSymbol: tokenSymbol,
                 capitalize: false,
-                plural: true,
+                plural: event.count.toNumber() !== 1,
               })}
             </div>
           ) : null}

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
@@ -67,10 +67,24 @@ export default function TapEventElem({
         style={{
           display: 'flex',
           justifyContent: 'space-between',
+          alignContent: 'space-between',
         }}
       >
-        <div style={smallHeaderStyle(colors)}>
-          <Trans>Distributed funds</Trans>
+        <div>
+          <div style={smallHeaderStyle(colors)}>
+            <Trans>Distributed funds</Trans>
+          </div>
+          {payoutEvents?.length ? (
+            <div
+              style={{
+                color: colors.text.primary,
+                fontWeight: 500,
+              }}
+            >
+              <CurrencySymbol currency="ETH" />
+              {formatWad(event.netTransferAmount, { precision: 4 })}
+            </div>
+          ) : null}
         </div>
 
         <div
@@ -149,19 +163,6 @@ export default function TapEventElem({
           </div>
         )}
       </div>
-
-      {payoutEvents?.length && payoutEvents.length > 1 ? (
-        <div
-          style={{
-            color: colors.text.primary,
-            fontWeight: 500,
-            textAlign: 'right',
-          }}
-        >
-          <CurrencySymbol currency="ETH" />
-          {formatWad(event.netTransferAmount, { precision: 4 })}
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
@@ -9,7 +9,11 @@ import { formatHistoricalDate } from 'utils/formatDate'
 import { formatWad } from 'utils/formatNumber'
 
 import { Trans } from '@lingui/macro'
-import { smallHeaderStyle } from 'components/activityEventElems/styles'
+import {
+  contentLineHeight,
+  primaryContentFontSize,
+  smallHeaderStyle,
+} from 'components/activityEventElems/styles'
 import { DistributePayoutsEvent } from 'models/subgraph-entities/v2/distribute-payouts-event'
 
 export default function DistributePayoutsElem({
@@ -61,10 +65,24 @@ export default function DistributePayoutsElem({
         style={{
           display: 'flex',
           justifyContent: 'space-between',
+          alignContent: 'space-between',
         }}
       >
-        <div style={smallHeaderStyle(colors)}>
-          <Trans>Distributed funds</Trans>
+        <div>
+          <div style={smallHeaderStyle(colors)}>
+            <Trans>Distributed funds</Trans>
+          </div>
+          {distributePayoutsEvents?.length ? (
+            <div
+              style={{
+                lineHeight: contentLineHeight,
+                fontSize: primaryContentFontSize,
+              }}
+            >
+              <CurrencySymbol currency="ETH" />
+              {formatWad(event.distributedAmount, { precision: 4 })}
+            </div>
+          ) : null}
         </div>
 
         <div
@@ -138,19 +156,6 @@ export default function DistributePayoutsElem({
           </div>
         )}
       </div>
-
-      {distributePayoutsEvents?.length ? (
-        <div
-          style={{
-            color: colors.text.primary,
-            fontWeight: 500,
-            textAlign: 'right',
-          }}
-        >
-          <CurrencySymbol currency="ETH" />
-          {formatWad(event.distributedAmount, { precision: 4 })}
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
@@ -1,5 +1,9 @@
 import { Trans } from '@lingui/macro'
-import { smallHeaderStyle } from 'components/activityEventElems/styles'
+import {
+  contentLineHeight,
+  primaryContentFontSize,
+  smallHeaderStyle,
+} from 'components/activityEventElems/styles'
 import EtherscanLink from 'components/EtherscanLink'
 import FormattedAddress from 'components/FormattedAddress'
 import { ThemeContext } from 'contexts/themeContext'
@@ -63,21 +67,39 @@ export default function DistributeReservedTokensEventElem({
         style={{
           display: 'flex',
           justifyContent: 'space-between',
+          alignContent: 'space-between',
         }}
       >
-        <div style={smallHeaderStyle(colors)}>
-          <Trans>
-            Distributed reserved{' '}
-            {tokenSymbolText({
-              tokenSymbol: tokenSymbol,
-              capitalize: false,
-              plural: true,
-            })}
-          </Trans>
+        <div>
+          <div style={smallHeaderStyle(colors)}>
+            <Trans>
+              Distributed reserved{' '}
+              {tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })}
+            </Trans>
+          </div>
+          {distributeEvents?.length ? (
+            <div
+              style={{
+                lineHeight: contentLineHeight,
+                fontSize: primaryContentFontSize,
+              }}
+            >
+              {formatWad(event.tokenCount, { precision: 0 })}{' '}
+              {tokenSymbolText({
+                tokenSymbol: tokenSymbol,
+                capitalize: false,
+                plural: true,
+              })}
+            </div>
+          ) : null}
         </div>
 
-        <div style={{ textAlign: 'right' }}>
-          <div style={smallHeaderStyle(colors)}>
+        <div>
+          <div style={{ ...smallHeaderStyle(colors), textAlign: 'right' }}>
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
             )}{' '}
@@ -136,18 +158,6 @@ export default function DistributeReservedTokensEventElem({
           </div>
         )}
       </div>
-
-      {distributeEvents?.length && distributeEvents?.length > 1 ? (
-        <div
-          style={{
-            color: colors.text.primary,
-            fontWeight: 500,
-            textAlign: 'right',
-          }}
-        >
-          {formatWad(event.tokenCount, { precision: 0 })}
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
@@ -92,7 +92,7 @@ export default function DistributeReservedTokensEventElem({
               {tokenSymbolText({
                 tokenSymbol: tokenSymbol,
                 capitalize: false,
-                plural: true,
+                plural: event.tokenCount.toNumber() !== 1,
               })}
             </div>
           ) : null}

--- a/src/pages/home/StatsSection.tsx
+++ b/src/pages/home/StatsSection.tsx
@@ -9,9 +9,11 @@ import { formattedNum } from 'utils/formatNumber'
 const Stat = ({
   value,
   label,
+  loading,
 }: {
   value: string | number | JSX.Element | undefined
   label: string | JSX.Element
+  loading: boolean
 }) => {
   const {
     theme: { colors },
@@ -34,7 +36,7 @@ const Stat = ({
           color: colors.text.brand.primary,
         }}
       >
-        {value}
+        {loading ? '-' : value}
       </div>
       <div style={{ fontSize: '1rem' }}>{label}</div>
     </div>
@@ -42,7 +44,7 @@ const Stat = ({
 }
 
 export function StatsSection() {
-  const { data: protocolLogs } = useSubgraphQuery({
+  const { data: protocolLogs, isLoading } = useSubgraphQuery({
     entity: 'protocolLog',
     keys: ['erc20Count', 'paymentsCount', 'projectsCount', 'volumePaid'],
   })
@@ -64,14 +66,17 @@ export function StatsSection() {
       <Stat
         value={stats?.projectsCount}
         label={<Trans>Projects on Juicebox</Trans>}
+        loading={isLoading}
       />
       <Stat
         value={<ETHAmount amount={stats?.volumePaid} />}
         label={<Trans>Raised on Juicebox</Trans>}
+        loading={isLoading}
       />
       <Stat
         value={formattedNum(stats?.paymentsCount)}
         label={<Trans>Payments made</Trans>}
+        loading={isLoading}
       />
     </section>
   )


### PR DESCRIPTION
## What does this PR do and why?

Closes #1323 and #1361. Accidentally did both on the same branch and didn't feel like moving 1361's work to a new branch 😅

Adds a '-' value while project summary stats are loading on the front page. 

Makes Distribute activity element consistent with Pay event design. Affects distribution event elems for V1 and V2 projects.

## Screenshots or screen recordings

<img width="876" alt="Screen Shot 2022-07-25 at 10 59 45 AM" src="https://user-images.githubusercontent.com/33093632/180810632-66e6f3cb-9488-4f02-b5d1-72a644a142c6.png">

<img width="432" alt="Screen Shot 2022-07-25 at 11 42 13 AM" src="https://user-images.githubusercontent.com/33093632/180819794-a403f29a-a882-44c4-a35f-7d8931920ca3.png">

<img width="431" alt="Screen Shot 2022-07-25 at 11 42 19 AM" src="https://user-images.githubusercontent.com/33093632/180819814-c1e093d4-3fd2-4e2d-85d8-781f68883239.png">

<img width="426" alt="Screen Shot 2022-07-25 at 11 42 44 AM" src="https://user-images.githubusercontent.com/33093632/180819835-2b0dcb8e-820c-47d2-b6fa-6ce5904673a1.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
