### PR TITLE
Fix erc 20 pay v2

### DIFF
--- a/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -121,12 +121,11 @@ export function V2ConfirmPayModal({
 
   async function pay() {
     if (!weiAmount) return
-    await form.validateFields()
 
     const {
       beneficiary,
       memo: textMemo,
-      preferClaimed,
+      preferClaimedTokens,
       stickerUrls,
       uploadedImage,
     } = form.getFieldsValue()
@@ -146,7 +145,7 @@ export function V2ConfirmPayModal({
             imageUrl: uploadedImage,
             stickerUrls,
           }),
-          preferClaimedTokens: !!preferClaimed,
+          preferClaimedTokens: Boolean(preferClaimedTokens),
           beneficiary: txBeneficiary,
           value: weiAmount,
         },

--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -27,7 +27,7 @@ export interface V2PayFormType {
   beneficiary?: string
   stickerUrls?: string[]
   uploadedImage?: string
-  preferClaimed?: boolean
+  preferClaimedTokens?: boolean
 }
 
 export const V2PayForm = ({
@@ -67,7 +67,6 @@ export const V2PayForm = ({
                 <Trans>Customize payment</Trans>
               </h3>
             }
-            style={{ marginBottom: '1rem' }}
           >
             <Form.Item
               label={t`Memo (optional)`}
@@ -113,9 +112,11 @@ export const V2PayForm = ({
                 <StickerSelection />
               </Form.Item>
             </Form.Item>
+
             <Form.Item name="uploadedImage">
               <FormImageUploader text={t`Add image`} />
             </Form.Item>
+
             <Form.Item extra={t`Mint tokens to a custom address.`}>
               <Space>
                 <Switch
@@ -150,8 +151,11 @@ export const V2PayForm = ({
                 </Form.Item>
               )}
             </Form.Item>
-            {hasIssuedTokens ? (
+
+            {hasIssuedTokens && (
               <Form.Item
+                name="preferClaimedTokens"
+                valuePropName="checked"
                 extra={
                   <Trans>
                     Mint this project's ERC-20 tokens to your wallet. Leave
@@ -161,15 +165,11 @@ export const V2PayForm = ({
                   </Trans>
                 }
               >
-                <Checkbox
-                  onChange={e =>
-                    form.setFieldsValue({ preferClaimed: e.target.checked })
-                  }
-                >
+                <Checkbox>
                   <Trans>Receive ERC-20</Trans>
                 </Checkbox>
               </Form.Item>
-            ) : null}
+            )}
           </MinimalCollapse>
 
           {projectMetadata && (

--- a/src/hooks/v2/transactor/PayETHPaymentTerminal.ts
+++ b/src/hooks/v2/transactor/PayETHPaymentTerminal.ts
@@ -41,7 +41,7 @@ export function usePayETHPaymentTerminalTx(): PayV2ProjectTx {
         ETH_TOKEN_ADDRESS,
         beneficiary,
         DEFAULT_MIN_RETURNED_TOKENS, // minReturnedTokens
-        preferClaimedTokens,
+        preferClaimedTokens, // _preferClaimedTokens
         memo || '',
         DEFAULT_DELEGATE_METADATA, //delegateMetadata
       ],

--- a/src/pages/api/ipfs/pin.page.ts
+++ b/src/pages/api/ipfs/pin.page.ts
@@ -34,7 +34,7 @@ const handler = async (req: ApiRequest, res: NextApiResponse) => {
       const pinata = getPinata()
       const pinData = await pinata.pinJSONToIPFS(data, options)
 
-      res.status(200).json({
+      return res.status(200).json({
         ...pinData,
       })
     } catch (error) {


### PR DESCRIPTION
## What does this PR do and why?

Fixes https://github.com/jbx-protocol/juice-interface/issues/1561

Specifically, fixes the "claim as ERC-20" checkbox.

### How to test

1. Go to http://localhost:3000/v2/p/1
2. Enter pay amount
3. Click pay
4. Open "customize payment" section
5. Check "Receive ERC-20" checkbox.
6. Click `pay` button
7. Open dev tools
8. Observe the logs.

The `pay` log should have `preferClaimedTokens` set to `true`

<img width="772" alt="Screen Shot 2022-07-28 at 3 18 42 PM" src="https://user-images.githubusercontent.com/12551741/181430099-b2ecc2a2-626c-4958-862d-ed3581c3e940.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
