### PR TITLE
Add support for server pre render

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,10 +1,15 @@
 # Infura project id
 NEXT_PUBLIC_INFURA_ID=
+# Additional Infura project id used for nextjs page rendering. This is needed
+# due to the whitelisting in prod of the main infura id
+PRE_RENDER_INFURA_ID=
 # Name of Infura network (e.g. 'mainnet', 'rinkeby')
 NEXT_PUBLIC_INFURA_NETWORK=mainnet
 
 # URL of Juicebox subgraph from thegraph.com
 NEXT_PUBLIC_SUBGRAPH_URL=
+# URL for discovery of the schema used in graphql generation
+GRAPHQL_SCHEMA_SUBGRAPH_URL=
 
 # Pinata gateway e.g. 'gateway.pinata.cloud'
 NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME=

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: ${NEXT_PUBLIC_SUBGRAPH_URL}
+schema: ${GRAPHQL_SCHEMA_SUBGRAPH_URL}
 documents: 'src/graphql/**/*.graphql'
 generates:
   src/generated/graphql.tsx:

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -1,6 +1,9 @@
 import { NetworkName } from 'models/network-name'
+import { isBrowser } from 'utils/isBrowser'
 
-const infuraId = process.env.NEXT_PUBLIC_INFURA_ID
+const infuraId = isBrowser()
+  ? process.env.NEXT_PUBLIC_INFURA_ID
+  : process.env.PRE_RENDER_INFURA_ID
 
 type NetworkInfo = {
   name: NetworkName

--- a/src/utils/isBrowser.ts
+++ b/src/utils/isBrowser.ts
@@ -1,0 +1,3 @@
+export function isBrowser() {
+  return typeof window !== 'undefined'
+}


### PR DESCRIPTION
## What does this PR do and why?

- Uses PRE_RENDER_INFURA_ID for server based calls infura.
- uses GRAPHQL_SCHEMA_SUBGRAPH_URL for schema generation

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
