### PR TITLE
1483 memo in reconfigure

### DIFF
--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/reconfigureFundingCycle.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/reconfigureFundingCycle.ts
@@ -8,9 +8,11 @@ import { EditingProjectData } from './editingProjectData'
 
 export const useReconfigureFundingCycle = ({
   editingProjectData,
+  memo,
   exit,
 }: {
   editingProjectData: EditingProjectData
+  memo: string
   exit: VoidFunction
 }) => {
   const {
@@ -92,6 +94,7 @@ export const useReconfigureFundingCycle = ({
           editingPayoutGroupedSplits,
           editingReservedTokensGroupedSplits,
         ],
+        memo,
       },
       {
         onDone() {
@@ -117,6 +120,7 @@ export const useReconfigureFundingCycle = ({
     editingReservedTokensGroupedSplits,
     nftRewardsCids,
     fundingCycle,
+    memo,
     exit,
     reconfigureV2FundingCycleTx,
   ])

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Divider, Modal, Space } from 'antd'
+import { Divider, Form, Modal, Space } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { useCallback, useContext, useState } from 'react'
 import { CaretRightFilled } from '@ant-design/icons'
@@ -12,6 +12,8 @@ import TokenDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/T
 
 import RulesDrawer from 'components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
+
+import { MemoFormInput } from 'components/inputs/Pay/MemoFormInput'
 
 import { V2ReconfigureProjectDetailsDrawer } from './drawers/V2ReconfigureProjectDetailsDrawer'
 import V2ReconfigureUpcomingMessage from './V2ReconfigureUpcomingMessage'
@@ -80,6 +82,7 @@ export default function V2ProjectReconfigureModal({
 }) {
   const { initialEditingData } = useInitialEditingData(visible)
   const editingProjectData = useEditingProjectData()
+  const [memo, setMemo] = useState('')
   const {
     fundingHasSavedChanges,
     fundingDrawerHasSavedChanges,
@@ -95,7 +98,7 @@ export default function V2ProjectReconfigureModal({
   } = useContext(V2ProjectContext)
 
   const { reconfigureLoading, reconfigureFundingCycle } =
-    useReconfigureFundingCycle({ editingProjectData, exit })
+    useReconfigureFundingCycle({ editingProjectData, memo, exit })
 
   const [projectHandleDrawerVisible, setProjectHandleDrawerVisible] =
     useState<boolean>(false)
@@ -217,6 +220,16 @@ export default function V2ProjectReconfigureModal({
         fundingCycleData={editingProjectData.editingFundingCycleData}
         fundAccessConstraints={editingProjectData.editingFundAccessConstraints}
       />
+      <Form layout="vertical">
+        <Form.Item
+          name="memo"
+          label={t`Memo (optional)`}
+          className={'antd-no-number-handler'}
+          extra={t`Add an on-chain memo to this payment.`}
+        >
+          <MemoFormInput value={memo} onChange={setMemo} />
+        </Form.Item>
+      </Form>
       {hideProjectDetails ? null : (
         <V2ReconfigureProjectDetailsDrawer
           visible={projectDetailsDrawerVisible}

--- a/src/hooks/v2/transactor/ReconfigureV2FundingCycleTx.ts
+++ b/src/hooks/v2/transactor/ReconfigureV2FundingCycleTx.ts
@@ -12,7 +12,6 @@ import { TransactorInstance } from 'hooks/Transactor'
 import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
 const DEFAULT_MUST_START_AT_OR_AFTER = '1'
-const DEFAULT_MEMO = ''
 
 export function useReconfigureV2FundingCycleTx(): TransactorInstance<{
   fundingCycleData: V2FundingCycleData
@@ -20,6 +19,7 @@ export function useReconfigureV2FundingCycleTx(): TransactorInstance<{
   fundAccessConstraints: V2FundAccessConstraint[]
   groupedSplits?: GroupedSplits<SplitGroup>[]
   mustStartAtOrAfter?: string // epoch seconds. anything less than "now" will start immediately.
+  memo: string
 }> {
   const { transactor, contracts } = useContext(V2UserContext)
   const { projectId } = useContext(V2ProjectContext)
@@ -31,6 +31,7 @@ export function useReconfigureV2FundingCycleTx(): TransactorInstance<{
       fundAccessConstraints,
       groupedSplits = [],
       mustStartAtOrAfter = DEFAULT_MUST_START_AT_OR_AFTER,
+      memo,
     },
     txOpts,
   ) => {
@@ -54,7 +55,7 @@ export function useReconfigureV2FundingCycleTx(): TransactorInstance<{
         mustStartAtOrAfter,
         groupedSplits,
         fundAccessConstraints,
-        DEFAULT_MEMO,
+        memo,
       ],
       txOpts,
     )

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -321,6 +321,7 @@ msgstr "Add a payout"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Add an on-chain memo to this payment."
 
@@ -1851,6 +1852,7 @@ msgstr "Memo"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Memo (optional)"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -326,6 +326,7 @@ msgstr "Añadir un pago"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Añadir un memo on-chain a este pago."
 
@@ -1856,6 +1857,7 @@ msgstr "Memo"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Memo (opcional)"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -326,6 +326,7 @@ msgstr "Ajouter un paiement"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr ""
 
@@ -1856,6 +1857,7 @@ msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Mémo (facultatif)"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -326,6 +326,7 @@ msgstr "Adicionar um pagamento"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Adicionar um memorando on-chain a este pagamento."
 
@@ -1856,6 +1857,7 @@ msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Memo (opcional)"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -326,6 +326,7 @@ msgstr "Добавить выплату"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr ""
 
@@ -1856,6 +1857,7 @@ msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -326,6 +326,7 @@ msgstr "Ödeme ekle"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr ""
 
@@ -1856,6 +1857,7 @@ msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -326,6 +326,7 @@ msgstr "添加支出对象"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "给这笔付款添加一个链上备注"
 
@@ -1856,6 +1857,7 @@ msgstr ""
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "备注（可选）"
 


### PR DESCRIPTION
## What does this PR do and why?

Closes #1483. Adds memo field to V2 project reconfigure modal. As far as I know, memo cannot be attached to a V1 project reconfiguration.

## Screenshots or screen recordings

<img width="640" alt="image" src="https://user-images.githubusercontent.com/33093632/181365761-1bfaafcc-1c2c-4041-ab09-4636d4ed596c.png">

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/33093632/181365778-9e78f2aa-ae34-4bd6-b1aa-4af835f65442.png">

https://rinkeby.etherscan.io/tx/0xd2394df746f48b8646c2669ec65b8c85a191cae3076bcfcd00c2b45e232bc02a#eventlog

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
