### PR TITLE
[8/x] Add label truncation for long numbers

### DIFF
--- a/src/components/veNft/VeNftSetupModal.tsx
+++ b/src/components/veNft/VeNftSetupModal.tsx
@@ -16,8 +16,18 @@ const VeNftSetupModal = ({ visible, onCancel }: VeNftSetupModalProps) => {
   const [addTierModalVisible, setAddTierModalVisible] = useState(false)
   const [variants, setVariants] = useState<VeNftVariant[]>([])
 
+  const sortVariants = (variants: VeNftVariant[]): VeNftVariant[] => {
+    return variants.sort((a, b) =>
+      a.tokensStakedMin > b.tokensStakedMin
+        ? 1
+        : b.tokensStakedMin > a.tokensStakedMin
+        ? -1
+        : 0,
+    )
+  }
+
   const handleAddVariant = (variant: VeNftVariant) => {
-    setVariants([...variants, variant])
+    setVariants(sortVariants([...variants, variant]))
   }
 
   const handleEditVariant = (index: number, newVariant: VeNftVariant) => {

--- a/src/components/veNft/VeNftVariantCard.tsx
+++ b/src/components/veNft/VeNftVariantCard.tsx
@@ -5,6 +5,8 @@ import { DeleteOutlined, LoadingOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { VeNftVariant } from 'models/v2/veNft'
 
+import { truncateLongNumber } from 'utils/formatNumber'
+
 import VeNftRewardTierModal from './VeNftRewardTierModal'
 
 export default function VeNftvariantCard({
@@ -28,9 +30,12 @@ export default function VeNftvariantCard({
 
   const tokensStakedLabel = () => {
     if (nextVariant) {
-      return `${variant.tokensStakedMin} - ${nextVariant.tokensStakedMin - 1}`
+      return `${truncateLongNumber(
+        variant.tokensStakedMin,
+        2,
+      )} - ${truncateLongNumber(nextVariant.tokensStakedMin - 1, 2)}`
     }
-    return `${variant.tokensStakedMin}+`
+    return `${truncateLongNumber(variant.tokensStakedMin, 2)}+`
   }
 
   if (!variant) return null

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -241,3 +241,25 @@ export const formatPercent = (
   }
   return (sharePct?.toNumber() / 100).toString()
 }
+
+export const truncateLongNumber = (num: number, digits: number) => {
+  const lookup = [
+    { value: 1, symbol: '' },
+    { value: 1e3, symbol: 'K' },
+    { value: 1e6, symbol: 'M' },
+    { value: 1e9, symbol: 'B' },
+    { value: 1e12, symbol: 'T' },
+    { value: 1e15, symbol: 'P' },
+    { value: 1e18, symbol: 'E' },
+  ]
+  const rx = /\.0+$|(\.[0-9]*[1-9])0+$/
+  const item = lookup
+    .slice()
+    .reverse()
+    .find(function (item) {
+      return num >= item.value
+    })
+  return item
+    ? (num / item.value).toFixed(digits).replace(rx, '$1') + item.symbol
+    : '0'
+}


### PR DESCRIPTION
## What does this PR do and why?

Adds a fancy function to display long numbers using K, M, B, T notation, ie 100K, 2M, 5B

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
