### PR TITLE
[5/x] Add veNft setup modal in project tools

### DIFF
--- a/src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
+++ b/src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
@@ -11,11 +11,16 @@ import { useDeployProjectPayerTx } from 'hooks/v2/transactor/DeployProjectPayerT
 import { useEditV2ProjectDetailsTx } from 'hooks/v2/transactor/EditV2ProjectDetailsTx'
 import useUserUnclaimedTokenBalance from 'hooks/v2/contractReader/UserUnclaimedTokenBalance'
 
+import { featureFlagEnabled } from 'utils/featureFlags'
+
+import VeNftSetupSection from 'components/veNft/VeNftSetupSection'
+
 import { V1TokenMigrationSetupSection } from './V1TokenMigrationSetupSection'
 import { AddToProjectBalanceForm } from '../../../Project/ProjectToolsDrawer/AddToProjectBalanceForm'
 import { PayableAddressSection } from '../../../Project/ProjectToolsDrawer/PayableAddressSection'
 import { TransferOwnershipForm } from '../../../Project/ProjectToolsDrawer/TransferOwnershipForm'
 import { TransferUnclaimedTokensForm } from '../../../Project/ProjectToolsDrawer/TransferUnclaimedTokensForm'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 
 const { TabPane } = Tabs
 
@@ -33,6 +38,8 @@ export function V2ProjectToolsDrawer({
 
   const isOwnerWallet = useIsUserAddress(projectOwnerAddress)
 
+  const veNftEnabled = featureFlagEnabled(FEATURE_FLAGS.VENFT)
+
   const OwnerTools = (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
       <V1TokenMigrationSetupSection />
@@ -49,6 +56,13 @@ export function V2ProjectToolsDrawer({
       <Divider />
 
       <ArchiveV2Project editV2ProjectDetailsTx={editV2ProjectDetailsTx} />
+
+      {veNftEnabled && (
+        <>
+          <Divider />
+          <VeNftSetupSection />
+        </>
+      )}
     </Space>
   )
 

--- a/src/components/veNft/VeNftSetupModal.tsx
+++ b/src/components/veNft/VeNftSetupModal.tsx
@@ -1,0 +1,21 @@
+import { t } from '@lingui/macro'
+import TransactionModal from 'components/TransactionModal'
+
+interface VeNftSetupModalProps {
+  visible: boolean
+  onCancel: VoidFunction
+}
+
+const VeNftSetupModal = ({ visible, onCancel }: VeNftSetupModalProps) => {
+  return (
+    <TransactionModal
+      title={t`Set Up veNFT Governance`}
+      visible={visible}
+      onCancel={onCancel}
+    >
+      Set up and launch veNFT governance for your project.
+    </TransactionModal>
+  )
+}
+
+export default VeNftSetupModal

--- a/src/components/veNft/VeNftSetupSection.tsx
+++ b/src/components/veNft/VeNftSetupSection.tsx
@@ -1,0 +1,37 @@
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+import { useState } from 'react'
+
+import VeNftSetupModal from 'components/veNft/VeNftSetupModal'
+
+const VeNftSetupSection = () => {
+  const [setupModalVisible, setSetupModalVisible] = useState(false)
+
+  return (
+    <>
+      <section>
+        <h3>
+          <Trans>Enable veNFT Governance</Trans>
+        </h3>
+        <p>
+          <Trans>Set up and launch veNFT governance for your project.</Trans>
+        </p>
+        <Button
+          type="primary"
+          size="small"
+          onClick={() => setSetupModalVisible(true)}
+        >
+          Launch Setup
+        </Button>
+      </section>
+      {setupModalVisible && (
+        <VeNftSetupModal
+          visible={setupModalVisible}
+          onCancel={() => setSetupModalVisible(false)}
+        />
+      )}
+    </>
+  )
+}
+
+export default VeNftSetupSection


### PR DESCRIPTION
## What does this PR do and why?

Adds a button in the project tools drawer for owners of a project to open the venft setup modal

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
