### PR TITLE
Redeem modal UI clean up

### DIFF
--- a/src/components/currency/ETHAmount.tsx
+++ b/src/components/currency/ETHAmount.tsx
@@ -9,7 +9,7 @@ import CurrencySymbol from '../CurrencySymbol'
 import ETHToUSD from './ETHToUSD'
 import { PRECISION_ETH } from 'constants/currency'
 
-const MIN_AMOUNT = parseWad(0.00001)
+const MIN_AMOUNT = parseWad(0.0001)
 
 /**
  * Render a given amount formatted as ETH. Displays USD amount in a tooltip on hover.
@@ -41,12 +41,26 @@ export default function ETHAmount({
     ? Math.min(decimalsCount, PRECISION_ETH)
     : precision
 
-  const formattedETHAmount = amount?.lte(MIN_AMOUNT)
-    ? '~0'
-    : formatWad(amount, {
-        precision: precisionAdjusted,
-        padEnd,
-      })
+  if (amount?.lte(MIN_AMOUNT)) {
+    return (
+      <Tooltip
+        title={
+          <span>
+            <CurrencySymbol currency="ETH" />
+            {formatWad(amount, { precision: 8 })}
+          </span>
+        }
+      >
+        <CurrencySymbol currency="ETH" />
+        ~0
+      </Tooltip>
+    )
+  }
+
+  const formattedETHAmount = formatWad(amount, {
+    precision: precisionAdjusted,
+    padEnd,
+  })
 
   return (
     <Tooltip title={<ETHToUSD ethAmount={amount} />}>

--- a/src/components/currency/ETHToUSD.tsx
+++ b/src/components/currency/ETHToUSD.tsx
@@ -18,6 +18,14 @@ export default function ETHToUSD({
     padEnd: true,
   })
 
+  if (usdAmount?.eq(0)) {
+    return (
+      <span>
+        <CurrencySymbol currency="USD" />0
+      </span>
+    )
+  }
+
   if (usdAmount?.gt(0)) {
     return (
       <span>

--- a/src/components/v1/V1Project/modals/RedeemModal.tsx
+++ b/src/components/v1/V1Project/modals/RedeemModal.tsx
@@ -182,9 +182,8 @@ export default function RedeemModal({
         <p>
           {overflow?.gt(0) ? (
             <Trans>
-              Tokens can be redeemed for a portion of this project's ETH
-              overflow, according to the bonding curve rate of the current
-              funding cycle.{' '}
+              Tokens can be redeemed for a portion of this project's overflow,
+              according to the redemption rate of the current funding cycle.{' '}
               <span style={{ fontWeight: 500, color: colors.text.warn }}>
                 Tokens are burned when they are redeemed.
               </span>

--- a/src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
@@ -1,30 +1,24 @@
 import { t, Trans } from '@lingui/macro'
-import { Form, Space } from 'antd'
+import { Descriptions, Form, Space } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 
 import InputAccessoryButton from 'components/InputAccessoryButton'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 
-import { CSSProperties, useContext, useState } from 'react'
-import { formatPercent, formatWad, fromWad, parseWad } from 'utils/formatNumber'
+import { useContext, useState } from 'react'
+import { formatWad, fromWad, parseWad } from 'utils/formatNumber'
 
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 import useTotalBalanceOf from 'hooks/v2/contractReader/TotalBalanceOf'
 import { NetworkContext } from 'contexts/networkContext'
-import { ThemeContext } from 'contexts/themeContext'
 import { formatRedemptionRate } from 'utils/v2/math'
 import { useETHReceivedFromTokens } from 'hooks/v2/contractReader/ETHReceivedFromTokens'
 import { V2_CURRENCY_USD } from 'utils/v2/currency'
 import { useRedeemTokensTx } from 'hooks/v2/transactor/RedeemTokensTx'
 import TransactionModal from 'components/TransactionModal'
 import ETHAmount from 'components/currency/ETHAmount'
-
-const statsStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'baseline',
-}
+import Callout from 'components/Callout'
 
 // This doubles as the 'Redeem' and 'Burn' modal depending on if project has overflow
 export default function V2RedeemModal({
@@ -36,9 +30,6 @@ export default function V2RedeemModal({
   onCancel?: VoidFunction
   onConfirmed?: VoidFunction
 }) {
-  const {
-    theme: { colors },
-  } = useContext(ThemeContext)
   const { userAddress } = useContext(NetworkContext)
   const {
     tokenSymbol,
@@ -67,8 +58,6 @@ export default function V2RedeemModal({
 
   if (!fundingCycle || !fundingCycleMetadata) return null
 
-  const share = formatPercent(totalBalance, totalTokenSupply)
-
   // 0.5% slippage for USD-denominated projects
   const minReturnedTokens = distributionLimitCurrency?.eq(V2_CURRENCY_USD)
     ? rewardAmount?.mul(1000).div(1005)
@@ -88,15 +77,17 @@ export default function V2RedeemModal({
   })
 
   let modalTitle: string
-  // Defining whole sentence for translations
-  if (primaryTerminalCurrentOverflow?.gt(0)) {
+
+  const hasOverflow = primaryTerminalCurrentOverflow?.gt(0)
+  const hasRedemptionRate = fundingCycleMetadata.redemptionRate.gt(0)
+
+  const canRedeem = hasOverflow && hasRedemptionRate
+
+  if (canRedeem) {
     modalTitle = t`Redeem ${tokensTextLong} for ETH`
   } else {
     modalTitle = t`Burn ${tokensTextLong}`
   }
-
-  const minReturnedTokensFormatted =
-    formatWad(minReturnedTokens, { precision: 8 }) || '--'
 
   const validateRedeemAmount = () => {
     const redeemBN = parseWad(redeemAmount ?? 0)
@@ -167,104 +158,97 @@ export default function V2RedeemModal({
       width={540}
       centered
     >
-      <Space direction="vertical" style={{ width: '100%' }}>
+      <Space direction="vertical" style={{ width: '100%' }} size="large">
         <div>
-          <p style={statsStyle}>
-            <Trans>
-              Redemption rate:{' '}
-              <span>
-                {formatRedemptionRate(fundingCycleMetadata.redemptionRate)}%
-              </span>
-            </Trans>
-          </p>
-          <div style={statsStyle}>
-            <Trans>
-              {tokenSymbolText({ tokenSymbol: tokenSymbol, capitalize: true })}{' '}
-              balance:{' '}
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-end',
-                }}
-              >
-                <div>
-                  {formatWad(totalBalance ?? 0, { precision: 0 })}{' '}
-                  {tokensTextShort}
-                </div>
-                <div
-                  style={{
-                    cursor: 'default',
-                    fontSize: '0.8rem',
-                    fontWeight: 500,
-                    color: colors.text.tertiary,
-                  }}
-                >
-                  ({share}% of supply)
-                </div>
+          {canRedeem ? (
+            <Space direction="vertical" size="middle">
+              <Callout>
+                <Trans>Tokens are burned when they are redeemed.</Trans>
+              </Callout>
+              <div>
+                <Trans>
+                  Redeem your tokens for a portion of this project's overflow.
+                  The current funding cycle's <strong>redemption rate</strong>{' '}
+                  determines your redemption value.
+                </Trans>
               </div>
-            </Trans>
-          </div>
-          <p style={statsStyle}>
-            <Trans>
-              Currently worth:{' '}
-              <span>
-                <ETHAmount amount={maxClaimable} />
-              </span>
-            </Trans>
-          </p>
-        </div>
-        <p>
-          {primaryTerminalCurrentOverflow?.gt(0) ? (
-            <Trans>
-              Tokens can be redeemed for a portion of this project's ETH
-              overflow, according to the redemption rate of the current funding
-              cycle.{' '}
-              <span style={{ fontWeight: 500, color: colors.text.warn }}>
-                Tokens are burned when they are redeemed.
-              </span>
-            </Trans>
+            </Space>
           ) : (
-            <span style={{ fontWeight: 500, color: colors.text.warn }}>
-              <Trans>
-                <strong>This project has no overflow</strong>, so you will not
-                receive any ETH for burning tokens.
-              </Trans>
-            </span>
+            <Callout>
+              {!hasOverflow && (
+                <Trans>
+                  <strong>This project has no overflow</strong>. You won't
+                  receive any ETH for burning your tokens.
+                </Trans>
+              )}
+              {!hasRedemptionRate && (
+                <Trans>
+                  <strong>This project has a 0% redemption rate</strong>. You
+                  won't receive any ETH for burning your tokens.
+                </Trans>
+              )}
+            </Callout>
           )}
-        </p>
-        <div>
-          <Form form={form}>
-            <FormattedNumberInput
-              name="redeemAmount"
-              min={0}
-              step={0.001}
-              placeholder="0"
-              value={redeemAmount}
-              accessory={
-                <InputAccessoryButton
-                  content={t`MAX`}
-                  onClick={() => setRedeemAmount(fromWad(totalBalance))}
-                />
-              }
-              formItemProps={{
-                rules: [{ validator: validateRedeemAmount }],
-              }}
-              disabled={totalBalance?.eq(0)}
-              onChange={val => setRedeemAmount(val)}
-            />
-          </Form>
-          {totalSupplyExceeded ? (
-            <div style={{ color: colors.text.failure, marginTop: 20 }}>
+        </div>
+
+        <Descriptions
+          column={1}
+          contentStyle={{ display: 'block', textAlign: 'right' }}
+        >
+          <Descriptions.Item label={<Trans>Redemption rate</Trans>}>
+            {formatRedemptionRate(fundingCycleMetadata.redemptionRate)}%
+          </Descriptions.Item>
+          <Descriptions.Item
+            label={
               <Trans>
-                You have exceeded the total token supply of{' '}
-                <strong>{formatWad(totalTokenSupply, { precision: 4 })}</strong>
+                Your{' '}
+                {tokenSymbolText({
+                  tokenSymbol,
+                })}{' '}
+                balance
               </Trans>
-            </div>
-          ) : null}
-          {primaryTerminalCurrentOverflow?.gt(0) &&
-          !totalSupplyExceeded &&
-          minReturnedTokens?.gt(0) ? (
+            }
+          >
+            {formatWad(totalBalance ?? 0, { precision: 0 })} {tokensTextShort}
+          </Descriptions.Item>
+          <Descriptions.Item label={<Trans>Redemption value</Trans>}>
+            <ETHAmount amount={maxClaimable} />
+          </Descriptions.Item>
+        </Descriptions>
+
+        <div>
+          <Form form={form} layout="vertical">
+            <Form.Item
+              label={
+                canRedeem ? (
+                  <Trans>Tokens to redeem</Trans>
+                ) : (
+                  <Trans>Tokens to burn</Trans>
+                )
+              }
+            >
+              <FormattedNumberInput
+                name="redeemAmount"
+                min={0}
+                step={0.001}
+                placeholder="0"
+                value={redeemAmount}
+                accessory={
+                  <InputAccessoryButton
+                    content={t`MAX`}
+                    onClick={() => setRedeemAmount(fromWad(totalBalance))}
+                  />
+                }
+                formItemProps={{
+                  rules: [{ validator: validateRedeemAmount }],
+                }}
+                disabled={totalBalance?.eq(0)}
+                onChange={val => setRedeemAmount(val)}
+              />
+            </Form.Item>
+          </Form>
+
+          {canRedeem && !totalSupplyExceeded && minReturnedTokens?.gt(0) ? (
             <div style={{ fontWeight: 500, marginTop: 20 }}>
               <>
                 {/* If USD denominated, can only define the lower limit (not exact amount), hence 'at least' */}
