### PR TITLE
Remove owner % reserved rate when reserved rate is 0

### DIFF
--- a/src/components/v1/shared/TicketModsList.tsx
+++ b/src/components/v1/shared/TicketModsList.tsx
@@ -100,7 +100,7 @@ export default function TicketModsList({
             ))
         : null}
 
-      {ownerPercent > 0 && (
+      {ownerPercent > 0 && reservedRate > 0 && (
         <Mod
           mod={{ beneficiary: owner, percent: ownerPercent }}
           value={

--- a/src/components/v2/shared/SplitList.tsx
+++ b/src/components/v2/shared/SplitList.tsx
@@ -48,7 +48,7 @@ export default function SplitList({
             />
           </div>
         ))}
-      {ownerPercentage ? (
+      {ownerPercentage && reservedRate ? (
         <SplitItem
           split={{
             beneficiary: projectOwnerAddress,


### PR DESCRIPTION
## What does this PR do and why?

Link to an issue - https://github.com/jbx-protocol/juice-interface/issues/1373

In this PR intention is to show the owner reserved rate only when reserved rate and owner percent are greater than zero.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
