### PR TITLE
add onBlur to format-input component

### DIFF
--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -17,6 +17,7 @@ export default function FormattedNumberInput({
   accessory,
   formItemProps,
   onChange,
+  onBlur,
   isInteger,
 }: {
   style?: CSSProperties
@@ -30,6 +31,7 @@ export default function FormattedNumberInput({
   prefix?: string
   accessory?: JSX.Element
   onChange?: (val?: string) => void
+  onBlur?: (val?: string) => void
   isInteger?: boolean
 } & FormItemExt) {
   const thousandsSeparator = ','
@@ -97,6 +99,9 @@ export default function FormattedNumberInput({
             disabled={disabled}
             onChange={_value => {
               onChange?.(_value?.toString())
+            }}
+            onBlur={_value => {
+              onBlur?.(_value?.toString())
             }}
           />
           <div


### PR DESCRIPTION
## What does this PR do and why?

Input fields have a onBlur function, we should support onBlur events, we'll need blur events to fix https://github.com/jbx-protocol/juice-interface/issues/1537. https://reactjs.org/docs/events.html#onblur



## Screenshots or screen recordings

N/A


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
