### PR TITLE
[1/x] Change venft form to use an int value for ease of parsing

### DIFF
--- a/src/components/veNft/VeNftCarousel.tsx
+++ b/src/components/veNft/VeNftCarousel.tsx
@@ -4,7 +4,7 @@ import { VeNftTokenMetadata, VeNftVariant } from 'models/v2/veNft'
 import VeNftCarouselItem from 'components/veNft/VeNftCarouselItem'
 
 type StakingNFTCarouselProps = {
-  tokensStaked: string
+  tokensStaked: number
   variants: VeNftVariant[]
   baseImagesHash: string
   form: FormInstance
@@ -21,7 +21,7 @@ export default function VeNftCarousel({
   const activeIdx = variants
     ? Math.max(
         variants.findIndex(variant => {
-          const curTokens = parseInt(tokensStaked)
+          const curTokens = tokensStaked
           return (
             variant.tokensStakedMin <= curTokens &&
             (variant.tokensStakedMax

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -35,7 +35,7 @@ import { shadowCard } from 'constants/styles/shadowCard'
 import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
 
 interface StakingFormProps {
-  tokensStaked: string
+  tokensStaked: number
   lockDuration: number
   beneficiary: string
 }
@@ -61,7 +61,7 @@ const VeNftStakingForm = ({
     useState(false)
   const [tokenApprovalLoading, setTokenApprovalLoading] = useState(false)
 
-  const tokensStaked = useWatch('tokensStaked', form) || '1'
+  const tokensStaked = useWatch('tokensStaked', form) || 1
   const lockDuration = useWatch('lockDuration', form) || 0
   const beneficiary = useWatch('beneficiary', form) || ''
 
@@ -99,7 +99,7 @@ const VeNftStakingForm = ({
     ? allowance.gte(parseWad(tokensStaked))
     : false
 
-  const votingPower = parseInt(tokensStaked) * (lockDuration / maxLockDuration)
+  const votingPower = tokensStaked * (lockDuration / maxLockDuration)
 
   const approveTx = useERC20Approve(tokenAddress)
   const approve = async () => {
@@ -140,7 +140,7 @@ const VeNftStakingForm = ({
   }, [lockDurationOptionsInSeconds, form])
 
   const initialValues: StakingFormProps = {
-    tokensStaked: minTokensAllowedToStake.toString(),
+    tokensStaked: minTokensAllowedToStake,
     lockDuration: 0,
     beneficiary: '',
   }
@@ -211,7 +211,7 @@ const VeNftStakingForm = ({
       <ConfirmStakeModal
         visible={confirmStakeModalVisible}
         tokenSymbolDisplayText={tokenSymbolDisplayText}
-        tokensStaked={parseInt(tokensStaked)}
+        tokensStaked={tokensStaked}
         lockDuration={lockDuration}
         beneficiary={beneficiary}
         votingPower={votingPower}

--- a/src/components/veNft/formControls/TokensStakedInput.tsx
+++ b/src/components/veNft/formControls/TokensStakedInput.tsx
@@ -1,6 +1,5 @@
 import { plural, t, Trans } from '@lingui/macro'
-import { Form } from 'antd'
-import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
+import { Form, InputNumber } from 'antd'
 import { BigNumber } from '@ethersproject/bignumber'
 import { FormInstance } from 'rc-field-form'
 import { useEffect } from 'react'
@@ -10,7 +9,7 @@ interface TokensStakedInputProps {
   form: FormInstance
   claimedBalance: BigNumber | undefined
   tokenSymbolDisplayText: string
-  tokensStaked: string
+  tokensStaked: number
   minTokensAllowedToStake: number
 }
 
@@ -23,7 +22,7 @@ const TokensStakedInput = ({
 }: TokensStakedInputProps) => {
   const totalBalanceInWad = fromWad(claimedBalance)
   const unstakedTokens = claimedBalance
-    ? parseInt(totalBalanceInWad) - parseInt(tokensStaked)
+    ? parseInt(totalBalanceInWad) - tokensStaked
     : 0
 
   useEffect(() => {
@@ -32,7 +31,7 @@ const TokensStakedInput = ({
   }, [minTokensAllowedToStake, form])
 
   const validateTokensStaked = () => {
-    const tokensStaked = parseInt(form.getFieldValue('tokensStaked'))
+    const tokensStaked = form.getFieldValue('tokensStaked')
     if (tokensStaked < minTokensAllowedToStake) {
       return Promise.reject(
         plural(minTokensAllowedToStake, {
@@ -67,9 +66,11 @@ const TokensStakedInput = ({
         </Trans>
       }
     >
-      <FormattedNumberInput
+      <InputNumber
         name="tokensStaked"
         value={tokensStaked}
+        min={0}
+        style={{ width: '100%' }}
         onChange={val => {
           form.setFieldsValue({ tokensStaked: val })
         }}


### PR DESCRIPTION
## What does this PR do and why?

Change staking form from using FormattedNumberInput with a string datatype to use an antd InputNumber instead. There were numerous problems being caused by decorators in the string value causing issues with parseWad.


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
