### PR TITLE
Add basic validation to github archive endpoint

### DIFF
--- a/src/pages/api/github/archive-project.page.ts
+++ b/src/pages/api/github/archive-project.page.ts
@@ -30,12 +30,16 @@ const handler = async (
   try {
     const { archived, projectId, metadata, handle, cv } = req.body
 
+    if (!projectId || !metadata || !handle) {
+      throw new Error()
+    }
+
     const headers = {
       Authorization: `Bearer ${githubToken}`,
     }
 
     const title = `[${archived ? 'ARCHIVE' : 'UNARCHIVE'}] Project: "${
-      metadata?.name
+      metadata.name
     }"`
 
     const body = `


### PR DESCRIPTION
As per title.

I think rogue issues are being created: https://github.com/jbx-protocol/juice-interface/issues/1549

This PR should prevent that.