### PR TITLE
Clean up Reconfiguration modal spacing

### DIFF
--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
@@ -93,7 +93,6 @@ export default function ReconfigurePreview({
   )
 
   const gutter = 20
-  const rowMargin = 20
 
   const secondRowColWidth = hasDuration && hasDistributionLimit ? 8 : 12
 
@@ -111,7 +110,7 @@ export default function ReconfigurePreview({
 
   return (
     <Space direction="vertical" size="middle">
-      <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
+      <Row gutter={gutter}>
         <Col md={12} sm={12}>
           <DurationStatistic duration={fundingCycle.duration} />
         </Col>
@@ -122,7 +121,7 @@ export default function ReconfigurePreview({
           />
         </Col>
       </Row>
-      <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
+      <Row gutter={gutter}>
         <Col md={12} sm={12}>
           <InflationRateStatistic
             inflationRate={
@@ -136,7 +135,7 @@ export default function ReconfigurePreview({
           <IssuanceRateStatistic issuanceRate={issuanceRate} />
         </Col>
       </Row>
-      <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
+      <Row gutter={gutter}>
         <Col md={secondRowColWidth} sm={12}>
           <ReservedTokensStatistic
             reservedRate={reservedRate}
@@ -156,7 +155,7 @@ export default function ReconfigurePreview({
           </Col>
         ) : null}
       </Row>
-      <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
+      <Row gutter={gutter}>
         <Col md={8}>
           <PausePayStatistic pausePay={fundingCycleMetadata.pausePay} />
         </Col>
@@ -171,7 +170,7 @@ export default function ReconfigurePreview({
           />
         </Col>
       </Row>
-      <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
+      <Row gutter={gutter}>
         {hasDuration ? (
           <Col span={24}>
             <ReconfigurationStatistic ballotAddress={fundingCycle.ballot} />

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/ReconfigurePreview.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from 'antd'
+import { Col, Row, Space } from 'antd'
 import {
   AllowMintingStatistic,
   AllowSetTerminalsStatistic,
@@ -110,7 +110,7 @@ export default function ReconfigurePreview({
     ) ?? '0'
 
   return (
-    <div style={{ padding: '0 0px' }}>
+    <Space direction="vertical" size="middle">
       <Row gutter={gutter} style={{ marginBottom: rowMargin }}>
         <Col md={12} sm={12}>
           <DurationStatistic duration={fundingCycle.duration} />
@@ -196,6 +196,6 @@ export default function ReconfigurePreview({
           projectOwnerAddress={userAddress}
         />
       )}
-    </div>
+    </Space>
   )
 }

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
@@ -154,11 +154,7 @@ export default function V2ProjectReconfigureModal({
       centered
       destroyOnClose
     >
-      <Space
-        direction="vertical"
-        size="middle"
-        style={{ width: '100%', marginBottom: 40 }}
-      >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
         {!hideProjectDetails && (
           <>
             <h4 style={{ marginBottom: 0 }}>
@@ -210,26 +206,30 @@ export default function V2ProjectReconfigureModal({
           reconfigureHasChanges={rulesDrawerHasSavedChanges}
           onClick={() => setRulesDrawerVisible(true)}
         />
+        <ReconfigurePreview
+          payoutSplits={editingProjectData.editingPayoutGroupedSplits.splits}
+          reserveSplits={
+            editingProjectData.editingReservedTokensGroupedSplits.splits
+          }
+          fundingCycleMetadata={editingProjectData.editingFundingCycleMetadata}
+          fundingCycleData={editingProjectData.editingFundingCycleData}
+          fundAccessConstraints={
+            editingProjectData.editingFundAccessConstraints
+          }
+        />
+
+        <Form layout="vertical">
+          <Form.Item
+            name="memo"
+            label={t`Memo (optional)`}
+            className={'antd-no-number-handler'}
+            extra={t`Add an on-chain memo to this reconfiguration.`}
+          >
+            <MemoFormInput value={memo} onChange={setMemo} />
+          </Form.Item>
+        </Form>
       </Space>
-      <ReconfigurePreview
-        payoutSplits={editingProjectData.editingPayoutGroupedSplits.splits}
-        reserveSplits={
-          editingProjectData.editingReservedTokensGroupedSplits.splits
-        }
-        fundingCycleMetadata={editingProjectData.editingFundingCycleMetadata}
-        fundingCycleData={editingProjectData.editingFundingCycleData}
-        fundAccessConstraints={editingProjectData.editingFundAccessConstraints}
-      />
-      <Form layout="vertical">
-        <Form.Item
-          name="memo"
-          label={t`Memo (optional)`}
-          className={'antd-no-number-handler'}
-          extra={t`Add an on-chain memo to this payment.`}
-        >
-          <MemoFormInput value={memo} onChange={setMemo} />
-        </Form.Item>
-      </Form>
+
       {hideProjectDetails ? null : (
         <V2ReconfigureProjectDetailsDrawer
           visible={projectDetailsDrawerVisible}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -347,9 +347,12 @@ msgstr "Add a payout"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Add an on-chain memo to this payment."
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
+msgstr "Add an on-chain memo to this reconfiguration."
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -352,9 +352,12 @@ msgstr "Añadir un pago"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Añadir un memo on-chain a este pago."
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
+msgstr ""
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -352,8 +352,11 @@ msgstr "Ajouter un paiement"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
+msgstr ""
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -352,9 +352,12 @@ msgstr "Adicionar um pagamento"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Adicionar um memorando on-chain a este pagamento."
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
+msgstr ""
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -352,8 +352,11 @@ msgstr "Добавить выплату"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
+msgstr ""
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -352,8 +352,11 @@ msgstr "Ödeme ekle"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
+msgstr ""
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -352,9 +352,12 @@ msgstr "添加支出对象"
 
 #: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 #: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "给这笔付款添加一个链上备注"
+
+#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
+msgid "Add an on-chain memo to this reconfiguration."
+msgstr ""
 
 #: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."

--- a/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -384,6 +384,7 @@ export function DistributionSplitsStatistic({
           totalValue={totalValue}
           projectOwnerAddress={projectOwnerAddress}
           showSplitValues={showSplitValues}
+          valueFormatProps={{ precision: 2 }}
         />
       )}
     />

--- a/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -378,14 +378,16 @@ export function DistributionSplitsStatistic({
         />
       }
       valueRender={() => (
-        <SplitList
-          splits={splits}
-          currency={currency}
-          totalValue={totalValue}
-          projectOwnerAddress={projectOwnerAddress}
-          showSplitValues={showSplitValues}
-          valueFormatProps={{ precision: 2 }}
-        />
+        <div style={{ fontSize: '0.9rem' }}>
+          <SplitList
+            splits={splits}
+            currency={currency}
+            totalValue={totalValue}
+            projectOwnerAddress={projectOwnerAddress}
+            showSplitValues={showSplitValues}
+            valueFormatProps={{ precision: 2 }}
+          />
+        </div>
       )}
     />
   )
@@ -409,11 +411,13 @@ export function ReservedSplitsStatistic({
         />
       }
       valueRender={() => (
-        <SplitList
-          splits={splits}
-          projectOwnerAddress={projectOwnerAddress}
-          totalValue={undefined}
-        />
+        <div style={{ fontSize: '0.9rem' }}>
+          <SplitList
+            splits={splits}
+            projectOwnerAddress={projectOwnerAddress}
+            totalValue={undefined}
+          />
+        </div>
       )}
     />
   )


### PR DESCRIPTION
## What does this PR do and why?

- improve spacing on reconfig modal
- fix memo `extra` copy.
- Make split font size smaller
- fix precision on payout split amounts

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="651" alt="Screen Shot 2022-08-01 at 11 11 08 AM" src="https://user-images.githubusercontent.com/12551741/182056507-23a5e2a0-9dd8-45b2-bb25-bdabf349e5fc.png"> | <img width="651" alt="Screen Shot 2022-08-01 at 11 17 36 AM" src="https://user-images.githubusercontent.com/12551741/182057014-e128e104-cd53-451e-84cb-2659278f3bb3.png"> |
| <img width="660" alt="Screen Shot 2022-08-01 at 11 11 43 AM" src="https://user-images.githubusercontent.com/12551741/182056562-005451a6-74b1-4ffa-b73c-45c06360d336.png"> | <img width="663" alt="Screen Shot 2022-08-01 at 11 17 27 AM" src="https://user-images.githubusercontent.com/12551741/182057001-d0be9d98-3fb5-45ec-8732-6d94cd6ebbb1.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
