### PR TITLE
Risk flag for custom ballot strategy and remove risk flag from funding history

### DIFF
--- a/src/components/Project/FundingCycleDetailWarning.tsx
+++ b/src/components/Project/FundingCycleDetailWarning.tsx
@@ -19,10 +19,12 @@ export default function FundingCycleDetailWarning({
 
   return (
     <Tooltip title={tooltipTitle}>
-      <span style={{ fontWeight: 500 }}>{children} </span>
-      <span style={{ color: colors.text.warn }}>
-        <ExclamationCircleOutlined />
-      </span>
+      <div style={{ display: 'flex' }}>
+        <span style={{ fontWeight: 500 }}>{children} </span>
+        <span style={{ color: colors.text.warn, marginLeft: '0.5rem' }}>
+          <ExclamationCircleOutlined />
+        </span>
+      </div>
     </Tooltip>
   )
 }

--- a/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -115,6 +115,10 @@ export default function FundingCycleDetails({
 
   const riskWarningText = FUNDING_CYCLE_WARNING_TEXT()
 
+  const ballotWarningText = unsafeFundingCycleProperties.noBallot
+    ? riskWarningText.noBallot
+    : riskWarningText.customBallot
+
   return (
     <div>
       <Descriptions
@@ -305,8 +309,11 @@ export default function FundingCycleDetails({
           :
         </span>{' '}
         <FundingCycleDetailWarning
-          showWarning={unsafeFundingCycleProperties.ballot}
-          tooltipTitle={riskWarningText.ballot}
+          showWarning={
+            unsafeFundingCycleProperties.noBallot ||
+            unsafeFundingCycleProperties.customBallot
+          }
+          tooltipTitle={ballotWarningText}
         >
           {ballotStrategy.name}
         </FundingCycleDetailWarning>

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -120,6 +120,10 @@ export default function FundingCycleDetails({
 
   const riskWarningText = FUNDING_CYCLE_WARNING_TEXT()
 
+  const ballotWarningText = unsafeFundingCycleProperties.noBallot
+    ? riskWarningText.noBallot
+    : riskWarningText.customBallot
+
   return (
     <div>
       <Descriptions
@@ -329,8 +333,11 @@ export default function FundingCycleDetails({
           :
         </span>{' '}
         <FundingCycleDetailWarning
-          showWarning={unsafeFundingCycleProperties.ballot}
-          tooltipTitle={riskWarningText.ballot}
+          showWarning={
+            unsafeFundingCycleProperties.noBallot ||
+            unsafeFundingCycleProperties.customBallot
+          }
+          tooltipTitle={ballotWarningText}
         >
           {ballotStrategy.name}
         </FundingCycleDetailWarning>

--- a/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
@@ -70,9 +70,15 @@ export default function V2FundingCycleSection({
     return <NoFundingCycle />
   }
 
-  const tabText = ({ text }: { text: string }) => {
+  const tabText = ({
+    text,
+    hideRiskFlag,
+  }: {
+    text: string
+    hideRiskFlag?: boolean
+  }) => {
     const hasRisks = fundingCycle && V2FundingCycleRiskCount(fundingCycle)
-    if (!hasRisks) {
+    if (!hasRisks || hideRiskFlag) {
       return text
     }
 
@@ -114,7 +120,7 @@ export default function V2FundingCycleSection({
       },
     {
       key: 'history',
-      label: tabText({ text: t`History` }),
+      label: tabText({ text: t`History`, hideRiskFlag: true }),
       content: (
         <CardSection>
           <FundingCycleHistory />

--- a/src/constants/fundingWarningText.ts
+++ b/src/constants/fundingWarningText.ts
@@ -4,7 +4,8 @@ export const RESERVED_RATE_WARNING_THRESHOLD_PERCENT = 90
 
 export type FundingCycleRiskFlags = {
   duration: boolean
-  ballot: boolean
+  noBallot: boolean
+  customBallot: boolean
   allowMinting: boolean
   metadataReservedRate: boolean
   metadataMaxReservedRate: boolean
@@ -15,7 +16,8 @@ export const FUNDING_CYCLE_WARNING_TEXT: () => {
 } = () => {
   return {
     duration: t`The project owner may reconfigure this funding cycle at any time, without notice.`,
-    ballot: t`Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors.`,
+    noBallot: t`Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors.`,
+    customBallot: t`The project owner is using an unverified contract for its reconfiguration strategy.`,
     allowMinting: t`The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors.`,
     metadataMaxReservedRate: t`Contributors will not receive any tokens in exchange for paying this project.`,
     metadataReservedRate: t`Contributors will receive a relatively small portion of tokens in exchange for paying this project.`,

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2506,13 +2506,13 @@ msgstr ""
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "Reconfiguration rules"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr ""
@@ -3057,6 +3057,10 @@ msgstr "The percentage this individual receives of the overall {reservedRate}% r
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr "The project owner can add and remove payment terminals."
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
+msgstr "The project owner is using an unverified contract for its reconfiguration strategy."
 
 #: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2511,13 +2511,13 @@ msgstr "Reconfiguración"
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "Reglas de reconfiguración"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Estrategia de reconfiguración"
@@ -3061,6 +3061,10 @@ msgstr "El porcentaje que éste individuo recibe del {reservedRate}% total de as
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
+msgstr ""
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2511,13 +2511,13 @@ msgstr "Reparamétrage"
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "Règles de reparamétrage"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Stratégie de reparamétrage"
@@ -3061,6 +3061,10 @@ msgstr "Le pourcentage que cet individu reçoit de l'allocation globale {reserve
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
+msgstr ""
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2511,13 +2511,13 @@ msgstr "Reconfiguração"
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "Regras de reconfiguração"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Estratégia de configuração"
@@ -3061,6 +3061,10 @@ msgstr "A porcentagem que este indivíduo recebe do {reservedRate}% total de alo
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
+msgstr ""
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2511,13 +2511,13 @@ msgstr "Реконфигурация"
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "Правила реконфигурации"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Стратегия изменения конфигурации"
@@ -3061,6 +3061,10 @@ msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
+msgstr ""
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2511,13 +2511,13 @@ msgstr "Yeniden yapılandırma"
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "Yeniden yapılandırma kuralları"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Yeniden yapılandırma stratejisi"
@@ -3061,6 +3061,10 @@ msgstr "Bu kişinin toplam %{reservedRate} rezerve token tahsisinden aldığı y
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
+msgstr ""
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2511,13 +2511,13 @@ msgstr "重新配置"
 
 #: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 #: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reconfiguration rules"
 msgstr "重新配置的规则"
 
 #: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 #: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 #: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "重新配置策略"
@@ -3061,6 +3061,10 @@ msgstr "这个个体收到的全部 {reservedRate}% 保留代币分配方案中�
 
 #: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
+msgstr ""
+
+#: src/constants/fundingWarningText.ts
+msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
 #: src/constants/fundingWarningText.ts

--- a/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -308,22 +308,29 @@ export function ReconfigurationStatistic({
 }: {
   ballotAddress: string
 }) {
+  const riskWarningText = FUNDING_CYCLE_WARNING_TEXT()
+  const ballot = getBallotStrategyByAddress(ballotAddress)
+
+  const noBallot = ballot.durationSeconds === 0
+  const customBallot = ballot.unknown
+
+  const ballotWarningText = customBallot
+    ? riskWarningText.customBallot
+    : riskWarningText.noBallot
+
   return (
     <Statistic
       title={
         <TooltipLabel
-          label={t`Reconfiguration rules`}
+          label={t`Reconfiguration strategy`}
           tip={t`How long before your next funding cycle must you reconfigure in order for changes to take effect.`}
         />
       }
       valueRender={() => {
-        const ballot = getBallotStrategyByAddress(ballotAddress)
         return (
           <FundingCycleDetailWarning
-            showWarning={
-              !ballot.durationSeconds || ballot.durationSeconds === 0
-            }
-            tooltipTitle={FUNDING_CYCLE_WARNING_TEXT().ballot}
+            showWarning={noBallot || customBallot}
+            tooltipTitle={ballotWarningText}
           >
             <div>
               {ballot.name}{' '}

--- a/src/utils/unsafeFundingCycleProperties.ts
+++ b/src/utils/unsafeFundingCycleProperties.ts
@@ -1,14 +1,15 @@
 import * as constants from '@ethersproject/constants'
+import { BallotStrategy } from 'models/ballot'
 
 import { RESERVED_RATE_WARNING_THRESHOLD_PERCENT } from 'constants/fundingWarningText'
 
 export default function unsafeFundingCycleProperties({
-  ballotAddress,
+  ballot,
   reservedRatePercentage,
   hasFundingDuration,
   allowMinting,
 }: {
-  ballotAddress: string | undefined
+  ballot: BallotStrategy
   reservedRatePercentage: number | undefined
   hasFundingDuration: boolean | undefined
   allowMinting: boolean | undefined
@@ -17,7 +18,8 @@ export default function unsafeFundingCycleProperties({
   // This object is based on type FundingCycle
   const configFlags = {
     duration: false,
-    ballot: false,
+    noBallot: false,
+    customBallot: false,
     allowMinting: false,
     metadataReservedRate: false,
     metadataMaxReservedRate: false,
@@ -28,8 +30,15 @@ export default function unsafeFundingCycleProperties({
    * Funding cycle reconfigurations can be created moments before a new cycle begins,
    * giving project owners an opportunity to take advantage of contributors, for example by withdrawing overflow.
    */
-  if (ballotAddress === constants.AddressZero) {
-    configFlags.ballot = true
+  if (ballot.address === constants.AddressZero) {
+    configFlags.noBallot = true
+  }
+
+  /**
+   * Custom, unverified ballot address
+   */
+  if (ballot.unknown) {
+    configFlags.customBallot = true
   }
 
   /**

--- a/src/utils/v1/fundingCycle.ts
+++ b/src/utils/v1/fundingCycle.ts
@@ -101,14 +101,14 @@ export const getUnsafeV1FundingCycleProperties = (
   fundingCycle: V1FundingCycle,
 ): FundingCycleRiskFlags => {
   const metadata = decodeFundingCycleMetadata(fundingCycle.metadata)
-  const ballotAddress = getBallotStrategyByAddress(fundingCycle.ballot).address
+  const ballot = getBallotStrategyByAddress(fundingCycle.ballot)
   const reservedRatePercentage = parseFloat(
     perbicentToPercent(metadata?.reservedRate),
   )
   const allowMinting = Boolean(metadata?.ticketPrintingIsAllowed)
 
   return unsafeFundingCycleProperties({
-    ballotAddress,
+    ballot,
     reservedRatePercentage,
     hasFundingDuration: hasFundingDuration(fundingCycle),
     allowMinting,

--- a/src/utils/v2/fundingCycle.ts
+++ b/src/utils/v2/fundingCycle.ts
@@ -189,12 +189,12 @@ export const getUnsafeV2FundingCycleProperties = (
   fundingCycle: V2FundingCycle,
 ): FundingCycleRiskFlags => {
   const metadata = decodeV2FundingCycleMetadata(fundingCycle.metadata)
-  const ballotAddress = getBallotStrategyByAddress(fundingCycle.ballot).address
+  const ballot = getBallotStrategyByAddress(fundingCycle.ballot)
   const reservedRatePercentage = parseFloat(fromWad(metadata?.reservedRate))
   const allowMinting = Boolean(metadata?.allowMinting)
 
   return unsafeFundingCycleProperties({
-    ballotAddress,
+    ballot,
     reservedRatePercentage,
     hasFundingDuration: fundingCycle.duration?.gt(0),
     allowMinting,


### PR DESCRIPTION
## What does this PR do and why?

- Risk flag for custom strategy (closes #613)
<img width="511" alt="Screen Shot 2022-07-26 at 1 00 22 pm" src="https://user-images.githubusercontent.com/96150256/180915345-c1999f00-7b50-4af3-810b-fb611f8e0a39.png">

- Remove risk flag from funding history (closes #1378)
<img width="584" alt="Screen Shot 2022-07-26 at 1 09 59 pm" src="https://user-images.githubusercontent.com/96150256/180915324-52f6d59a-3c1a-47b6-b029-3b793d2847e0.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
