### PR TITLE
1453 project beneficiary fix

### DIFF
--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -83,18 +83,24 @@ export default function SplitItem({
     }
     return (
       <div>
-        <div style={{ fontWeight: 500 }}>
-          <Link
-            href={v2ProjectRoute({ projectId: split.projectId })}
-            target="_blank"
-          >
-            <Tooltip title={getProjectTooltip()}>
-              <a className="text-primary hover-text-action-primary hover-text-decoration-underline">
-                {getProjectLabel()}
-              </a>
-            </Tooltip>
-          </Link>
+        <div>
+          <Tooltip title={getProjectTooltip()}>
+            <span>
+              <Link
+                href={v2ProjectRoute({ projectId: split.projectId })}
+                target="_blank"
+              >
+                <a
+                  className="text-primary hover-text-action-primary hover-text-decoration-underline"
+                  style={{ fontWeight: 500 }}
+                >
+                  {getProjectLabel()}
+                </a>
+              </Link>
+            </span>
+          </Tooltip>
         </div>
+
         <div
           style={{
             fontSize: '.8rem',

--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -1,5 +1,5 @@
 import { CrownFilled, LockOutlined } from '@ant-design/icons'
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { useContext } from 'react'
@@ -18,6 +18,7 @@ import useMobile from 'hooks/Mobile'
 import Link from 'next/link'
 import TooltipIcon from 'components/TooltipIcon'
 import { v2ProjectRoute } from 'utils/routes'
+import useProjectHandle from 'hooks/v2/contractReader/ProjectHandle'
 
 export default function SplitItem({
   split,
@@ -42,6 +43,10 @@ export default function SplitItem({
     theme: { colors },
   } = useContext(ThemeContext)
 
+  const { data: handle } = split.projectId
+    ? useProjectHandle({ projectId: parseInt(split.projectId) })
+    : { data: undefined }
+
   const isProjectOwner = projectOwnerAddress === split.beneficiary
   const isJuiceboxProject = split.projectId
     ? BigNumber.from(split.projectId).gt(0)
@@ -62,24 +67,33 @@ export default function SplitItem({
   const itemFontSize = isMobile ? '0.9rem' : 'unset'
 
   const JuiceboxProjectBeneficiary = () => {
+    const getProjectTooltip = () => {
+      return split.projectId
+        ? t`Juicebox V2 project with ID ${parseInt(split.projectId)}`
+        : t`Juicebox V2 project`
+    }
+    const getProjectLabel = () => {
+      if (handle) {
+        return t`@${handle}`
+      }
+      if (split.projectId) {
+        return t`Project ${parseInt(split.projectId)}`
+      }
+      return t`Unknown Project`
+    }
     return (
       <div>
-        {/* TODO figure out project "handles" with ENS resolution */}
-
         <div style={{ fontWeight: 500 }}>
-          <Tooltip
-            title={<Trans>Juicebox V2 project with ID {split.projectId}</Trans>}
+          <Link
+            href={v2ProjectRoute({ projectId: split.projectId })}
+            target="_blank"
           >
-            <Link
-              href={v2ProjectRoute({ projectId: split.projectId })}
-              target="_blank"
-            >
+            <Tooltip title={getProjectTooltip()}>
               <a className="text-primary hover-text-action-primary hover-text-decoration-underline">
-                @{split.projectId}
+                {getProjectLabel()}
               </a>
-            </Link>
-          </Tooltip>
-          :
+            </Tooltip>
+          </Link>
         </div>
         <div
           style={{

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -258,6 +258,10 @@ msgstr "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgid "@"
 msgstr ""
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr "@{handle}"
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr "@{handle} not found"
@@ -1727,6 +1731,10 @@ msgid "Juicebox V1 project ID"
 msgstr "Juicebox V1 project ID"
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr "Juicebox V2 project"
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Juicebox V2 project with ID {0}"
 
@@ -2401,6 +2409,10 @@ msgstr "Project token"
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
+msgstr "Project {0}"
 
 #: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
@@ -3398,6 +3410,7 @@ msgstr "Unarchive project"
 msgid "Unavailable"
 msgstr "Unavailable"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr "Unknown Project"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -263,6 +263,10 @@ msgstr "<0>{tokenSymbol} dirección de ERC-20:</0><1/>"
 msgid "@"
 msgstr "@"
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr ""
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
@@ -1732,6 +1736,10 @@ msgid "Juicebox V1 project ID"
 msgstr ""
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Proyecto de Juicebox V2 con ID {0}"
 
@@ -2405,6 +2413,10 @@ msgstr "Token de proyecto"
 
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
 msgstr ""
 
 #: src/components/NewDeployNotAvailable.tsx
@@ -3403,6 +3415,7 @@ msgstr "Desarchivar proyecto"
 msgid "Unavailable"
 msgstr "No disponible"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -263,6 +263,10 @@ msgstr "<0>{tokenSymbol} adresse de l'ERC-20 : </0><1/>"
 msgid "@"
 msgstr "@"
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr ""
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
@@ -1732,6 +1736,10 @@ msgid "Juicebox V1 project ID"
 msgstr ""
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Projet Juicebox V2 avec Identifiant {0}"
 
@@ -2405,6 +2413,10 @@ msgstr "Token du projet"
 
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
 msgstr ""
 
 #: src/components/NewDeployNotAvailable.tsx
@@ -3403,6 +3415,7 @@ msgstr "Désarchiver le projet"
 msgid "Unavailable"
 msgstr "Indisponible"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -263,6 +263,10 @@ msgstr "<0>{tokenSymbol} Endereço ERC-20:</0><1/>"
 msgid "@"
 msgstr "@"
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr ""
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
@@ -1732,6 +1736,10 @@ msgid "Juicebox V1 project ID"
 msgstr ""
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Projeto Juicebox V2 com ID {0}"
 
@@ -2405,6 +2413,10 @@ msgstr "Token do Projeto"
 
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
 msgstr ""
 
 #: src/components/NewDeployNotAvailable.tsx
@@ -3403,6 +3415,7 @@ msgstr "Desarquivar projeto"
 msgid "Unavailable"
 msgstr "Indisponível"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -263,6 +263,10 @@ msgstr "<0>{tokenSymbol} ERC20 адрес:</0> <1/>"
 msgid "@"
 msgstr "@"
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr ""
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
@@ -1732,6 +1736,10 @@ msgid "Juicebox V1 project ID"
 msgstr ""
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr ""
 
@@ -2405,6 +2413,10 @@ msgstr "Токен проекта"
 
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
 msgstr ""
 
 #: src/components/NewDeployNotAvailable.tsx
@@ -3403,6 +3415,7 @@ msgstr "Разархивировать проект"
 msgid "Unavailable"
 msgstr "Недоступно"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -263,6 +263,10 @@ msgstr "<0>{tokenSymbol} ERC-20 adresi:</0> <1/>"
 msgid "@"
 msgstr "@"
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr ""
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
@@ -1732,6 +1736,10 @@ msgid "Juicebox V1 project ID"
 msgstr ""
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "{0} Kimlikli Juicebox V2 projesi"
 
@@ -2405,6 +2413,10 @@ msgstr "Proje token'ı"
 
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
 msgstr ""
 
 #: src/components/NewDeployNotAvailable.tsx
@@ -3403,6 +3415,7 @@ msgstr "Projeyi arşivden kaldır"
 msgid "Unavailable"
 msgstr "Mevcut değil"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -263,6 +263,10 @@ msgstr "<0>{tokenSymbol} ERC-20 地址：</0><1/>"
 msgid "@"
 msgstr "@"
 
+#: src/components/v2/shared/SplitItem.tsx
+msgid "@{handle}"
+msgstr ""
+
 #: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
@@ -1732,6 +1736,10 @@ msgid "Juicebox V1 project ID"
 msgstr ""
 
 #: src/components/v2/shared/SplitItem.tsx
+msgid "Juicebox V2 project"
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Juicebox V2 上标识为 {0} 的项目"
 
@@ -2405,6 +2413,10 @@ msgstr "项目代币"
 
 #: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
+msgstr ""
+
+#: src/components/v2/shared/SplitItem.tsx
+msgid "Project {0}"
 msgstr ""
 
 #: src/components/NewDeployNotAvailable.tsx
@@ -3403,6 +3415,7 @@ msgstr "取消项目的存档状态"
 msgid "Unavailable"
 msgstr "不可用"
 
+#: src/components/v2/shared/SplitItem.tsx
 #: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""


### PR DESCRIPTION
## What does this PR do and why?

Closes #1453. On project payout splits for V2 projects, uses project handle if available, and if not converts the projectID from hex notation to int. Currently running parseInt in the component, but could be worth fixing in the useProjectSplits hook.

## Screenshots or screen recordings

<img width="594" alt="image" src="https://user-images.githubusercontent.com/33093632/181372918-44016a66-6934-4a68-9e97-20e51e122a28.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
