### PR TITLE
Move ERC20 warning to callout

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -81,14 +81,19 @@ export default function PayoutSplitsCard({
 
   function DistributeButton(): JSX.Element {
     return (
-      <Button
-        type="ghost"
-        size="small"
-        onClick={() => setDistributePayoutsModalVisible(true)}
-        disabled={distributeButtonDisabled}
+      <Tooltip
+        title={<Trans>No funds available to distribute.</Trans>}
+        visible={distributeButtonDisabled ? undefined : false}
       >
-        <Trans>Distribute funds</Trans>
-      </Button>
+        <Button
+          type="ghost"
+          size="small"
+          onClick={() => setDistributePayoutsModalVisible(true)}
+          disabled={distributeButtonDisabled}
+        >
+          <Trans>Distribute funds</Trans>
+        </Button>
+      </Tooltip>
     )
   }
 
@@ -126,15 +131,10 @@ export default function PayoutSplitsCard({
                 ownerAddress={projectOwnerAddress}
               />
             </Skeleton>
-            {distributableAmount?.eq(0) ? (
-              <Tooltip title={<Trans>No funds available to distribute.</Trans>}>
-                <div>
-                  <DistributeButton />
-                </div>
-              </Tooltip>
-            ) : (
+
+            <div>
               <DistributeButton />
-            )}
+            </div>
           </div>
         )}
 

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -20,8 +20,7 @@ import { useSetProjectSplits } from 'hooks/v2/transactor/SetProjectSplits'
 import { NetworkContext } from 'contexts/networkContext'
 import { MAX_DISTRIBUTION_LIMIT, splitPercentFrom } from 'utils/v2/math'
 import { formatWad } from 'utils/formatNumber'
-
-import { ExclamationCircleOutlined } from '@ant-design/icons'
+import Callout from 'components/Callout'
 
 import CurrencySymbol from 'components/CurrencySymbol'
 
@@ -85,31 +84,6 @@ const getLockedSplits = (splits: Split[]) => {
 const getEditableSplits = (splits: Split[]) => {
   const editableSplits = splits.filter(split => !isLockedSplit(split))
   return editableSplits
-}
-
-const DescriptionParagraphOne = () => (
-  <p>
-    <Trans>
-      Reconfigure payouts as percentages of your distribution limit.
-    </Trans>
-  </p>
-)
-const DescriptionParagraphTwo = () => {
-  const {
-    theme: { colors },
-  } = useContext(ThemeContext)
-  return (
-    <p>
-      <Space size="small">
-        <ExclamationCircleOutlined
-          style={{
-            color: colors.text.warn,
-          }}
-        />
-        <Trans>Changes to payouts will take effect immediately.</Trans>
-      </Space>
-    </p>
-  )
 }
 
 const DistributionLimitHeader = ({
@@ -293,17 +267,23 @@ export const EditPayoutsModal = ({
       <Modal
         visible={visible}
         confirmLoading={modalLoading}
-        title="Edit payouts"
-        okText="Save payouts"
-        cancelText={modalLoading ? 'Close' : 'Cancel'}
+        title={<Trans>Edit payouts</Trans>}
+        okText={<Trans>Save payouts</Trans>}
+        cancelText={modalLoading ? t`Close` : t`Cancel`}
         onOk={() => onSplitsConfirmed(editingSplits)}
         onCancel={onCancel}
         width={720}
       >
-        <div>
-          <DescriptionParagraphOne />
-          <DescriptionParagraphTwo />
-        </div>
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <div>
+            <Trans>
+              Reconfigure payouts as percentages of your distribution limit.
+            </Trans>
+          </div>
+          <Callout>
+            <Trans>Changes to payouts will take effect immediately.</Trans>
+          </Callout>
+        </Space>
         <DistributionLimitHeader style={{ marginTop: 32, marginBottom: 16 }} />
         <Space
           direction="vertical"

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -149,11 +149,6 @@ const VeNftStakingForm = ({
 
   return (
     <>
-      <Callout>
-        <Trans>
-          Only project tokens claimed as ERC-20 tokens can be staked for NFTs.
-        </Trans>
-      </Callout>
       <Form
         layout="vertical"
         style={{ width: '100%' }}
@@ -162,6 +157,12 @@ const VeNftStakingForm = ({
       >
         <div style={{ ...shadowCard(theme), padding: 25 }}>
           <Space direction="vertical" size={'large'} style={{ width: '100%' }}>
+            <Callout style={{ background: theme.colors.background.l1 }}>
+              <Trans>
+                Only project tokens claimed as ERC-20 tokens can be staked for
+                NFTs.
+              </Trans>
+            </Callout>
             <div>
               <Row gutter={20}>
                 <Col span={14}>

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -31,6 +31,8 @@ import { useVeNftTokenMetadata } from 'hooks/veNft/VeNftTokenMetadata'
 
 import { useVeNftResolverTokenUri } from 'hooks/veNft/VeNftResolverTokenUri'
 
+import Callout from 'components/Callout'
+
 import { shadowCard } from 'constants/styles/shadowCard'
 import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
@@ -147,6 +149,11 @@ const VeNftStakingForm = ({
 
   return (
     <>
+      <Callout>
+        <Trans>
+          Only project tokens claimed as ERC-20 tokens can be staked for NFTs.
+        </Trans>
+      </Callout>
       <Form
         layout="vertical"
         style={{ width: '100%' }}

--- a/src/components/veNft/formControls/TokensStakedInput.tsx
+++ b/src/components/veNft/formControls/TokensStakedInput.tsx
@@ -61,11 +61,6 @@ const TokensStakedInput = ({
           {unstakedTokens} {tokenSymbolDisplayText} remaining
         </Trans>
       }
-      tooltip={
-        <Trans>
-          Only project tokens claimed as ERC-20 tokens can be staked for NFTs.
-        </Trans>
-      }
     >
       <FormattedNumberInput
         name="tokensStaked"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2130,7 +2130,7 @@ msgstr "Once launched, your first funding cycle <0>can't be changed</0>. You can
 msgid "Only lowercase letters"
 msgstr "Only lowercase letters"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -673,6 +673,7 @@ msgstr ""
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Cancel"
@@ -771,6 +772,7 @@ msgstr "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to E
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1348,6 +1350,7 @@ msgid "Edit payout"
 msgstr "Edit payout"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr "Edit payouts"
 
@@ -2851,6 +2854,7 @@ msgid "Save payout"
 msgstr "Save payout"
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Save payouts"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -678,6 +678,7 @@ msgstr "¿Puedo eliminar un proyecto?"
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Cancelar"
@@ -776,6 +777,7 @@ msgstr "Reclamar {tokenTextLong} convertirá tu balance de {tokenTextShort} a to
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1353,6 +1355,7 @@ msgid "Edit payout"
 msgstr "Editar pago"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr "Editar pagos"
 
@@ -2856,6 +2859,7 @@ msgid "Save payout"
 msgstr "Guardar pago"
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Guardar pagos"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2135,7 +2135,7 @@ msgstr "Una vez lanzado, tu primer ciclo de financiamiento <0>no se puede cambia
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -678,6 +678,7 @@ msgstr "Puis-je supprimer un projet ?"
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Annuler"
@@ -776,6 +777,7 @@ msgstr "Si vous réclamez {tokenTextLong} votre solde {tokenTextShort} sera conv
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1353,6 +1355,7 @@ msgid "Edit payout"
 msgstr "Modifier un paiement"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
@@ -2856,6 +2859,7 @@ msgid "Save payout"
 msgstr "Sauvegarder le paiement"
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Sauvegarder les paiements"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2135,7 +2135,7 @@ msgstr "Une fois lancé, votre premier cycle de financement <0>ne peut plus êtr
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2135,7 +2135,7 @@ msgstr "Uma vez lançado, o seu primeiro ciclo de financiamento <0>não pode ser
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -678,6 +678,7 @@ msgstr "Posso excluir um projeto?"
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Cancelar"
@@ -776,6 +777,7 @@ msgstr "Reivindicar {tokenTextLong} irá converter o seu saldo de {tokenTextShor
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1353,6 +1355,7 @@ msgid "Edit payout"
 msgstr "Editar pagamento"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr "Editar pagamentos"
 
@@ -2856,6 +2859,7 @@ msgid "Save payout"
 msgstr "Salvar pagamento"
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Salvar pagamentos"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -678,6 +678,7 @@ msgstr "Могу ли я удалить проект?"
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Отменить"
@@ -776,6 +777,7 @@ msgstr "Требование {tokenTextLong} токенов конвертиру
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1353,6 +1355,7 @@ msgid "Edit payout"
 msgstr ""
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
@@ -2856,6 +2859,7 @@ msgid "Save payout"
 msgstr ""
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Сохранить платежи"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -678,6 +678,7 @@ msgstr "Bir projeyi silebilir miyim?"
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "İptal"
@@ -776,6 +777,7 @@ msgstr "{tokenTextLong} token'larınızı talep etmeniz, {tokenTextShort} bakiye
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1353,6 +1355,7 @@ msgid "Edit payout"
 msgstr "Ödemeyi düzenle"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
@@ -2856,6 +2859,7 @@ msgid "Save payout"
 msgstr "Ödemeyi kaydet"
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Ödemeleri kaydet"
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -2135,7 +2135,7 @@ msgstr "Bir kez başlatıldığında, ilk finansman döngünüz <0>değiştirile
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2135,7 +2135,7 @@ msgstr "一旦启动，你的第一个筹款周期 <0>不能再更改</0>。 你
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
+#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -678,6 +678,7 @@ msgstr "我可以删除一个项目吗？"
 #: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 #: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 #: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "取消"
@@ -776,6 +777,7 @@ msgstr "领取 {tokenTextLong} 代币将会以 ERC-20 格式铸造你的 {tokenT
 #: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
 #: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 #: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 #: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 #: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
@@ -1353,6 +1355,7 @@ msgid "Edit payout"
 msgstr "编辑支出对象"
 
 #: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
@@ -2856,6 +2859,7 @@ msgid "Save payout"
 msgstr "保存支出对象"
 
 #: src/components/v1/shared/forms/PayModsForm.tsx
+#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "保存开支配置"
 

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -313,7 +313,7 @@ textarea.ant-input::placeholder {
 }
 
 // added a wrapping Form.Item on FormattedNumberInput which gave it Form.Item's margin-bottom
-.formatted-number-input .ant-form-item {
+.ant-form-item.formatted-number-input {
   margin-bottom: 0;
   width: 100%;
 }


### PR DESCRIPTION
## What does this PR do and why?

Moves the warning about needing ERC-20 tokens to lock from a tooltip to a callout

## Screenshots or screen recordings

<img width="622" alt="image" src="https://user-images.githubusercontent.com/33093632/181407852-e19483a1-7857-462b-b79a-9b3ea07915d4.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