@@ -273,12 +257,13 @@ export default function V2RedeemModal({
                   <>
                     {inUSD ? (
                       <Trans>
-                        You will receive at least {minReturnedTokensFormatted}{' '}
-                        ETH
+                        You will receive at least{' '}
+                        <ETHAmount amount={minReturnedTokens} />
                       </Trans>
                     ) : (
                       <Trans>
-                        You will receive {minReturnedTokensFormatted} ETH
+                        You will receive{' '}
+                        <ETHAmount amount={minReturnedTokens} />
                       </Trans>
                     )}
                   </>
@@ -286,12 +271,13 @@ export default function V2RedeemModal({
                   <>
                     {inUSD ? (
                       <Trans>
-                        You would receive at least {minReturnedTokensFormatted}{' '}
-                        ETH
+                        You would receive at least{' '}
+                        <ETHAmount amount={minReturnedTokens} />
                       </Trans>
                     ) : (
                       <Trans>
-                        You would receive {minReturnedTokensFormatted} ETH
+                        You would receive{' '}
+                        <ETHAmount amount={minReturnedTokens} />
                       </Trans>
                     )}
                   </>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -185,7 +185,10 @@ msgstr ""
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr ""
 
-msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
+msgid "<0>This project has a 0% redemption rate</0>. You won't receive any ETH for burning your tokens."
+msgstr ""
+
+msgid "<0>This project has no overflow</0>. You won't receive any ETH for burning your tokens."
 msgstr ""
 
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
@@ -1883,6 +1886,9 @@ msgstr ""
 msgid "Redeem veNFT"
 msgstr ""
 
+msgid "Redeem your tokens for a portion of this project's overflow. The current funding cycle's <0>redemption rate</0> determines your redemption value."
+msgstr ""
+
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr ""
 
@@ -1907,7 +1913,7 @@ msgstr ""
 msgid "Redemption rate:"
 msgstr ""
 
-msgid "Redemption rate: <0>{0}%</0>"
+msgid "Redemption value"
 msgstr ""
 
 msgid "Refresh"
@@ -2417,6 +2423,9 @@ msgstr ""
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr ""
 
+msgid "Tokens are burned when they are redeemed."
+msgstr ""
+
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr ""
 
@@ -2429,10 +2438,7 @@ msgstr ""
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr ""
 
-msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
-msgstr ""
-
-msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
+msgid "Tokens can be redeemed for a portion of this project's overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr ""
 
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
@@ -2445,6 +2451,12 @@ msgid "Tokens receiver"
 msgstr ""
 
 msgid "Tokens reserved"
+msgstr ""
+
+msgid "Tokens to burn"
+msgstr ""
+
+msgid "Tokens to redeem"
 msgstr ""
 
 msgid "Tokens:"
@@ -2729,9 +2741,6 @@ msgstr ""
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr ""
 
-msgid "You have exceeded the total token supply of <0>{0}</0>"
-msgstr ""
-
 msgid "You have set a funding cycle target."
 msgstr ""
 
@@ -2756,19 +2765,19 @@ msgstr ""
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-msgid "You will receive at least {minReturnedTokensFormatted} ETH"
+msgid "You will receive <0/>"
+msgstr ""
+
+msgid "You will receive at least <0/>"
 msgstr ""
 
 msgid "You will receive {0}{1} ETH"
 msgstr ""
 
-msgid "You will receive {minReturnedTokensFormatted} ETH"
+msgid "You would receive <0/>"
 msgstr ""
 
-msgid "You would receive at least {minReturnedTokensFormatted} ETH"
-msgstr ""
-
-msgid "You would receive {minReturnedTokensFormatted} ETH"
+msgid "You would receive at least <0/>"
 msgstr ""
 
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
@@ -2832,6 +2841,9 @@ msgid "Your unclaimed {tokenTextLong}"
 msgstr ""
 
 msgid "Your voting power"
+msgstr ""
+
+msgid "Your {0} balance"
 msgstr ""
 
 msgid "Zero"
@@ -2925,9 +2937,6 @@ msgid "{0} are distributed to anyone who pays this project. If the project has s
 msgstr ""
 
 msgid "{0} balance"
-msgstr ""
-
-msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr ""
 
 msgid "{0} days"


### PR DESCRIPTION
## What does this PR do and why?

- Clean up redeem/burn modal UI
- Fix Burn modal when redemption rate is 0%

## Screenshots or screen recordings

| state | before | after |
| --- | --- | --- |
| redeemable state | <img width="559" alt="Screen Shot 2022-08-01 at 2 12 57 PM" src="https://user-images.githubusercontent.com/12551741/182073887-5eca9a7a-5f45-42a4-b855-b0db7d63da9d.png"> | <img width="547" alt="Screen Shot 2022-08-01 at 2 08 52 PM" src="https://user-images.githubusercontent.com/12551741/182073539-a4b3949b-cd48-4333-a67b-9fff5f4802e5.png"> |
| no overflow | <img width="554" alt="Screen Shot 2022-08-01 at 2 15 56 PM" src="https://user-images.githubusercontent.com/12551741/182074180-99036afd-e0b2-4967-981d-f8efab084025.png"> | <img width="550" alt="Screen Shot 2022-08-01 at 11 40 50 AM" src="https://user-images.githubusercontent.com/12551741/182072509-f25608e0-f1b2-430c-a100-2b05e4bb6bc5.png"> |
| 0% redemption rate |<img width="553" alt="Screen Shot 2022-08-01 at 2 16 53 PM" src="https://user-images.githubusercontent.com/12551741/182074267-75df829d-dba8-4361-8749-e614c3727fba.png"> | <img width="550" alt="Screen Shot 2022-08-01 at 2 02 32 PM" src="https://user-images.githubusercontent.com/12551741/182072842-f5e108a1-fd49-42cf-8f72-093f05bbeead.png"> |


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
