### PR TITLE
Optimistic update of staking form on call for approval

### DIFF
--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -22,7 +22,6 @@ import VeNftCarousel from 'components/veNft/VeNftCarousel'
 import StakingTokenRangesModal from 'components/veNft/VeNftStakingTokenRangesModal'
 import ConfirmStakeModal from 'components/veNft/VeNftConfirmStakeModal'
 
-import { reloadWindow } from 'utils/windowUtils'
 import { parseWad } from 'utils/formatNumber'
 
 import { emitSuccessNotification } from 'utils/notifications'
@@ -62,6 +61,8 @@ const VeNftStakingForm = ({
   const [confirmStakeModalVisible, setConfirmStakeModalVisible] =
     useState(false)
   const [tokenApprovalLoading, setTokenApprovalLoading] = useState(false)
+  const [optimisticAllowanceResult, setOptimisticAllowanceResult] =
+    useState(false)
 
   const tokensStaked = useWatch('tokensStaked', form) || '1'
   const lockDuration = useWatch('lockDuration', form) || 0
@@ -97,9 +98,9 @@ const VeNftStakingForm = ({
     userAddress,
     VENFT_CONTRACT_ADDRESS,
   )
-  const hasAdequateApproval = allowance
-    ? allowance.gte(parseWad(tokensStaked))
-    : false
+  const hasAdequateApproval =
+    optimisticAllowanceResult ||
+    (allowance ? allowance.gte(parseWad(tokensStaked)) : false)
 
   const votingPower = parseInt(tokensStaked) * (lockDuration / maxLockDuration)
 
@@ -120,7 +121,7 @@ const VeNftStakingForm = ({
         onConfirmed() {
           setTokenApprovalLoading(false)
           emitSuccessNotification(t`Successfully approved ERC-20 spending.`)
-          reloadWindow()
+          setOptimisticAllowanceResult(true)
         },
       },
     )


### PR DESCRIPTION
## What does this PR do and why?

When a user calls the approve token for transaction message, instead of reloading the window, there is an optimistic update of the hasAdequateApproval value which lets the user fill the form and begin staking

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
