### PR TITLE
[6/x] Add MVP for veNFT tiers editing form

### DIFF
--- a/src/components/veNft/VeNftRewardTierModal.tsx
+++ b/src/components/veNft/VeNftRewardTierModal.tsx
@@ -1,0 +1,87 @@
+import { t } from '@lingui/macro'
+import { Form, Input, Modal } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import { ModalMode } from 'components/formItems/formHelpers'
+import TooltipLabel from 'components/TooltipLabel'
+
+import NftUpload from 'components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload'
+import { VeNftVariant } from 'models/v2/veNft'
+import { useEffect } from 'react'
+
+import TokensStakedMinInput from 'components/veNft/formControls/TokensStakedMinInput'
+
+export type VeNftFormFields = {
+  name: string
+  tokensStakedMin: number
+  imageUrl: string
+}
+
+export default function VeNftRewardTierModal({
+  id,
+  visible,
+  onClose,
+  onChange,
+  mode,
+  variant,
+}: {
+  id: number
+  visible: boolean
+  onClose: VoidFunction
+  mode: ModalMode
+  variant?: VeNftVariant
+  onChange: (variant: VeNftVariant) => void
+}) {
+  const [nftForm] = useForm<VeNftFormFields>()
+
+  const onFormSaved = async () => {
+    await nftForm.validateFields()
+
+    const variant = {
+      id,
+      name: nftForm.getFieldValue('name'),
+      tokensStakedMin: nftForm.getFieldValue('tokensStakedMin'),
+      imageUrl: nftForm.getFieldValue('imageUrl'),
+    } as VeNftVariant
+
+    onChange(variant)
+    onClose()
+
+    if (mode === 'Add') {
+      nftForm.resetFields()
+    }
+  }
+
+  useEffect(() => {
+    if (variant) {
+      nftForm.setFieldsValue({
+        name: variant.name,
+        tokensStakedMin: variant.tokensStakedMin,
+        imageUrl: variant.imageUrl,
+      })
+    }
+  })
+
+  return (
+    <Modal
+      visible={visible}
+      okText={mode === 'Edit' ? t`Save NFT reward` : t`Add NFT reward`}
+      onOk={onFormSaved}
+      onCancel={onClose}
+      title={mode === 'Edit' ? t`Edit NFT reward` : t`Add NFT reward`}
+    >
+      <Form layout="vertical" form={nftForm}>
+        <TokensStakedMinInput form={nftForm} />
+        <NftUpload form={nftForm} />
+        <Form.Item
+          name={'name'}
+          label={
+            <TooltipLabel label={t`Name`} tip={t`Give this NFT a name.`} />
+          }
+          rules={[{ required: true }]}
+        >
+          <Input type="string" autoComplete="off" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  )
+}

--- a/src/components/veNft/VeNftSetupModal.tsx
+++ b/src/components/veNft/VeNftSetupModal.tsx
@@ -1,5 +1,11 @@
-import { t } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
+import { Button, Space } from 'antd'
 import TransactionModal from 'components/TransactionModal'
