### PR TITLE
fix icon cut off on safari

### DIFF
--- a/src/styles/antd-overrides/icon.scss
+++ b/src/styles/antd-overrides/icon.scss
@@ -1,0 +1,3 @@
+.anticon svg {
+  height: auto;
+}

--- a/src/styles/antd-overrides/index.scss
+++ b/src/styles/antd-overrides/index.scss
@@ -27,3 +27,4 @@
 @import 'menu.scss';
 @import 'skeleton.scss';
 @import 'radio.scss';
+@import 'icon.scss';


### PR DESCRIPTION
## What does this PR do and why?
Fixed icons getting cut off in safari, need to post a before and after image confirming fix


![CleanShot 2022-07-26 at 18 40 15@2x](https://user-images.githubusercontent.com/2502947/181124624-56d51195-5eb8-4dc7-aae5-d277ebcd610f.png)


Confirm items aren't cut off in the deploy preview on safari, firefox, chrome.

https://github.com/jbx-protocol/juice-interface/issues/1298

Would you mind if I merge with graphite after LGTM?

## Screenshots or screen recordings

TODO will add
## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
