### PR TITLE
Improve EthAmount precision for small numbers

### DIFF
--- a/src/components/currency/ETHAmount.tsx
+++ b/src/components/currency/ETHAmount.tsx
@@ -1,12 +1,14 @@
 import { Tooltip } from 'antd'
 
 import { BigNumber } from '@ethersproject/bignumber'
-import { formatWad, parseWad } from 'utils/formatNumber'
+import { formatWad, fromWad, parseWad } from 'utils/formatNumber'
 import { betweenZeroAndOne } from 'utils/bigNumbers'
 
 import CurrencySymbol from '../CurrencySymbol'
 
 import ETHToUSD from './ETHToUSD'
+
+const MAX_PRECISION = 6
 
 /**
  * Render a given amount formatted as ETH. Displays USD amount in a tooltip on hover.
@@ -25,7 +27,11 @@ export default function ETHAmount({
     (BigNumber.isBigNumber(amount) && betweenZeroAndOne(amount)) ||
     betweenZeroAndOne(parseWad(amount))
 
-  const precisionAdjusted = isBetweenZeroAndOne ? 4 : precision
+  const decimalsCount = fromWad(amount).split('.')[1]?.length ?? 0
+
+  const precisionAdjusted = isBetweenZeroAndOne
+    ? Math.min(decimalsCount, MAX_PRECISION)
+    : precision
 
   const formattedETHAmount = formatWad(amount, {
     precision: precisionAdjusted,


### PR DESCRIPTION
## What does this PR do and why?

Currently, really small ETH amounts aren't displayed in places like activity feed (see https://juicebox.money/p/peel)

This PR uses the numbers actual decimal count to determine precision in `ETHAmount`. Only applies to numbers less than 0.

Sets a max precision of 6.

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="534" alt="Screen Shot 2022-07-31 at 8 07 29 AM" src="https://user-images.githubusercontent.com/12551741/182002442-3b269969-3824-475c-80c8-dc0e36475417.png"> | <img width="527" alt="Screen Shot 2022-07-31 at 8 05 35 AM" src="https://user-images.githubusercontent.com/12551741/182002445-8a47fca0-f6f6-46b0-b7cd-e384751cafd1.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