+import { VeNftVariant } from 'models/v2/veNft'
+import { useState } from 'react'
+
+import VeNftRewardTierModal from 'components/veNft/VeNftRewardTierModal'
+import VeNftvariantCard from 'components/veNft/VeNftVariantCard'
 
 interface VeNftSetupModalProps {
   visible: boolean
@@ -7,14 +13,71 @@ interface VeNftSetupModalProps {
 }
 
 const VeNftSetupModal = ({ visible, onCancel }: VeNftSetupModalProps) => {
+  const [addTierModalVisible, setAddTierModalVisible] = useState(false)
+  const [variants, setVariants] = useState<VeNftVariant[]>([])
+
+  const handleAddVariant = (variant: VeNftVariant) => {
+    setVariants([...variants, variant])
+  }
+
+  const handleEditVariant = (index: number, newVariant: VeNftVariant) => {
+    const newVariants = variants.map((tier, i) =>
+      i === index
+        ? {
+            ...tier,
+            ...newVariant,
+          }
+        : tier,
+    )
+    setVariants(newVariants)
+  }
+
+  const handleDeleteVariant = (id: number) => {
+    setVariants([...variants.slice(0, id), ...variants.slice(id + 1)])
+  }
+
   return (
-    <TransactionModal
-      title={t`Set Up veNFT Governance`}
-      visible={visible}
-      onCancel={onCancel}
-    >
-      Set up and launch veNFT governance for your project.
-    </TransactionModal>
+    <>
+      <TransactionModal
+        title={t`Set Up veNFT Governance`}
+        visible={visible}
+        onCancel={onCancel}
+      >
+        <Trans>Set up and launch veNFT governance for your project.</Trans>
+        <Space direction="vertical" size="large" style={{ width: '100%' }}>
+          {variants.map((variant, index) => (
+            <VeNftvariantCard
+              key={index}
+              variant={variant}
+              nextVariant={
+                index === variants.length - 1 ? undefined : variants[index + 1]
+              }
+              onChange={newVariant => handleEditVariant(index, newVariant)}
+              onDelete={() => handleDeleteVariant(index)}
+            />
+          ))}
+        </Space>
+        <Button
+          type="dashed"
+          onClick={() => {
+            setAddTierModalVisible(true)
+          }}
+          style={{ marginTop: 15 }}
+          block
+        >
+          <Trans>Add reward tier</Trans>
+        </Button>
+      </TransactionModal>
+      {addTierModalVisible && (
+        <VeNftRewardTierModal
+          id={variants.length}
+          visible={addTierModalVisible}
+          onChange={handleAddVariant}
+          onClose={() => setAddTierModalVisible(false)}
+          mode="Add"
+        />
+      )}
+    </>
   )
 }
 

--- a/src/components/veNft/VeNftSetupSection.tsx
+++ b/src/components/veNft/VeNftSetupSection.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import VeNftSetupModal from 'components/veNft/VeNftSetupModal'
 
 const VeNftSetupSection = () => {
-  const [setupModalVisible, setSetupModalVisible] = useState(false)
+  const [setupModalVisible, setSetupModalVisible] = useState(true)
 
   return (
     <>

--- a/src/components/veNft/VeNftVariantCard.tsx
+++ b/src/components/veNft/VeNftVariantCard.tsx
@@ -1,0 +1,123 @@
+import { Button, Col, Image, Row, Tooltip } from 'antd'
+import { ThemeContext } from 'contexts/themeContext'
+import { useContext, useState } from 'react'
+import { DeleteOutlined, LoadingOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
+import { VeNftVariant } from 'models/v2/veNft'
+
+import VeNftRewardTierModal from './VeNftRewardTierModal'
+
+export default function VeNftvariantCard({
+  variant,
+  nextVariant,
+  onChange,
+  onDelete,
+}: {
+  variant: VeNftVariant
+  nextVariant?: VeNftVariant
+  onChange: (variant: VeNftVariant) => void
+  onDelete: VoidFunction
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const [editTierModalVisible, setEditTierModalVisible] =
+    useState<boolean>(false)
+  const [imageLoading, setImageLoading] = useState<boolean>(true)
+
+  const tokensStakedLabel = () => {
+    if (nextVariant) {
+      return `${variant.tokensStakedMin} - ${nextVariant.tokensStakedMin - 1}`
+    }
+    return `${variant.tokensStakedMin}+`
+  }
+
+  if (!variant) return null
+  return (
+    <>
+      <Row
+        style={{
+          background: colors.background.l0,
+          border: `1px solid ${colors.stroke.tertiary}`,
+          display: 'flex',
+          width: '100%',
+          cursor: 'pointer',
+          padding: '15px 8px 15px 20px',
+        }}
+        onClick={() => setEditTierModalVisible(true)}
+      >
+        <Col
+          md={16}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            flexDirection: 'column',
+          }}
+        >
+          <Row
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 17,
+              width: '100%',
+            }}
+          >
+            <Col style={{ color: colors.text.action.primary }} md={7}>
+              {tokensStakedLabel()}
+            </Col>
+            <Col style={{ display: 'flex', fontWeight: 500 }} md={15}>
+              <span>{variant.name}</span>
+            </Col>
+          </Row>
+        </Col>
+        <Col
+          md={5}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          {imageLoading ? (
+            <LoadingOutlined style={{ fontSize: '30px' }} />
+          ) : null}
+          <Image
+            src={variant.imageUrl}
+            alt={variant.name}
+            height={'90px'}
+            style={{
+              display: imageLoading ? 'none' : 'unset',
+              objectFit: 'cover',
+              maxWidth: '90px',
+            }}
+            onLoad={() => setImageLoading(false)}
+            onClick={e => e.stopPropagation()}
+          />
+        </Col>
+        <Col md={3}>
+          <Tooltip title={<Trans>Delete NFT</Trans>}>
+            <Button
+              type="text"
+              onClick={e => {
+                onDelete()
+                // prevent opening modal
+                e.stopPropagation()
+              }}
+              icon={<DeleteOutlined />}
+              style={{ height: 16, float: 'right' }}
+            />
+          </Tooltip>
+        </Col>
+      </Row>
+      <VeNftRewardTierModal
+        id={variant.id}
+        visible={editTierModalVisible}
+        variant={variant}
+        mode="Edit"
+        onClose={() => setEditTierModalVisible(false)}
+        onChange={onChange}
+      />
+    </>
+  )
+}

--- a/src/components/veNft/formControls/TokensStakedMinInput.tsx
+++ b/src/components/veNft/formControls/TokensStakedMinInput.tsx
@@ -1,0 +1,32 @@
+import { t, Trans } from '@lingui/macro'
+import { Form, FormInstance } from 'antd'
+import InputAccessoryButton from 'components/InputAccessoryButton'
+import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
+import { VeNftFormFields } from 'components/veNft/VeNftRewardTierModal'
+
+export default function ContributionFloorFormItem({
+  form,
+}: {
+  form: FormInstance<VeNftFormFields>
+}) {
+  const validatecontributionFloorAmount = () => {
+    const value = form.getFieldValue('tokensStakedMin')
+    if (value === undefined || value <= 0) {
+      return Promise.reject(t`Amount required`)
+    }
+    return Promise.resolve()
+  }
+
+  return (
+    <Form.Item
+      name={'tokensStakedMin'}
+      label={<Trans>Contribution threshold</Trans>}
+      extra={t`Contributors receive the NFT when they contribute at least this amount.`}
+      rules={[{ required: true, validator: validatecontributionFloorAmount }]}
+    >
+      <FormattedNumberInput
+        accessory={<InputAccessoryButton content={'ETH'} disabled />}
+      />
+    </Form.Item>
+  )
+}

--- a/src/models/v2/veNft.ts
+++ b/src/models/v2/veNft.ts
@@ -3,6 +3,7 @@ export type VeNftVariant = {
   name: string
   tokensStakedMin: number
   tokensStakedMax?: number
+  imageUrl?: string
 }
 
 export type VeNftTokenMetadata = {


### PR DESCRIPTION
## What does this PR do and why?

Adds the modal which is used to build out the information for the tiers for venft staking. Reuses many of the components from NFT rewards, but slightly modified.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
