### PR TITLE
[3/x] Add hook to fetch veNft name from contract

### DIFF
--- a/src/components/veNft/VeNftDrawer.tsx
+++ b/src/components/veNft/VeNftDrawer.tsx
@@ -11,6 +11,8 @@ import { useVeNftResolverAddress } from 'hooks/veNft/VeNftResolverAddress'
 import { useVeNftUserTokens } from 'hooks/veNft/VeNftUserTokens'
 import { useVeNftVariants } from 'hooks/veNft/VeNftVariants'
 
+import { useVeNftName } from 'hooks/veNft/VeNftName'
+
 import { drawerStyle } from 'constants/styles/drawerStyle'
 
 export function VeNftDrawer({
@@ -20,7 +22,7 @@ export function VeNftDrawer({
   visible: boolean
   onClose: VoidFunction
 }) {
-  const veNftProjectName = 'veBanny'
+  const { data: name } = useVeNftName()
   const { data: lockDurationOptions } = useVeNftLockDurationOptions()
   const { data: resolverAddress } = useVeNftResolverAddress()
   const { data: variants } = useVeNftVariants()
@@ -32,7 +34,7 @@ export function VeNftDrawer({
   )
 
   const veNft: VeNftContextType = {
-    name: veNftProjectName,
+    name,
     lockDurationOptions,
     resolverAddress,
     variants,

--- a/src/hooks/veNft/VeNftName.ts
+++ b/src/hooks/veNft/VeNftName.ts
@@ -1,0 +1,11 @@
+import useV2ContractReader from 'hooks/v2/contractReader/V2ContractReader'
+import { useVeNftContract } from 'hooks/veNft/VeNftContract'
+
+import { VENFT_CONTRACT_ADDRESS } from 'constants/veNft/veNftProject'
+
+export function useVeNftName() {
+  return useV2ContractReader<string>({
+    contract: useVeNftContract(VENFT_CONTRACT_ADDRESS),
+    functionName: 'name',
+  })
+}


### PR DESCRIPTION
## What does this PR do and why?

Previously, the project name was hardcoded. This PR adds a hook to fetch the name from the contract and set it on the context.


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
