### PR TITLE
Fix payable address beneficiary bug

### DIFF
--- a/src/components/MinimalCollapse.tsx
+++ b/src/components/MinimalCollapse.tsx
@@ -21,7 +21,7 @@ export function MinimalCollapse({
       {...props}
     >
       <CollapsePanel key="1" header={header}>
-        {children}
+        <div style={{ paddingLeft: '1.5rem' }}>{children}</div>
       </CollapsePanel>
     </Collapse>
   )

--- a/src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Collapse, Form, Input, Switch } from 'antd'
+import { Collapse, Input, Switch } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
 import TooltipLabel from 'components/TooltipLabel'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
@@ -8,11 +8,19 @@ import * as constants from '@ethersproject/constants'
 import { EthAddressInput } from 'components/inputs/EthAddressInput'
 
 export default function AdvancedOptionsCollapse({
+  memo,
+  setMemo,
+  customBeneficiaryAddress,
+  setCustomBeneficiaryAddress,
   tokenMintingEnabled,
   setTokenMintingEnabled,
   preferClaimed,
   setPreferClaimed,
 }: {
+  memo: string | undefined
+  setMemo: Dispatch<SetStateAction<string | undefined>>
+  customBeneficiaryAddress: string | undefined
+  setCustomBeneficiaryAddress: Dispatch<SetStateAction<string | undefined>>
   tokenMintingEnabled: boolean
   setTokenMintingEnabled: Dispatch<SetStateAction<boolean>>
   preferClaimed: boolean
@@ -50,14 +58,14 @@ export default function AdvancedOptionsCollapse({
                 </Trans>
               }
             />
-            <Form.Item name="memo">
-              <Input
-                placeholder={t`Payment made through payable address`}
-                type="string"
-                autoComplete="off"
-                style={{ marginTop: 5 }}
-              />
-            </Form.Item>
+            <Input
+              value={memo}
+              onChange={e => setMemo(e.target.value)}
+              placeholder={t`Payment made through payable address`}
+              type="string"
+              autoComplete="off"
+              style={{ marginTop: 5 }}
+            />
           </div>
           <div style={{ display: 'flex', marginTop: advancedSettingsMargin }}>
             <TooltipLabel
@@ -90,6 +98,9 @@ export default function AdvancedOptionsCollapse({
               <Switch
                 onChange={checked => {
                   setCustomBeneficiaryEnabled(checked)
+                  if (!checked) {
+                    setCustomBeneficiaryAddress(undefined)
+                  }
                 }}
                 checked={customBeneficiaryEnabled}
                 style={{ marginLeft: switchMargin }}
@@ -97,9 +108,10 @@ export default function AdvancedOptionsCollapse({
             </div>
           ) : null}
           {tokenMintingEnabled && customBeneficiaryEnabled ? (
-            <Form.Item name="customBeneficiaryAddress">
-              <EthAddressInput />
-            </Form.Item>
+            <EthAddressInput
+              value={customBeneficiaryAddress}
+              onChange={setCustomBeneficiaryAddress}
+            />
           ) : null}
           {tokenMintingEnabled &&
           tokenAddress &&

--- a/src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
@@ -1,11 +1,11 @@
 import { t, Trans } from '@lingui/macro'
-import { Collapse, Input, Switch } from 'antd'
-import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+import { Input, Space, Switch } from 'antd'
 import TooltipLabel from 'components/TooltipLabel'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { Dispatch, SetStateAction, useContext, useState } from 'react'
 import * as constants from '@ethersproject/constants'
 import { EthAddressInput } from 'components/inputs/EthAddressInput'
+import { MinimalCollapse } from 'components/MinimalCollapse'
 
 export default function AdvancedOptionsCollapse({
   memo,
@@ -28,116 +28,103 @@ export default function AdvancedOptionsCollapse({
 }) {
   const { tokenAddress } = useContext(V2ProjectContext)
 
-  const [activeKey, setActiveKey] = useState<number>()
   const [customBeneficiaryEnabled, setCustomBeneficiaryEnabled] =
     useState<boolean>(false)
 
-  const advancedSettingsMargin = '20px'
-  const switchMargin = '20px'
+  const switchMargin = '1rem'
 
   return (
-    <Collapse style={{ border: 'none' }} activeKey={activeKey}>
-      <CollapsePanel
-        header={
-          <span onClick={() => setActiveKey(activeKey === 0 ? undefined : 0)}>
-            <Trans>Advanced options (optional)</Trans>
-          </span>
-        }
-        key={0}
-        style={{ border: 'none', marginLeft: '-18px' }}
-      >
-        <div style={{ paddingLeft: '24px', marginTop: '-15px' }}>
-          <div>
+    <MinimalCollapse header={<Trans>Advanced (optional)</Trans>}>
+      <Space size="middle" direction="vertical">
+        <div>
+          <TooltipLabel
+            label={t`Payment memo`}
+            tip={
+              <Trans>
+                The onchain memo for each payment made to this address. The
+                project's payment feed will include the memo alongside the
+                payment.
+              </Trans>
+            }
+          />
+          <Input
+            value={memo}
+            onChange={e => setMemo(e.target.value)}
+            type="string"
+            autoComplete="off"
+            style={{ marginTop: 5 }}
+          />
+        </div>
+        <div style={{ display: 'flex' }}>
+          <TooltipLabel
+            label={t`Token minting enabled`}
+            tip={t`Determines whether tokens will be minted from payments to this address.`}
+          />
+          <Switch
+            onChange={setTokenMintingEnabled}
+            checked={tokenMintingEnabled}
+            style={{ marginLeft: switchMargin }}
+          />
+        </div>
+        {tokenMintingEnabled &&
+        tokenAddress &&
+        tokenAddress !== constants.AddressZero ? (
+          <div style={{ display: 'flex' }}>
             <TooltipLabel
-              label={t`Custom memo`}
+              label={t`Mint tokens as ERC-20`}
               tip={
                 <Trans>
-                  The onchain memo for each transaction made through the
-                  address. It will appear in the project's payment feed when
-                  someone pays this address.
+                  When checked, payments to this address will mint this
+                  project's ERC-20 tokens to the beneficiary's wallet. Payments
+                  will cost more gas. When unchecked, Juicebox will track the
+                  beneficiary's new tokens when they pay. The beneficiary can
+                  claim their ERC-20 tokens at any time.
                 </Trans>
               }
             />
-            <Input
-              value={memo}
-              onChange={e => setMemo(e.target.value)}
-              placeholder={t`Payment made through payable address`}
-              type="string"
-              autoComplete="off"
-              style={{ marginTop: 5 }}
+            <Switch
+              style={{ marginLeft: switchMargin }}
+              checked={preferClaimed}
+              onChange={setPreferClaimed}
             />
           </div>
-          <div style={{ display: 'flex', marginTop: advancedSettingsMargin }}>
+        ) : null}
+
+        {tokenMintingEnabled ? (
+          <div
+            style={{
+              display: 'flex',
+            }}
+          >
             <TooltipLabel
-              label={t`Token minting enabled`}
-              tip={t`Determines whether tokens will be minted from payments to this address.`}
+              label={t`Custom token beneficiary`}
+              tip={
+                <Trans>
+                  By default, newly minted tokens will go to the wallet who
+                  sends funds to the address. You can enable this to set the
+                  token beneficiary to a custom address.
+                </Trans>
+              }
             />
             <Switch
-              onChange={setTokenMintingEnabled}
-              checked={tokenMintingEnabled}
+              onChange={checked => {
+                setCustomBeneficiaryEnabled(checked)
+                if (!checked) {
+                  setCustomBeneficiaryAddress(undefined)
+                }
+              }}
+              checked={customBeneficiaryEnabled}
               style={{ marginLeft: switchMargin }}
             />
           </div>
-          {tokenMintingEnabled ? (
-            <div
-              style={{
-                display: 'flex',
-                margin: `${advancedSettingsMargin} 0 14px`,
-              }}
-            >
-              <TooltipLabel
-                label={t`Custom token beneficiary`}
-                tip={
-                  <Trans>
-                    By default, newly minted tokens will go to the wallet who
-                    sends funds to the address. You can enable this to set the
-                    token beneficiary to a custom address.
-                  </Trans>
-                }
-              />
-              <Switch
-                onChange={checked => {
-                  setCustomBeneficiaryEnabled(checked)
-                  if (!checked) {
-                    setCustomBeneficiaryAddress(undefined)
-                  }
-                }}
-                checked={customBeneficiaryEnabled}
-                style={{ marginLeft: switchMargin }}
-              />
-            </div>
-          ) : null}
-          {tokenMintingEnabled && customBeneficiaryEnabled ? (
-            <EthAddressInput
-              value={customBeneficiaryAddress}
-              onChange={setCustomBeneficiaryAddress}
-            />
-          ) : null}
-          {tokenMintingEnabled &&
-          tokenAddress &&
-          tokenAddress !== constants.AddressZero ? (
-            <div style={{ display: 'flex', marginTop: advancedSettingsMargin }}>
-              <TooltipLabel
-                label={t`Mint tokens as ERC-20`}
-                tip={
-                  <Trans>
-                    When checked, payments to this address will mint this
-                    project's ERC-20 tokens to the beneficiary's wallet.
-                    Payments will cost more gas. When unchecked, Juicebox will
-                    track the beneficiary's new tokens when they pay. The
-                    beneficiary can claim their ERC-20 tokens at any time.
-                  </Trans>
-                }
-              />
-              <Switch
-                style={{ marginLeft: switchMargin }}
-                checked={preferClaimed}
-                onChange={setPreferClaimed}
-              />
-            </div>
-          ) : null}
-        </div>
-      </CollapsePanel>
-    </Collapse>
+        ) : null}
+        {tokenMintingEnabled && customBeneficiaryEnabled ? (
+          <EthAddressInput
+            value={customBeneficiaryAddress}
+            onChange={setCustomBeneficiaryAddress}
+          />
+        ) : null}
+      </Space>
+    </MinimalCollapse>
   )
 }

--- a/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
@@ -4,11 +4,12 @@ import { useState } from 'react'
 import { TransactionReceipt } from '@ethersproject/providers'
 import { TransactorInstance } from 'hooks/Transactor'
 
-import { Modal } from 'antd'
+import { Modal, Space } from 'antd'
 import { JBDiscordLink } from 'pages/home/QAs'
 import EtherscanLink from 'components/EtherscanLink'
 import CopyTextButton from 'components/CopyTextButton'
 import TransactionModal from 'components/TransactionModal'
+import Callout from 'components/Callout'
 import { DeployProjectPayerTxArgs } from 'hooks/v2/transactor/DeployProjectPayerTx'
 import { emitErrorNotification } from 'utils/notifications'
 
@@ -122,35 +123,40 @@ export default function LaunchProjectPayerModal({
         confirmLoading={loadingProjectPayer}
         transactionPending={transactionPending}
       >
-        <p>
-          <Trans>
-            Create an Ethereum address that can be used to pay your project
-            directly.
-          </Trans>
-        </p>
-        <p>
-          <Trans>
-            Tokens minted from payments to this address will belong to the payer
-            by default. However, if someone pays the project through a custodial
-            service platform such as Coinbase,{' '}
-            <strong>
-              tokens can't be issued to their personal wallets and will be lost
-            </strong>
-            .
-          </Trans>
-        </p>
-        {/* TODO: we should consider reworking this */}
-        {/* Form that controls internals of the AdvancedOptionsCollapse */}
-        <AdvancedOptionsCollapse
-          memo={memo}
-          setMemo={setMemo}
-          customBeneficiaryAddress={customBeneficiaryAddress}
-          setCustomBeneficiaryAddress={setCustomBeneficiaryAddress}
-          tokenMintingEnabled={tokenMintingEnabled}
-          setTokenMintingEnabled={setTokenMintingEnabled}
-          preferClaimed={preferClaimed}
-          setPreferClaimed={setPreferClaimed}
-        />
+        <Space direction="vertical" size="middle">
+          <div>
+            <Trans>
+              Create an Ethereum address that can be used to pay your project
+              directly.
+            </Trans>
+          </div>
+          <div>
+            <Trans>
+              By default, the payer will receive any project tokens minted from
+              the payment.
+            </Trans>
+          </div>
+
+          <Callout>
+            <Trans>
+              Contributors who pay this address from a custodial service
+              platform (like Coinbase){' '}
+              <strong>won't receive project tokens</strong>.
+            </Trans>
+          </Callout>
+          {/* TODO: we should consider reworking this */}
+          {/* Form that controls internals of the AdvancedOptionsCollapse */}
+          <AdvancedOptionsCollapse
+            memo={memo}
+            setMemo={setMemo}
+            customBeneficiaryAddress={customBeneficiaryAddress}
+            setCustomBeneficiaryAddress={setCustomBeneficiaryAddress}
+            tokenMintingEnabled={tokenMintingEnabled}
+            setTokenMintingEnabled={setTokenMintingEnabled}
+            preferClaimed={preferClaimed}
+            setPreferClaimed={setPreferClaimed}
+          />
+        </Space>
       </TransactionModal>
       <Modal
         visible={confirmedModalVisible}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -417,8 +417,8 @@ msgid "Adjust incentives for paying your project."
 msgstr "Adjust incentives for paying your project."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
-msgstr "Advanced options (optional)"
+msgid "Advanced (optional)"
+msgstr "Advanced (optional)"
 
 #: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
@@ -666,6 +666,10 @@ msgstr "By default, all unallocated funds can be distributed to the project owne
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr "By default, the payer will receive any project tokens minted from the payment."
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr ""
@@ -887,6 +891,10 @@ msgstr "Contributor rate"
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr "Contributors receive the NFT when they contribute at least this amount."
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
@@ -972,10 +980,6 @@ msgstr "Current owner: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Currently worth: <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr "Custom memo"
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2279,8 +2283,8 @@ msgid "Payment equivalent"
 msgstr "Payment equivalent"
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
-msgstr "Payment made through payable address"
+msgid "Payment memo"
+msgstr "Payment memo"
 
 #: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
@@ -3172,8 +3176,8 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "The number of project tokens minted when 1 ETH is contributed."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
-msgstr "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
+msgstr "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -3424,10 +3428,6 @@ msgstr "Tokens can be redeemed for a portion of this project's ETH overflow, acc
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -422,8 +422,8 @@ msgid "Adjust incentives for paying your project."
 msgstr "Ajusta los incentivos por pagar tu proyecto."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
-msgstr "Opciones avanzadas (opcional)"
+msgid "Advanced (optional)"
+msgstr ""
 
 #: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
@@ -671,6 +671,10 @@ msgstr "Por defecto, todos los fondos no asignados pueden ser distribuidos a la 
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Por defecto, tokens recientemente minteados irán a la billetera que envíe los fondos a la dirección. Puedes activar esto para establecer una dirección personalizada como beneficiario del token."
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr ""
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "¿Puedo cambiar el contrato de mi proyecto después de haber sido creado?"
@@ -892,6 +896,10 @@ msgstr "Tasa de Contribuidor"
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr ""
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Los contribuyentes serán retribuidos esta cantidad de tokens de tu proyecto por ETH contribuido."
@@ -977,10 +985,6 @@ msgstr "Dueño actual: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Actualmente vale: <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr "Memo personalizado"
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2284,8 +2288,8 @@ msgid "Payment equivalent"
 msgstr "Pago equivalente"
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
-msgstr "Pago hecho a través de una dirección pagable"
+msgid "Payment memo"
+msgstr ""
 
 #: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
@@ -3177,8 +3181,8 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "El número de tokens de proyecto acuñados cuando se contribuye 1 ETH."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
-msgstr "El memo onchain para cada transacción hecha a través de la dirección. Este aparecerá en el tablero de pagos del proyecto cuando alguien pague a esta dirección."
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
+msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -3429,10 +3433,6 @@ msgstr "Los tokens se pueden canjear por una porción del excedente de ETH, de a
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Los tokens no pueden ser reclamados porque no se ha emitido un token ERC-20 para este proyecto. Los tokens ERC-20 deben ser emitidos por el dueño del proyecto."
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr "Los tokens acuñados de pagos a esta dirección pertenecerán al pagador por defecto. Sin embargo, si alguien paga el proyecto a través de una plataforma de servicio de custodia como Coinbase, <0>los tokens no pueden ser emitidos a sus billeteras personales y se perderán</0>."
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -422,8 +422,8 @@ msgid "Adjust incentives for paying your project."
 msgstr "Définir des récompenses au paiement de votre projet."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
-msgstr "Options avancées (facultatif)"
+msgid "Advanced (optional)"
+msgstr ""
 
 #: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
@@ -671,6 +671,10 @@ msgstr "Par défaut, tous les fonds non assignés peuvent être distribués au p
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Par défaut, les tokens nouvellement frappés iront au portefeuille qui envoie des fonds à l'adresse. Vous pouvez activer ceci pour associer le bénéficiaire de tokens à une adresse customisée."
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr ""
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Puis-je changer mon contrat de projet après l'avoir créé ?"
@@ -892,6 +896,10 @@ msgstr ""
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr ""
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Les contributeurs recevront ce montant de tokens de votre projet par ETH contribué."
@@ -977,10 +985,6 @@ msgstr "Propriétaire actuel: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Valeur actuelle : <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr "Customiser le mémo"
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2284,8 +2288,8 @@ msgid "Payment equivalent"
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
-msgstr "Paiement effectué par le biais d'une adresse de facturation"
+msgid "Payment memo"
+msgstr ""
 
 #: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
@@ -3177,8 +3181,8 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
-msgstr "Le mémo en chaîne pour chaque transaction réalisée par biais de l'adresse. Il apparaîtra dans le flux de paiement du projet quand quelqu'un paie à cette adresse."
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
+msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -3429,10 +3433,6 @@ msgstr "Les tokens peuvent être récupérés d'une partie de l'overflow d'ETH d
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Les tokens ne peuvent pas être réclamés, car aucun token ERC-20 a été émis pour ce projet. Les tokens ERC-20 doivent être émis par le propriétaire du projet."
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr "Les tokens frappés à partir des paiements à cette adresse appartiendront au payeur par défaut. Cependant, si quelqu'un paie le projet à partir d'une plateforme de service custodial, comme Coinbase, <0>les tokens ne peuvent pas être émis vers leurs portefeuilles personnels et seront perdus</0>."
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -422,8 +422,8 @@ msgid "Adjust incentives for paying your project."
 msgstr "Ajuste incentivos para o pagamento do seu projeto."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
-msgstr "Opções avançadas (opcional)"
+msgid "Advanced (optional)"
+msgstr ""
 
 #: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
@@ -671,6 +671,10 @@ msgstr "Por padrão, todos os fundos não alocados podem ser distribuídos para 
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Por padrão, tokens recentemente emitidos irão para a carteira de quem enviou os fundos para o endereço. Você pode habilitar isso para configurar um endereço personalizado como beneficiário token."
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr ""
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Posso mudar o contrato do meu projeto após ele ter sido criado?"
@@ -892,6 +896,10 @@ msgstr "Taxa de contribuinte"
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr ""
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Contribuidores serão recompensados com essa quantidade de tokens de seu projeto por ETH contribuído."
@@ -977,10 +985,6 @@ msgstr "Atual proprietário: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Atualmente vale: <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr "Nota personalizada"
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2284,8 +2288,8 @@ msgid "Payment equivalent"
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
-msgstr "Pagamento feito através de endereço de pagamento"
+msgid "Payment memo"
+msgstr ""
 
 #: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
@@ -3177,8 +3181,8 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "O número de tokens do projeto emitidos quando 1 ETH é contribuído."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
-msgstr "A nota onchain para cada transação feita a partir do endereço. Isso irá aparecer no feed de pagamentos do projeto quando alguém pagar a esse endereço."
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
+msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -3429,10 +3433,6 @@ msgstr "Tokens podem ser resgatados por uma porção do overflow em ETH deste pr
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Tokens não podem ser reivindicados, pois nenhum token ERC-20 foi emitido para este projeto. Tokens ERC-20 devem ser emitidos pelo proprietário do projeto."
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr "Tokens criados dos pagamentos para esse endereço pertencerão, por padrão, ao pagador. Entretanto, se alguém pagar o projeto através de uma plataforma de serviços com custódia, tal como o aplicativo Coinbase, <0>tokens não poderão ser emitidos para suas carteiras pessoais e serão perdidos</0>."
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -422,7 +422,7 @@ msgid "Adjust incentives for paying your project."
 msgstr "Отрегулируйте стимулы для оплаты вашего проекта."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
+msgid "Advanced (optional)"
 msgstr ""
 
 #: src/pages/projects/ProjectsTabs.tsx
@@ -671,6 +671,10 @@ msgstr "По умолчанию все нераспределенные сред
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr ""
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Могу ли я изменить контракт своего проекта после его создания?"
@@ -892,6 +896,10 @@ msgstr ""
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr ""
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "За каждый внесенный ETH вкладчики получат это количество токенов вашего проекта."
@@ -977,10 +985,6 @@ msgstr "Текущий владелец: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "На данный момент стоит: <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr ""
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2284,7 +2288,7 @@ msgid "Payment equivalent"
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
+msgid "Payment memo"
 msgstr ""
 
 #: src/components/RichImgPreview.tsx
@@ -3177,7 +3181,7 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
@@ -3429,10 +3433,6 @@ msgstr "Токены могут быть выкуплены за часть пе
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Токены не могут быть востребованы, поскольку для этого проекта не выпущен токен ERC-20. Токены ERC-20 должны быть выпущены владельцем проекта."
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr ""
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -422,8 +422,8 @@ msgid "Adjust incentives for paying your project."
 msgstr "Projenize gelecek ödemeler için teşvikleri ayarlayın."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
-msgstr "Gelişmiş seçenekler (isteğe bağlı)"
+msgid "Advanced (optional)"
+msgstr ""
 
 #: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
@@ -671,6 +671,10 @@ msgstr "Aksi istenmediği takdirde, tahsis edilmemiş bütün fonlar proje sahib
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Varsayılan olarak, yeni basılan token'lar, adrese fon gönderen cüzdana gider. Token faydalanıcısını özel bir adres olarak belirlemek için bunu etkinleştirebilirsiniz."
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr ""
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Projemin sözleşmesini oluşturulduktan sonra değiştirebilir miyim?"
@@ -892,6 +896,10 @@ msgstr "Katkıda bulunan oranı"
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr ""
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Katkıda bulunanlar, katkıda bulundukları ETH başına bu miktarda proje token'ı ile ödüllendirilecektir."
@@ -977,10 +985,6 @@ msgstr "Güncel sahibi: {ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "Güncel değeri: <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr "Özel not"
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2284,8 +2288,8 @@ msgid "Payment equivalent"
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
-msgstr "Ödeme adresi üzerinden yapılan ödeme"
+msgid "Payment memo"
+msgstr ""
 
 #: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
@@ -3177,8 +3181,8 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "1 ETH katkıda bulunulduğunda basılan proje token'larının sayısı."
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
-msgstr "Adres aracılığıyla yapılan her işlem için zincir üstü not. Birisi bu adrese ödeme yaptığında projenin ödeme akışında bu not görünecektir."
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
+msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -3429,10 +3433,6 @@ msgstr "Token'lar, mevcut finansman döngüsünün kullanım oranına göre bu p
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Bu proje için herhangi bir ERC-20 token'ı çıkarılmamış olduğundan token'lar talep edilemez. ERC-20 token'ları proje sahibi tarafından çıkarılmalıdır."
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr "Bu adrese yapılan ödemelerden basılan token'lar varsayılan olarak ödeyene ait olacaktır. Ancak, birisi projeye Coinbase gibi bir emanet hizmeti platformu aracılığıyla ödeme yaparsa <0>token'lar kişisel cüzdanlarına çıkarılamaz ve kaybedilir</0>."
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -422,8 +422,8 @@ msgid "Adjust incentives for paying your project."
 msgstr "调整激励措施，以便鼓励其他人或项目向你的项目付款。"
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Advanced options (optional)"
-msgstr "高级选项（可选）"
+msgid "Advanced (optional)"
+msgstr ""
 
 #: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
@@ -671,6 +671,10 @@ msgstr "默认的情况下，所有未分配资金可被分发给项目拥有者
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "默认情况下，新铸造代币会分发给向这个地址付款的钱包地址。打开此选项可以把代币受益人设置为一个自定义地址。"
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "By default, the payer will receive any project tokens minted from the payment."
+msgstr ""
+
 #: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "项目合约创建后，我还更改它吗?"
@@ -892,6 +896,10 @@ msgstr "捐款铸造比率"
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
+#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
+msgstr ""
+
 #: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "捐款人每捐一个 ETH 就可以获得这个数量的项目代币。"
@@ -977,10 +985,6 @@ msgstr "当前项目方：{ownerAddress}"
 #: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/>{0}</0>"
 msgstr "当前价值： <0><1/>{0}</0>"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Custom memo"
-msgstr "自定义备注"
 
 #: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 #: src/utils/ballot.ts
@@ -2284,8 +2288,8 @@ msgid "Payment equivalent"
 msgstr ""
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "Payment made through payable address"
-msgstr "通过可支付地址支付的款项"
+msgid "Payment memo"
+msgstr ""
 
 #: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
@@ -3177,8 +3181,8 @@ msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "捐款 1 ETH 铸造的项目代币数量。"
 
 #: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-msgid "The onchain memo for each transaction made through the address. It will appear in the project's payment feed when someone pays this address."
-msgstr "通过这个地址进行的每一笔交易的链上备注。如果有人向这个地址付款，链上备注会出现在项目的付款情况一栏内。"
+msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
+msgstr ""
 
 #: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
@@ -3429,10 +3433,6 @@ msgstr "可以通过赎回代币，按当前筹款周期的赎回比率来获取
 #: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "因为 ERC-20 代币还没有签发，所以目前还不能领取代币。ERC-20 代币必须由项目方来签发。"
-
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-msgid "Tokens minted from payments to this address will belong to the payer by default. However, if someone pays the project through a custodial service platform such as Coinbase, <0>tokens can't be issued to their personal wallets and will be lost</0>."
-msgstr "向这个地址付款铸造出来的代币默认属于付款人。但是，如果有人通过类似 Coinbase 这样的托管式服务平台来给项目付款， <0>代币不会分发到他们的个人钱包且将会丢失</0>。"
 
 #: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 #: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx


### PR DESCRIPTION
## What does this PR do and why?

Passes the null address into the contract when custom beneficiary is unset

## Screenshots or screen recordings

<img width="512" alt="Screen Shot 2022-07-28 at 1 35 26 pm" src="https://user-images.githubusercontent.com/96150256/181417307-129f3e8c-4e29-48bc-a4e4-7a3cf202f3a2.png">

<img width="629" alt="Screen Shot 2022-07-28 at 1 35 33 pm" src="https://user-images.githubusercontent.com/96150256/181417332-02a4601d-8c86-426a-887b-f3c263126884.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
