### PR TITLE
remove update webpack config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpack = require('webpack')
 
+/**
+ * @type {import('next').NextConfig}
+ */
 module.exports = {
   staticPageGenerationTimeout: 90,
-  webpack5: true,
   webpack: config => {
     config.resolve.fallback = { fs: false, module: false }
     // Adds __DEV__ to the build to fix bug in apollo client `__DEV__ is not defined`.


### PR DESCRIPTION
## What does this PR do and why?
After the first diff, the next.js server was logging this error:
```
[
  {
    "instancePath": "",
    "schemaPath": "#/additionalProperties",
    "keyword": "additionalProperties",
    "params": {
      "additionalProperty": "webpack5"
    },
    "message": "must NOT have additional properties"
  }
]
```
after googling, removing the `webpack5` config seemed like the right fix.

The error was resolved. More here: https://github.com/vercel/next.js/issues/39161

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
