### PR TITLE
[1/2] Remove string origins from translation files

### DIFF
--- a/.linguirc.json
+++ b/.linguirc.json
@@ -7,7 +7,8 @@
   ],
   "format": "po",
   "formatOptions": {
-    "lineNumbers": false
+    "lineNumbers": false,
+    "origins": false
   },
   "orderBy": "messageId",
   "fallbackLocales": {

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,4441 +13,3051 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr "$ve{tokenSymbolDisplayText} Received"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "({realTokenAllocationPercent}% of all newly minted tokens)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "0% fee"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 year"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr "1. Get funded."
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. Project details"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr "1. Set ENS name"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. Funding cycle"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr "2. Give ownership"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr "2. Set text record"
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 hours"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr "3. Manage your funds"
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. Review and deploy"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 days"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr "4. Build trust."
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 days"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 days"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr ""
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr "<0/> contributed"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr "<0/> overflow received"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr "<0/> will go to the project owner: <1/>"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "<0/>{0} after {feePercentage}% JBX membership fee"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} distributed"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr "<0>Contribution floor:</0> {0} ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr "<0>Description: </0><1/>"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "<0>Learn more</0> about burning tokens."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr "<0>Website:</0> <1>{0}</1>"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr "@{handle}"
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr "@{handle} not found"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "A project can be archived by its owner from the tools menu on the project page."
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr "A veNft can only be redeemed if the project currently has overflow."
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVED"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr "Add Lock Duration Option"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr "Add NFT reward"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "Add a payout"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Add an on-chain memo to this payment."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr "Add an on-chain memo to this reconfiguration."
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr ""
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr "Add handle"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr "Add lock duration option"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr "Add new payout"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "Add payout"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr "Add reward tier"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr "Add terminal"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr "Add the V1 Token Payment Terminal to your project."
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr "Add token"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr "Add token allocation"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr "Address required"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "Address:"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "Address: <0/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "Adjust incentives for paying your project."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr "Advanced (optional)"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "All"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "All events"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr "Allow terminal configuration"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Allow token minting"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "Allowed"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "Amount"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "Amount of ERC-20 tokens to claim"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr "Amount required"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "Amount to distribute"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr "Amount:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr "Amounts"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr ""
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr "Approve token for transaction"
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "Archive project"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "Are you sure you want to start over?"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "Assets"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr "Attach a sticker"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr "Attach the image to be associated with this NFT."
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr "Auto claim"
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr "Automate funding cycles"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr "Automated funding cycles enable the following characteristics:"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Available funds are distributed according to the payouts below."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr "Available funds can be distributed according to the payouts below{0}."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr ""
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "Back to top"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Balance exceeded"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "Balance of the project owner's wallet."
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiary"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Beneficiary address"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr "Beneficiary:"
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr ""
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "Block number"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "Burn project tokens"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Burn {0} {tokensTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "Burn {tokensLabel}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "Burn {tokensTextLong}"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "By default, all unallocated funds can be distributed to the project owner's wallet."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr "By default, the payer will receive any project tokens minted from the payment."
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr ""
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Cannot redeem tokens for ETH because this project has no overflow."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr "Change ENS name"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr "Change project handle"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr "Changes to payouts will take effect immediately."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "Changes to project details will take effect immediately."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "Changes to these attributes can be made at any time and will be applied to your project immediately."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr "Changes to your reserved token allocation will take effect immediately."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr "Changes will take effect according to the project's custom ballot contract."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr "Character"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr "Choose how you would like to configure your payouts."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr "Claim {tokenTextPlural}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr "Claim {tokenTextPlural} as ERC-20 tokens"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "Claim {tokenTextShort}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "Claim {tokenTextShort} as ERC-20 tokens"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "Claim {tokensLabel} as ERC-20"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "Close"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr "Close, I'll do these later"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr "Collection name"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr "Collection symbol"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "Configure how your project will collect and spend funds."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "Configure restrictions for your funding cycles."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "Configure the dynamics of your project's token."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr "Confirm Stake"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr ""
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr "Connect Wallet"
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr "Connect wallet"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr "Connect wallet to claim"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "Connect wallet to deploy"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr "Connect wallet to distribute"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr "Connect wallet to issue"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Connect wallet to pay"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr "Connect wallet to transfer"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "Connect your wallet to see your holdings."
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "Connect your wallet to see your projects."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "Connected wallet not authorized"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr "Contribution threshold"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr "Contributor rate"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr "Contributors receive the NFT when they contribute at least this amount."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "Contributors will not receive any tokens in exchange for paying this project."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "Contributors will see this message before they pay your project."
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr ""
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr "Create a payable address (optional)"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Create an Ethereum address that can be used to pay your project directly."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "Create payable address"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr "Create payment address"
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "Create project"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr "Created ETH-ERC20 payment address"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr "Crowdfunding"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr ""
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "Current 3rd Party Exchange Rates"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "Current owner: {ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr "Currently worth: <0><1/></0>"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "Custom token beneficiary"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr "Customize your project's \"pay\" button. Leave blank to use the default."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr "Cycle #{0} -"
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr "DAOs"
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr ""
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "Date"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "Date created"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr "Day"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "Days"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr "Days to lock tokens"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr "Delete NFT"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr "Delete Option"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr "Delete payout"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr "Delete token allocation"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr "Deploy funding cycle configuration"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr "Deploy payment address"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr "Deploy payment address contract"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "Deploy project"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "Deploy project on {signerNetwork}"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "Deploy project to {0}"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "Deployed ERC20 token"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr "Deployed payment addresses can be found in the Tools drawer on the project page."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "Deposit 1 wei to @{handle}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr "Description"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr "Design how your tokens should work."
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr ""
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr "Determines whether tokens will be minted from payments to this address."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "Disabled"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "Disabled when your project's funding cycle duration is 0."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "Disabled when your project's funding cycle has no duration."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr "Discard"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr "Disclose any details to your contributors before they pay your project."
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr "Discord link"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr ""
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "Distribute funds"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "Distribute reserved {tokenTextPlural}"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "Distribute {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "Distribute {tokensText}"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "Distributed Funds"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr "Distributed Reserves"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr "Distributed Tokens"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr "Distributed funds"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr "Distributed reserved {0}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr "Distributing funds to Juicebox projects won't incur fees."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr "Distribution"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr "Distribution Limit <0/>:"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "Distribution limit"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Distribution limit, duration and payouts"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr "Distribution limit: <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr "Do I need this?"
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr "Do not include .eth"
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "Documentation on v1.1 contracts"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "Done"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "Download CSV"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "Download CSV of payments"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "Download CSV of project activity"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "Download CSV of {0} holders"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr "Duration (seconds)"
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr "ENS Name"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr "ERC20 Deployed"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr "ETH-ERC20 Address Created"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr "ETH-ERC20 Payment addresses"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr "Edit NFT reward"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr "Edit allocation"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr "Edit payout"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr "Edit payouts"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "Edit project"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "Edit project details"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "Edit reserved token allocation"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "Edit token allocation"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "Edit tracked assets"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr "Enable veNFT Governance"
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr "Enable veNFT to Spend Unclaimed Tokens"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr ""
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr "Enabling token minting will appear risky to contributors."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr ""
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Error loading holders"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "Error loading payments"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr "Error parsing form"
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr "Error uploading file"
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explore projects"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr "Extend Lock"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr "Extend lock successful. Results will be indexed in a few moments."
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr "Failed to update project metadata"
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr "Fee from <0><1/></0>"
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "File must be less than {formattedSize}{unit}"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr "Fund and operate your thing, your way."
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr "Fund anything. Grow together."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "Funding"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "Funding cycle details"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr "Funding cycle preview"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr "Funding cycle required."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "Funding distribution"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "Funding target"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr "General"
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "Give feedback"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr "Give this NFT a name."
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr "Grant permission"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr "Has Juicebox been audited?"
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "Holdings"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr "Hours"
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "How do I create a project?"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr "How do I decide?"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr "How do I set the redemption rate?"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr "How does it work?"
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr "How the {reservedPercentage}% of your project's reserved tokens will be split."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr "How to Juice."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr "I accept this project's <0>risks</0>."
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr "I have read and accept the <0>Terms of Service</0>."
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "I understand"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr "ID: {projectId}"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "If you're unsure if you need to claim, you probably don't."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr "Image file"
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr ""
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "In treasury"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr ""
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr "Indie creators and builders"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr "Infinite (no limit)"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "Initial issuance rate"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr "Initial mint rate"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr "Insufficient token balance"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr "Invalid address"
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Issue ERC-20"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "Issue ERC-20 token"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr "Issue an ERC-20 token (optional)"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "Issue token"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "JBX Fee ({feePercentage}%):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr "Join <0>hundreds of projects</0> sippin' the Juice."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "Juicebox Project ID"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr "Juicebox V1 project ID"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr "Juicebox V2 project"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Juicebox V2 project with ID {0}"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Juicebox loading animation"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Juicebox project"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr "Juicebox puts the fun back in funding so you can focus on building."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "Later"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "Latest"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "Latest payments"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr "Launch funding cycle"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr "Launch veNFT"
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr "Launch your project"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr "Leave blank to start immediately."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr "Link Juicebox V1 project"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr "Lock ${tokenSymbolDisplayText} for Voting Power"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr "Lock Duration"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr "Lock Durations ({0} options)"
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr "Lock duration"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr "Lock successful. Results will be indexed in a few moments."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Lock until"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr "Locked {tokenSymbolDisplayText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Locked:"
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "MAX"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr "Manage your {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "Manage {tokenText}"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr "Memo"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Memo (optional)"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr "Memo included on-chain"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrate to Juicebox V1.1"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr "Mint NFT to a custom address."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "Mint as ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Mint project tokens on demand"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr "Mint rate"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr "Mint this project's ERC-20 tokens to your wallet."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr "Mint tokens"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr "Mint tokens as ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "Mint tokens to a custom address."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "Mint {tokensLabel}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "Mint {tokensTokenLower}"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr "Minutes"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr "More information"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr "More trending projects"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "Move your {tokensLabel} from the Juicebox contract to your wallet."
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr "My projects"
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr "NFT projects"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr "NFT reward"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr "NFT rewards"
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "NO LIMIT"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr ""
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "New"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "Next: Funding cycle"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "Next: Review and deploy"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "No"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr "No NFT reward tiers"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr "No active funding cycle."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr "No beneficiary selected. Is your wallet connected?"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr "No funds available to distribute."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "No limit (infinite)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr "No reserved tokens available to distribute."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr "Not a valid ETH address"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr ""
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "Note"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr "Notice from {0}"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr "Only lowercase letters"
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "Other assets in this project's owner's wallet."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr "Other details"
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr "Overflow"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr ""
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr "Owned by: <0/>"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "Owner can mint tokens at any time."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr "Owner can set the project's payment terminals."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Owner is not allowed to mint tokens."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr "Owner isn't allowed to set the project's payment terminals."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr "Owner token minting"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr "Owner tools"
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr "Paid"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr ""
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "Pause received payments"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr ""
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "Pay amount must be greater than 0."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr ""
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr ""
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "Payer"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr "Payment address contract:"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr "Payment equivalent"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr "Payment memo"
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr "Payment memo image"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr "Payment options"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr ""
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr "Payments are paused in this funding cycle."
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr "Payments made"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr "Payout is locked"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "Payout recipients"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "Payouts"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "Payouts (optional)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "Percent"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr "Percentage allocation"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Percentage:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr "Percentages"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Percentages must add up to 100% or less"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "Potential risks"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr "Preview"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "Preview:"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr "Project Created"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr "Project ID must be a number."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "Project ID:"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr "Project Links"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr "Project Page Customizations"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "Project Token"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "Project configuration"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr "Project created by"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr "Project details can be edited at any time."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Project details reconfigurations will create a separate transaction."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "Project is accepting payments this funding cycle."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "Project is not accepting payments this funding cycle."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr "Project launch successful"
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr "Project not found"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "Project owner (you)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "Project token"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr "Project {0}"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "Project {name} will be available soon! Try refreshing the page shortly."
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr "Project {projectId}"
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Project {projectId} not found"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr ""
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "Projects that you have created."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "Projects that you hold tokens for."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr "Provide a link to additional information about this NFT."
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr "Raised on Juicebox"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr "Range"
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr "Read less"
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr "Read more"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "Receive ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr "Receive ERC-20 tokens"
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "Receive {receiveText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr "Recipient"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr "Recipient Address"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr "Recipient address"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "Recipients will receive payouts in ETH."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr ""
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "Reconfiguration rules"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Reconfigure"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr "Reconfigure payouts as percentages of your distribution limit."
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr "Reconfigure project and funding details"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "Reconfigure project details"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "Reconfigure token"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "Reconfigure upcoming"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigure upcoming funding cycles"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr "Redeem"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr "Redeem successful. Results will be indexed in a few moments."
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr "Redeem veNFT"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Redeem {0} {tokensTextShort} for ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "Redeem {tokensLabel} for ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "Redeem {tokensTextLong} for ETH"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Redeemed"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr "Redeeming this NFT will burn the token and return..."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Redemption rate"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr "Redemption rate:"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "Redemption rate: <0>{0}%</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "Refresh"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr "Relaunch your funding cycle on the new Juicebox V2 contracts."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "Required"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr "Reserve a percentage of freshly minted tokens for your project to use."
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "Reserved rate"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr "Reserved token allocation"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "Reserved token allocation (optional)"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "Reserved {tokenSymbolPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "Reserved {tokensText}"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "Resources"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "Restrict payments and printing tokens."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr ""
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr "Review and confirm stake"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr "Review and launch funding cycle"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr ""
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr "Reward contributors with NFT's."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr "Reward contributors with NFTs when they meet your configured funding criteria."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "Rules for determining how funding cycles can be reconfigured"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr ""
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr ""
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr "Save NFT reward"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr "Save NFT rewards"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr "Save Option"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "Save changes"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "Save handle"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr "Save payout"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Save payouts"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr ""
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "Save rules"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "Save token allocation"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "Save token configuration"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "Save tracked assets"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr "Second"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr "Seconds"
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "See transaction"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr "Set ENS name"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr "Set Up veNFT Governance"
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr "Set a distribution limit"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr "Set a project handle (optional)"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr "Set project handle"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr "Set text record for {0}"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr "Set this to the sum of all your payouts"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr "Set up V1 token migration"
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr "Set up and launch veNFT governance for your project."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr "Set up token migration"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Since you have not set a funding duration, changes to these settings will be applied immediately."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr "Some funding cycle settings may put project contributors at risk."
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr "Some of the project's current funding cycle properties may indicate risk for contributors."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "Something went wrong."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr "Spaces are not allowed"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr "Stake {tokensLabel} for NFT"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr "Staked {tokenSymbolDisplayText}"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr "Staking Summary:"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr ""
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr ""
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr "Start over"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr "Start raising funds"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr "Start time (seconds, Unix time)"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr "Step 1. Add V1 token payment terminal"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr "Step 2. Link your Juicebox V1 project"
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr "Successfully approved ERC-20 spending."
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Sum of percentages cannot exceed 100%"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "Sum of percentages cannot exceed 100%."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr "Swap for V2 {tokenSymbolFormattedPlural}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr "Swap for V2 {tokenText}"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr "Terminal configuration"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr "Text record is set"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "The amount of tokens to mint to the receiver."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "The balance of the project owner's wallet."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "The balance of this project in the Juicebox contract."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "The number of project tokens minted when 1 ETH is contributed."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr "The project owner can add and remove payment terminals."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr "The project owner is using an unverified contract for its reconfiguration strategy."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "The project owner may reconfigure this funding cycle at any time, without notice."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr "The redemption rate determines the amount of overflow each token can be redeemed for."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr "The total funds this Juicebox project has received since it was created."
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "These attributes can be changed at any time."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "This address is an unrecognized strategy contract. Make sure it is correct!"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr "This address will receive the tokens minted from paying this project."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr "This is the maximum amount of funds that can leave the treasury each funding cycle."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr ""
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr "This project is archived and can't be paid."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr "This project reserves some of the newly minted tokens for itself."
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "This project uses the V2 version of the Juicebox contracts."
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr "This project's balance in the Juicebox contract."
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "This will erase all of your changes."
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "This will reset the data for your new project. All changes will be lost."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr "Time Remaining"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr "Time remaining for changes made to affect the next funding cycle:"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr "Token amount"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr "Token beneficiary address"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr "Token beneficiary:"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "Token minting allows the project owner to mint project tokens at any time."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr "Token minting enabled"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "Token name"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr "Token name is required"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "Token symbol"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr "Token symbol is required"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr "Tokens are required."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr "Tokens for you"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "Tokens receiver"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr "Tokens reserved"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "Tokens:"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "Total raised"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr "Total staked period"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr "Total staked {tokenSymbolDisplayText}"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr "Transaction failed"
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transaction pending..."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr "Transaction unsuccessful"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "Transfer unclaimed {tokenSymbolShort}"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "Transfer {tokenSymbolShort}"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "Trending"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr "Trending projects"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr ""
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr "Twitter handle"
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "Unarchive project"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Unavailable"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr "Unknown Project"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr "Unlock"
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr "Unlock successful. Results will be indexed in a few moments."
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr "Unlock veNFT"
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr ""
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr "Untrack token"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr "Update your veNFT's lock duration."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr "Upload an image"
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "Uploaded to: <0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr "Uploaded to: <0>{value}</0>"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr "V1 token migration"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr "V1 tokens to swap"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr "V2"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "Version of the terminal contract used by this project."
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr "View token ranges"
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr ""
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr "VotePWR"
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr "WAGMI!"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "Wallet address"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr "What are automated funding cycles?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr "What is the V1 Token Payment Terminal?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "When enabled, the project owner can manually mint any amount of tokens to any address."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr "When enabled, the project owner can set the project's payment terminals."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "When enabled, your project cannot receive direct payments."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "Who is Peel?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr "Will be rounded to <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "Would you like to issue an ERC-20 token to be used as this project's token?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Yes"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr "You can edit your project details after creation at any time, but the transaction will cost gas."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "You don't have a funding cycle duration. Changes you make will take effect immediately."
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr "You don't have enough tokens to stake."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "You don't hold tokens for any Juicebox project."
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr "You don't own any veNFTs!"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr "You have exceeded the total token supply of <0>{0}</0>"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr "You have unsaved changes. Are you sure you want to discard them?"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "You haven't created any projects yet."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr "You must grant permission to swap your tokens."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr "You must own this V1 project."
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr "You must review and accept the Terms of Service."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr "You must review and accept the risks."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr "You receive an NFT for contributing over <0>{0} ETH</0>."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr "You will receive at least {minReturnedTokensFormatted} ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "You will receive {0}{1} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "You will receive {minReturnedTokensFormatted} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr "You would receive at least {minReturnedTokensFormatted} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr "You would receive {minReturnedTokensFormatted} ETH"
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr "You're all set!"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr "You've completed this step."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr "Your V1 balance"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr "Your V1 {tokenSymbolFormatted} balance"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "Your new payable address:"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Your project can still receive payments directly through the Juicebox protocol contracts."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "Your transaction has been submitted and is awaiting confirmation."
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr "Your unclaimed token balance: {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "Your unclaimed {tokenTextLong}"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr "Your voting power"
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr "Zero"
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr "called by <0/>"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr "day"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr ""
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr ""
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "hours"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "last {trendingWindowDays} days"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "loading"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "locked until {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "matching \"{searchText}\""
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "minutes"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "project"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "project owner"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "projects"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "seconds"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr "tokens per ETH contributed"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr "veNFT"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr "veNFT Tiers ({0} variants)"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr "{0, plural, one {# payment address} other {# payment addresses}}"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "{0} after JBX fee"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr "{0} tokens/ETH"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr "{0} unclaimed"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "{0} withdrawn"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr "{0} {tokenTextPlural} reserved"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr "{0}%"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr "{0}% of all newly minted tokens."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr ""
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr "{0}% to {1}"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "{0}/{1} withdrawn"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr ""
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} has no market for {tokenSymbol}."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "{formattedTimeLeft} left"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "{formattedTimeLeft} until #{0}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr "{inflationRate} tokens / ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr "{issuanceRate} tokens / ETH"
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# payment} other {# payments}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr "{tokenSymbolDisplayText} range"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr "{tokenSymbolDisplayText} to lock"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 address"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "{tokenTextSingular} recipients"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "{tokensText} reserved"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} amount"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr "{unclaimedBalanceFormatted} {tokenText} claimable"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% of total supply"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,4441 +18,3051 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "({realTokenAllocationPercent}% de todos los tokens recién acuñados)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "0% de comisión"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 año"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. Detalles del proyecto"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr "100% de excedente"
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. Ciclo de financiamiento"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 horas"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr "Espera de 3 días"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. Revisar y desplegar"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 días"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 días"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr "Espera de 7 días"
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 días"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr "<0/> Los proyectos archivados no han sido modificados o eliminados en la blockchain, y todavía pueden ser interactuados directamente a través de los contratos de Juicebox."
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr ""
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr "Saldo del propietario <0/>"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "<0/>{0} después de {feePercentage}% de la cuota de membresía JBX"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} distribuidos"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "<0><1/>{netDistributionAmount}</0> después de la tarifa JBX de {feePercentage}%"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1>Este proyecto no tiene excedente</1>, así que no recibirás ETH por quemar tokens.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr "<0>Una curva de adhesión recompensa a la gente que espera más para canjear sus tokens por excedente.</0><1>Por ejemplo, con una curva de adhesión del 70 %, canjear el 10 % del suministro de tokens en un momento dado reclamará alrededor del 7 % del excedente total.</1><2>El resto se deja para compartir entre los poseedores de tokens.</2>,<3>Para obtener más información, mira este <4>video corto</4> sobre curvas de adhesión</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr "<0>Un mecanismo como Juicebox en el que los compromisos financieros iniciales deben cumplirse a lo largo del tiempo solo está garantizado dentro de un ecosistema como Ethereum.</0><1>Ethereum provee un entorno público donde las apps de internet como Juicebox pueden ejecutarse sin necesidad de permisos o confianza, y de forma imparable.</1><2>Esto significa que cualquiera puede ver el código que están usando, cualquiera puede usar el código sin pedir permiso, y nadie puede arruinar el código o eliminarlo.</2><3>La gente que usa Juicebox están interactuando entre ellos a través de infraestructura pública—no es un servicio corporativo privado con fines de lucro que negocia el intercambio.</3><4>Juicebox fue creado para permitir que la gente y proyectos sean pagados por crear arte público e infraestructura, tanto o más que lo que ganarían trabajando por fines corporativos. No más negocios turbios.</4>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr "<0>Un proyecto puede elegir reservar un porcentaje de tokens para él mismo. En vez de ser distribuido para pagar usuarios, este porcentaje de tokens se acuña para el proyecto.</0><1>Tener estos tokens le da derecho a un proyecto una parte de su propio excedente.</1>"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr "<0>Tasa de descuento</0>, para reducir la tasa de emisión del token de tu proyecto (tokens por ETH) cada ciclo de financiamiento."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr "<0>Sí sabes cuanto necesita obtener tu proyecto en un periodo para ser sostenible, puedes establecer un objetivo de financiamiento con esa cantidad. Si tu proyecto gana más que eso, el sobrante se bloquea en un fondo de excedente. Cualquiera que posea los tokens de tu proyecto puede reclamar una porción del fondo de excedente a cambio de canjear sus tokens.</0><1> Para más información, revisa este <2>video corto</2>.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr "<0>Juicebox es un protocolo de mínimo de gobernanza. Solo hay unas pocas palancas que se pueden ajustar, ninguna de las cuales impone cambios para los usuarios sin su consentimiento. El contrato inteligente de gobernanza de Juicebox puede ajustar estas palancas.</0><1>El protocolo de Juicebox es gobernado por una comunidad de poseedores de tokens JBX que votan las propuestas de forma quincenal.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr "<0>Juicebox es un protocolo abierto en Ethereum que se financia utilizando el mismo Juicebox. Puedes revisar las especificaciones del presupuesto contractualizado <1>specs</1>. </0><2>Los proyectos que construyen en juicebox pagan un {JB_FEE}% de la cuota de membresía JBX de los fondos retirados al tesoro de JuiceboxDAO. Los proyectos pueden usar sus JBX para participar en la gobernanza de JuiceboxDAO y su tesoro colectivo, así como canjearlos por su creciente <3>excedente</3>. La cuota también está sujeta a cambios por los votos de los miembros JBX.</2>"
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "<0>Aprende más</0> acerca de quemar tokens."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>Aprende más</0> acerca de la duración del ciclo de financiación."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr "<0>Aprende más</0> acerca de ciclos de financiación."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr "<0>Aprende más</0> acerca del excedente."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>NOTA:</0> Este proyecto tiene un balance de 0. Los proyectos no pueden ser migrados sin un balance. Para migrar un proyecto, primero págalo o usa el botón de abajo para depositar 1 wei (0.000000000000000001 o 10<1>-18</1> ETH)."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0>Ninguna duración configurada.</0>El financiamiento puede ser reconfigurado en cualquier momento. Las reconfiguraciones empezarán en el nuevo ciclo de financiamiento."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0>Nota:</0> Estas propiedades <1>no</1> se podrán editar inmediatamente dentro de un ciclo de financiamiento. Solo pueden ser cambiadas para <2>próximos</2> ciclos de financiamiento."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>Nota:</0> Los tokens no se pueden reclamar porque no se ha emitido un token ERC-20 para este proyecto. Los tokens ERC-20 deben ser emitidos por el dueño del proyecto."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr "<0>En una tasa de canje menor, canjear un token incrementa el valor de cada token restante, creando un incentivo para mantener tokens más tiempo que otros poseedores.</0> <1>Una tasa de canje del 100% significa que todos los tokens tendrán el mismo valor, sin importar cuando se canjeen.</1>Aprende más en este <2>video corto</2>."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0> Es la DAO que maneja la interfaz frontend de juicebox.money. Puedes contactar a Peel mediante <1>Discord de Peel</1> o <2>Discord de Juicebox</2>."
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr "<0>Ciclos de financiamiento recurrentes</0>. Por ejemplo, distribuye fondos del tesoro de tu proyecto cada semana."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>El objetivo es 0.</0> El balance completo del proyecto será considerado excedente. <1>Aprende más</1> acerca de excedentes."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr "<0>Ese es el plan, pero los contratos básicos de Juicebox primero serán activados en la red principal de Ethereum.</0><1>El equipo de contratos pronto comenzarán a trabajar en terminales de pago L2 para proyectos Juicebox.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr "<0>Hay pruebas de unidad escritas para cada condición de cada función en los contratos y pruebas de integración para cada flujo de trabajo que admite el protocolo.</0><1>También se escribió un script para ejecutar de forma iterativa las pruebas de integración utilizando un generador de entrada aleatoria, priorizando los casos extremos. El código ha superado con éxito más de 1 millón de casos de prueba a través de este script de prueba de estrés.</1> <2>El código siempre podría usar más ojos y más críticas para aumentar la confianza de la comunidad. Únete a nuestro <3>Discord</3> y revisa el código en <4>GitHub</4> para trabajar con nosotros.</2>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0>Este proyecto no tiene excedente</0>, así que no recibirás ETH por quemar tokens."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr "<0>Este sitio web (juicebox.money) se conecta a los contratos inteligentes del protocolo Juicebox, desplegados en la red Ethereum. (nota: cualquier otra persona puede crear un sitio web que también se conecte a estos mismos contratos inteligentes. Por ahora, no confíes en ningún otro sitio que no sea este para acceder al protocolo de Juicebox).</0><1>La creación de un proyecto de Juicebox le otorga un NFT (ERC-721) que representa la propiedad sobre él. Quien sea propietario de este NFT puede configurar las reglas del juego y cómo se distribuyen los pagos.</1><2>Los tokens del proyecto que se acuñan y distribuyen como resultado de un pago recibido son ERC-20. La cantidad de tokens acuñados y distribuidos son proporcionales al volumen de pagos recibidos, ponderados por la tasa de descuento del proyecto a lo largo del tiempo.</2>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "<0>El total de tokens del proyecto acuñados</0> cuando se contribuye 1 ETH. Esto puede cambiar con el tiempo de acuerdo a la tasa de descuento y la cantidad de tokens reservados de ciclos de financiamiento futuros."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr "<0>Los usuarios financian su proyecto pagando por usar su aplicación o servicio, o como patrocinadores o inversores al realizar un pago directamente al contrato inteligente de su proyecto (como en esta aplicación).</0><1>Para los usuarios que pagan a través de su aplicación, debe canalizar esos fondos a través de los contratos inteligentes de Juicebox para que reciban tokens a cambio.</1>"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>Tus tokens {tokenSymbol} sin reclamar:</0>{0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} dirección de ERC-20:</0><1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr "@"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "Un proyecto puede ser archivado por su propietario desde el menú de herramientas en la página del proyecto."
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un proyecto puede reservar un porcentaje de los tokens acuñados de los pagos que recibe. Los tokens reservados pueden ser distribuidos de acuerdo a la asignación que está debajo en cualquier momento."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un proyecto puede reservar un porcentaje de tokens acuñados de cada pago que reciba. Los tokens reservados pueden ser distribuidos de acorde a la asignación que está debajo en cualquier momento."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr ""
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "El tiempo de vida de un proyecto se define en ciclos de financiación. Si se establece un objetivo de financiación, el proyecto no podrá retirar más de ese objetivo durante la duración del ciclo."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr "Una reconfiguración para el siguiente ciclo de financiación debe ser presentada al menos 3 días antes de que empiece."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr "Una reconfiguración para el siguiente ciclo de financiación debe ser presentada al menos 7 días antes de que empiece."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Un porcentaje reservado de más del 90% es riesgoso para los contribuidores. Los contribuidores no recibirán suficientes tokens por su contribución."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr ""
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVADO"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr "DISPONIBLE"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr "Actividad"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "Añadir un pago"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Añadir un memo on-chain a este pago."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr "Añadir fondos al saldo de este proyecto sin crear tokens."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr "Añadir imagen"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr "Añadir nuevo pago"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "Añadir pago"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr "Añadir al saldo"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr "Añadir al saldo"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr "Añadir token"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr "Añadir distribución de token"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr "Dirección"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "Dirección:"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "Dirección: <0/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "Ajusta los incentivos por pagar tu proyecto."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "Todos"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr "Todos los activos"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "Todos los eventos"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr "Todos los fondos pueden ser distribuidos por el proyecto. El proyecto no tendrá excedente (lo mismo que establecer el objetivo a infinito)."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr "Todos los fondos recibidos por el tesoro serán distribuidos. Los poseedores de tokens <0>no recibirán ETH</0> cuando quemen sus tokens."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr "Todo {0} irá al dueño del proyecto:"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "Asigna una porción de los tokens reservados de tu proyecto a otras wallets de Ethereum o proyectos de Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr "Permitir tokens creados"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Permitir acuñación de tokens"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "Permitido"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr "Casi de forma definitiva."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "Cantidad"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "Cantidad de tokens ERC-20 a reclamar"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr "Cantidad de tokens recién acuñados <0>reservados para el proyecto</0> cuando se contribuye 1 ETH. Los tokens de reserva se reservan para el dueño del proyecto por defecto, pero el dueño también puede asignarlos a las direcciones de otras billeteras."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr "Cantidad de tokens de proyecto recién acuñados <0>reservados para el proyecto</0> cuando se contribuye 1 ETH. Se asignan todos los tokens reservados al dueño del proyecto por defecto, pero también se pueden asignar a otras direcciones de billeteras."
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr "Monto pagado"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr "Cantidad requerida"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "Monto a distribuir"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr "Cantidad:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr "Cantidades"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Cualquier cambio que hagas surtirá efecto en el <0>ciclo de financiamiento#{0}</0>. El ciclo de financiamiento actual. (#{currentFCNumber}) no será alterado."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr "Cualquier reconfiguración de un próximo ciclo de financiación surtirá efecto una vez que finalice el ciclo actual. Un proyecto sin estrategia podría ser vulnerable a ser retirado por su dueño."
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "Archivar proyecto"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "Archivado"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "¿Estás seguro de que quieres volver a empezar?"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "Activos"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr "Adjuntar un sticker"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr "Automatizar ciclos de financiamiento"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr "Los ciclos de financiamiento automatizados habilitan las siguientes características:"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr "Disponible tras comisión:"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Los fondos disponibles son distribuidos acorde a los pagos a continuación."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr "Los fondos disponibles pueden ser distribuidos de acuerdo a los pagos de abajo{0}."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr "Disponible:"
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "Regresa arriba"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Balance excedido"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "Balance en la cartera del dueño del proyecto."
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiario"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Dirección de beneficiario"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr "Dar las gracias a la comunidad Ethereum por fabricar la infraestructura y la economía para hacer posible Juicebox."
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "Número de bloque"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Construido para:"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "Quemar tokens del proyecto"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Quema tus {tokensLabel}. No recibirás ETH de regreso porque este proyecto no tiene excedente."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Quemar {0} {tokensTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "Quemar {tokensLabel}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "Quemar {tokensTextLong}"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "Por defecto, todos los fondos no asignados pueden ser distribuidos a la wallet del dueño del proyecto."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Por defecto, tokens recientemente minteados irán a la billetera que envíe los fondos a la dirección. Puedes activar esto para establecer una dirección personalizada como beneficiario del token."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "¿Puedo cambiar el contrato de mi proyecto después de haber sido creado?"
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr "¿Puedo eliminar un proyecto?"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "No se pueden canjear tokens por ETH porque este proyecto no tiene excedente."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr "Los cambios a los pagos surtirán efecto de inmediato."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "Los cambios a los detalles del proyecto tendrán efecto inmediato."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "Se pueden hacer cambios a estos atributos en cualquier momento y serán aplicados a tu proyecto inmediatamente."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr "Los cambios a las configuraciones de financiamiento de tu proyecto requieren un periodo aprobado por la comunidad para surtir efecto, lo cual actúa como salvaguardia contra rug pulls. Tus partidarios no necesitan confiar en ti — aunque ya lo hacen."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr "Los cambios surtirán efecto de acuerdo al contrato personalizado de votación del proyecto."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Los cambios que hagas surtirán efecto de acuerdo a tu <0>{0}</0> regla de reconfiguración (primer ciclo de financiamiento siguiente <1>{1}</1> desde ahora)."
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Marca esto para acuñar {tokenSymbol} ERC-20 a tu cartera. Deja desmarcado para que tu balance de tokens sea registrado por Juicebox, ahorrando gas en está transacción. Siempre puedes reclamar tus tokens ERC-20 después."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr "Elige como te gustaría configurar tus pagos."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr "Reclamar {tokenTextPlural}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr "Reclamar {tokenTextPlural} como tokens ERC-20"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "Reclamar {tokenTextShort}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "Reclamar {tokenTextShort} como tokens ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "Reclamar {tokensLabel} como ERC-20"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Reclamar tokens {tokenSymbol} convertirá tu balance de {tokenSymbol} a ERC-20 y los acuñará a tu cartera."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Reclamar {tokenTextLong} convertirá tu balance de {tokenTextShort} a tokens ERC-20 y las acuñará a tu cartera."
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr "Cerrar, los haré después"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "Asigna porciones de tus fondos para la gente o proyectos que quieres apoyar, o a los colaboradores a los que les quieres pagar. Cuando te pagan, también a ellos."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "Configura cómo tu proyecto recolectará y gastará los fondos."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "Configura restricciones para tus ciclos de financiamiento."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "Configura la dinámica del token de tu proyecto."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr "¡Felicitaciones por lanzar tu proyecto! Los siguientes pasos son opcionales y se pueden completar en cualquier momento."
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr "Conectar billetera"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr "Conectar billetera para reclamar"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "Conecta tu billetera para desplegar"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr "Conectar billetera para distribuir"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr "Conectar billetera para emitir"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Conecta tu cartera para pagar"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr "Conectar billetera para transferir"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "Conecta tu billetera para ver tus activos."
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "Conecta tu billetera para ver tus proyectos."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "Billetera conectada no autorizada"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr "Dirección de contrato: {0}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr "Tasa de Contribuidor"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Los contribuyentes serán retribuidos esta cantidad de tokens de tu proyecto por ETH contribuido."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "Los contribuyentes no recibirán ningún token a cambio de sus pagos a este proyecto."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr "Los contribuidores recibirán <0>{discountRatePercent}%</0> más tokens por contribuciones que hagan este ciclo de financiamiento en comparación con el próximo ciclo de financiamiento."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "Los contribuyentes recibirán una porción relativamente pequeña de tokens a cambio de sus pagos a este proyecto."
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "Los contribuyentes verán este mensaje antes de pagar tu proyecto."
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr "¡Copiado!"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "Copiar a portapapeles"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr "Crea una dirección de pago (opcional)"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr "Crea una dirección Ethereum para tu proyecto. Permite los pagos directos sin pasar por la página Juicebox de tu proyecto."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Crea una dirección Ethereum que pueda ser usada para pagar tu proyecto directamente."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "Crear dirección pagable"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr ""
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "Crear proyecto"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "Crea tu propio token #ERC-20 para representar la participación en tu proyecto. Los contribuyentes recibirán estos tokens cuando paguen tu proyecto."
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr "Actual"
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "Tasas de cambio de terceras partes actuales"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "Dueño actual: {ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr "Estrategia personalizada"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "Beneficiario de token personalizado"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr "Personaliza el botón de \"pagar\" de tu proyecto. Deja en blanco para usar el valor por defecto."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Ciclo #{0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr "Ciclo #{0} -"
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr "Tema oscuro"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "Fecha"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "Fecha de creación"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "Días"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr "Borrar pago"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr "Borrar asignación de tokens"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr "Desplegar configuración de ciclo de financiamiento"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "Desplegar proyecto"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "Desplegar proyecto en {signerNetwork}"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "Desplegar proyecto a {0}"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "Desplegar token ERC20"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "Deposita 1 wei a @{handle}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr "Diseña tu proyecto"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Detalles"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr "Determinar si es que los tokens serán minteados desde pagos hacia esta dirección."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "Desactivado"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "Desactivado cuando el límite de distribución de tu ciclo de financiamiento es <0>Sin límite</0> (infinito)"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "Deshabilitado cuando la duración del ciclo de financiamiento de tu proyecto es 0."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "Desactivado cuando el ciclo de financiamiento de tu proyecto no tiene duración."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr "Descartar"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr "Expón todo detalle a tus colaboradores antes de que paguen tu proyecto."
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr "Discord"
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr "Enlace a Discord"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr "Tasa de descuento"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr "Exhibe los ERC-20 y otros tokens de proyectos Juicebox que este dueño de proyecto posee."
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "Desplegar tokens ERC-20 y otros tokens de Juicebox que están en esta cartera del dueño del proyecto."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr "Distribuye un porcentaje de todos los fondos recibidos a entidades. Tu límite de distribución será <0>infinito</0>."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr "Distribuye una cantidad específica de fondos a entidades cada ciclo de financiamiento. Tu límite de distribución será igual a la <0>suma de todas las cantidades de tus pagos.</0>"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "Distribuye fondos disponibles a otras wallets de Ethereum o proyectos de Juicebox como pagos. Usa esto para pagarle a colaboradores, caridades, proyectos de Juicebox de los que dependas, o a cualquier otro. Los fondos son distribuidos cuando un retiro se hace desde tu proyecto."
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "Distribuir fondos"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "Distribuir los {tokenTextPlural} reservados"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "Distribuir {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "Distribuir {tokensText}"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr "Distribuido"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "Fondos Distribuidos"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr "Reservas Distribuidas"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr "Tokens Distribuidos"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr "Fondos distribuidos"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr "{0} reservados distribuidos"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr "La distribución de fondos a los proyectos de Juicebox no incurrirá en cuotas."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr "Distribución"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr "Límite de distribución<0/>:"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "Límite de distribución"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "El límite de distribución es 0: Todos los fondos serán considerados excedente y pueden ser canjeados por los holders de tokens."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr "El límite de distribución es infinito. <0>El proyecto controlará como se distribuyen todos los fondos, y ninguno puede ser canjeado por poseedores de tokens.</0>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Límite de distribución, duración y pagos"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr "Límite de distribución: <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr "¿Tengo que volver mi proyecto de código abierto para usar Juicebox como modelo de negocio?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr "Documentos"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "Documentación en contratos v1.1"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr "¿Un proyecto se beneficia de su exceso?"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "Hecho"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "Descargar CSV"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "Descargar CSV de pagos"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "Descargar CSV de la actividad del proyecto"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "Descargar CSV de {0} holders"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr "Duración"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr "Duración (segundos)"
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "Los tokens ERC-20 solo se pueden acuñar una vez que se ha emitido un token ERC-20 para este proyecto."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr "ERC20 Desplegado"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Cada pago recibirá su porcentaje de este total cada ciclo de financiamiento si hay suficiente en el tesoro. En caso contrario, recibirán el porcentaje de lo que haya en el tesoro."
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr "Editar pago"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr "Editar pagos"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "Editar proyecto"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "Editar detalles del proyecto"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "Editar la asignación de tokens reservados"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "Editar la asignación de tokens"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "Editar activos en seguimiento"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr ""
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr "Activado"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr "Activar esto permite al dueño del proyecto acuñar manualmente cualquier cantidad de tokens a cualquier dirección."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "Activar esto acuñará tokens ERC-20 {tokenSymbol}. De lo contrario tokens {tokenSymbol} no reclamados serán acuñados, que podrán reclamarse después como ERC-20 por el beneficiario."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "Habilitando esto acuñará {tokenSymbol} tokens ERC-20. De lo contrario, los tokens {tokenSymbol} no reclamados serán acuñados, los cuales, podrán ser reclamados después como tokens ERC-20 por el receptor."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr "Permitir acuñar tokens parecerá arriesgado a los contribuidores."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr "Fin"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Error al cargar holders"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "Error al cargar pagos"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explorar proyectos"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "Preguntas frecuentes"
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr "Preguntas frecuentes"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr "No se ha podido actualizar la metadata del proyecto"
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "El archivo debe ser menor que {formattedSize}{unit}"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr "Financia lo que sea. Crezcan juntos."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "Financiamiento"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr "Ciclo de financiamiento"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "Detalles del ciclo de financiamiento"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr "Duración del ciclo de financiamiento"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr "Vista previa del ciclo de financiamiento"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr "Ciclo de financiamiento requerido."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr "Meta-objetivo del ciclo de financiamiento"
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "Los ciclos de financiamiento pueden ser reconfigurados momentos antes de que empiece un nuevo ciclo, sin la necesidad de notificar a los contribuyentes."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "Distribución de fondos"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "Objetivo de financiamiento"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr "Los fondos serán distribuidos a:"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr "General"
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "Da retroalimentación"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr "Ve a Etherscan"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr "Usuario"
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr "Atención"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr "Historial"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr "Holders"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "Tenencias"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr "Horas"
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr "¿Qué tan descentralizado es Juicebox?"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr "¿Cómo archivo un proyecto?"
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "¿Cómo creo un proyecto?"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr "¿Cómo lo decido?"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr "¿Cómo establezco la tasa de canje?"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr "¿Cómo se han puesto a prueba los contratos?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "En cuánto tiempo antes de que empiece el siguiente ciclo de financiamiento debes hacer la reconfiguración de forma que los cambios surtan efecto."
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "Cuanto durará un ciclo de financiamiento. Las <0>reconfiguraciones</0> del ciclo de financiamiento, solo tendrán efecto para los <1>próximos</1> ciclos de financiamiento, p. ej. una vez que el ciclo de financiamiento actual haya terminado."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr "Cómo se dividirá el {reservedPercentage}% de los tokens reservados de tu proyecto."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr "Cómo tu proyecto distribuirá los fondos."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "Entiendo"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr "ID: {projectId}"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Si está bloqueado, esto no se puede editar o remover hasta que el bloqueo caduque o el ciclo de financiamiento sea reconfigurado."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Si está bloqueado, esta división no se puede editar o remover hasta que el bloqueo expire o el ciclo de financiamiento es reconfigurado."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr "Si no recaudas la suma de todos tus pagos (<0/>{distributionLimit}), esta dirección recibirá {0}% de todos los fondos que recaudes."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr "Si no recaudas este monto, tus divisiones recibirán el porcentaje de lo que recaudes."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "Si ya has desplegado una dirección de pago y la has perdido, por favor contacta al equipo de Juicebox mediante <0>Discord.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "Si estás interesado en crear un proyecto pero aún estás confundido sobre como empezar, considera ver este <0>video instructivo</0>. También sientete libre de contactarnos mediante el <1>Discord de Juicebox</1> ¡donde nuestro equipo estará feliz de traer a la vida tu idea de proyecto!"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "Si dudas de si necesitas reclamar tus tokens, probablemente no deberías hacerlo."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr "En Juicebox"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "En el tesoro"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr "En billetera"
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr "Incentivos"
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr "Creadores y constructores Indie"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr "Infinito (sin límite)"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "Tasa de emisión inicial"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr "Tasa inicial de acuñación"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Emitir ERC-20"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "Emitir token ERC-20"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "Emite un ERC-20 para que sea usado como token de este proyecto. Una vez emitido, cualquiera puede reclamar su balance existente de tokens como el nuevo token."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr "Emite un token ERC-20 (opcional)"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "Emitir token"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "No es posible eliminar los datos de un proyecto de la blockchain, pero podemos ocultarlo en la app si quiere evitar que la gente lo vea o interactúe con ellos — simplemente háganos saber en <0>Discord</0>. Tenga en cuenta que la gente todavía podrá utilizar su proyecto interactuando directamente con el contrato."
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr "Sería mucho más cool si lo haces"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr "Comisión de JBX ({0}%):"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "Tarifa JBX ({feePercentage}%):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "ID de proyecto Juicebox"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Proyecto de Juicebox V2 con ID {0}"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Animación de carga de Juicebox"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Proyecto de Juicebox"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr "Pagado por última vez"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "Después"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "Último"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "Últimos pagos"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr "Lanzar ciclo de financiamiento"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr "Lanza tu proyecto"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr "Dejar en blanco para empezar de inmediato."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr "Tema luminoso"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr "Cargar más"
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr ""
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquear hasta"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Bloqueado:"
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr "Logo"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "MÁXIMO"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Administra"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr "Maneja tu {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "Administrar {tokenText}"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr "Máximo {MAX_DESCRIPTION_LENGTH} caracteres"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr "Memo"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Memo (opcional)"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr "Memo incluído en-cadena"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrar a Juicebox V1.1"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "Acuñar como ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "Acuña nuevos {tokensLabel} a una cuenta. Solo el propietario de un proyecto, un operador designado, o uno de los delegados de su terminal puede acuñar sus tokens."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Crea tokens del proyecto a demanda"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr "Tasa de acuñación"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr "Acuñar tokens"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr "Mintear tokens como ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "Acuña tokens a una dirección personalizada."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "Acuñar {tokensLabel}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "Acuñar {tokensTokenLower}"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr "Minutos"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr ""
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "Mueve tus {tokensLabel} del contrato de Juicebox a tu billetera."
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "SIN LÍMITE"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr "Nombre"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "Nuevo"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr "Los {tokenSymbolPlural} recién acuñados <0>recibidos por contribuyentes</0> por cada ETH que contribuyen al tesoro."
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "Siguiente: Ciclo de financiamiento"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "Siguiente: Revisar y desplegar"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "No"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr "No hay ciclo de financiamiento activo."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Sin actividad, todavía"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Sin meta-objetivo de financiamiento: Este proyecto va a controlar cómo serán distribuidos todos los fondos, y ninguno podrá ser canjeado por los tenedores de los tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "No se pueden distribuir fondos afuera del tesoro. Solo los poseedores de tokens pueden acceder a los fondos canjeando sus tokens."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "Sin límite (infinito)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr "No más que el objetivo del ciclo de financiación puede ser distribuido por el proyecto en un solo ciclo de financiación."
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Sin ciclos de financiamiento pasados"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr "Sin estrategia"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr "Sin meta-objetivo de financiamiento"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr "Sin meta-objetivo establecida."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr "No es una dirección de ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr "No establecido"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "Nota"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Nota: los tokens pueden ser acuñados manualmente cuando se permita en el ciclo de financiamiento actual. Esto puede ser cambiado por dueño del proyecto para ciclos próximos."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr "Aviso de {0}:"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr "Una vez lanzado, tu primer ciclo de financiamiento <0>no se puede cambiar</0>. Puedes reconfigurar los ciclos próximos de acuerdo a las <1>reglas de reconfiguración</1> del proyecto."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "Otros activos en la billetera del dueño de este proyecto."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr ""
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr "Excedente"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr "El excedente es creado si el saldo de tu proyecto excede el objetivo de financiamiento. El exceso puede ser canjeado por los poseedores de tokens de tu proyecto."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "El dueño puede acuñar tokens en cualquier momento."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "El dueño no está autorizado para emitir tokens."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr "Acuñación de tokens por el dueño"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr "Herramientas del propietario"
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr "Pagado"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr "Pagado como <0/>"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr "Pausar pagos"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "Pausar pagos recibidos"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr "Pagar"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr "Pagar cantidad"
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "El monto del pago debe ser mayor que 0."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr "Botón de pago"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr "Texto del botón de pago"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr "Declaración por pago"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr "Pagar {0}"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "Pagador"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "Pagar <0>{0}</0> no es una inversión; es una manera de apoyar el proyecto. Cualquier valor o utilidad de los tokens que recibas es determinada por {1}."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr "Actúalmente, los pagos a este proyecto se encuentran desactivados."
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr "Pago equivalente"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr ""
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr "Imagen de memo de pago"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr "Pagos"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr "Pagos pausados"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "Beneficiarios del pago"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "Pagos"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "Pagos (opcional)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "Pagos a direcciones Ethereum incurren en un {feePercentage}% de cuota. Tu proyecto recibirá JBX de regreso acorde a la tasa de emisión actual."
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "Porcentaje"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr "Asignación porcentual"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Porcentaje:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr "Porcentajes"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Los porcentajes deben sumar 100% o menos"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr "Podcast"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "Riesgos potenciales"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr "Vista previa"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "Vista previa:"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr "Proyecto Creado"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr "El ID de proyecto debe ser un número."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "ID de proyecto:"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "Token de proyecto"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "Configuración de proyecto"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr "Proyecto creado por"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr "Descripción del proyecto"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr "Detalles del proyecto"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr "Los detalles del proyecto se pueden editar en cualquier momento."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Las reconfiguraciones de los detalles del proyecto, crearán una transacción separada."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr "Usuario del proyecto"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr "El usuario de tu proyecto debe ser único."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "El proyecto está aceptando pagos este ciclo de financiamiento."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "El proyecto no está aceptando pagos este ciclo de financiamiento."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr "Lanzamiento de proyecto exitoso"
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr "Nombre del proyecto"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr "Nombre del proyecto, usuario, links y otros detalles."
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr "Dueño del proyecto"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "Dueño del proyecto (tú)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "Los propietarios de proyectos pueden configurar un período de demora, lo que significa que las reconfiguraciones para un próximo ciclo de financiamiento deben enviarse en un determinado número de días antes de que comience. Por ejemplo, un período de demora de 3 días significa que las reconfiguraciones deben enviarse al menos 3 días antes de que comience el próximo ciclo de financiación. Esto les da a los poseedores de tokens tiempo para reaccionar a la decisión y reduce la posibilidad de rug-pulls."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "Token de proyecto"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr ""
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "¡El proyecto {name} estará disponible pronto! Intenta refrescar la página en un momento."
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr "Proyecto {projectId}"
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Proyecto {projectId} no encontrado"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr "Proyectos"
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "Los proyectos pueden ser creados con una tasa de descuento opcional para incentivar a los patrocinadores a contribuir más pronto que tarde. La cantidad de tokens recompensados por monto pagado a tu proyecto disminuye según la tasa de descuento con cada nuevo ciclo de financiamiento. Una tasa de descuento mayor va a incentivar a los benefactores a financiar tu proyecto más pronto que tarde."
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr "Proyectos en Juicebox"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "Proyectos que tú has creado."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "Proyectos de los que holdeas tokens."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "Los proyectos que usan una tarifa reservada {reservedRateRiskyMin}% o más parecerán arriesgados para los colaboradores, como un número relativamente pequeño de tokens serán recibidos a cambio de pagar por tu proyecto."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Clasificaciones basadas en el número de contribuciones y volumen obtenido en los últimos {trendingWindow} días. <0>Ver código</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr ""
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "Recibir ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "Recibe {receiveText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr "Beneficiario"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr "Dirección de beneficiario"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "Los beneficiarios recibirán los pagos en ETH."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr "Reconfiguración"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "Reglas de reconfiguración"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Estrategia de reconfiguración"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr "Reconfigurar pagos como porcentajes de tu límite de distribución."
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr "Reconfigura los detalles de proyecto y financiamiento"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "Reconfigura los detalles del proyecto"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "Reconfigurar token"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "Reconfigurar próximos"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamiento próximos"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Canjea tus {tokensLabel} por una porción del excedente del proyecto. Cualquier {tokensLabel} que canjees será quemado."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Canjear {0} {tokensTextShort} por ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "Canjea {tokensLabel} por ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "Canjear {tokensTextLong} por ETH"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Canjeado"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Porcentaje de canje"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "Tasa de redención<0>{0}%</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr "Relanza tu ciclo de financiamiento con los nuevos contratos de Juicebox V2."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "Requerido"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr "Reserva un porcentaje de los tokens recién acuñados para que tu proyecto los use."
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "Cuota reservada"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "La tasa de reservación es 0%, pero tiene asignación de tokens reservados. Considera añadir una tasa de reservación que sea mayor que 0, o quitar la asignación de tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr "Asignación de tokens reservados"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "Asignación de tokens reservados (opcional)"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr "Colocación de tokens reservados"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr "Tokens reservados"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr "{0} Reservados"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "{tokenSymbolPlural} Reservados"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "{tokenTextPlural}<0>{reservedTokensFormatted}{tokenTextPlural}</0> reservados"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "{tokensText} reservados"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "Recursos"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "Restringir pagos y emisión de tokens."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr "Acciones restringidas"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr "Revisa & Despliega"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr "Revisar y lanzar ciclo de financiamiento"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr "Revisar proyecto"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr "Recompensar a miembros específicos de la comunidad con tokens."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr "Reglas"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "Reglas para determinar cómo se pueden reconfigurar los ciclos de financiamiento"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr "Reglas para cómo pueden realizarse cambios a tu proyecto."
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr "Reglas para cómo pueden ser reconfigurados los ciclos de financiamiento de este proyecto."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr "Guardar"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "Guardar cambios"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr "Guardar configuración de financiamiento"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "Guardar usuario"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr "Guardar pago"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Guardar pagos"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr "Guardar detalles del proyecto"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr "Guardar reconfiguración"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "Guardar las reglas"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "Guardar asignación de tokens"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "Guardar configuración de los tokens"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "Guardar activos en seguimiento"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr "Buscar proyectos por usuario"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr "Segundos"
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Ver transacción"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr "Establecer un límite de distribución"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr "Establece una duración del ciclo de financiamiento"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr "Establece una meta-objetivo del ciclo de financiamiento"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr "Establece la cantidad de fondos que te gustaría recaudar cada ciclo de financiamiento. Cualquier fondo recaudado dentro del objetivo de financiamiento puede ser distribuido por el proyecto, y no puede ser canjeado por los tenedores de tokens de tu proyecto."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr "Establece la duración de tus ciclos de financiamiento."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr "Establécelo en la suma de todos tus pagos"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr "¿Deberías de usar Juicebox?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Como no has establecido una duración de financiamiento, los cambios a estos ajustes serán aplicados de inmediato."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr ""
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "Algo salió mal."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr "Gasto"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr "Empezar"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr "Empezar de Nuevo"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr "Volver a comenzar"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr "Hora de inicio (segundos, tiempo Unix)"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "La suma de los porcentajes no puede exceder 100%"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "La suma de los porcentajes no puede exceder 100%."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr "Objetivo"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "La meta-ojetivo es 0: Todos los fondos serán considerados excedente y pueden ser canjeados al quemar tokens del proyecto."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr "La <0>tasa de emisión</0> de tu segundo ciclo de financiamiento será <1>{0} tokens por 1 ETH</1>, entonces <2>{1} tokens por 1 ETH </2>para tu tercer ciclo de financiamiento y así sucesivamente."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr "El protocolo JBX está inauditado, y los proyectos contruidos sobre este pueden ser vulnerables a bugs o exploits. ¡Sé inteligente!"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "La dirección de cualquier contrato inteligente desplegado en {0} que implemente <0>esta interfaz</0>."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr "La dirección que debería recibir los tokens acuñados por pagar este proyecto."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "La cantidad de tokens que este proyecto tiene reservados. Estos tokens pueden ser distribuidos a los beneficiarios de tokens reservados."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "La cantidad de tokens a acuñar al receptor."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "La cantidad que ha sido distribuida desde el balance de Juicebox en este ciclo de financiamiento, fuera del límite actual de distribución. No se puede distribuir más del límite de distribución en un solo ciclo de financiación; cualquier ETH restante en Juicebox es excedente, hasta que comience el siguiente ciclo."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "El monto que ha sido distribuido desde el saldo Juicebox en este ciclo de financiación, fuera del objetivo actual. No más que el objetivo de financiación puede ser distribuido en un solo ciclo de financiación—cualquier ETH remanente en Juicebox es excedente, hasta que el siguiente ciclo comience."
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "El balance de la cartera del dueño del proyecto."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "El balance de este proyecto en el contrato de Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "El límite de distribución para el ciclo es 0, lo que significa que todos los fondos en Juicebox actualmente son considerados excedente. El excedente puede ser redimido por los poseedores de tokens, pero no distribuidos."
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "El futuro será liderado por creadores y las comunidades serán los dueños."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "El monto máximo de fondos permitidos para ser distribuidos desde el tesoro del proyecto cada ciclo de financiamiento."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr "La cantidad máxima de fondos que pueden ser distribuidos desde el tesoro cada ciclo de financiamiento."
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "El monto máximo de fondos que puede ser distribuido desde este proyecto en un ciclo de financiamiento. Los fondos serán retirados en ETH sin importar la moneda que tú escojas."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr "El número de tokens de proyecto acuñados cuando se contribuye 1 ETH en el primer ciclo de financiamiento."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "El número de tokens de proyecto acuñados cuando se contribuye 1 ETH."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "El porcentaje que éste individuo recibe del {reservedRate}% total de asignación de tokens reservados"
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "El dueño del proyecto puede acuñar cualquier oferta de tokens en cualquier momento, diluyendo así la porción de tokens de todos los contribuyentes existentes."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "El dueño del proyecto puede reconfigurar este ciclo de financiamiento en cualquier momento, sin necesidad de notificar."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr "La tasa de emisión del token del proyecto bajará por este porcentaje cada ciclo de financiamiento. Una tasa de descuento más alta incentivará a los contribuyentes a pagar el proyecto antes."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr "La proporción de tokens otorgados por monto de pago irán disminuyendo por este porcentaje con cada ciclo de financiamiento nuevo. Una mayor tasa de descuento incentivará a los partidarios a pagar tu proyecto más antes que después."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "La tasa de canje determina la cantidad de excedente por la que cada token puede ser canjeado en cualquier momento. En una tasa de canje baja, canjear un token incrementa el valor de cada token restante, creando un incentivo para holdear los tokens por más tiempo que otros. Una tasa de canje del 100% significa que todos los tokens tendrán igual valor sin importar el cuándo fueron canjeados."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr "La tasa de canje determina la cantidad de excedente por el que se puede canjear cada token."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "El objetivo para este ciclo de financiamiento es 0, lo que significa que todos los fondos en Juicebox actualmente se consideran excedente. El excedente puede canjearse por poseedores de tokens, pero no distribuidos."
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr "Los fondos totales que este proyecto Juicebox ha recibido desde que fue creado."
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr "No hay pagos definidos para este ciclo de financiamiento. El dueño del proyecto recibirá todos los fondos disponibles."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "No hay beneficiarios de tokens reservados definidos para este ciclo de financiamiento. El dueño del proyecto recibirá todos los tokens disponibles."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "Estos atributos pueden cambiarse en cualquier momento."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "Estos ajustes <0>no</0> serán editables inmediatamente dentro de un ciclo de financiamiento. Solo pueden ser cambiados para <1>próximos</1> ciclos de financiamiento."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "Esta dirección es un contrato de estrategia no reconocida. ¡Asegúrate de que esté correcta!"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr "Está dirección recibirá cualquier token acuñado cuando el receptor del proyecto es pagado."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr "Esta dirección recibirá los tokens acuñados por pagar este proyecto."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "Este ciclo de financiación puede representar riesgos a los contribuidores. Revisa los detalles del ciclo de financiación antes de pagar este proyecto."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr "Este es la cantidad máxima de fondos que pueden dejar el tesoro en cada ciclo de financiamiento."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr "Está lista está usando un índice experimental de datos y puede ser incorrecta para algunos proyectos."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr "Este proyecto está archivado y no puede ser pagado."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "Este proyecto está usando actualmente el contrato terminal de Juicebox V1. Nuevas utilidades introducidas en V1.1 permiten al dueño del proyecto:"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "Este proyecto usa la versión V2 de los contratos de Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr "El balance de este proyecto en el contrato de Juicebox."
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Esta tasa determina la cantidad de excedente por la que cada token puede ser canjeado en cualquier momento dado. En una menor curva de adhesión, canjear un token incrementa el valor de cada token restante, creando un incentivo para holdear tokens por más tiempo que otros. Una curva de adhesión del 100% significa que todos los tokens tendrán un valor igual sin importar cuando hayan sido canjeados."
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "Esto borrará todos tus cambios."
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr "Esto reiniciará los datos para tu nuevo proyecto. Todos los cambios se perderán."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr "Para: <0/>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Dirección del token: <0/>"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr "Cantidad de tokens"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr "Dirección de beneficiario de token"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr "Beneficiario del token:"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr "Los poseedores <0>no pueden canjear sus tokens</0> por nada de ETH cuando la tasa de emisión es 0."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr "Acuñación del token"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "Acuñar tokens permite al dueño del proyecto acuñar tokens del proyecto en cualquier momento."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr "Minteo de tokens activado"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "La acuñación de tokens solo está disponible para proyectos V1.1. La acuñación de tokens puede ser activada o desactivada al reconfigurar el ciclo de financiamiento del proyecto."
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "Nombre del token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr "Se requiere el nombre del Token"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr "Valor de canje del token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "Símbolo del token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr "Se requiere el símbolo del Token"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr "Los tokens que <0>los contribuyentes recibirán</0> cuando contribuyan 1 ETH."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr "Los tokens <0>reservados para el proyecto</0> cuando se contribuye 1 ETH."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr "Los tokens son obtenidos por alguien que paga tu proyecto, y pueden ser canjeados por excedente si tu proyecto tiene un objetivo de financiamiento establecido."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr "Los tokens pueden ser acuñados manualmente cuando se permite en el ciclo de financiamiento actual. El dueño del proyecto puede activar o desactivar la acuñación para ciclos próximos."
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "Los tokens pueden canjearse por una porción del <0>excedente</0> de un proyecto, permitiéndote beneficiarte de su éxito. Después de todo, tú le ayudaste a llegar ahí. El token podría también darte privilegios únicos exclusivos para miembros, y permitirte contribuir a la gobernanza de la comunidad."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Los tokens pueden ser canjeados por una porción del ETH excedente de este proyecto, de acuerdo con la tasa de curva de adhesión del presente ciclo de financiamiento. <0>Los tokens son quemados cuando se canjean.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Los tokens se pueden canjear por una porción del excedente de ETH, de acuerdo con la tasa de redención del ciclo de financiamiento actual. <0>Los tokens son quemados cuando son canjeados.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Los tokens no pueden ser reclamados porque no se ha emitido un token ERC-20 para este proyecto. Los tokens ERC-20 deben ser emitidos por el dueño del proyecto."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "Beneficiario de los token"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "Tokens:"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr "Herramientas"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr "Fondos totales:"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "Total recaudado"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr "Suministro total"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr "Total: {0}%"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr "La transacción falló"
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transacción pendiente..."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr "Transacción fallida"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr "Transferir propiedad"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "Transferir {tokenSymbolShort} no reclamados"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "Transferir {tokenSymbolShort}"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "Tendencias"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr "Identificador de Twitter"
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "Desarchivar proyecto"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "No disponible"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A menos que los pagos estén en pausa en la configuración del ciclo de financiamiento, tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo de Juicebox."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr "Proyecto sin título"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr "Dejar de seguir token"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Próximos"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "Las actualizaciones que hagas en esta sección solo serán aplicadas a los <0>próximos</0> ciclos de financiamiento."
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr "Subir"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "Subido a: <0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr "Usa <0>Cantidades</0> cuando quieras configurar un <1>límite de distribución</1>. Los fondos del tesoro que exceden el límite de distribución son llamados <2>excedente</2>. Los poseedores de tokens pueden canjear (quemar) sus tokens por una porción del excedente. <3>Aprende más</3>."
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr "Usa <0>Porcentajes</0> cuando quieras configurar un <1>límite de distribución infinito.</1> Con un límite de distribución infinito, tu proyecto reserva todos los fondos para sí mismo. Tu proyecto no tendrá excedente, así que los tokens jamás se podrán canjear por ETH. <2>Aprende más</2>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "Se recomienda usar una duración. Permitir que los ciclos de financiación sean reconfigurados en cualquier momento les parecerá arriesgado a los colaboradores."
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "Se recomienda usar una estrategia de reconfiguración. Los proyectos sin estrategia les parecerán arriesgados a los colaboradores."
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr "V1"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr "V1.1"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr "V2"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "Versión del contrato terminal usado por este proyecto."
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr "Volumen"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr ""
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr "WAGMI!"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "Dirección de billetera virtual"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr ""
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr "Sitio web"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr "¿Qué son los ciclos de financiamiento automatizados?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr "¿Qué son tokens de la comunidad?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr "¿Cuáles son los riesgos?"
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr "¿Cuánto cuesta Juicebox?"
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr "¿Qué es el excedente (overflow)?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr "¿Qué es la curva de adhesión?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr "¿Qué es la tasa de descuento?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr "¿Qué está sucediendo detrás de escena?"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr "Cuando está marcado, los pagos a esta dirección acuñarán tokens ERC-20 de este proyecto a la billetera del beneficiario. Los pagos costarán más gas. Cuando esté desmarcado, Juicebox rastreará los nuevos tokens del beneficiario cuando paguen. El beneficiario puede reclamar sus tokens ERC-20 en cualquier momento."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Cuando está habilitado, el dueño del proyecto puede acuñar manualmente cualquier cantidad de tokens a cualquier dirección."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "Cuando está habilitado tu proyecto no puede recibir pagos directos."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "Cuando alguien paga tu proyecto, ellos recibirán tokens de tu proyecto en retorno. Los tokens pueden ser canjeados por una porción de los fondos de excedente de tu proyecto; cuando tu ganas, tu comunidad gana contigo. Aproveche el token de su proyecto para otorgar derechos de gobernanza, acceso a la comunidad u otros beneficios de membresía."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Cuando acuñar tokens es permitido, el dueño de este proyecto tiene permiso de acuñar cualquier número de tokens para cualquier dirección a su discreción. Esto tiene el efecto de diluir a todos los poseedores de tokens actuales, sin incrementar el saldo de la tesorería del proyecto. El dueño del proyecto puede reconfigurar esto junto con todas las demás propiedades del ciclo de financiamiento."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Cuando sea que alguien pague tu proyecto, este porcentaje de tokens recién acuñados será reservado y el resto irá al pagador. Los tokens de reserva son reservados para el dueño del proyecto por defecto, pero también pueden ser asignados a otras direcciones de billeteras por el dueño. Una vez que los tokens son reservados, cualquiera puede \"acuñarlos\", lo que los distribuye a sus receptores previstos."
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr "¿Quién financia los proyectos en Juicebox?"
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "¿Quién es Peel?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr "¿Por qué Ethereum?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr "¿Por qué querría poseer los tokens del proyecto?"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr "Será redondeado a <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr "¿Va a funcionar en L2s?"
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr "Con Juicebox, los proyectos están construidos y mantenidos por punks motivados que son remunerados de forma transparente, y financiados por una comunidad de usuarios y patrocinadores que son recompensados a la par con el éxito de los proyectos que apoyan."
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr "Sin ciclos de financiamiento, el dueño de proyecto puede empezar un nuevo ciclo de financiamiento (Ciclo de Financiamiento #2) a discreción. <0>Aprende más.</0>"
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr "Espacio de trabajo"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "¿Deseas emitir un token ERC-20 para ser usado como token de este proyecto?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Sí"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr "Puedes editar los detalles de tu proyecto tras su creación en cualquier momento, pero la transacción costará gas."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Puedes canjear tus {tokenTextLong} por excedente sin reclamarlos. Puedes transferir tus {tokenTextLong} no reclamados a otra dirección del menú de Herramientas, que puede ser accesado desde el ícono de la herramienta en la esquina superior derecha de este proyecto."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Todavía, puedes canjear tus tokens {tokenSymbol} por el exceso sin reclamarlos y puedes transferir tus tokens {tokenSymbol} sin reclamar a otra dirección desde el menú de Herramientas, el cual puedes encontrar en el icóno de la llave inglesa en la esquina superior derecha de este proyecto."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "No tienes una duración de ciclo de financiamiento. Los cambios que hagas surtirán efecto de inmediato."
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "No holdeas tokens para ningún proyecto de Juicebox."
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Has configurado que todos los fondos sean distribuidos desde el tesoro. La suma de tus pagos actuales no es 100%, así que el remanente irá al dueño del proyecto."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Has establecido un objetivo del ciclo de financiamiento."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr "Tienes cambios sin guardar. ¿Estás seguro que deseas descartarlos?"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "No has creado ningún proyecto todavía."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Vas a recibir {0}{1} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Recibirás {minReturnedTokensFormatted} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Podrás emitir tokens ERC-20 una vez el contrato de tu proyecto haya sido desplegado. Hasta entonces, el protocolo rastreará mientras tanto los balances de los tokens, permitiendo a tus seguidores ganar tokens y canjearlos por el excedente."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr "Tu proyecto Juicebox no tiene ciclo de financiamiento activo. Lanza un ciclo de financiamiento para volver a habilitar los pagos en tu proyecto."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Tu balance"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr "Tu configuración de ciclo de financiamiento se ha pre-llenado con la configuración con la que se lanzó originalmente. Si necesitas personalizarlo, contáctanos."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "Tu nueva dirección pagable:"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Tu proyecto aún puede recibir pagos directamente a través de los contratos del protocolo Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr "Tu proyecto no puede recibir pagos directos mientras se encuentre en pausa."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr "Tu proyecto está financiado a través de los ciclos de financiamiento. Un ciclo de financiamiento tiene un objetivo y una duración. La configuración del ciclo de financiamiento de tu proyecto dependerá del tipo de proyecto que estés iniciando."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr "Tu proyecto aparecerá archivado, y no podrá recibir pagos a través de la app juicebox.money. Puedes desarchivar un proyecto en cualquier momento. Dale unos días a tu proyecto para que aparezca bajo el filtro \"archivado\" en la página de Proyectos."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "Tu proyecto inmediatamente aparecerá activo en la app juicebox.money. Por favor da unos días para que aparezca en la lista de proyectos \"activos\" en la Página de Proyectos."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr "El objetivo y duración de tu ciclo de financiamiento."
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "Tu transacción ha sido presentada y está esperando confirmación."
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr "Tu balance de tokens no reclamados: {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "Tus {tokenTextLong} no reclamados"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr "Cero"
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "{0}% después de la comisión de JBX"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr "llamado por <0/>"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr "días"
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr "usuario"
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "horas"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "últimos {trendingWindowDays} días"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "cargando"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "bloqueado hasta {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "coincidencia \"{searchText}\""
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "minutos"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "o <0><1> compra el {tokenText} en el exchange <2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "proyecto"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "dueño del proyecto"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "proyectos"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "segundos"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr "tokens por cada ETH contribuido"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr "tokens canjeados"
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr "hasta"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "{0} después de la comisión de JBX"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr "{0} atrás"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{0} se distribuyen a cualquiera que pague este proyecto. Si el proyecto ha establecido un objetivo de financiamiento, los tokens pueden ser canjeados por una porción del excedente del proyecto, sea que ya hayan sido reclamados o no."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr "{0} de balance"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} balance: <0><1>{1}{tokensTextShort}</1><2>({share}% de suministro)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr "{0} días"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr "{0} para ti"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr "{0} holders"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr "{0} reservados"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr "{0} tokens/ETH"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr "{0} en total"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr "{0} no reclamados"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "{0} retirado"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr "{0} {tokenTextPlural} reservados"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr "{0}%"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr "{0}% de todos los tokens recién acuñados."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr "{0}% del suministro"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr "{0}% a <0/>"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr "{0}% a {1}"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "{0}/{1} retirado"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr "{count} total"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} no tiene mercado para el token {tokenSymbol}."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "{formattedTimeLeft} restante"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "{formattedTimeLeft} hasta #{0}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr "{inflationRate} tokens / ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr "{issuanceRate} tokens / ETH"
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} reservada) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pago} other {# pagos}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "{tokenSymbolPluralCap} recibidos por cada ETH pagado al tesoro. Esto puede cambiar con el tiempo de acuerdo con la tasa de descuento y la cantidad de tokens reservados de ciclos de financiamiento próximos."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} dirección ERC-20"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Tipo de cambio de {tokenSymbol}/ETH en {exchangeName}."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "{tokenTextSingular} beneficiarios"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} son distribuidos a cualquiera que pague este proyecto. Si el proyecto tiene un objetivo de financiamiento, los tokens pueden ser canjeados por una porción del excedente del proyecto, hayan sido estos reclamados o no."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "{tokensText} reservados"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "cantidad de {tokensTokenUpper}"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr "{unclaimedBalanceFormatted}{tokenText} reclamables"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage} % de suministro total"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -18,4441 +18,3051 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "({realTokenAllocationPercent}% de tous les tokens récemment frappés)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "0% de frais"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 an"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. Détails du projet"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr "100% overflow"
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. Cycle de financement"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 heures"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr "3 jours de délai"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. Réviser et appliquer"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 jours"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 jours"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr "7 jours de délai"
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 jours"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr "<0/> Les projets archivés n'ont pas été modifiés ou supprimés de la blockchain et peuvent toujours être intégrés directement à travers les contrats Juicebox."
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr ""
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr "<0/> solde du propriétaire"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "<0/>{0} après {feePercentage}% frais de membre JBX"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} distribués"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "<0><1/>{netDistributionAmount}</0> après {feePercentage}% des frais JBX"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1> Ce projet n'a pas d'overflow</1>, donc vous ne recevrez aucun ETH pour avoir brûlé des tokens.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr "<0>Un projet peut choisir de se réserver un pourcentage de tokens. Au lieu d'être distribué aux utilisateurs payants, ce pourcentage de tokens est plutôt frappé pour le projet.</0><1>La détention de ces tokens permet qu'un projet s'empare d'une partie de son propre overflow.</1>"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr "<0>Taux de remise</0>, pour réduire le taux d'émission de tokens de votre projet (tokens par ETH) à chaque cycle de financement."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr "<0>Juicebox est un protocole de gouvernance minimale. Il n'y a que quelques leviers qui peuvent être réglés, et aucun n'impose de changements aux utilisateurs sans leur consentement. Le contrat intelligent de gouvernance Juicebox peut ajuster ces leviers.</0><1>Le protocole Juicebox est régi par une communauté de détenteurs de tokens JBX qui votent sur les propositions toutes les deux semaines.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr "<0>Juicebox est un protocole ouvert sur Ethereum qui est financé à l'aide de Juicebox lui-même. Vous pouvez consulter les spécifications budgétaires contractuelles <1>ici</1>.</0><2>Les projets construits sur Juicebox paient des {JB_FEE}% frais d'adhésion JBX à partir des fonds retirés vers la trésorerie de JuiceboxDAO. Les projets peuvent ensuite utiliser leur JBX pour participer à la gouvernance de JuiceboxDAO et de sa trésorerie collective, ainsi que pour récupérer à partir de son <3>overflow</3> croissant. Les frais sont également susceptibles de changer via les votes des membres JBX.</2>"
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "<0>En savoir plus</0> sur la frappe de tokens."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>En savoir plus</0> sur la durée du cycle de financement."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr "<0>En savoir plus</0> sur les cycles de financement."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr "<0>En savoir plus</0> sur l'overflow."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>REMARQUE :</0> Ce projet a un solde de 0. Les projets ne peuvent pas migrer sans un solde. Pour migrer ce projet, vous devez le payer ou utiliser le bouton ci-dessous pour verser 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0>Aucune durée n'a été établie.</0>Le financement peut être reconfiguré à tout moment. Les reconfigurations déclencheront un nouveau cycle de financement."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0>Remarque :</0> Ces propriétés <1>ne</1> seront pas immédiatement éditables dans un cycle de financement. Elles ne peuvent être modifiées que pour les <2>prochains</2> cycles de financement."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>Remarque : </0> Les tokens ne peuvent pas être réclamés, car aucun token ERC-20 a été émis pour ce projet. Les tokens ERC-20 doivent être émis par le propriétaire du projet."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr "<0>À un taux de récupération inférieur, l'échange d'un token augmente la valeur de chaque token restant, créant une incitation à conserver les tokens plus longtemps que les autres détenteurs.</0> <1>Un taux de récupération de 100 % signifie que tous les tokens auront la même valeur quelle que soit la date d'échange.</1>En savoir plus dans cette <2>courte vidéo</2>."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0> c'est la DAO qui gère l'interface principale de juicebox.money. Vous pouvez contacter Peel à travers le <1>Peel Discord</1> ou le <2>Juicebox Discord</2>."
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr "<0>Cycles de financement récurrents</0>. Par exemple, distribuer des fonds de la trésorerie de votre projet toutes les semaines."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>L'objectif est de 0.</0> La totalité du solde du projet sera considérée comme de l'overflow. <1>En savoir plus</1> sur l'overflow."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr "<0>C'est cela le plan, mais les principaux contrats Juicebox seront d'abord déployés sur le réseau principal Ethereum.</0><1>L'équipe des contrats commencera bientôt à travailler sur les terminaux de paiement L2 pour les projets Juicebox.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr "<0>Il y a des tests unitaires écrits pour chaque condition de chaque fonction dans les contrats, ainsi que des tests d'intégration pour chaque flux de travail pris en charge par le protocole.</0><1>Il y avait également un script écrit pour exécuter de manière itérative les tests d'intégration à l'aide d'un générateur d'entrées aléatoires, en accordant la priorité aux cas extrêmes. Le code a atteint avec succès plus d'un million de cas de test grâce à ce script de simulation de crise.</1> <2>Le code pourrait toujours utiliser plus d'agents pour surveiller et plus de critiques pour renforcer la confiance de la communauté. Rejoignez notre <3>Discord</3> et consultez le code sur <4>GitHub</4> pour travailler avec nous.</2>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0> Ce projet n'a pas d'overflow</0>, donc vous ne recevrez aucun ETH pour avoir brûlé des tokens."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr "<0>Les utilisateurs financent votre projet en payant pour utiliser votre application ou votre service, ou en tant que mécène ou investisseur en effectuant un paiement directement sur le contrat intelligent de votre projet (comme sur cette application).</0><1>Pour les utilisateurs payant via votre application, vous devez acheminer ces fonds a travers les contrats intelligents Juicebox afin qu'ils reçoivent des tokens en retour.</1>"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>Vos tokens non réclamés {tokenSymbol} :</0> {0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} adresse de l'ERC-20 : </0><1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr "@"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "Un projet peut être archivé par son propriétaire, dans le menu des outils de la page du projet."
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un projet peut réserver un pourcentage de tokens frappés à partir des paiements reçus. Les tokens réservés peuvent être distribués à tout moment, selon les allocations ci-dessous."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Un projet peut réserver un pourcentage de tokens frappés de chaque paiement reçu. Les tokens réservés peuvent être distribués à tout moment, selon les allocations ci-dessous."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr ""
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "La durée de vie d'un projet est définie en cycles de financement. Si un objectif de financement est fixé, le projet ne peut retirer que la somme définie pour la durée du cycle."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr "Le reparamétrage d'un cycle de financement à venir doit être soumis au moins 3 jours avant son début."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr "Le reparamétrage d'un cycle de financement à venir doit être soumis au moins 7 jours avant son début."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Un taux réservé supérieur à 90% est risqué pour les contributeurs. Les contributeurs ne recevront pas beaucoup de tokens pour leur contribution."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr ""
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARCHIVÉ"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr "DISPONIBLE"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr "Activité"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "Ajouter un paiement"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr "Ajouter des fonds au solde de ce projet sans frapper des tokens."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr "Ajouter une image"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr "Ajouter un nouveau paiement"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "Ajouter un paiement"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr "Ajouter au solde"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr "Ajouter au solde"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr "Ajouter l'allocation de token"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr "Adresse"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "Adresse :"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "Adresse : <0/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "Définir des récompenses au paiement de votre projet."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "Tout"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr "Tous les actifs"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "Tous les évènements"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr "Tous les fonds peuvent être distribués par le projet. Le projet n'aura pas d'overflow (le même que définir un objectif infini)."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr "Tous les fonds reçus par la trésorerie seront distribués. Les détenteurs de tokens ne recevront <0>aucun ETH</0> en brûlant leurs tokens."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr "Tout {0} sera destiné au propriétaire du projet :"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "Destinez une portion des tokens réservés à votre projet à d'autres portefeuilles Ethereum ou à des projets Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr "Permettre la frappe de tokens"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Autoriser la frappe de tokens"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "Autorisé"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr "Définitivement."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "Somme"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "Montant de tokens ERC-20 à réclamer"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr "Montant de tokens récemment frappés <0>réservés pour le projet</0> lorsque 1 ETH est contribué. Le propriétaire se voit attribué l'ensemble de tokens réservés par défaut, mais ils peuvent également être attribués à d'autres adresses de portefeuille."
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr "Somme payée"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "Montant à distribuer"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr "Montant :"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr "Montants"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Toutes les modifications que vous apportez prendront effet dans le <0>cycle de financement #{0}</0>. Le cycle de financement actuel (#{currentFCNumber}) ne sera pas modifié."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr "Tout reparamétrage d'un cycle de financement à venir sera effectif une fois que le cycle en cours aura fini."
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "Archiver le projet"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "Archivé"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "Êtes-vous sûr de vouloir recommencer ?"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "Actifs"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr "Ajouter un autocollant"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr "Cycle de financement automatisé"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr "Les cycles de financement automatisés permettent les caractéristiques suivantes :"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr "Disponible après le frais :"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Les fonds disponibles sont distribués selon les paiements ci-dessous."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr "Les fonds disponibles peuvent être distribués selon les paiements ci-dessous{0}."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr "Disponible :"
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "Haut de page"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Solde dépassé"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "Solde du portefeuille du propriétaire du projet."
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Bénéficiaire"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Adresse du bénéficiaire"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr "Bravo à la communauté Ethereum pour avoir créé l'infrastructure et l'économie nécessaires pour rendre Juicebox possible."
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "Numéro de blocage"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Construit pour :"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "Brûler les tokens du projet"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Brûler vos {tokensLabel}. Vous ne recevrez pas d'ETH en retour car ce projet n'a pas d'overflow."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Brûler {0} {tokensTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "Brûler {tokensLabel}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "Brûler {tokensTextLong}"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "Par défaut, tous les fonds non assignés peuvent être distribués au portefeuille du propriétaire."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Par défaut, les tokens nouvellement frappés iront au portefeuille qui envoie des fonds à l'adresse. Vous pouvez activer ceci pour associer le bénéficiaire de tokens à une adresse customisée."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Puis-je changer mon contrat de projet après l'avoir créé ?"
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr "Puis-je supprimer un projet ?"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Il n'est pas possible de récupérer des tokens pour ETH car ce projet n'a pas d'overflow."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "Les modifications apportées aux détails du projet prendront effet immédiatement."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "Ces attributs peuvent être modifiés à tout moment et les changements seront appliqués immédiatement à votre projet."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr "Les modifications prendront effet selon les choix de projet du contrat au scrutin."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Les modifications que vous apportez prendront effet selon votre <0>{0}</0> règle de reconfiguration (le prochain cycle de financement à compter<1>{1}</1> de cette date)."
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Cochez ceci pour frapper {tokenSymbol} ERC-20 vers votre portefeuille. Laissez décoché pour que votre solde soit suivi par Juicebox, tout en économisant du gaz dans cette transaction. Vous pouvez toujours réclamer vos tokens ERC-20 plus tard."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr "Choisissez comment souhaitez-vous paramétrer vos paiements."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr "Réclamer {tokenTextPlural}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr "Réclamer {tokenTextPlural} comme tokens ERC-20"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "Réclamer {tokenTextShort}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "Réclamer {tokenTextShort} comme tokens ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "Réclamer {tokensLabel} en tant que ERC-20"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Si vous réclamez {tokenSymbol} les tokens, cela va convertir votre solde {tokenSymbol} en tokens ERC-20 et les frapper vers votre portefeuille."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Si vous réclamez {tokenTextLong} votre solde {tokenTextShort} sera converti en tokens ERC-20 et ils seront frappés vers votre portefeuille."
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "Fermer"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr "Fermez, je ferai ceux-ci plus tard"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "Destinez des parties de vos fonds à des personnes ou à des projets que vous voulez soutenir, ou à des contributeurs que vous voulez payer. Lorsque vous êtes payé, eux aussi le seront."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "Configurez la façon dont votre projet collectera et dépensera les fonds."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "Configurer les restrictions pour vos cycles de financement."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "Configurer la dynamique du token de votre projet."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr ""
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr "Connectez-vous"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr "Connecter le portefeuille"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr "Connecter au portefeuille pour réclamer"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "Connectez un portefeuille à déployer"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr "Connecter au portefeuille pour distribuer"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr "Connecter au portefeuille pour émettre"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Connectez un portefeuille pour payer"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr "Connecter au portefeuille pour transférer"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "Connectez votre portefeuille pour voir vos participations."
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "Connectez votre portefeuille pour voir vos projets."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "Portefeuille connecté non autorisé"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr "Adresse du contrat : {0}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Les contributeurs recevront ce montant de tokens de votre projet par ETH contribué."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "Les contributeurs ne recevront aucun token en échange pour avoir payé ce projet."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr "Les contributeurs recevront <0>{discountRatePercent}%</0> plus de tokens pour les contributions faites à ce cycle de financement par rapport au prochain cycle de financement."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "Les contributeurs recevront une petite portion des tokens en échange pour avoir payé ce projet."
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "Les contributeurs verront ce message avant de payer."
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr "Copié !"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "Copier dans le presse-papier"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr "Créer une adresse de paiement (facultatif)"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr "Créez une adresse Ethereum pour votre projet. Il permet d'effectuer des paiements directs sans passer par la page de votre projet Juicebox."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Créez une adresse Ethereum qui peut être utilisée pour payer directement votre projet."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "Créer une adresse de paiement"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr ""
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "Créer un projet"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "Créez votre propre token ERC-20 pour représenter le stake de votre projet. Les contributeurs recevront ces tokens lorsqu'ils auront payé votre projet."
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr "En cours"
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "Taux de change actuels des tiers"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "Propriétaire actuel: {ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr "Stratégie personnalisée"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "Bénéficiaire de token personnalisé"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr "Customisez le bouton « payer » de votre projet. Laissez vide pour utiliser le bouton par défaut."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Cycle #{0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr "Mode sombre"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "Date"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "Date créée"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "Jours"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr "Supprimer paiement"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr "Supprimer l'allocation de token"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "Déployer le projet"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "Déployer le projet sur {signerNetwork}"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "Déployer le projet à {0}"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "Token ERC20 déployé"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "Déposez 1 wei pour @{handle}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr "Créez votre projet"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Détails"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr "Détermine si les tokens seront frappés à partir des paiements effectués à cette adresse."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "Désactivé lorsque la limite de distribution de votre cycle de financement est <0>Aucune limite</0> (infinie)"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "Désactivé lorsque la durée du cycle de financement de votre projet est de 0."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "Désactivé lorsque le cycle de financement de votre projet n'a pas de durée."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr "Supprimer"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr "Divulguez tous les détails de vos contributions avant qu'ils ne paient votre projet."
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr "Discord"
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr "Taux de remise"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "Montrer les tokens ERC-20 et d'autres tokens de projet Juicebox qui sont dans le portefeuille du propriétaire de ce projet."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr "Distribuer à des entités un pourcentage de tous les fonds reçus. Votre limite de distribution sera <0>infinie</0>."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr "Distribuer à des entités un montant spécifique de fonds, à chaque cycle de financement. Votre limite de distribution sera égale à la <0>somme de tous les montants de paiement.</0>"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "Distribuez les fonds disponibles, en tant que paiement à d'autres portefeuilles Ethereum ou à des projets Juicebox. Utilisez-le pour payer les contributeurs, les projets Juicebox desquels vous dépendez, faire des dons de charité, ou payer n'importe qui d'autre. Les fonds sont distribués à chaque fois qu'un retrait de votre projet est effectué."
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "Distribuer les fonds"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "Distribuez les {tokenTextPlural} réservés"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "Distribuer {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "Distribuer {tokensText}"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr "Distribué"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "Fonds Distribués"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr "Réserves Distribuées"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr "Tokens Distribués"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr "Fonds Distribués"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr "Distribué réservé {0}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr "La distribution de fonds aux projets Juicebox n'entraînera pas de frais."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr "Distribution"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr "Limite de distribution<0/> :"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "Limite de distribution"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "La limite de distribution est de 0 : Tous les fonds seront considérés comme de l'overflow et pourront être récupérés par les titulaires de token."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr "La limite de distribution est infinie. <0>Le projet contrôlera la manière dont tous les fonds seront distribués et aucun fonds ne pourra être récupéré par les titulaires de tokens.</0>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Limite de distribution, durée et paiements"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr "Dois-je rendre mon projet open source pour utiliser Juicebox comme son modèle économique ?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr "Documents"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "Documents dans v1.1 contrats"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr "Un projet est-il bénéficié par son propre overflow ?"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "Finalisé"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "Télécharger CSV"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "Télécharger CSV des paiements"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "Télécharger CSV de l'activité de votre projet"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "Télécharger CSV des {0} titulaires"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr "Durée"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr "Durée (secondes)"
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "Les tokens ERC-20 ne peuvent être frappés que lorsqu'un token ERC-20 a été émis pour ce projet."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr "ERC20 Déployé"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Chaque paiement recevra son pourcentage de ce total à chaque cycle de financement s'il y en a assez dans la trésorerie. Sinon, ils recevront leur pourcentage de tout ce que dispose la trésorerie."
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr "Modifier un paiement"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "Modifier le projet"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "Modifier les détails du projet"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "Modifier l'allocation des tokens réservés"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "Modifier l'allocation de token"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "Modifier les actifs suivis"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr ""
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr "Activés"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr "L'activation de cette option permet au propriétaire du projet de frapper manuellement n'importe quelle quantité de tokens pour n'importe quelle adresse."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "En activant cette option cela frappera les {tokenSymbol} tokens ERC-20. Faute de quoi, les {tokenSymbol} tokens non réclamés seront frappés et pourront être réclamés ultérieurement comme ERC-20 par le destinataire."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr "Désactiver la frappe de tokens peut sembler risqué aux contributeurs."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr "Fin"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Erreur lors du chargement des titulaires"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "Erreur lors du chargement des paiements"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explorer des projets"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr "FAQs"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr "Échec de la mise à jour des métadonnées du projet"
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "Le fichier doit être inférieur à {formattedSize}{unit}"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr "Financez quoi que ce soit. Grandissez ensemble."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "Financement"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr "Cycle de financement"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "Détails du cycle de financement"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr "Durée du cycle de financement"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr "Aperçu du cycle de financement"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr "Cycle de financement requis."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr "Objectif du cycle de financement"
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "Les cycles de financement peuvent être reconfigurés juste avant le début d'un nouveau cycle, sans que les contributeurs ne soient notifiés."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "Distribution des fonds"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "Objectif de financement"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr "Les fonds seront distribués à :"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr "Général"
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "Donner un feedback"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr "Allez à Etherscan"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr "Identifiant"
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr "Attention"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr "Historique"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr "Titulaires"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "Participations"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr "Heures"
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr "À quel point Juicebox est-il décentralisé ?"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr "Comment archiver un projet ?"
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "Comment créer un projet ?"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr "Comment définir le taux de récupération ?"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr "Comment les contrats ont été testés ?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "Combien de temps avant votre prochain cycle de financement devrez-vous reconfigurer afin que les modifications soient prises en compte."
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "La durée d'un cycle de financement. Les <0>reparamétrages</0> d'un cycle de financement ne prendront effet qu'aux cycles de financement <1>suivants</1>, i.e. une fois que le cycle de financement en cours aura fini."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr "Comment le {reservedPercentage}% des tokens réservés de votre projet sera réparti."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr "Comment votre projet distribuera les fonds."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "Je comprends"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr "Identifiant"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr "Identifiant : {projectId}"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Si bloqué, ceci ne peut pas être modifié ou supprimé avant que le blocage expire ou le cycle de financement soit reconfiguré."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Si bloquée, cette répartition ne peut pas être modifiée ou supprimée avant que le blocage expire ou le cycle de financement soit reconfiguré."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr "Si vous ne collectez pas ce montant, vos répartitions recevront leur pourcentage de tout ce que vous collectez."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "Si vous avez déjà déployé une adresse de paiement et que vous l'avez perdue, veuillez contacter l'équipe Juicebox par le biais de <0>Discord.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "Si vous souhaitez créer un projet, mais que vous ne savez toujours pas par où commencer, pensez à regarder cette <0>vidéo d'instructions</0>. N'hésitez pas non plus à nous contacter sur le <1>Discord Juicebox</1> où notre équipe sera ravie de vous aider à donner vie à votre idée de projet !"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "Si vous n'êtes pas sûr de pouvoir le réclamer, probablement vous ne pouvez pas."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr "Dans Juicebox"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "En trésorerie"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr "Dans le portefeuille"
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr "Récompenses"
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr "Créateurs indépendants et constructeurs"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr "Infini (aucune limite)"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "Taux d'émission initiale"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr "Taux de frappe initial"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Émettre ERC-20"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "Émettre un token ERC-20"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "Émettre un token ERC-20 pour être utilisé comme token de ce projet. Une fois émis, n'importe qui peut réclamer le solde de tokens existant dans le nouveau token."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr "Émettre un token ERC-20 (facultatif)"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "Émettre un token"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "Il n'est pas possible de supprimer les données d'un projet de la blockchain, mais nous pouvons les masquer dans l'application si vous souhaitez empêcher les gens de les voir ou d'interagir avec. Faites-le nous savoir dans <0>Discord</0> . Gardez à l'esprit que l'ont peut toujours utiliser votre projet en interagissant directement avec le contrat."
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr "Ce serait beaucoup plus cool si vous le faisiez"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr "Frais de JBX ({0}%) :"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "Frais JBX ({feePercentage}%):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "Identifiant du projet Juicebox"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Projet Juicebox V2 avec Identifiant {0}"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Animation de chargement de Juicebox"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Projet Juicebox"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr "Dernier paiement"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "Plus tard"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "Dernier"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "Derniers paiements"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr "Lancer le cycle de financement"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr "Lancez votre projet"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr "Laisser vide pour commencer immédiatement."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr "Mode clair"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr "Télécharger d'avantage"
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr ""
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Bloquer jusqu'à"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Bloqué :"
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr "Logo"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "MAX"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Gérer"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "Gérer {tokenText}"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr "{MAX_DESCRIPTION_LENGTH} caractères au maximum"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Mémo (facultatif)"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrer vers Juicebox V1.1"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "Frapper en tant que ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "Frapper un nouveau {tokensLabel} dans un compte. Seulement le propriétaire du projet, un opérateur désigné ou un des délégués du terminal peuvent frapper ces tokens."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Frapper des tokens de projet sur demande"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr "Taux de frappe"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr "Frapper des tokens comme ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "Frapper des tokens vers une adresse personnalisée."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "Frapper {tokensLabel}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "Frapper {tokensTokenLower}"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr "Minutes"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr ""
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "Transférer vos {tokensLabel} du contrat Juicebox vers votre portefeuille."
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "AUCUNE LIMITE"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr "Nom"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "Nouveau"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr ""
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "Suivant : Cycle de financement"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "Suivant : Réviser et appliquer"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "Non"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr "Aucun cycle de financement actif."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Aucune activité"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Aucun objectif de financement : le projet contrôlera la manière dont tous les fonds sont distribués, et rien ne pourra être récupéré par les titulaires de tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "Aucun fonds ne peut être distribué en dehors de la trésorerie. Les fonds ne sont accessibles qu'aux détenteurs de tokens qui échangent leurs tokens."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "Aucune limite (infini)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr "Seulement l'objectif du cycle de financement peut être distribué par le projet en un seul cycle."
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Aucun cycle de financement précédent"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr "Aucune stratégie"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr "Aucun objectif"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr "Aucun objectif défini."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr "Pas encore défini"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "Remarque"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Remarque : Les tokens peuvent être frappés manuellement lorsqu'ils sont autorisés dans le cycle de financement en cours. Cela peut être modifié par le propriétaire du projet pour les prochains cycles."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr "Notification de {0} :"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr "Une fois lancé, votre premier cycle de financement <0>ne peut plus être modifié</0>. Vous pouvez reparamétrer les cycles de financement à venir selon les <1>règles de reparamétrage</1> du projet."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "Autres actifs dans le portefeuille du propriétaire de ce projet."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr ""
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr "Overflow"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr "Un overflow est créé si le solde de votre projet dépasse votre objectif de financement du cycle. L'overflow peut être récupéré par les détenteurs de tokens de votre projet."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "Le propriétaire peut frapper des tokens à tout moment."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Le propriétaire n'est pas autorisé à frapper des tokens."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr "Frappe de token par le propriétaire"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr "Outils du propriétaire"
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr "Payé"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr "Payé comme <0/>"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr "Suspendre les paiements"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "Suspendre les paiements reçus"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr "Suspendu"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr "Payer"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr "Payer le montant"
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "Le montant à payer doit être supérieur à 0."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr "Bouton \"payer\""
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr "Texte du bouton \"payer\""
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr "Déclaration pour le paiement"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr "Payer {0}"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "Payeur"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "Un paiement <0>{0}</0> n'est pas un investissement, c'est une façon de soutenir le projet. Toute valeur ou utilité des tokens que vous recevez est déterminée par {1}."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr "Le paiement de ce projet est actuellement désactivé."
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr ""
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr "Mémo image de paiement"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr "Paiements"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr "Paiements suspendus"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr "Le paiement est verrouillé"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "Bénéficiaires du paiement"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "Paiements"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "Paiements (optionnel)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "Les paiements aux adresses Ethereum entraînent des frais de {feePercentage}%. Votre projet recevra des JBX en retour, au taux d'émission actuel."
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "Pourcentage"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr "Pourcentage d'allocation"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Pourcentage :"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr "Pourcentages"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Les pourcentages doivent totaliser 100% ou moins"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr "Podcast"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "Risques potentiels"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "Aperçu :"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr "Projet Créé"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr "L'identifiant du projet doit être un numéro."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "Identifiant du projet :"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "Token du projet"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "Paramètres du projet"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr "Projet créé par"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr "Description du projet"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr "Détails du projet"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr "Les détails du projet peuvent être modifiés à tout moment."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Les modifications des détails du projet créeront une transaction à part."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr "Identifiant du projet"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr "L'identifiant du projet doit être unique."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "Le projet accepte des paiements dans ce cycle de financement."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "Le projet n'accepte pas des paiements dans ce cycle de financement."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr "Démarrage du projet réussi"
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr "Nom du projet"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr "Nom du projet, identifiant, liens et autres détails du projet."
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr "Propriétaire du projet"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "Propriétaire du projet (vous)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "Les propriétaires de projet peuvent définir une période de délai, ce qui signifie que les redéfinitions d'un cycle de financement à venir doivent être soumises un certain nombre de jours avant qu'il ne commence. Par exemple, un délai de 3 jours signifie que les redéfinitions doivent être soumises au moins 3 jours avant le début du prochain cycle de financement. Cela donne aux détenteurs de tokens le temps de réagir à la décision et réduit les risques d'arnaque."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "Token du projet"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr ""
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "Le projet {name} sera bientôt disponible ! Essayez d'actualiser la page sous peu."
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr "Projet {projectId}"
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Projet {projectId} introuvable"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr "Projets"
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "Les projets peuvent être créés avec un taux de remise facultatif conçu pour inciter les financeurs à contribuer plus tôt. Le nombre de tokens récompensés par montant versé à votre projet sera déduit du taux de remise à chaque nouveau cycle de financement. Un taux d'actualisation plus élevé incitera les supporters à payer votre projet plus tôt."
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr "Les projets dans Juicebox"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "Les projets que vous avez créés."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "Projets pour lesquels vous détenez de tokens."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "Les projets utilisant un taux réservé de {reservedRateRiskyMin}% ou plus sembleront risqués pour les contributeurs, car un nombre relativement faible de tokens sera reçu en échange du financement de votre projet."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Classements basés sur le nombre de contributions et le volume gagné au cours des derniers {trendingWindow} jours. <0>Voir le code</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr ""
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "Recevoir des ERC20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "Recevoir {receiveText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr "Destinataire"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr "Adresse du destinataire"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "Les bénéficiaires recevront les paiements en ETH."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr "Reparamétrage"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "Règles de reparamétrage"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Stratégie de reparamétrage"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Modifier les paramètres"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr "Reconfigurer les détails du projet et du financement"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "Modifier les détails du projet"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "Modifier les paramètres du token"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "Modifier les prochains cycles"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurer les prochains cycles de financement"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Récupérer vos {tokensLabel} d'une portion de l'overflow du projet. Aucun {tokensLabel} récupéré sera brûlé."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Récupérer {0} {tokensTextShort} pour ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "Récupérer {tokensLabel} pour ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "Récupérer {tokensTextLong} pour ETH"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Récupéré"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Taux de récupération"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "Taux de récupération : <0>{0}%</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "Actualiser"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr "Relancez votre cycle de financement dans les nouveaux contrats Juicebox V2."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "Demandé"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr "Réserver un pourcentage de nouveaux tokens créés à être utilisé par votre projet."
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "Taux de réservation"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "Le taux réservé est de 0% mais l'allocation de tokens est réservée. Envisagez d'ajouter un taux réservé supérieur à zéro ou supprimez l'allocation de tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "Allocation de tokens réservés (optionnel)"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr "Allocation de tokens réservés"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr "Tokens réservés"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr "Réservés {0}"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "Réservé {tokenSymbolPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "Réservé {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "Réservés {tokensText}"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "Ressources"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "Limiter les paiements et l'impression de tokens."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr "Actions restreintes"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr "Réviser et appliquer"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr "Examiner et lancer le cycle de financement"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr "Réviser le projet"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr "Récompenser des membres spécifiques de la communauté avec des tokens."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr "Règles"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "Règles pour déterminer comment les cycles de financement peuvent être modifiés"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr "Règles sur la façon dont les modifications peuvent être apportées à votre projet."
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr "Règles pour déterminer comment les cycles de financement peuvent être modifiés."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "Sauvegarder les modifications"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr "Sauvegarder les paramètres de financement"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "Sauvegarder l'identifiant"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr "Sauvegarder le paiement"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Sauvegarder les paiements"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr "Sauvegarder les détails du projet"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr "Sauvegarder les modifications"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "Sauvegarder les règles"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "Sauvegarder l'allocation de token"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "Sauvegarder le paramétrage du token"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "Sauvegarder les actifs suivis"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr "Rechercher un projet par son identifiant"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr "Secondes"
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Voir la transaction"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr "Définir une limite de distribution"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr "Définir la durée du cycle de financement"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr "Définir l'objectif du cycle de financement"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr "Définissez le montant de fonds que vous souhaitez collecter à chaque cycle de financement. Tous les fonds collectés dans le cadre de l'objectif du cycle de financement peuvent être distribués par le projet et ne peuvent pas être récupérés par les titulaires de tokens de votre projet."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr "Définissez la durée de vos cycles de financement."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr "Définissez ceci sur la somme de tous vos paiements"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr "Faut-il Juicebox ?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Vous n'avez pas défini une durée de financement, les modifications apportées à ces paramètres seront appliquées immédiatement."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr ""
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "Quelque chose a mal tourné."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr "Dépenses"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr "Début"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr "Recommencer"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr "Heure de début (secondes, heure Unix)"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "La somme des pourcentages ne peut pas dépasser 100%"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "La somme des pourcentages ne peut pas dépasser 100%."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr "Objectif"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "L'objectif est de 0 : Tous les fonds seront considérés comme de l'overflow et pourront être récupérés en brûlant les tokens du projet."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr "Le protocole JBX n'est pas audité et les projets construits dessus peuvent être vulnérables aux bogues ou aux exploits. Soyez intelligent !"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "L'adresse de tout contrat intelligent déployé sur {0} qui implémente <0>cette interface</0>."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr "L'adresse qui doit recevoir les tokens émis pour le paiement de ce projet."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "Le montant de tokens réservés pour ce projet. Ces tokens peuvent être distribués aux bénéficiaires des tokens réservés."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "Le montant de tokens à frapper pour le bénéficiaire."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "Le montant distribué à partir du solde Juicebox dans ce cycle de financement, hors de la limite actuelle de distribution. Pas plus que la limite de distribution ne peut être distribué au cours d'un seul cycle de financement—tout ETH restant dans Juicebox est overflow jusqu'au début du prochain cycle."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "Le montant distribué à partir du solde Juicebox dans ce cycle de financement, hors l'objectif de financement actuel. Pas plus que l'objectif de financement ne peut être distribué au cours d'un seul cycle de financement - tout ETH restant dans Juicebox est overflow jusqu'au début du cycle suivant."
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "Le solde du portefeuille du propriétaire du projet."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "Le solde de ce projet dans le contrat Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "La limite de distribution pour ce cycle de financement est de 0, ce qui signifie que tous les fonds dans Juicebox sont actuellement considérés comme overflow. L'overflow peut être échangé par les holders de tokens, mais pas distribué."
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "L'avenir sera dirigé par des créateurs et appartiendra aux communautés."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "Le montant maximal de fonds pouvant être distribué à partir de la trésorerie du projet à chaque cycle de financement."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr "Le montant maximal de fonds pouvant être distribué à partir de la trésorerie, à chaque cycle de financement."
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "Le montant maximal des fonds pouvant être distribués à partir de ce projet au cours d'un cycle de financement. Les fonds seront retirés en ETH, quelle que soit la devise que vous choisissez."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "Le pourcentage que cet individu reçoit de l'allocation globale {reservedRate}% de tokens réservés"
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "Le propriétaire du projet peut frapper n'importe quelle offre de tokens à tout moment, diluant la part de tokens de tous les contributeurs existants."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "Le propriétaire du projet peut modifier les paramètres de ce cycle de financement à tout moment, sans préavis."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr "Le taux d'émission de token de votre projet diminuera de ce pourcentage à chaque cycle de financement. Un taux de remise plus élevé incitera les financeurs à payer votre projet plus tôt."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr "La proportion de tokens récompensés par montant de paiement diminuera à ce pourcentage, à chaque nouveau cycle de financement. Un taux de remise plus élevé incitera les financeurs à payer votre projet plus tôt."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr "Le taux de récupération détermine le montant d'overflow pour lequel chaque token peut être échangé."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "L'objectif pour ce cycle de financement est de 0, ce qui signifie que tous les fonds sur Juicebox sont actuellement considérés comme de l'overflow. L'overflow peut être récupéré par les titulaires de tokens, mais il ne peut pas être distribué."
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr "Le total des fonds que ce projet Juicebox a reçu depuis sa création."
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr "Aucun paiement n'est défini pour ce cycle de financement. Le propriétaire du projet recevra tous les fonds disponibles."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "Il n'y a pas de bénéficiaire de tokens réservés définis pour ce cycle de financement. Le propriétaire du projet recevra tous les tokens disponibles."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "Ces attributs peuvent être modifiés à tout moment."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "Ces paramètres<0> ne seront pas</0> modifiables immédiatement au cours d'un cycle de financement. Ils ne peuvent être modifiés que pour les cycles de financement <1>à venir</1>."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "Cette adresse est un contrat stratégique non reconnu. Assurez-vous qu'il est correct !"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr "Cette adresse recevra tous les tokens frappés lorsque le projet bénéficiaire sera payé."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr "Cette adresse recevra les tokens frappés en payant ce projet."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "Ce cycle de financement peut présenter des risques pour les contributeurs. Vérifiez les détails du cycle de financement avant de payer ce projet."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr "Ceci est le montant maximal de fonds qui peut sortir de la trésorerie à chaque cycle de financement."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr "Cette liste utilise un index de données expérimental et peut être inexacte pour certains projets."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr "Ce projet a été archivé et ne peut pas être payé."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "Ce projet utilise actuellement le contrat de terminal Juicebox V1. Les nouvelles fonctionnalités introduites dans V1.1 permettent au propriétaire du projet de :"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "Ce projet utilise la version V2 des contrats Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr "Le solde de ce projet dans le contrat Juicebox."
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Ce taux détermine le montant oveflow pour lequel chaque token peut être récupérer à un moment donné. Sur une courbe de liaison inférieure, le rachat d'un token augmente la valeur de chaque token restant, ce qui incite à holder les tokens plus longtemps que les autres. Une courbe de liaison de 100 % signifie que tous les tokens auront la même valeur, quel que soit le moment où ils sont échangés."
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "Cela effacera toutes vos modifications."
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr "À : <0/>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Adresse du token : <0/>"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr "Adresse du bénéficiaire de token"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr "Bénéficiaire de token :"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr "Frappe de tokens"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "Frapper des tokens permet au propriétaire du projet de frapper les tokens du projet à tout moment."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr "Frappe de tokens activée"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "La frappe de tokens n'est disponible que pour les projets V1.1. La frappe de tokens peut être activée ou désactivée en reconfigurant le cycle de financement du projet."
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "Nom du token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr "Le nom du token est requis"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr "Valeur d'échange du token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "Symbole du token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr "Le symbole du token est requis"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr "Tokens <0>réservés pour le projet</0> quand 1 ETH est contribué."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr "Les tokens sont gagnés par toute personne qui paie votre projet et peuvent être récupérés de l'overflow si votre projet a défini un objectif de financement."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "Les tokens peuvent être récupérés d'une partie de l' <0>overflow</0> d'un projet, vous permettant ainsi de bénéficier de son succès. Après tout, vous l'avez aidé à y arriver. Le token peut également vous donner des privilèges exclusifs réservés aux membres et vous permettre de contribuer à la gouvernance de la communauté."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Les tokens peuvent être récupérés d'une partie de l'overflow d'ETH de ce projet, selon le taux de la courbe de liaison du cycle de financement en cours. <0>Les tokens sont brûlés lorsqu'ils sont récupérés.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Les tokens peuvent être récupérés d'une partie de l'overflow d'ETH de ce projet, selon le taux de rachat du cycle de financement en cours. <0> Les tokens sont brûlés lorsqu'ils sont récupérés.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Les tokens ne peuvent pas être réclamés, car aucun token ERC-20 a été émis pour ce projet. Les tokens ERC-20 doivent être émis par le propriétaire du projet."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "Bénéficiaire de tokens"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "Tokens :"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr "Outils"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr "Total de fonds :"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "Total collecté"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr "Offre totale"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr "Total : {0}%"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr "Transaction ratée"
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transaction en attente..."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr "Transaction échouée"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr "Transférer la propriété"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "Transférér les {tokenSymbolShort} non réclamés"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "Transférer {tokenSymbolShort}"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "Tendance"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "Désarchiver le projet"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Indisponible"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Modifications non sauvegardées"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr "Projet sans titre"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "À venir"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "Les mises à jour que vous apportez à cette section ne seront appliquées qu'aux cycles de financement <0>à venir</0>."
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr "Importer"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "Importé vers : <0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr "Utilisez l'option <0>Montants</0> lorsque vous souhaitez configurer une <1>limite de distribution</1>. Les fonds de la trésorerie qui dépassent la limite de distribution sont appelés <2>overflow</2>. Les détenteurs de tokens peuvent échanger (brûler) leurs tokens contre une partie de l'overflow . <3>En savoir plus </3>."
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "L'utilisation d'une durée est recommandée. Permettre à tout moment de reconfigurer les cycles de financement paraîtra risqué aux contributeurs."
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "Il est recommandé d'utiliser une stratégie de reconfiguration. Les projets sans stratégie sembleront risqués aux contributeurs."
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr "V1"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr "V1.1"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr "V2"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "Version du contrat terminal utilisé par ce projet."
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr "Volume"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr ""
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr "WAGMI !"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "Adresse du portefeuille"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr ""
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr "Site internet"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr "Que sont les cycles de financement automatisés ?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr "Que sont les tokens de la communauté ?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr "Quels sont les risques ?"
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr "Combien coûte Juicebox ?"
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr "Qu'est-ce que l'oveflow ?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr "Qu'est-ce qu'une courbe de liaison ?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr "Qu'est-ce qu'un taux de remise ?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr "Que se passe-t-il sous le capot ?"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr "Lorsqu'ils sont vérifiés, les paiements à cette adresse frapperont les tokens ERC-20 de ce projet vers le portefeuille du bénéficiaire. Les paiements coûteront plus de gaz. Quand ils ne sont pas vérifiés, Juicebox suivra les nouveaux tokens du bénéficiaire quand ils paient. Le bénéficiaire peut réclamer ses tokens ERC-20 à tout moment."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Lorsque cette option est activée, le propriétaire du projet peut frapper manuellement n'importe quelle quantité de tokens vers n'importe quelle adresse."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "Lorsque cette option est activée, votre projet ne peut pas recevoir de paiements directs."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "Lorsque quelqu'un paie votre projet, il reçoit les tokens de votre projet en retour. Les tokens peuvent être échangés contre une partie des fonds de'overflow de votre projet ; quand vous gagnez, votre communauté gagne avec vous. Tirez parti du token de votre projet pour accorder des droits de gouvernance, un accès à la communauté ou d'autres avantages d'adhésion."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Lorsque la frappe de tokens est autorisée, le propriétaire de ce projet a la permission de frapper n'importe quel nombre de tokens vers n'importe quelle adresse de son choix. Cela a pour effet de diluer tous les détenteurs de tokens actuels, sans augmenter le solde de trésorerie du projet. Le propriétaire du projet peut le reconfigurer avec tous les autres paramètres du cycle de financement."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr "Qui finance les projets Juicebox ?"
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "Qu'est-ce que Peel ?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr "Pourquoi Ethereum ?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr "Pourquoi devrais-je vouloir posséder les tokens d'un projet ?"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr "Ce sera arrondi à <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr "Cela fonctionnera-t-il sur les L2s ?"
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr "Avec Juicebox, les projets sont construits et maintenus par des punks motivés qui sont payés de manière transparente et financés par une communauté d'utilisateurs et de mécènes qui sont récompensés au fur et à mesure que les projets qu'ils soutiennent réussissent."
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr "En l'absence de cycles de financement, le propriétaire du projet peut démarrer un nouveau cycle de financement (cycle de financement #2) à la demande. <0>En savoir plus.</0>"
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr "Espace de travail"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "Souhaitez-vous émettre un token ERC-20 à utiliser comme token de ce projet ?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Oui"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr "Vous pouvez modifier les détails de votre projet à tout moment après sa création, mais la transaction coûtera du gaz."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Vous pouvez toujours récupérer vos tokens {tokenTextLong} de l'overflow sans les réclamer. Vous pouvez transférer vos tokens non réclamés {tokenTextLong} vers une autre adresse à partir du menu Outils, accessible à partir de l'icône clé dans le coin supérieur droit de ce projet."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Vous pouvez toujours récupérer vos tokens {tokenSymbol} de l'overflow sans les réclamer, et vous pouvez transférer vos tokens {tokenSymbol} non réclamés vers une autre adresse à partir du menu Outils, accessible à partir de l'icône en forme de clé anglaise dans le coin supérieur droit de ce projet. ."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "Vous n'avez pas une durée de cycle de financement. Les modifications que vous apportez prendront effet immédiatement."
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Vous ne détenez pas de tokens pour aucun projet Juicebox."
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Vous avez configuré pour que tous les fonds soient distribués à partir de la trésorerie. Vos paiements actuels ne totalisent pas 100%, le reste ira donc au propriétaire du projet."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Vous avez défini un objectif du cycle de financement."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr "Vous avez des modifications non sauvegardées. Voulez-vous vraiment les supprimer ?"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "Vous n'avez pas encore créé aucun projet."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Vous recevrez {0}{1} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Vous recevrez {minReturnedTokensFormatted} d'ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Vous pourrez émettre des tokens ERC-20 une fois votre contrat de projet déployé. Jusque-là, le protocole suivra les soldes de tokens, permettant à vos financeurs de gagner des tokens et de les récupérer de l'overflow entre-temps."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr "Votre projet Juicebox n'a pas de cycle de financement actif. Lancez un cycle de financement pour réactiver les paiements dans votre projet."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Votre solde"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr "Les paramètres de votre cycle de financement ont été préremplis à l'aide des paramètres initialement utilisés pour le lancer. Si vous avez besoin de le personnaliser, contactez-nous."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "Votre nouvelle adresse de paiement :"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Votre projet pourra encore recevoir des paiements directement à travers les contrats du protocole Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr "Votre projet ne peut pas recevoir de paiements directs lorsqu'il est en pause."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr "Votre projet est financé sur plusieurs cycles de financement. Un cycle de financement a un objectif de financement et une durée. La configuration du cycle de financement de votre projet dépendra du type de projet que vous démarrez."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "Votre projet apparaîtra immédiatement actif sur l'application juicebox.money. Veuillez patienter quelques jours pour qu'il apparaisse dans la liste des projets \"actifs\" sur la page Projets."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr "Objectif et durée du cycle de financement de votre projet."
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "Votre transaction a été envoyée et est en attente de confirmation."
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr "Votre solde de tokens non réclamé : {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "Vos {tokenTextLong} non réclamés"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr "Zéro"
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "après {0}% de frais JBX"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr "appelé par <0/>"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr "jours"
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr "identifiant"
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "heures"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "derniers {trendingWindowDays} jours"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "chargement en cours"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "bloqué jusqu'à {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "correspondant à \"{searchText}\""
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "minutes"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "ou <0><1>acheter {tokenText} en échange<2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "projet"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "propriétaire du projet"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "projets"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "secondes"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr "tokens par ETH contribué"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr "tokens récupérés"
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr "jusqu'à"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "{0} après les frais JBX"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr "il y a {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{0} sont distribués à tous ceux qui paient ce projet. Si le projet a défini un objectif de financement, les tokens peuvent être récupérés d'une partie de l'overflow du projet, qu'ils aient été déjà réclamés ou non."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr "{0} solde"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} solde : <0><1>{1} {tokensTextShort}</1><2>({share}% d'offre)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr "{0} jours"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr "{0} pour vous"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr "{0} titulaires"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr "{0} réservé"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr "{0} tokens/ETH"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr "{0} total"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr "{0} non réclamé"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "{0} retiré"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr "{0} {tokenTextPlural} réservé"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr "{0}% de tous les tokens nouvellement frappés."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr "{0}% de l'offre"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr "{0}% à <0/>"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr "{0}% à {1}"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "{0}/{1} retiré"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr "{count} total"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} n'a pas de marché pour {tokenSymbol}."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "{formattedTimeLeft} restant"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "{formattedTimeLeft} jusqu'à #{0}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr "{inflationRate} tokens / ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr "{issuanceRate} tokens / ETH"
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} réservé) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# paiement} other {# paiements}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "{tokenSymbolPluralCap} reçu par ETH payé à la trésorerie. Cela peut changer au fil du temps en fonction du taux de remise et de la quantité de tokens réservés des cycles de financement à venir."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} adresse ERC-20"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Taux de change {tokenSymbol}/ETH sur {exchangeName}."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "{tokenTextSingular} bénéficiaires"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} sont distribués à tous ceux qui paient ce projet. Si le projet a défini un objectif de financement, les tokens peuvent être récupérés d'une partie de l'overflow du projet, qu'ils aient déjà été réclamés ou non."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "{tokensText} réservés"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} montant"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr "{unclaimedBalanceFormatted} {tokenText} réclamable"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de l'offre totale"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -18,4441 +18,3051 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "({realTokenAllocationPercent}% de todos os tokens recentemente criados)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "0% de taxa"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 ano"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. Detalhes do projeto"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr "100% overflow"
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. Ciclo de financiamento"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 horas"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr "3 dias de atraso"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. Revisar e implementar"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 dias"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 dias"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr "7 dias de atraso"
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 dias"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr "<0/> Os projetos arquivados não foram modificados ou excluídos no Blockchain e ainda podem ser integrados diretamente através dos contratos do Juicebox."
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr ""
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr "<0/> saldo do proprietário"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "<0/>{0} depois de {feePercentage}% da taxa de membro JBX"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} distribuído"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "<0><1/>{netDistributionAmount}</0> após taxa de JBX de {feePercentage}%"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1> Este projeto não tem overflow</1>, então você não receberá nenhum ETH por queimar tokens.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr "<0>Uma curva de vínculo recompensa pessoas que esperam mais tempo para reivindicar os tokens deles por overflow.</0><1> Por exemplo, com a curva de vínculo de 70%, resgatando 10% do fornecimento de token, a qualquer momento, irá reivindicar por volta de 7% do overflow total.</1><2>O restante é deixado para compartilhar entre titulares de token.</2>,<3> Para mais informações, confira este <4>curto vídeo</4> sobre curvas de vínculo.</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr "<0>Um mecanismo como Juicebox, em que os compromissos financeiros devem ser cumpridos gradualmente, só é garantido num ecossistema como o Ethereum.</0><1>O Ethereum fornece um ambiente público em que aplicativos de internet como Juicebox podem rodar livre de permissões, incansavelmente e de modo imparável.</1><2>sso significa que qualquer pessoa pode visualizar o código que eles utilizam, qualquer pessoa é capaz de usar o código sem pedir permissão, e ninguém pode modíficar, quebrar ou derrubar o código.</2><3>As pessoas, ao utilizar o Juicebox, estão interagindo umas com as outras a partir de uma infraestrutura pública — não uma privada ou serviço corporativo com fins lucrativos que intermediam o câmbio.</3><4>O Juicebox foi construído para permitir que as pessoas e os projetos sejam pagos pela criação de arte pública e infraestrutura, tanto quanto ou mais do que trabalhariam para fins empresariais. Chega de negócios sombrios.</4>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr "<0>Um projeto pode escolher reservar uma porcentagem de tokens para ele mesmo. Ao em vez de ser distribuído para pagar os usuários, a porcentagem de tokens é emitida para o projeto.</0><1>Manter esses tokens dá direito a um projeto para uma parte de seu próprio overflow.</1>"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr "<0>Taxa de desconto</0>, para reduzir a taxa de emissão de tokens do seu projeto (tokens por ETH) para cada ciclo de financiamento."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr "<0>Se você sabe o quanto seu projeto precisa ganhar durante um periodo de tempo para ser sustentável, você pode colocar seu objetivo de financiamento como essa quantia. Se seu projeto ganhar mais que essa quantia, o excesso será restrito a um conjunto de overflow. Qualquer um com tokens de seu projeto pode reivindicar uma porção desse conjunto de overflow em troca de resgatar seus tokens.</0><1>Para mais informações, confira este <2>curto vídeo</2>.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr "<0>O Juicebox é um protocolo de governança mínima. Existem apenas algumas poucas alavancas que pode ser ajustadas, nenhuma delas impõe mudanças para os usuários sem o consentimento deles. A governança de contrato inteligente do Juicbebox pode ser ajustada por essas alavancas.</0><1>O protocolo Juicebox é administrado pela comunidade de titulares de token JBX que votam quinzenalmente em propostas.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr "<0>O Juicebox é um protocolo aberto em Ethereum que é disponibilizado utilizando o próprio Juicebox. Você pode conferir as especificações do orçamento contratualizado <1>aqui</1>. </0><2> Os projetos que se constroem no Juicebox pagam {JB_FEE}% de uma taxa de membro JBX dos fundos retirados dentro da tesouraria do JuiceboxDAO. Os projetos, então, podem utilizar de seus JBX para participar da governança do JuiceboxDAO e de sua tesouraria coletiva, assim como para resgatar de seu crescente <3>overflow</3>. A taxa está sujeita a alterações via votos de todos os membros JBX.</2>"
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "<0>Aprender mais</0> sobre queima de tokens."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>Saiba mais</0> sobre a duração do ciclo de financiamento."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr "<0>Saiba mais</0> sobre ciclos de financiamento."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr "<0>Saiba mais</0> sobre overflow."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>NOTA:</0> Este projeto tem um saldo de 0. Os projetos não podem ser migrados sem um saldo. Para migrar um projeto, primeiramente deve pagá-lo ou usar o botão abaixo para depositar 1 Wei (0.000000000000000001 o 10<1>-18</1> ETH)."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0>Nenhuma duração definida.</0>Financiamento pode ser reconfigurado a qualquer momento. Reconfigurações iniciarão um novo ciclo de financiamento."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0>Nota:</0>Essas propriedades <1>não</1> serão editáveis imediatamente durante um um ciclo de financiamento. Elas só poderão ser alteradas para <2>próximos</2> ciclos de financiamento."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>Nota:</0> Tokens não podem ser reivindicados, pois nenhum token ERC-20 foi emitido para este projeto. Tokens ERC-20 devem ser emitidos pelo dono do projeto."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr "<0>Em uma taxa de resgate menor, o resgate de um token aumenta o valor de cada token remanescente, criando um incentivo para segurar tokens por mais tempos do que outros titulares.</0><1>A taxa de resgate em 100% significa que todos os tokens irão ter um mesmo valor independentemente quando eles forem resgatados.</1>Aprenda mais neste <2>curto vídeo</2>."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0> é a DAO que gere a parte da interface do juicebox.money. Pode contatar a Peel mediante <1>Discord de Peel</1> ou <2>Discord de Juicebox</2>."
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr "<0>Ciclos de financiamento recorrentes</0>. Por exemplo, distribua os fundos da tesouraria do seu projeto toda semana."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>O objetivo é 0.</0> O saldo do projeto inteiro será considerado overflow. <1>Saiba mais</1>sobre overflow."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr "<0>Esste é o plano, mas o principais contratos do Juicebox serão, primeiramente, implantados para o Ethereum Mainnet.</0><1> O time de contrato irá, brevemente, começar a trabalhar nos terminais de pagamento L2 para os projetos Juicebox.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr "<0> Existem testes de unidades para cada condição de cada função nos contratos, e testes de integração para cada fluxo de trabalho que o protocolo apoia.</0><1> Existe também um script escrito para rodar iterativamente os testes de integração, utilizando um gerador de input aleatório, priorizando casos extremos. O código passou, satisfatoriamente, mais de 1 milhão de testes através desse script de stress-testing.</1><2> O código sempre pode utilizar de mais olhos e críticas para continuar com a confiança da comunidade. Entre em nosso <3>Discord</3> e confira o código no <4>GitHub</4> para trabalhar conosco.</2>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0>Este projeto não tem overflow</0>, então você não receberá nenhum ETH por queimar tokens."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr "<0>Este website (juicebox.money) tem conexão com os contratos inteligentes do protocolo Juicebox, implementado na rede Ethereum. (nota: qualquer um pode criar um site que também conecte com esses mesmos contratos inteligentes. Por agora, não confie em nenhum site que não seja esse para acessar o protocolo Juicebox).</0><1>A criação de um protocolo Juicebox emite para você um NFT (ERC-721) que representa uma propriedade sobre ele. Qualquer um que seja proprietário desse NFT pode configurar as regras do jogo e como os pagamentos são distribuídos.</1><2>Os tokens do projeto, que são emitidos e distribuídos como resultado de um pagamento recebido, são do ERC-20. A quantidade de tokens emitidos e distribuídos são proporcionais ao volume de pagamentos recebidos, ponderados pela taxa de desconto do projeto ao longo do tempo.</2>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "<0>O total de tokens do projeto emitidos</0> quando 1 ETH é contribuído. Isso pode mudar ao longo do tempo, de acordo com a taxa de desconto e quantidade de tokens reservados para futuros ciclos de financiamento."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr "<0>Os usuários financiam seu projeto pagando para usar o seu aplicativo ou serviço, ou como um patrocinador ou investidor fazendo um pagamento diretamente para o contrato inteligente do seu projeto (como neste app).</0><1>Para usuários pagando através de seu aplicativo, você deve rotear esses fundos através dos contratos inteligentes do Juicebox para que eles recebam tokens em troca.</1>"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>Os seus não reinvidicados {tokenSymbol} tokens:</0>{0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} Endereço ERC-20:</0><1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr "@"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "Um projeto pode ser arquivado por seu dono através do menu de ferramentas na página do projeto."
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Um projeto pode reservar uma porcentagem de tokens gerados por pelos pagamentos recebidos. Tokens reservados podem ser distribuídos a qualquer momento conforme a alocação abaixo."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Um projeto pode reservar uma porcentagem de tokens gerados por cada pagamento recebido. Tokens reservados podem ser distribuídos a qualquer momento conforme a alocação abaixo."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr ""
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "O tempo de vida de um projeto é definido em ciclos de financiamento. Se for definida uma meta de financiamento, o projeto não poderá retirar mais do que a meta para a duração do ciclo."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr "Uma reconfiguração de um ciclo de financiamento que se aproxima deve ser submetida pelo menos 3 dias antes do seu início."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr "Uma reconfiguração de um ciclo de financiamento deve ser submetida pelo menos 7 dias antes do seu início."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Uma tava de reserva de mais de 90% é um risco para os contribuidores. Os contribuidores não receberão muitos tokens por sua contribuição."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr ""
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARQUIVADO"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr "DISPONÍVEL"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr "Atividade"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "Adicionar um pagamento"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "Adicionar um memorando on-chain a este pagamento."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr "Adicionar fundos ao saldo deste projeto sem produzir tokens."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr "Adicionar imagem"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr "Adicionar novo pagamento"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "Adicionar pagamento"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr "Adicionar ao saldo"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr "Adicionar ao saldo"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr "Adicionar alocação de token"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr "Endereço"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "Endereço:"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "Endereço:<0/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "Ajuste incentivos para o pagamento do seu projeto."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "Tudo"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr "Todos os ativos"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "Todos os eventos"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr "Todos os fundos podem ser distribuídos pelo projeto. O projeto não terá overflow (o mesmo que definir o objetivo ao infinito)."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr "Todos os fundos recebidos pela tesouraria serão distribuídos. Donos de tokens <0>não receberão ETH</0> ao queimar seus tokens."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr "Tudo {0} irá para o proprietário do projeto:"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "Defina uma porção dos tokens reservados por seu projeto para outras carteiras de Ethereum ou projetos do Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr "Permitir a produção de tokens"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Permitir emissão de token"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "Permitido"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr "Definitivamente."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "Quantidade"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "Quantidade de tokens ERC-20 para reivindicar"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr "A quantidade de tokens do projeto, recentemente emitidos, <0>reservados para o projeto</0> quando 1 ETH é contribuído. Esses tokens são reservados para o proprietário do projeto por padrão, mas podem ser também alocados para outro endereço de carteira pelo proprietário."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr "A quantidade de tokens do projeto, recentemente emitidos, <0>reservados para o projeto</0> quando 1 ETH é contribuído. O proprietário do projeto é alocado para os tokens reservados por padrão, mas pode ser também alocado para outros endereços de carteira."
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr "Montante pago"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "Quantidade para distribuir"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr "Quantidade:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr "Quantidades"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Quaisquer mudanças que você fizer terão efeitos no <0>ciclo de financiamento #{0}</0>. O ciclo de financiamento atual (#{currentFCNumber}) não será alterado."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr "Qualquer reconfiguração de um ciclo de financiamento próximo terá efeito assim que o ciclo atual termine. Um projeto sem estratégia pode ser vulnerável e acabar sofrendo um golpe (rug-pull, por exemplo) pelo dono."
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "Arquivar projeto"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "Arquivado"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "Você tem certeza que quer começar novamente?"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "Ativos"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr "Anexar um sticker"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr "Automatizar ciclos de financiamento"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr "Ciclos de financiamento automatizados permitem as seguintes características:"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr "Disponível após a taxa:"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Fundos disponíveis são distribuídos conforme os pagamentos abaixo."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr "Fundos disponíveis podem ser distribuídos conforme os pagamentos abaixo{0}."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr "Disponível:"
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "De volta ao início"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Saldo excedido"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "Saldo da carteira do dono do projeto."
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Beneficiário"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Endereço do beneficiário"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr "Grandes aplausos à comunidade Ethereum por criar a infraestrutura e economia a fim de tornar o Juicebox possível."
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "Número de Blockchain"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Construído para:"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "Queimar os tokens do projeto"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Queime seus {tokensLabel}. Você não receberá ETH em retorno porque este projeto não tem overflow."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Queimar {0} {tokensTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "Queimar {tokensLabel}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "Queimar {tokensTextLong}"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "Por padrão, todos os fundos não alocados podem ser distribuídos para a carteira do dono do projeto."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Por padrão, tokens recentemente emitidos irão para a carteira de quem enviou os fundos para o endereço. Você pode habilitar isso para configurar um endereço personalizado como beneficiário token."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Posso mudar o contrato do meu projeto após ele ter sido criado?"
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr "Posso excluir um projeto?"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Não é possível reivindicar tokens por ETH, porque este projeto não tem overflow."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr "Mudanças nos pagamentos entrarão em vigor imediatamente."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "Mudanças nos detalhes do projeto serão implementadas imediatamente."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "As mudanças para esses atribuitos podem ser feitas a qualquer momento e irão ser aplicadas ao seu projeto imediatamente."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr "Mudanças para a configuração de financiamento do seu projeto necessitam de um período pré-acordado com a comunidade para serem implementadas, pois isso serve como uma medida de segurança contra \"puxadas de tapete\". Seus apoiadores não precisam confiar em você — mesmo que eles já confiem."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Mudanças que você fizer terão efeito de acordo com sua regra de reconfiguração <0>{0}</0> (o primeiro ciclo de financiamento após o <1>{1}</1> a partir de agora)."
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Marque isso para emitir os tokens {tokenSymbol} ERC-20 do projeto para sua carteira. Deixe desmarcados para deixar que o Juicebox monitore o seu saldo de tokens, economizando o gás da transação. Você sempre pode reivindicar seus tokens posteriormente."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr "Escolha como você gostaria de configurar seus pagamentos."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr "Reivindicar {tokenTextPlural}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr "Reivindicar {tokenTextPlural} como tokens ERC-20"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "Reivindicar {tokenTextShort}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "Reivindicar {tokenTextShort} como tokens ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "Reivindicar {tokensLabel} como token ERC-20"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Reivindicar os tokens {tokenSymbol} irá converter o seu saldo de {tokenSymbol} para tokens ERC-20 e irá emiti-los em sua carteira."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Reivindicar {tokenTextLong} irá converter o seu saldo de {tokenTextShort} para tokens ERC-20 e irá emiti-los em sua carteira."
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "Fechar"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr "Feche, eu farei isso depois"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "Garanta porções dos seus fundos para pessoas ou projetos que você quer apoiar, ou contribuidores que você quer pagar. Quando você for pago, eles também serão."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "Configurar como seu projeto irá coletar e gastar fundos."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "Configurar restrições para seus ciclos de financiamento."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "Configurar as dinâmicas de seu token de projeto."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr "Parabéns pelo lançamento do seu projeto! Os próximos passos são opcionais e podem ser completados a qualquer momento."
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr "Conectar carteira"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr "Conecte uma carteira para reivindicar"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "Conecte uma carteira para implementar"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr "Conecte uma carteira para distribuir"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr "Conecte uma carteira para emitir"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Conecte uma carteira para pagar"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr "Conecte uma carteira para transferir"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "Conecte sua carteira para ver seus ativos."
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "Conecte sua carteira para ver seus projetos."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "Carteira conectada não autorizada"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr "Endereço de contato: {0}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr "Taxa de contribuinte"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Contribuidores serão recompensados com essa quantidade de tokens de seu projeto por ETH contribuído."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "Contribuidores não receberão tokens em troca de pagar por este projeto."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr "Os contribuidores irão receber <0>{discountRatePercent}%</0> mais tokens por contribuições que eles tenham feito neste ciclo de financiamento comparado ao próximo ciclo de financiamento."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "Contribuidores receberão uma porção relativamente pequena de tokens em troca de pagar por este projeto."
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "Contribuintes verão essa mensagem antes de pagar seu projeto."
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr "Copiado!"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr "Criar um endereço de pagamento (opcional)"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr "Criar um endereço Ethereum para o seu projeto. Habilite pagamentos diretos sem ter que ir para a página do seu projeto Juicebox."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Criar um endereço Ethereum que pode ser usado para pagar ao seu projeto diretamente."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "Criar endereço de pagamento"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr ""
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "Criar projeto"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "Crie seu próprio token ERC-20 para representar a participação em seu projeto. Contribuidores receberão esses tokens quando eles pagarem seu projeto."
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr "Atual"
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "Taxas de câmbio atuais de Third-party"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "Atual proprietário: {ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr "Estratégia personalizada"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "Titular de token personalizado"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr "Personalize o botão de \"pagar\" do seu projeto. Deixe em branco para utilizar o padrão."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Ciclo #{0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr "Ciclo #{0} -"
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr "Tema escuro"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "Data"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "Data criada"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "Dias"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr "Deletar pagamento"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr "Deletar alocação de token"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr "Implemente a configuração do ciclo de financiamento"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "Implementar projeto"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "Implementar projeto no {signerNetwork}"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "Implementar o projeto para {0}"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "Token ERC20 implementado"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "Deposite 1 Wei para @{handle}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr "Crie seu projeto"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Detalhes"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr "Determine se os tokens serão emitidos a partir de pagamentos neste endereço."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "Desabilitado quando o limite de distribuição do seu ciclo de financiamento é <0>Sem limite</0> (infinito)"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "Desativado quando a duração do ciclo de financiamento do seu projeto for 0."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "Desativado quando o ciclo de financiamento do projeto não tem duração."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr "Descartar"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr "Exponha todos os detalhes aos seus contribuidores antes que paguem o seu projeto."
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr "Discord"
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr "Taxa de desconto"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "Mostrar os tokens ERC-20 e outros tokens de projetos do Juicebox que estejam na carteira do dono do projeto."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr "Distribua a porcentagem de todos os fundos recebidos por entidades. O seu limite de distribuição será de <0>infinito</0>."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr "Distribua uma quantidade específica de fundos a entidades a cada ciclo de financiamento. O seu limite de distribuição será igual a <0>soma de toda a quantidade de pagamentos.</0>"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "Distribua fundos disponíveis para outras carteiras de Ethereum ou projetos do Juicebox como pagamento. Use isso para pagar contribuidores, caridade, projetos do Juicebox dos quais você depende, ou qualquer outra pessoa. Fundos são distribuídos quando ocorre uma retirada de seu projeto."
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "Distribuir fundos"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "Distribuir {tokenTextPlural} reservados"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "Distribuir {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "Distribuir {tokensText}"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr "Distribuído"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "Fundos distribuídos"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr "Reservas distribuídas"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr "Tokens distribuídos"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr "Fundos distribuídos"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr "Reservados distribuídos {0}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr "A distribuição de fundos para os projetos Juicebox não irão incorrer em taxas."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr "Distribuição"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr "Limite de distribuição <0/>:"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "Limite de distribuição"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "O limite de distribuição é 0: Todos os fundos serão considerados overflow e podem ser resgatados pelos detentores de tokens."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr "O limite de distribuição é infinito. <0>O projeto controlará como todos os fundos serão distribuídos e nenhum fundo poderá ser resgatado pelos titulares de tokens.</0>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Limite de distribuição, duração e pagamentos"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr "Limite de distribuição: <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr "Tenho que fazer meu projeto de código aberto para usar Juicebox como seu modelo de negócios?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr "Documentos"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "Documentação em v1.1 contratos"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr "Um projeto é beneficiado pelo seu próprio overflow?"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "Feito"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "Baixar CSV"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "Baixar pagamentos em CSV"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "Baixar atividade do projeto em CSV"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "Baixar CSV de {0} titulares"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr "Duração"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr "Duração (segundos)"
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "Os tokens ERC-20 apenas podem ser criados uma vez que o token ERC-20 tenha sido emitido para este projeto."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr "ERC20 Implementado"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Cada pagamento você receberá a porcentagem deste total a cada ciclo de financiamento, caso haja o suficiente na tesouraria. Caso contrário, eles receberão a porcentagem de qualquer coisa que estiver na tesouraria."
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr "Editar pagamento"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr "Editar pagamentos"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "Editar projeto"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "Editar detalhes do projeto"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "Editar a alocação de tokens reservados"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "Editar alocação de token"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "Editar ativos rastreados"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr ""
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr "Ativado"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr "Ativar isto permite o proprietário do projeto produzir manualmente qualquer quantidade de tokens para qualquer endereço."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "Ativando isto, irá criar {tokenSymbol} tokens ERC-20. Por outro lado, tokens {tokenSymbol} não reivindicados serão criados, os quais poderão ser reivindicados depois como ERC-20 pelo destinatário."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr "Habilitar a emissão de token irá aparentar arriscado aos contribuidores."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr "Fim"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Erro ao carregar titulares"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "Erro ao carregar pagamentos"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Explore projetos"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr "FAQs"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr "Houve falha na atualização do metadado do projeto"
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "O arquivo deve ter menos que {formattedSize}{unit}"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr "Financie qualquer coisa. Cresça em conjunto."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "Financiamento"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr "Ciclo de financiamento"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "Detalhes do ciclo de financiamento"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr "Duração do ciclo de financiamento"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr "Pré-visualização de ciclo de financiamento"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr "Ciclo de financiamento necessário."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr "Objetivo do ciclo de financiamento"
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "Ciclos de financiamento podem ser reconfigurados momentos antes de um novo ciclo começar, sem notificar os contribuidores."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "Distribuição de fundos"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "Objetivo de financiamento"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr "Os fundos serão distribuídos para:"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr "Geral"
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "Dê um feedback"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr "Vá para Etherscan"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr "Identificador"
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr "Atenção"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr "Histórico"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr "Titulares"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "Propriedades"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr "Horas"
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr "Quão descentralizado é o Juicebox?"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr "Como arquivo um projeto?"
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "Como eu posso criar um projeto?"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr "Como eu posso decidir?"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr "Como eu defino a taxa de redenção?"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr "De que forma os contratos foram testados?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "Quanto tempo antes do seu próximo ciclo de financiamento você deve reconfigurar para que as mudanças tenham efeito."
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "Por quanto tempo durará um ciclo de financiamento. As <0>reconfigurações</0> de ciclo de financiamento só terão efeito para os <1>próximos</1> ciclos de financiamento, ou seja, quando o ciclo de financiamento atual terminar."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr "Como os {reservedPercentage}% dos tokens reservados do seu projeto serão divididos."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr "Como o seu projeto distribuirá fundos."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "Eu entendo"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr "ID: {projectId}"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Se trancado, isto não pode ser editado ou removido até o período de trancamento expirar, ou o ciclo de financiamento ser reconfigurado."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Se trancado, essa divisão não pode ser editada ou removida até o período de trancamento expirar, ou o ciclo de financiamento ser reconfigurado."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr "Se você não aumentar a soma de todos os seus pagamentos (<0/>{distributionLimit}), esse endereço receberá {0}% de todos os fundos que você arrecadou."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr "Se você não arrecadar esta quantidade, os seus splits irão receber as porcentagens de tudo o que arrecadou."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "Se você já implantou um endereço de pagamento e o perdeu, por favor, contate o time do Juicebox por meio do <0>Discord.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "Se está interessado em criar um projeto, mas ainda está confuso sobre como começar, considere assistir a este <0>vídeo instrutivo</0>. Também se sinta livre para nos contatar no <1>Discord do Juicebox</1>, no qual nosso time estará muito feliz em ajudar a trazer a ideia do seu projeto à vida!"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "Caso tenha dúvidas se precisa reivindicar seus tokens, você provavelmente não deveria fazer isso."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr "No Juicebox"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "Na tesouraria"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr "Na carteira"
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr "Incentivos"
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr "Criadores e construtores indies"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr "Infinito (sem limite)"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "Taxa de emissão inicial"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr "A taxa inicial de emissão"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Emitir ERC-20"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "Emitir token ERC-20"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "Emita um token ERC-20 como token deste projeto. Uma vez emitido, qualquer pessoa pode reivindicar seu saldo de tokens existentes no novo token."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr "Emitir um token ERC-20 (opcional)"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "Emitir token"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "Não é possível remover os dados de um projeto da blockchain, mas podemos esconder no aplicativo se você quiser impedir que pessoas vejam ou interajam com ele — basta nos avisar no <0>Discord</0>. Tenha em mente que pessoas ainda poderão usar o seu projeto interagindo diretamente com o contrato."
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr "Seria muito mais legal se você fizesse"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr "Taxa de JBX ({0}%):"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "Taxa de JBX ({feePercentage}%):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "ID do projeto Juicebox"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Projeto Juicebox V2 com ID {0}"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Animação de carregamento do Juicebox"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Projeto do Juicebox"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr "Último pagamento"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "Mais tarde"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "Último"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "Últimos pagamentos"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr "Lançar ciclo de financiamento"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr "Lance seu projeto"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr "Deixar em branco para iniciar imediatamente."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr "Tema claro"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr ""
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Trancar até"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Trancado:"
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr "Logotipo"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "MÁX"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Administrar"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr "Gerencie seu {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "Administre {tokenText}"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr "Máximo de {MAX_DESCRIPTION_LENGTH} caracteres"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "Memo (opcional)"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "Migrar para Juicebox V1.1"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "Emitir como ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "Criar novos {tokensLabel} dentro de uma conta. Só o proprietário do projeto, um operador designado, ou um dos delegados do seu terminal podem criar seus tokens."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Crie tokens do projeto sob demanda"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr "Taxa de emissão"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr "Emitir tokens como ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "Crie tokens para um endereço personalizado."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "Criar {tokensLabel}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "Criar {tokensTokenLower}"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr "Minutos"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr ""
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "Mova seus {tokensLabel} do contrato do Juicebox para sua carteira."
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "SEM LIMITE"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr "Nome"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "Novo"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr "{tokenSymbolPlural}, recentemente emitidos, <0>recebidos pelos contribuidores</0> por ETH que eles contribuíram para a tesouraria."
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "Próximo: Ciclo de financiamento"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "Próximo: Revisar e implementar"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "Não"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr "Nenhum ciclo de financiamento ativo."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Nenhuma atividade ainda"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Sem meta de financiamento: Este projeto irá controlar como serão distribuídos todos os fundos e nada poderá ser resgatado pelos titulares de tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "Os fundos não podem ser distribuídos para fora da tesouraria. Os fundos podem ser acessados apenas por titulares de token ao resgatarem os tokens."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "Sem limite (infinito)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr "Apenas o objetivo do ciclo de financiamento pode ser distribuído pelo projeto em um único ciclo de financiamento."
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Nenhum ciclo de financiamento passado"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr "Sem estratégia"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr "Sem meta"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr "Sem meta definida."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr "Não estabelecido"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "Nota"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Nota: Tokens podem ser criados manualmente quando permitidos no atual ciclo de financiamento. Isso pode ser modificado pelo proprietário do projeto para os próximos ciclos."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr "Aviso de {0}:"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr "Uma vez lançado, o seu primeiro ciclo de financiamento <0>não pode ser modificado</0>. Você pode reconfigurar os próximos ciclos de financiamento de acordo com <1>as regras de reconfiguração</1> do projeto."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "Outros ativos na carteira do proprietário deste projeto."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr ""
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr "Overflow"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr "Overflow é criado se o saldo do seu projeto exceder o meta do seu ciclo de financiamento. O overflow pode ser resgatado pelos titulares do token do seu projeto."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "O proprietário é capaz de emitir tokens a qualquer momento."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "O proprietário não é capaz de emitir tokens."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr "Proprietário do token emitido"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr "Ferramentas do proprietário"
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr "Pago"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr "Pago como <0/>"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr "Pausar pagamentos"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "Pausar pagamentos recebidos"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr "Pagar"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr "Pagar o montante"
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "O valor do pagamento deve ser maior que 0."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr "Botão de pagar"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr "Texto do botão \"pagar\""
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr "Pagar divulgação"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr "Pagar {0}"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "Pagador"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "Pagar <0>{0}</0> não é um investimento — é uma forma de apoiar o projeto. Qualquer valor ou aplicabilidade dos tokens que recebe está determinado por {1}."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr "O pagamento deste projeto está atualmente indisponível."
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr ""
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr "A imagem da nota de pagamento"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr "Pagamentos"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr "Pagamentos pausados"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr "O pagamento está bloqueado"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "Recipientes de pagamento"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "Pagamentos"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "Pagamentos (opcional)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "Pagamentos para endereços Ethereum implicam em uma taxa {feePercentage}%. O seu projeto irá receber JBX em troca, na taxa atual de emissão."
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "Porcentagem"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr "Porcentagem de alocação"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Porcentagem:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr "Porcentagens"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Porcentagens devem atingir 100% ou menos"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr "Podcast"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "Riscos potenciais"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "Pré-visualizar:"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr "Projeto Criado"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr "A ID do projeto precisa ser um número."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "ID do projeto:"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "Token do Projeto"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "Configuração do projeto"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr "Projeto criado por"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr "Descrição do projeto"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr "Detalhes do projeto"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr "Os detalhes do projeto podem ser editados a qualquer momento."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "As reconfiguracões dos detalhes do projeto irão criar uma transação separada."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr "Identificador do projeto"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr "O identificador do projeto deve ser único."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "O projeto está aceitando pagamentos neste ciclo de financiamento."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "O projeto não está aceitando pagamentos neste ciclo de financiamento."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr "Lançamento do projeto bem-sucedido"
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr "Nome do projeto"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr "Nome, identificador, links e outros detalhes do projeto."
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr "Proprietário do projeto"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "Proprietário do projeto (você)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "Donos de projeto podem configurar um período de demora, que significa que reconfigurações para um ciclo de financiamento futuro precisam ser submetidas um certo número de dias antes de seu início. Por exemplo, um período de demora de 3 dias significa que reconfigurações precisam ser submetidas pelo menos 3 dias antes do próximo ciclo de financiamento comece. Isso dá tempo para que os donos de tokens reajam às decisões e reduz o risco de ‘puxadas de tapete’."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "Token do Projeto"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr ""
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "O projeto {name} ficará disponível logo! Tente recarregar a página em breve."
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr "Projeto {projectId}"
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Projeto {projectId} não encontrado"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr "Projetos"
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "Os projetos podem ser criados com uma taxa de desconto opcional com intuito de incentivar os colaboradores o quanto antes. A quantidade de tokens recompensados pelo montante pago para o seu projeto irá diminuir conforme a taxa de desconto a cada novo ciclo de financiamento. Uma taxa de desconto maior irá incentivar os apoiadores a financiar seu projeto o quanto antes."
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr "Projetos no Juicebox"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "Projetos que você criou."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "Projetos dos quais você possui tokens."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "Projetos utilizando uma taxa de reserva de {reservedRateRiskyMin}% ou mais aparentarão ser mais arriscados para os contribuidores, pois uma quantia relativamente pequena de tokens será recebida em troca de pagar por seu projeto."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Rankings baseados em número de contribuições e volume ganho nos últimos {trendingWindow} dias. <0>Ver código</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr ""
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "Receber ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "Receba {receiveText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr "Recipiente"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr "Endereço do recipiente"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "Recipientes receberão os pagamentos em ETH."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr "Reconfiguração"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "Regras de reconfiguração"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Estratégia de configuração"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Reconfigurar"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr "Reconfigurar os pagamentos como porcentagens do seu limite de distribuição."
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr "Reconfigure o projeto e os detalhes do financiamento"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "Reconfigurar detalhes do projeto"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "Reconfigurar token"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "Reconfigurar próximos ciclos"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Reconfigurar ciclos de financiamento futuros"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Resgate seus {tokensLabel} por uma porção do overflow do projeto. Qualquer {tokensLabel} que você resgatar será queimado."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Resgatar {0} {tokensTextShort} por ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "Resgatar {tokensLabel} para ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "Resgatar {tokensTextLong} por ETH"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Resgatado"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Taxa de resgate"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "Taxa de resgate: <0>{0}%</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr "Relance o seu ciclo de financiamento com os novos contratos Juicebox V2."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "Necessário"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr "Reservar uma porcentagem dos tokens recentemente emitidos para o uso de seu projeto."
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "Taxa de reserva"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "A taxa de reserva é 0%, mas a alocação de tokens reservado está ativa. Considere adicionar uma taxa de reserva maior do que zero, ou remover a alocação de tokens."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr "Alocação de token reservado"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "Alocação de tokens reservados (opcional)"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr "Alocações de token reservado"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr "Tokens reservados"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr "{0} Reservados"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "{tokenSymbolPlural} reservados"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "{tokenTextPlural} reservados: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "{tokensText} Reservados"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "Recursos"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "Restringir pagamentos e impressão de tokens."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr "Ações restritas"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr "Revisar & Implementar"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr "Revise e lance o ciclo de financiamento"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr "Revisar projeto"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr "Recompense membros específicos da comunidade com tokens."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr "Regras"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "Regras para determinar quantos ciclos de financiamento podem ser reconfigurados"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr "Regras sobre como fazer mudanças no seu projeto."
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr "Regras para como os ciclos de financiamento deste projeto podem ser reconfigurados."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr "Salvar"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "Salvar alterações"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr "Salvar configuração de financiamento"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "Salvar identificador"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr "Salvar pagamento"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Salvar pagamentos"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr "Salvar detalhes do projeto"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr "Salvar reconfiguração"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "Salvar regras"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "Salvar alocação de token"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "Salvar configuração de token"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "Salvar ativos rastreados"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr "Procurar projetos pelo identificador"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr "Segundos"
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Ver transação"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr "Definir um limite de distribuição"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr "Defina a duração de ciclo de financiamento"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr "Defina o objetivo de um ciclo de financiamento"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr "Defina a quantidade de fundos que você gostaria de aumentar a cada ciclo de financiamento. Quaisquer fundos arrecadados dentro do valor alvo do ciclo de financiamento podem ser distribuídos pelo projeto, e não podem ser resgatados pelos donos dos tokens de seu projeto."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr "Defina a duração de seus ciclos de financiamento."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr "Defina isso na soma de todos os seus pagamentos"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr "Você deveria usar o Juicebox?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Como você não colocou uma duração de financiamento, as mudanças para essas configurações serão aplicadas imediatamente."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr ""
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "Algo deu errado."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr "Gastos"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr "Começo"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr "Comece novamente"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr "Hora de início (segundos, tempo Unix)"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Soma de porcentagens não pode exceder 100%"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "Soma de porcentagens não pode exceder 100%."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr "Objetivo"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "O objetivo é 0: Todos os fundos serão considerados overflow e podem ser resgatados ao queimar os tokens do projeto."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr "A <0>taxa de emissão</0> de seu segundo ciclo de financiamento será de <1>{0} tokens por 1 ETH</1>, depois <2>{1} tokens por 1 ETH </2>para o seu terceiro ciclo de financiamento e assim por diante."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr "O protocolo JBX não é auditado e projetos criados nele podem estar vulneráveis a bugs ou exploits. Seja inteligente!"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "O endereço de qualquer contrato inteligente implementado no {0} que executa <0>essa interface</0>."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr "O endereço que deve receber os tokens do pagamento deste projeto."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "A quantidade de tokens para este projeto foi reservada. Esses tokens podem ser distribuídos para beneficiários de tokens reservados."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "Quantidade de tokens para emitir ao destinatário."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "A quantidade que foi distribuída a partir do saldo do Juicebox neste ciclo de financiamento, fora do atual limite de distribuição. Apenas o limite de distribuição pode ser distribuído em um único ciclo de financiamento — qualquer ETH restante no Juicebox é overflow, até o próximo ciclo começar."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "O montante que foi distribuído a partir do saldo do Juicebox neste ciclo de financiamento, fora do atual objetivo de financiamento. Apenas o objetivo de financiamento pode ser distribuído em um único ciclo de financiamento - qualquer ETH restante no Juicebox é overflow, até o próximo ciclo começar."
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "O saldo da carteira do dono do projeto."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "O saldo deste projeto no contrato do Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "O limite de distribuição deste ciclo de financiamento é 0, o que significa que todos os fundos no Juicebox são atualmente considerados overflow. Overflow pode ser resgatado por detentores de tokens, mas não distribuído."
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "O futuro será liderado pelos criadores, e pertencente às comunidades."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "A quantia máxima de fundos que podem ser distribuídos da tesouraria do projeto a cada ciclo de financiamento."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr "A quantia máxima de fundos que podem ser distribuídos da sua tesouraria a cada ciclo de financiamento."
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "A quantidade máxima de fundos que pode ser distribuída deste projeto em um ciclo de financiamento. Os fundos serão retirados em ETH independente de qual moeda você escolher."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr "O número de tokens do projeto emitidos quanto 1 ETH é contribuído no primeiro ciclo de financiamento."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "O número de tokens do projeto emitidos quando 1 ETH é contribuído."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "A porcentagem que este indivíduo recebe do {reservedRate}% total de alocação de token reservado"
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "O dono do projeto pode criar qualquer quantidade de tokens a qualquer momento, diluindo o valor dos tokens de todos os contribuidores."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "O dono deste projeto pode reconfigurar o ciclo de financiamento a qualquer momento, sem aviso prévio."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr "A taxa de emissão de token do seu projeto irá diminuir de acordo com essa porcentagem a cada ciclo de financiamento. Uma taxa de desconto maior irá incentivar que contribuidores paguem o projeto mais cedo."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr "A proporção de tokens recompensamos por valor de pagamento diminuirá nesta porcentagem com cada novo ciclo de financiamento. Uma taxa de desconto mais alta incentivará apoiadores a pagar seu projeto mais rápido."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "A taxa de resgate determina a quantidade de overflow que cada token pode ser resgatado a qualquer momento. Em uma taxa de resgate menor, resgatar um token aumenta o valor de cada token remanescente, criando um incentivo para segurar tokens por mais tempo que outros. Uma curva de ligação de 100% significa que todos os tokens terão o mesmo valor independentemente de onde foram resgatados."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr "A taxa de resgate determina a quantidade de overflow pela qual cada token pode ser resgatado."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "O objetivo desse ciclo de financiamento é 0, o que significa que todos os fundos no Juicebox são atualmente considerados overflow. Overflow pode ser resgatado por detentores de tokens, mas não distribuído."
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr "Os fundos totais que o projeto Juicebox recebeu desde quando foi criado."
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr "Não há pagamentos definidos para este ciclo de financiamento. O dono do projeto receberá todos os fundos disponíveis."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "Não há recipientes de tokens reservados definidos para este ciclo de financiamento. O dono do projeto receberá todos os fundos disponíveis."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "Esses atributos podem ser modificados a qualquer momento."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "Essas ferramentas <0>não</0> serão editáveis imediatamente durante um ciclo de financiamento. Elas só poderão ser modificadas para <1>próximos</1> ciclos de financiamento."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "Este endereço é um contrato de estratégia não reconhecido. Tenha certeza que está correto!"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr "Este endereço receberá qualquer token criado quando o projeto de destino for pago."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr "Este endereço deverá receber os tokens emitidos do pagamento deste projeto."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "Este ciclo de financiamento pode representar riscos para os contribuidores. Avalie os detalhes de ciclo de financiamento antes de pagar este projeto."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr "Esta é a quantidade máxima de fundos que pode deixar na tesouraria de cada ciclo de financiamento."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr "Essa lista está usando um índice de dados experimental e pode ser impreciso para alguns projetos."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr "Este projeto está arquivado e não pode ser pago."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "Este projeto está atualmente usando o contrato de terminal do Juicebox V1. Novas adições introduzidas na V1.1 permitem ao dono do projeto:"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "Este projeto usa a versão V2 dos contratos do Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr "Este saldo do projeto no contrato Juicebox."
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Esta taxa determina a quantidade de overflow que cada token pode ser resgatado a qualquer momento. Em uma curva de ligação menor, resgatar um token aumenta o valor de cada token remanescente, criando um incentivo para segurar tokens por mais tempo que outros. Uma curva de ligação de 100% significa que todos os tokens terão o mesmo valor independentemente de onde foram resgatados."
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "Isso vai apagar todas as suas mudanças."
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr "Para: <0/>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Endereço de token: <0/>"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr "Endereço do beneficiário de token"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr "Beneficiário de token:"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr "Os titulares de token <0>não podem reivindicar os tokens deles</0> por quaisquer ETH quando a taxa de resgaste for 0."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr "Criação de tokens"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "A criação de token permite o proprietário do projeto criar tokens do projeto a qualquer momento."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr "Emissão de token habilitada"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "A criação de token está disponível apenas para projetos V1.1. A criação de token pode ser habilitada ou desabilitada pela reconfiguração do ciclo de financiamento do projeto."
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "O nome do token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr "Nome de token é obrigatório"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr "Valor de resgate do token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "O símbolo do token"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr "Símbolo de token é obrigatório"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Tokens"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr "Os tokens que <0>os contribuidores irão receber</0> quando eles contribuírem 1 ETH."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr "Os tokens <0>reservados para o projeto</0> quando 1 ETH for contribuído."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr "Tokens são ganhos por todos que pagam por seu projeto e podem ser resgatados por overflow se seu projeto tem um objetivo de financiamento definido."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "Os tokens podem ser resgatados por uma porção <0>overflow</0> de um projeto, lhe permitindo beneficiar de seu existo. Afinal, você ajudou a chegar até aqui. O token poderia lhe dar privilégios únicos e exclusivos para membros, além de contribuir com a administração da comunidade."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Tokens podem ser resgatados por uma porção do overflow em ETH deste projeto, conforme a taxa de curva de ligação atual. <0>Tokens são queimados ao serem resgatados.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Tokens podem ser resgatados por uma porção do overflow em ETH deste projeto, conforme a taxa de resgate do ciclo de financiamento atual. <0>Tokens são queimados ao serem resgatados.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Tokens não podem ser reivindicados, pois nenhum token ERC-20 foi emitido para este projeto. Tokens ERC-20 devem ser emitidos pelo proprietário do projeto."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "Destinatário de tokens"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "Tokens:"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr "Total de fundos:"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "Total arrecadado"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr "Fornecimento total"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr "Total: {0}%"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr "Transação falhou"
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Transação pendente..."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr "Transação malsucedida"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr "Transferir propriedade"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "Transferir {tokenSymbolShort} não resgatados"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "Transferir {tokenSymbolShort}"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "Tendências"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr "Nick do Twitter"
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "Desarquivar projeto"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Indisponível"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "A não ser que os pagamentos estejam pausados nas suas configurações de ciclo de financiamento, o seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Mudanças não salvas"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr "Projeto sem título"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Futuro"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "Atualizações que você fizer nesta seção só serão aplicadas aos <0>próximos</0> ciclos de financiamento."
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr "Carregar"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "Feito upload para: <0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr "Utilize <0>Quantidades</0> quando você quiser configurar um <1>limite de distribuição</1>. Os fundos da tesouraria que excedem o limite de distribuição são chamados de <2>overflow</2>. Os titulares de token podem reivindicar (queimar) os tokens deles por uma parte do overflow. <3>Leia mais</3>."
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr "Utilize <0>Porcentagens</0> quando você quiser configurar um <1>limite de distribuição infinito.</1> Com um limite de distribuição infinito, o seu projeto reserva todos fundos para ele mesmo. O seu projeto não vai ter overflow, então, os tokens nunca vão poder ser reivindicados por ETH. <2>Leia mais</2>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "Usar uma duração é recomendado. Permitir a reconfiguração de ciclos de financiamento a qualquer momento aparentará ser arriscado para os contribuidores."
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "Usar uma estratégia de reconfiguração é recomendado. Projetos sem estratégia aparentarão ser de alto risco para os contribuidores."
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr "V1"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr "V1.1"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr "V2"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "Versão do contrato de terminal utilizado por este projeto."
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr "Volume"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr ""
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr "WAGMI!"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "Endereço da carteira"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr ""
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr "Website"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr "O que são os ciclos de financiamento automatizados?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr "O que são tokens da comunidade?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr "Quais são os riscos?"
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr "Quanto custa o Juicebox?"
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr "O que é overflow?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr "O que é uma curva de ligação?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr "O que é uma taxa de desconto?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr "Como funciona o Juicebox?"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr "Quando avaliados, os pagamentos para esse endereço irá emitir os ERC-20 tokens do projeto para a carteira do beneficiário. Os pagamentos irão custar mais gás. Quando não avaliados, o Juicebox irá rastrear os tokens dos novos beneficiários quando forem pagos. O beneficiário pode reivindicar os ERC-20 tokens dele a qualquer momento."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Quando ativado, o dono do projeto pode manualmente emitir qualquer quantidade de tokens para qualquer endereço."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "Quando ativado, seu projeto não pode receber pagamentos diretos."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "Quando alguém paga por seu projeto, eles recebem tokens em troca. Tokens podem ser resgatados por uma porção dos fundos de overflow do seu projeto; quando você ganha, sua comunidade ganha com você. Utilize os tokens do seu projeto para garatir direitos administrativos, acesso à comunidade ou outros benefícios de membro."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Quando a criação de tokens é permitida, o dono deste projeto tem permissão de criar qualquer número de tokens para qualquer endereço à seu critério. Isso tem o efeito de diluir os detentores de token, sem aumentar o saldo do projeto. O dono do projeto pode reconfigurar isso junto de todas as outras propriedades do ciclo de financiamento."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Quando alguém paga seu projeto, essa porcentagem de tokens recém emitidos será reservada e o resto irá para quem pagou. Os tokens reservados estão reservados por padrão, mas também podem ser alocados em outros endereços de carteiras pelo proprietário. Uma vez que os tokens estão reservados, qualquer um pode \"emití-los\", que, por sua vez, distribuem-nos para seus recipientes esperados."
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr "Quem financia os projetos do Juicebox?"
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "Quem é Peel?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr "Por que Ethereum?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr "Por que eu devo querer possuir tokens de um projeto?"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr "Será arredondado para <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr "Irá funcionar nos L2s?"
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr "Com Juicebox, projetos são construídos e mantidos por “punks” motivados, sendo pagos de forma transparente, e financiados por uma comunidade de usuários e patrocinadores que são recompensados conforme os projetos que eles apoiam são bem sucedidos."
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr "Sem ciclos de financiamento, o proprietário do projeto pode começar um novo ciclo de financiamento (#2 Ciclo de Financiamento) no momento desejado. <0>Saiba mais.</0>"
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr "Área de trabalho"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "Você desejaria emitir um token ERC-20 para que seja usado como um token do projeto?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Sim"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr "Você pode editar os detalhes do seu projeto após a criação, a qualquer momento, mas a transação irá custar gás."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Você pode resgatar seus {tokenTextLong} para overflow sem reivindica-los. Você pode transferir seus {tokenTextLong} não-reivindicados para outro endereço do menu de Ferramentas, o qual pode ser acessado pelo icone de chave-inglesa no canto superior direito deste projeto."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Você ainda pode resgatar seus tokens {tokenSymbol} para overflow sem reivindica-los e pode transferir seus tokens {tokenSymbol} não-reivindicados para outro endereço do menu de Ferramentas, o qual pode ser acessado pelo icone de chave-inglesa no canto superior direito deste projeto."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "Você não possui uma duração de ciclo de financiamento. Mudanças que você fizer terão efeito imediatamente."
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Você não possui token de nenhum projeto Juicebox."
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Você configurou para que todos os fundos sejam distribuídos a partir de sua tesouraria. Os seus pagamentos atuais não somam até 100%, então, o restante irá para o proprietário do projeto."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Você definiu a meta do ciclo de financiamento."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr "Você tem mudanças não salvas. Você tem certeza que quer descartar elas?"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "Você ainda não criou nenhum projeto."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Você receberá {0}{1} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Você receberá {minReturnedTokensFormatted} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Você poderá emitir tokens ERC-20 uma vez que o contrato de seu projeto tenha sido lançado. Até lá, o protocolo rastreará os saldos de tokens, permitindo, enquanto isso, que os seus apoiadores ganhem tokens e os resgatem por overflow."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr "O seu projeto Juicebox não tem nenhum ciclo de financiamento ativo. Lance um ciclo de financiamento para reativar os pagamentos do seu projeto."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Seu saldo"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr "A configuração do seu ciclo de financiamento tem sido pré-preenchida usando a configuração com que você, originalmente, lançou. Caso precise de customizá-la, entre em contato conosco."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "Seu novo endereço de pagamento:"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "Seu projeto ainda pode receber pagamentos diretamente através do protocolo de contratos Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr "O seu projeto não poderá receber pagamentos diretos enquanto se encontrar pausado."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr "O seu projeto é financiado através dos ciclos de financiamento. Um ciclo de financiamento tem um objetivo e uma duração. A configuração do ciclo de financiamento de seu projeto dependerá do tipo de projeto que você esteja iniciando."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr "O seu projeto aparecerá arquivado e não poderá receber pagamentos através do app juicebox.money. Você pode desarquivar um projeto a qualquer momento. Aguarde alguns dias para que o seu projeto apareça sob o filtro \"arquivado\" na Página de Projetos."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "O seu projeto irá imediatamente aparecer ativo no app juicebox.money. Por favor, aguarde alguns dias para que apareça na lista de projetos \"ativos\" na Página de Projetos."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr "Objetivo e duração do ciclo de financiamento do seu projeto."
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "Sua transação foi submetida e está aguardando confirmação."
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr "O seu saldo de token não resgatado: {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "Os seus {tokenTextLong} não reivindicados"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr "Zero"
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "depois da taxa de {0}% de JBX"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr "chamado por <0/>"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr "dias"
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr "controlar"
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "horas"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "últimos {trendingWindowDays} dias"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "carregando"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "trancado até {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "coincidindo \"{searchText}\""
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "minutos"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "ou <0><1> compre {tokenText} em troca<2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "projeto"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "proprietário do projeto"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "projetos"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "segundos"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "tokens"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr "tokens por ETH contribuído"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr "tokens resgatados"
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr "até"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "{0} spós a taxa de JBX"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr "{0} atrás"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{0} são distribuídos para qualquer pessoa que pague este projeto. Se o projeto já definiu o objetivo de financiamento, os tokens podem ser resgatados por uma porção de overflow do projeto, tendo eles (ou não) sido reivindicados ainda."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr "{0} saldo"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} saldo: <0><1>{1}{tokensTextShort}</1><2>({share}% de fornecimento)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr "{0} dias"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr "{0} para você"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr "{0} titulares"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr "{0} reservado"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr "{0} tokens/ETH"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr "{0} total"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr "{0} não reivindicados"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "{0} retirado"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr "{0} {tokenTextPlural} reservados"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr "{0}%"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr "{0}% de todos os tokens recentemente emitidos."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr "{0}% do fornecimento"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr "{0}% a <0/>"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr "{0}% a {1}"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "{0}/{1} retirado"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr "{count} total"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} não tem mercado para {tokenSymbol}."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "{formattedTimeLeft} restante"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "{formattedTimeLeft} até #{0}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr "{inflationRate} tokens / ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr "{issuanceRate} tokens / ETH"
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} reservado) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# pagamento} other {# pagamentos}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "{tokenSymbolPluralCap} recebido por ETH pagos para o tesouro. Isto pode modificar-se através do tempo conforme a taxa de desconto e a quantidade de tokens reservados de futuros ciclos de financiamento."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} Endereço ERC-20"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{tokenSymbol}/ETH taxa de câmbio em {exchangeName}."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "Recipientes de {tokenTextSingular}"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} são distribuídos para qualquer pessoa que pague este projeto. Se o projeto já definiu o objetivo de financiamento, os tokens podem ser resgatados por uma porção de overflow do projeto caso eles tenham ou não sido reivindicados ainda."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "{tokensText} reservados"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "quantidade de {tokensTokenUpper}"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr "{unclaimedBalanceFormatted} {tokenText} reivindicável"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% de fornecimento total"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -18,4441 +18,3051 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "({realTokenAllocationPercent}% всех вновь выпущенных токенов)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "0% комиссия"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 год"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. Детали проекта"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr "100% превышение"
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. Цикл финансирования"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 часа"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr "3-дневная задержка"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. Обзор и развертывание"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 дней"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 дней"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr "7-дневная задержка"
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 дней"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr "<0/> Архивные проекты не были изменены или удалены в блокчейне, и с ними по-прежнему можно взаимодействовать напрямую через контракты Juicebox."
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr ""
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr "<0/> баланс владельца"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "<0/>{0} после {feePercentage}% членского взноса JBX"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} распределено"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "<0><1/>{netDistributionAmount}</0> после {feePercentage}% JBX комиссии"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1>В этом проекте нет переполнения</1>, поэтому вы не получите ETH за сжигание токенов..</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "<0>Узнайте больше</0> о сжигании токенов."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>Подробнее</0> о продолжительности цикла финансирования."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr "<0>Подробнее</0> о продолжительности цикла финансирования."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr "<0>Узнайте больше</0> о переполнении."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>ПРИМЕЧАНИЕ:</0>Этот проект имеет баланс 0. Проекты не могут быть перенесены без баланса. Чтобы перенести этот проект, сначала оплатите его или используйте кнопку ниже, чтобы внести 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0> Продолжительность не установлена.</0> Финансирование может быть перенастроено в любое время. При изменении конфигурации начинается новый цикл финансирования."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0> Примечание. </0> Свойства цикла финансирования <1>n не <1>n будут редактируемыми непосредственно в цикле финансирования. Их можно изменить только на <2> предстоящих <2> цикла финансирования."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>Примечание:</0> Токены не могут быть востребованы, поскольку для этого проекта не выпущен токен ERC-20. Токены ERC-20 должны быть выпущены владельцем проекта."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0> - это DAO, управляющее интерфейсом фронтенда juicebox.money. Вы можете связаться с Peel либо через <1>Peel Discord</1>, либо через <2>Juicebox Discord</2>."
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>Цель - 0.</0> Весь баланс проекта будет считаться переполнением. <1> Узнайте больше</1> о переполнении."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0>У этого проекта нет переполнения</0>, поэтому вы не получите никаких ETH за сжигание токенов."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>Ваши невостребованные {tokenSymbol} токены:</0> {0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} ERC20 адрес:</0> <1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr "@"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "Проект может быть архивирован его владельцем из меню инструментов на странице проекта."
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Проект может резервировать процент выпущенных токенов с каждого платежа, который он получает. Зарезервированные токены могут быть распределены в соответствии с приведенным ниже распределением в любое время."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr ""
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "Срок действия проекта определен в циклах финансирования. Если установлен целевой показатель финансирования, проект может вывести не более целевого показателя на период действия цикла."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr "Реконфигурацию/план изменений для предстоящего цикла финансирования необходимо отправить не менее чем за 7 дней до его начала."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr "Реконфигурацию/план изменений для предстоящего цикла финансирования необходимо отправить не менее чем за 3 дня до его начала."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "Резервная ставка более 90% является рискованной для вкладчиков. Вкладчики не получат много токенов за свой вклад."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr ""
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "АРХИВИРОВАНО"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr "ДОСТУПНО"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr "Активность"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "Добавить выплату"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr "Пополняйте средства на баланс этого проекта без создания жетонов."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr "Добавить изображение"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "Добавить выплату"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr "Добавить к балансу"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr "Добавить к балансу"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr "Адрес"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "Адрес:"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "Адреса: {0}/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "Отрегулируйте стимулы для оплаты вашего проекта."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "Все"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr "Все активы"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "Все события"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr "все средства могут быть распределены по проекту, и в проекте не будет переполнения. (Это то же самое, что и установка цели на бесконечность)."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr "Все {0} будут направлены владельцу проекта:"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "Выделите часть зарезервированных токенов вашего проекта на другие кошельки Ethereum или проекты Juicebox."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr "Разрешить майнинг токенов"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Разрешить минтить токены"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "Разрешено"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr "Почти определенно."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "Количество"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "Количество токенов ERC-20, на которые можно претендовать"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr "Оплаченная сумма"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "Сумма к распределению"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Любые внесенные вами изменения вступят в силу в <0>цикле финансирования #{0}</0>. Текущий цикл финансирования (#{currentFCNumber}) не будет изменен."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr "Любая перенастройка на предстоящий цикл финансирования вступит в силу после завершения текущего цикла. Проект, не имеющий стратегии или плана, может быть уязвим для владельца."
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "Заархивировать проект"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "В архиве"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "Вы уверены, что хотите начать все сначала?"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "Активы"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr "Доступно после комиссии:"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Доступные средства распределяются в соответствии с приведенными ниже выплатами."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr "Доступно:"
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "Вернуться наверх"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Баланс превышен"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "Баланс кошелька владельца проекта."
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Получатель"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Адрес получателя"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr "Большое спасибо сообществу Ethereum за создание инфраструктуры и экономики, что сделало Juicebox возможным."
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "Номер блока"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr "Блог"
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Создан для:"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "Сжечь токены проекта"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "Сожгите свой {tokensLabel}. Вы не получите ETH взамен, потому что у этого проекта нет перетока."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "Сжечь {0} {tokensTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "Сжечь {tokensLabel}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "Сжечь {tokensTextLong}"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "По умолчанию все нераспределенные средства могут быть распределены на кошелек владельца проекта."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Могу ли я изменить контракт своего проекта после его создания?"
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr "Могу ли я удалить проект?"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Невозможно обменять токены на ETH, так как в этом проекте нет переполнения."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "Изменения в деталях проекта вступят в силу немедленно."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "Изменения этих атрибутов можно внести в любое время, и они будут немедленно применены к вашему проекту."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr "Изменения в конфигурации финансирования вашего проекта требуют одобренного сообществом периода для вступления в силу, что служит защитой от перетягивания ковра. Ваши сторонники не обязаны доверять вам — даже если они уже доверяют."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr "Изменения вступят в силу в соответствии с пользовательским контрактом проекта."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Проверьте это, чтобы минтить {tokenSymbol} ERC-20 на ваш кошелек. Оставьте флажок не отмеченным, чтобы ваш баланс токенов отслеживался Juicebox, экономя газ на этой транзакции. Вы всегда можете потребовать свои токены ERC-20 позже."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "Требовать {tokenTextShort}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "Получить {tokenTextShort} в качестве токенов ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "Получить {tokensLabel} как ERC-20"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Требование {tokenSymbol} токенов конвертирует ваш {tokenSymbol} баланс в токены ERC-20 и отчеканит их в вашем кошельке."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "Требование {tokenTextLong} токенов конвертирует ваш {tokenTextShort} баланс в токены ERC-20 и отчеканит их в вашем кошельке."
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "Выделите часть своих средств людям или проектам, которых вы хотите поддержать, или спонсорам, которым вы хотите платить. Когда вам платят, им тоже платят."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "Настройте, как ваш проект будет собирать и расходовать средства."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "Настройте ограничения для ваших циклов финансирования."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "Настройте динамику токена вашего проекта."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr ""
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "Подключите кошелёк для развертывания"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Подключите кошелёк для оплаты"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "Подключите свой кошелек, чтобы увидеть свои активы."
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "Подключите свой кошелек, чтобы увидеть свои проекты."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "Подключенный кошелек не авторизован"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr "Адрес контракта: {0}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "За каждый внесенный ETH вкладчики получат это количество токенов вашего проекта."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "Участники не получат никаких токенов в обмен на оплату этого проекта."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "Участники получат относительно небольшую часть токенов в обмен на оплату этого проекта."
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "Вкладчики увидят это сообщение до того, как оплатят ваш проект."
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr "Скопировано!"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "Копировать в буфер обмена"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Создать Ethereum-адрес, который можно использовать для прямой оплаты вашего проекта."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "Создать адреса для оплаты"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr ""
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "Создать проект"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "Создать свой собственный токен ERC-20 для представления доли в вашем проекте. Вкладчики будут получать эти токены при оплате вашего проекта."
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr "Текущий"
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "Текущие курсы обмена валют сторонних организаций"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "Текущий владелец: {ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr "Индивидуальная стратегия"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "Пользовательский бенефициарий токенов"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr ""
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Цикл #{0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr "Тёмная тема"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "Дата"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "Дата создания"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "Дней"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr ""
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "Развернуть проект"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "Развернуть проект на {signerNetwork}"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "Развернуть проект на {0}"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "Развернутый токен ERC20"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "Депозит 1 wei на @{handle}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr "Создай свой проект"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Подробности"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "Отключен"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "Отключен, если лимит распределения вашего цикла финансирования <0>Нет лимита</0> (бесконечный)"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "Отключено, если длительность цикла финансирования вашего проекта равна 0."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "Отключен, если цикл финансирования вашего проекта не имеет продолжительности."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr ""
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr ""
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr "Дискорд"
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr "Учетная ставка "
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "Отображение токенов ERC-20 и других токенов проекта Juicebox, которые находятся в кошельке владельца этого проекта."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "Распределяйте доступные средства на другие кошельки Ethereum или проекты Juicebox в качестве выплат. Используйте это, чтобы платить вкладчикам, благотворительным организациям, проектам Juicebox, от которых вы зависите, или кому-либо еще. Средства распределяются всякий раз, когда производится вывод средств из вашего проекта."
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "Распределить средства"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "Распространить зарезервированные {tokenTextPlural}"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "Распределить {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "Распределить {tokensText}"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr "Распределено"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "Распределенные средства"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "Лимит распределения"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "Лимит распределения равен 0: Все средства будут считаться переполненными и могут быть выкуплены держателями токенов."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Лимит распределения, продолжительность и выплаты"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr "Должен ли я сделать свой проект открытым, чтобы использовать Juicebox в качестве бизнес-модели?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr "Документы"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "Документация по контрактам версии 1.1"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr "Выигрывает ли проект от собственного переполнения?"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "Готово"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "Скачать CSV"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "Скачать CSV данных о платежах"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "Скачать CSV о активности проекта"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "Загрузить CSV из {0} держателей"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr "Продолжительность"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "Токены ERC-20 могут быть отчеканены только после выпуска токена ERC-20 для данного проекта."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "Редактировать проект"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "Редактирование деталей проекта"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "Изменить зарезервированное распределение токенов"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "Изменить распределение токенов"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "Изменить отслеживаемые активы"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr ""
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr "Разрешено"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr "Включение этой опции позволяет владельцу проекта вручную минтить любое количество токенов на любой адрес."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr ""
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr "Конец"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Ошибка загрузки владельцев"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "Ошибка загрузки платежей"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "FAQ (Вопросы)"
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr "FAQ (Вопросы)"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr ""
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "Финансирование"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr "Цикл финансирования"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "Детали цикла финансирования"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr "Продолжительность цикла финансирования"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr "Цель цикла финансирования"
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "Циклы финансирования можно изменить за несколько минут до начала нового цикла без уведомления вкладчиков."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "Распределение финансирования"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "Цель финансирования"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr "Средства будут распределены по следующим направлениям:"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr ""
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "Оставьте свой отзыв"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr "Перейти к Etherscan"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr "Никнейм"
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr "Уведомления"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr "История"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr "Держатели"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "Держатели"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr "Насколько децентрализован Juicebox?"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr "Как я могу заархивировать проект?"
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "Как я могу создать проект?"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr "Как проверялись контракты?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "За какое время до следующего цикла финансирования необходимо изменить конфигурацию, чтобы изменения вступили в силу."
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "Как долго продлится один цикл финансирования. Цикл финансирования <0> перенастройки <0> вступят в силу только для <1> предстоящих <1> циклов финансирования, т. е. после завершения текущего цикла финансирования."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr "Как ваш проект будет зарабатывать деньги и управлять ими."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "Я понимаю"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Если блокировка заблокирована, ее нельзя изменить или удалить, пока не истечет срок блокировки или не будет изменена конфигурация цикла финансирования."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Если этот раздел заблокирован, его нельзя редактировать или удалить, пока не истечет срок блокировки или не будет изменена конфигурация цикла финансирования."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "Если вы уже установили оплачиваемый адрес и потеряли его, пожалуйста, свяжитесь с командой Juicebox через <0>Discord.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "Если вы заинтересованы в создании проекта, но не знаете, как начать, посмотрите это <0>инструктивное видео</0>. Также не стесняйтесь обращаться в <1>Juicebox Discord</1>, где наша команда будет рада помочь воплотить вашу идею проекта в жизнь!"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "Если вы не уверены, нужно ли вам предъявлять претензии, вы, вероятно, этого не делаете."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr "В Juicebox"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "В казначействе"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr "В кошельке"
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr "Поощрения"
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "Первоначальная ставка эмиссии"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "Выпуск ERC-20"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "Выпуск токенов ERC-20"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "Выпустите токен ERC-20, который будет использоваться в качестве токена этого проекта. После выпуска любой желающий может заявить о своем существующем балансе токенов в новом токене."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "Выдача токенов"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "Удалить данные проекта из блокчейна невозможно, но мы можем скрыть их в приложении, если вы хотите, чтобы люди не могли видеть их или взаимодействовать с ними - просто сообщите нам об этом в <0>Discord</0>. Помните, что люди по-прежнему смогут использовать ваш проект, взаимодействуя непосредственно с контрактом."
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr "Было бы намного круче, если бы вы это сделали"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr "Комиссия JBX ({0}%):"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "Комиссия JBX ({feePercentage}%):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "ID проекта Juicebox"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Juicebox загружающаяся анимация"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Проект Juicebox"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr "Последний платеж"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "Позже"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "Последние"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "Последние платежи"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr "Светлая тема"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr "Загрузить ещё"
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr ""
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Заблокировать до"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr ""
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr "Логотип"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "Максимум"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Управление"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "Управление {tokenText}"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "Перейти на Juicebox V1.1"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "Минтить как ERC-20"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "Чеканить новые {tokensLabel} на счет. Чеканить токены может только владелец проекта, назначенный оператор или один из делегатов его терминала."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Создание токенов проекта по требованию"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "Чеканка жетонов на пользовательский адрес."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "Чеканить {tokensLabel}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "Чеканить {tokensTokenLower}"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr ""
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "Переместите {tokensLabel} из контракта Juicebox в свой кошелек."
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "БЕЗ ОГРАНИЧЕНИЯ"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr "Название"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "Новый"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr ""
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "Следующее: Цикл финансирования"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "Следующее: Обзор и развертывание"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "Нет"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr ""
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Нет активности"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Нет цели финансирования: проект будет контролировать, как распределяются все средства, и ничего не может быть обменяно владельцами токенов."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "Без ограничений (бесконечный)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr "Не более одного целевого показателя цикла финансирования можно распределить по проекту в рамках одного цикла финансирования."
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Нет прошлых циклов финансирования"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr "Нет стратегии/или плана"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr "Нет цели"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr "Цель не установлена."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr "Не установлено"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "Примечание"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Примечание: Токены могут быть отчеканены вручную, если это разрешено в текущем цикле финансирования. Это может быть изменено владельцем проекта для последующих циклов."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr "Уведомление от {0}:"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "Другие активы в кошельке владельца этого проекта."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr ""
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr "Переполнение создается, если остаток вашего проекта превышает цель цикла финансирования. Переполнение может быть использовано владельцами токенов вашего проекта."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "Владелец может минтить токены в любое время."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Владельцу не разрешается минтить токены."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr ""
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr ""
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr "Оплачено как <0/>"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr "Приостановить платежи"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "Приостановить полученные платежи"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr "Приостановлено"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr "Оплатить"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr "Сумма платежа"
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "Сумма платежа должна быть больше 0."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr "Кнопка \"Оплатить\""
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr "Кнопка оплаты"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr "Раскрытие информации о платеже"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr "Заплатить {0}"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "Плательщик"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "Оплата {0} не является вложением – это способ поддержать проект. Любое значение или ценность полученных вами токенов определяется {1}."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr "Оплата этого проекта в настоящее время отключена."
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr ""
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr "Платежи"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr "Платежи приостановлены"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "Получатели выплат"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr ""
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "Выплаты (необязательно)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "При выплатах на адреса Ethereum взимается комиссия в размере {feePercentage}%. Ваш проект получит взамен JBX по текущему курсу."
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "Процент"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr ""
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Сумма процентов должна составлять 100 % или меньше"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr "Подкаст"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "Потенциальные риски"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "Предварительный просмотр:"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "ID проекта:"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "Токен проекта"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "Конфигурация проекта"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr ""
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr "Описание Проекта"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr "Детали проекта"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Для изменения конфигурации деталей проекта будет создана отдельная транзакция."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr "Никнейм проекта"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr "Никнейм проекта должен быть уникальным."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "Проект принимает платежи в этом цикле финансирования."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "Проект не принимает платежи в этом цикле финансирования."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr ""
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr "Название проекта"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr "Название проекта, описание, ссылки и другие детали."
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr "Владелец проекта"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "Владелец проекта (вы)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "Владельцы проектов могут настроить период задержки, что означает, что изменения в конфигурации предстоящего цикла финансирования должны быть представлены за определенное определенное количество дней до его начала. Например, период задержки в 3 дня означает, что изменения конфигурации должны быть представлены не позднее чем за 3 дня до начала следующего цикла финансирования. Это дает держателям токенов время отреагировать на принятое решение и снижает вероятность rug-pulls."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "Токен проекта"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr ""
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Проект {projectId} не найден"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr "Проекты"
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "Проекты могут быть созданы с дополнительной ставкой скидки, призванной стимулировать сторонников делать взносы раньше, а не позже. Количество токенов, начисляемых на сумму, внесенную в ваш проект, будет уменьшаться на величину дисконтной ставки с каждым новым циклом финансирования. Более высокая ставка скидки будет стимулировать сторонников вносить деньги в ваш проект раньше, чем позже."
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr "Проекты в Juicebox"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "Проекты, которые вы создали."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "Проекты, в которых вы держите токены."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "Проекты, использующие зарезервированную ставку в размере {reservedRateRiskyMin}% или выше, будут казаться вкладчикам рискованными, поскольку в обмен на оплату вашего проекта будет получено относительно небольшое количество токенов."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Рейтинг, основанный на количестве вкладов и объеме, полученном за последние {trendingWindow} дней. <0>Увидеть код</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr ""
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "Получить ERC-20"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "Получить{receiveText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "Пользователи будут получать выплаты в ETH."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr "Реконфигурация"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "Правила реконфигурации"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Стратегия изменения конфигурации"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Перенастройте"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "Перенастроить детали проекта"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "Перенастроить токен"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "Перенастроить предстоящие "
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Перенастроить предстоящие циклы финансирования"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "Обменяйте свои {tokensLabel} на часть перелива проекта. Все {tokensLabel}, которые вы выкупите, будут сожжены."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "Обменять {0} {tokensTextShort} за ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "Обменять {tokensLabel} за ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "Обменять {tokensTextLong} за ETH"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Коэффициент выкупа"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "Ставка выкупа: <0>{0}%</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "Обновить"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "Требуется"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "Резервная ставка"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "Зарезервированная ставка равна 0%, но зарезервировано выделение токенов. Рассмотрите возможность добавления зарезервированной ставки, которая больше нуля, или снимите выделение токенов."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "Зарезервированные распределения токенов (необязательно)"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr "Зарезервированные распределения токенов"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr "Зарезервированные токены"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr "Зарезервировано {0}"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "Зарезервировано {tokenSymbolPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "Зарезервировано {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "Зарезервировано {tokensText}"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "Pесурсы"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "Ограничить платежи и печать токенов."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr "Ограниченные действия"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr "Обзор & Развертывание"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr "Просмотр проекта"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr "Награждайте определенных членов сообщества токенами."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr "Правила"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "Правила определения того, как можно изменить конфигурацию циклов финансирования"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr "Правила внесения изменений в ваш проект."
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr "Правила изменения конфигурации циклов финансирования этого проекта."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "Сохранить изменения"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr "Сохранить конфигурацию финансирования"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "Сохранить имя"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr ""
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Сохранить платежи"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr "Сохранить детали проекта"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr "Сохранить перенастройки"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "Сохранить правила"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "Сохранить распределение токена"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "Сохранить конфигурацию токена"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "Сохранить отслеживаемые активы"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr "Поиск проектов по имени"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "Увидить трансакцию"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr ""
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr "Установите продолжительность цикла финансирования"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr "Установите продолжительность цикла финансирования"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr "Установите количество средств для каждого цикла финансирования. Любые средства, собранные в рамках цикла финансирования, могут быть распределены по проекту и не могут быть использованы владельцами токенов вашего проекта."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr "Установите длину циклов финансирования."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr "Следует ли вам заниматься Juicebox?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Поскольку вы не установили срок финансирования, изменения в этих настройках будут применены немедленно."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr ""
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "Что-то пошло не так."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr "Расходы"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr "Начать"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr "Начать заново"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Сумма процентов не может превышать 100%"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "Сумма процентов не может превышать 100%."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr "Цель"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "Цель - 0: Все средства будут считаться переполненными и могут быть использованы при сжигании токенов."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr "Протокол JBX не прошел аудит, и проекты, построенные на нем, могут быть уязвимы для ошибок или эксплойтов. "
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "Адрес любого смарт-контракта, развернутого на {0}, который реализует <0>этот интерфейс</0>."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr "Адрес, который должен получить токены, которые не были обменены для оплаты этого проекта."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "Количество токенов, зарезервированных данным проектом. Эти токены могут быть распределены среди бенефициаров зарезервированных токенов."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "Количество токенов для передачи получателю."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "Сумма, которая была распределена из баланса Juicebox в этом цикле финансирования, из текущего лимита распределения. За один цикл финансирования может быть распределено не более лимита распределения - все оставшиеся ETH в Juicebox переполняются до начала следующего цикла."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "Сумма, которая была распределена из баланса Juicebox в этом цикле финансирования, из текущего целевого показателя финансирования. Объем средств не превышает целевого показателя финансирования в рамках одного цикла финансирования: любой оставшийся ETH в Juicebox переполнен, до начала следующего цикла."
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "Баланс кошелька владельца проекта."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "Баланс этого проекта в контракте Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Лимит распределения для этого цикла финансирования равен 0, то есть все средства в Juicebox в настоящее время считаются переполнением. Переполнение может быть выкуплено держателями токенов, но не распределено."
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "Будущее будет возглавляться создателями и принадлежать сообществам."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "Максимальная сумма средств, которую разрешено распределять из казны проекта в каждом цикле финансирования."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr ""
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "Максимальная сумма средств, которая может быть распределена из этого проекта за один цикл финансирования. Средства будут выводиться в ETH независимо от выбранной вами валюты."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "Владелец проекта может чеканить любое количество токенов в любое время, уменьшая долю токенов всех существующих участников."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "Владелец проекта может изменить конфигурацию этого цикла финансирования в любое время без предварительного уведомления."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr "Соотношение вознаграждения токенов на сумму платежа будет уменьшаться на этот процент с каждым новым циклом финансирования. Более высокая учетная ставка будет стимулировать сторонников платить за ваш проект раньше, чем позже."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Коэффициент выкупа определяет количество перелива, за которое каждый токен может быть выкуплен в любой момент времени. При более низкой ставке выкупа, выкуп токена увеличивает стоимость каждого оставшегося токена, создавая стимул держать токены дольше, чем другие держатели. Коэффициент выкупа 100% означает, что все токены будут иметь равную ценность независимо от того, когда они будут выкуплены."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Целью данного цикла финансирования является 0, то есть все средства в Juicebox в настоящее время считаются переполнением. Переполнение может быть использовано держателями токенов, но не распределено."
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "Для данного цикла финансирования не определены резервные получатели токенов. Владелец проекта получит все доступные токены."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "Эти параметры могут быть изменены в любое время."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "Эти настройки <0> не <0> будут доступны для редактирования немедленно в течение цикла финансирования. Они могут быть изменены только для <1> предстоящих <1> циклов финансирования."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "Этот адрес является непризнанным стратегическим контрактом. Убедитесь, что он правильный!"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr "Этот адрес будет получать все токены, сделанные при оплате проекта получателя."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "Этот цикл финансирования может представлять риски для вкладчиков. Перед оплатой этого проекта проверьте детали цикла финансирования."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr "Этот список использует экспериментальный индекс данных и может быть неточным для некоторых проектов."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "Этот проект в настоящее время использует терминальный контракт Juicebox V1. Новые функции, представленные в версии 1.1, позволяют владельцу проекта:"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "В этом проекте используется версия V2 контрактов Juicebox."
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr ""
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Эта ставка определяет количество переполнения, за которое каждый токен может быть выкуплен в любой момент времени. При более низкой кривой связывания выкуп токена увеличивает стоимость каждого оставшегося токена, создавая стимул держать токены дольше, чем другие. Кривая облигаций, равная 100%, означает, что все токены будут иметь одинаковую ценность независимо от того, когда они будут выкуплены."
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "Это удалит все ваши изменения."
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr "Кому: <0/>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Токен"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Адрес токена: <0/>"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr "Производство токенов"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "Минтинг токенов позволяет владельцу проекта выпускать токены проекта в любое время."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "Создание токенов доступно только для проектов версии 1.1. Возможность создания токенов может быть включена или отключена путем изменения конфигурации цикла финансирования проекта."
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "Название токена"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr "Стоимость погашения токенов"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "Символ токена"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Жетоны"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr "Токены зарабатываются любым, кто оплачивает ваш проект, и могут быть обменены на реальные деньги которые находятся в излишке, если ваш проект установил цель финансирования."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "Жетоны можно обменять на часть <0>переполнения</0> проекта, что позволит вам воспользоваться его успехом. В конце концов, вы помогли ему достичь успеха. Токен также может дать вам эксклюзивные привилегии только-для-членов сообщества и позволить вам внести свой вклад в управление сообществом."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Токены могут быть выкуплены за часть переполнения ETH данного проекта в соответствии со скоростью ставки кривой связывания текущего цикла финансирования. <0> Токены сгорают, когда их выкупают.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Токены могут быть выкуплены за часть переполненного ETH данного проекта в соответствии со скоростью выкупа в текущем цикле финансирования. <0> Токены сгорают, когда их выкупают.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Токены не могут быть востребованы, поскольку для этого проекта не выпущен токен ERC-20. Токены ERC-20 должны быть выпущены владельцем проекта."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "Получатель токенов"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "Токены:"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr "Инструменты"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr "Всего средств:"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "Итого собрано"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr "Общее предложение"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr "Итого: {0}%"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "Транзакция ожидается..."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr "Передача права собственности"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "Передача невостребованного {tokenSymbolShort}"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "Перевод {tokenSymbolShort}"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "Тенденции"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr "Твиттер"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "Разархивировать проект"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Недоступно"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Несохраненные изменения"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr "Безымянный проект"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Предстоящие"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "Обновления, внесенные вами в этот раздел, будут применяться только к <0>предстоящим</0> циклам финансирования."
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr "загрузить"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "Загружено : <0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "Рекомендуется использовать продолжительность. Предоставление возможности изменения конфигурации циклов финансирования в любое время покажется вкладчикам рискованным."
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "Рекомендуется использовать стратегию реконфигурации. Проекты без стратегии покажутся участникам рискованными."
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr "V1"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr "V1.1"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "Версия терминального контракта, используемая в этом проекте."
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr "Объём"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr ""
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "Адрес кошелька"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr ""
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr "Что такое токены сообщества?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr "Какие риски?"
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr "Сколько стоит Juicebox?"
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr "Что такое переполнение или излишек финансов?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr "Что такое кривая связи?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr "Что такое дисконтная ставка?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr "Что творится под капотом?"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Если эта функция включена, владелец проекта может вручную минтить любое количество токенов на любой адрес."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "Если эта функция включена, ваш проект не сможет получать прямые платежи."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "Когда кто-то платит вашему проекту, он получает взамен токены вашего проекта. Токены могут быть обменены на часть средств вашего проекта; когда вы выигрываете, ваше сообщество выигрывает вместе с вами. Используйте токены вашего проекта для предоставления прав управления, доступа к сообществу или других привилегий для участников."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Когда допускается обработка токенов, владелец этого проекта имеет разрешение на удаление любого количества токенов на любой адрес по своему усмотрению. Это влечет за собой размытие всех текущих владельцев токенов без увеличения казначейского баланса проекта. Владелец проекта может перенастроить это вместе со всеми остальными свойствами цикла финансирования."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr "Кто финансирует проекты Juicebox?"
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "Кто такой Peel?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr "Почему Эфириум/Ethereum?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr "Почему я должен владеть токенами проекта?"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr "Будет ли работать на L2?"
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr "С помощью Juicebox проекты создаются и поддерживаются мотивированными панками, получающими оплату и финансируемыми сообществом пользователей и покровителей, которые получают вознаграждение по мере успеха проектов, которые они поддерживают."
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr "Рабочее пространство"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "Хотите ли вы выпустить токен ERC-20, который будет использоваться в качестве токена этого проекта?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Да"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Вы можете выкупить свои {tokenTextLong} для переполнения, не заявляя о них. Вы можете перевести невостребованный {tokenTextLong} на другой адрес из меню Инструменты, доступ к которому можно получить с помощью значка гаечного ключа в правом верхнем углу этого проекта."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "Вы по-прежнему можете выкупить свои {tokenSymbol} токены для переполнения, не требуя их, и вы можете перевести свои невостребованные {tokenSymbol} токены на другой адрес из меню «Инструменты», доступ к которому можно получить с помощью значка гаечного ключа в правом верхнем углу этого проекта."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "У вас нет продолжительности цикла финансирования. Внесенные вами изменения вступят в силу немедленно."
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Вы не владеете токенами ни для одного проекта Juicebox."
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Вы установили цель цикла финансирования."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr ""
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "Вы еще не создали ни одного проекта."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "Вы получите {0}{1} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "Вы получите {minReturnedTokensFormatted} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Вы сможете выпускать ERC-20 токены после того, как ваш контракт по проекту будет установлен. До тех пор протокол будет отслеживать балансы токенов, позволяя вашим сторонникам заработать токены и использовать их для переполнения."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Ваш баланс"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "Ваш новый адрес для оплаты:"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr "Ваш проект не может получать прямые платежи в то время как он приостановлен."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr "Ваш проект финансируется через циклы финансирования. Цикл финансирования имеет цель финансирования и продолжительность. Конфигурация цикла финансирования вашего проекта будет зависеть от типа проекта, который вы начинаете."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "Ваш проект сразу станет активным в приложении juicebox.money. Пожалуйста, дайте несколько дней, чтобы он появился в списке \"активных\" проектов на странице Проекты."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr "Цель и продолжительность цикла финансирования вашего проекта."
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "Ваша транзакция была отправлена и ожидает подтверждения."
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "Ваш невостребованный {tokenTextLong}"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr ""
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "после  {0}% комиссии JBX"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr "дней"
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr "никнейм"
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "часы"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "последние {trendingWindowDays} дней"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "загрузка"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "заблокировано до {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "соответствие с\"{searchText}\""
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "минуты"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "или <0><1>купить {tokenText} на бирже <2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "проект"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "владелец проекта"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "проекты"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "секунды"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "токен"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "токены"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr "погашенных токенов"
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr "до"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "{0} после комиссии JBX"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr "{0} лет назад"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{0} распределяются среди всех, кто платит этому проекту. Если проект установил цель финансирования, токены могут быть выкуплены за часть переполнения проекта независимо от того, были ли они еще востребованы."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr "{0} баланс"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} баланс: <0><1>{1} {tokensTextShort}</1><2>({share}% от предложения)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr "{0} дней"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr "{0} для вас"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr "{0} держатели"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr "{0} зарезервировано"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr "{0} всего"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "{0} снято"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr "{0}% от поставки"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr "{0}% до <0/>"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr "{0}% к {1}"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "{0}{1} снято"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr "Итого {количество}"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} не имеет пула ликвидности для {tokenSymbol}."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "{formattedTimeLeft} осталось"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "{formattedTimeLeft} до #{0}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr ""
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{название}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} зарезервировано) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# платеж} other {# платежи}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC20 адрес"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "Обменный курс {tokenSymbol}/ETH на {exchangeName}."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "{tokenTextSingular} получатели"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} распространяются среди всех, кто оплачивает этот проект. Если проектустановил целевой показатель финансирования, токены могут быть выкуплены для частипереполнения проекта независимо от того, были ли они еще востребованы или нет."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "{tokensText} зарезервировано"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} количество"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "{userOwnershipPercentage}% от общего объема предложения"
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -18,4441 +18,3051 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "(%{0})"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "(tüm yeni basılmış token'ların %{realTokenAllocationPercent} kadarı)."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "%0 ücret"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 yıl"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. Proje ayrıntıları"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr "%100 taşma"
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. Finansman döngüsü"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 saat"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr "3 günlük gecikme"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. İncele ve Başlat"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 gün"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 gün"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr "7 günlük gecikme"
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 gün"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr "<0/> Arşivlenen projeler blok zincirinde değiştirilmemiştir veya silinmemiştir ve yine de doğrudan Juicebox sözleşmeleri aracılığıyla etkileşime girilebilir."
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr ""
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr "<0/> sahip bakiyesi"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "%{feePercentage} JBX üyelik ücretinden sonra kalan <0/>{0}"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} dağıtıldı"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "%{feePercentage} JBX ücretinden sonra dağıtılan net <0><1/>{netDistributionAmount}</0>"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1>Bu projede taşma bulunmadığından</1> token'ları yakma karşılığında ETH almayacaksınız.</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr "<0>Bir bağlılık eğrisi, token'larınızı taşma için kullanmak üzere daha uzun süre bekleyen kişileri ödüllendirir.</0><1>Örneğin, %70'lik bir bağlılık eğrisiyle, herhangi bir zamanda token arzının %10'unu kullanmak, toplam taşma miktarının yaklaşık %7'sini talep edecektir.</1><2> Geri kalan, token sahipleri arasında paylaşılmak üzere bırakılır.</2>,<3>Daha fazla bilgi için, bağlılık eğrisi ile ilgili bu <4>kısa videoyu</4> izleyin.</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr "<0>Juicebox gibi, önceden verilen finansal taahhütlerin zaman içinde yerine getirilmesi gereken bir mekanizma, yalnızca Ethereum gibi bir ekosistem içinde garanti edilebilir.</0><1>Ethereum, Juicebox gibi internet uygulamalarının izne veya güvene dayalı olmadan çalışabileceği, durdurulamaz ve herkese açık bir ortam sağlar.</1><2>Bunun anlamı herkesin kullanılan kodu görebileceği, herkesin izin istemeden kodu kullanabileceği ve hiç kimsenin koda müdahale edemeyeceği veya kaldıramayacağıdır. </2><3>Juicebox'ı kullanan kişiler, herkese açık bir altyapı aracılığıyla birbirleriyle etkileşime girer. Borsaya aracılık eden özel, kâr amaçlı kurumsal bir hizmet aracılığıyla değil.</3><4>Juicebox, insanların ve projelerin herkese açık sanat ve altyapı yaratmak için çalışırken, kurumsal amaçlar için çalıştıklarında kazanacaklarına eşit veya daha fazla kazanmalarını sağlayabilmek için inşa edildi. Artık karanlık işlere yer yok.</4>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr "<0>Bir proje, token'ların bir yüzdesini kendisi için rezerve etmeyi seçebilir. Bu token yüzdesi, ödeme yapan kullanıcılara dağıtılmak yerine proje için basılır.</0><1>Bu token'ları tutmak, projeye kendi taşma payının bir kısmını alma hakkı verir.</1>"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr "<0>İndirim oranı</0>, her finansman döngüsünde projenizin token çıkarma oranını (ETH başına token) azaltmak için kullanılır."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr "<0>Projenizin sürdürülebilir kalmasını sağlamak için belirli bir sürede ne kadar finansmana ihtiyacınız olduğunu biliyorsanız bu miktarı içeren bir finansman hedefi oluşturabilirsiniz. Projeniz bu miktardan fazla kazanırsa artan miktar bir taşma havuzuna aktarılır. Projenizin token'larına sahip olan herkes, token'larını kullanarak taşma havuzunun bir kısmını talep edebilir. </0><1>Daha fazla bilgi için bu <2>kısa videoya</2> göz atın.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr "<0>Juicebox, yönetişim açısından minimal bir protokoldür. Ayarlanabilecek yalnızca birkaç seçenek vardır ve bunların hiçbirinde değişiklikler kullanıcıların rızası olmadan uygulanmaz. Juicebox yönetişim akıllı sözleşmesi bu seçenekleri ayarlayabilir.</0><1>Juicebox protokolü, tekliflere iki haftada bir oy veren JBX token sahiplerinden oluşan bir topluluk tarafından yönetilir.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr "<0>Juicebox, Ethereum üzerinde Juicebox'ın kendisi kullanılarak finanse edilen açık bir protokoldür. Sözleşmeye dayalı bütçe spesifikasyonlarına <1>buradan</1> göz atabilirsiniz.</0><2>Juicebox üzerine inşa edilen projeler, çekilen fonlardan JuiceboxDAO hazinesine %{JB_FEE} JBX üyelik ücreti öder. Projeler daha sonra JBX'lerini JuiceboxDAO ve kolektif hazinesinin yönetimine katılmak ve büyüyen <3>taşma</3> oranından talep etmek için kullanabilirler. Bu ücret de JBX üyelerinin oylarıyla değişime açıktır.</2>"
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "Token yakma hakkında <0>daha fazla bilgi edinin</0>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "Finansman döngü süresi hakkında <0>daha fazla bilgi edinin</0>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr "Finansman döngüleri hakkında <0>daha fazla bilgi edinin</0>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr "Taşma hakkında <0>daha fazla bilgi edinin</0>."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>NOT:</0> Bu projenin bakiyesi 0. Projeler bakiye olmadan taşınamaz. Bu projeyi taşımak için önce ödemesini yapın veya 1 wei (0.00000000000000001 veya 10<1>-18</1> ETH) yatırmak için aşağıdaki butonu kullanın."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0>Süre ayarlanmadı.</0>Finansman herhangi bir zamanda yeniden yapılandırılabilir. Yeniden yapılandırmalar yeni bir finansman döngüsü başlatır."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0>Not:</0> Bu özellikler, bir finansman döngüsü içinde doğrudan <1>düzenlenemez</1>. Özellikler yalnızca <2>yaklaşan</2> finansman döngüleri için değiştirilebilir."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>Not:</0> Bu proje için herhangi bir ERC-20 token'ı çıkarılmadığından token'lar talep edilemez. ERC-20 token'ları proje sahibi tarafından çıkarılmalıdır."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr "<0>Daha düşük bir kullanım oranında, bir token'ı kullanmak, kalan her bir token'ın değerini artırır ve token'ları diğerlerinden daha uzun süre tutmak için bir teşvik yaratır.</0> <1>%100'lük bir kullanım oranı, ne zaman kullanıldıklarına bakılmaksızın tüm token'ların eşit değere sahip olacağı anlamına gelir.</1>Bu <2>kısa video</2> ile daha fazla bilgi edinin."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0>, juicebox.money kullanıcı arayüzünü yöneten DAO'dur. Peel'e <1>Peel Discord</1> veya <2>Juicebox Discord</2> aracılığıyla ulaşabilirsiniz."
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr "<0>Yinelenen finansman döngüleri</0>. Örneğin, her hafta projenizin hazinesinden fon dağıtılması."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>Hedef 0.</0> Projenin tüm bakiyesi taşma olarak kabul edilecektir. Taşma hakkında <1>daha fazla bilgi edinin</1>."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr "<0>Plan bu, ancak temel Juicebox sözleşmeleri önce Ethereum Mainnet'te devreye alınacak.</0><1>Sözleşme ekibi yakında Juicebox projeleri için L2 ödeme terminalleri üzerinde çalışmaya başlayacak.</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr "<0>Sözleşmelerdeki her işlevin her koşulu için yazılmış birim testleri ve protokolün desteklediği her iş akışı için entegrasyon testleri vardır.</0><1>Ayrıca entegrasyon testlerini bir rastgele giriş üreteci kullanarak yinelemeli olarak çalıştırmak için yazılmış, uç durumlara öncelik veren bir komut dosyası da vardı. Kod, bu stres testi komut dosyası aracılığıyla 1 milyondan fazla test senaryosunu başarıyla geçti.</1> <2>Kod, topluluğun güvenini artırmak için her zaman daha fazla göz ve daha fazla eleştiriden faydalanabilir. <3>Discord</3>'umuza katılın ve bizimle çalışmak için <4>GitHub</4>'daki kodu inceleyin.</2>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0>Bu projede taşma bulunmadığından</0> token'ları yakma karşılığında ETH almayacaksınız."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr "<0>Bu web sitesi (juicebox.money), Ethereum ağında devreye alınmış Juicebox protokolünün akıllı sözleşmelerine bağlanır. (Not: Aynı akıllı sözleşmelere bağlanan bir web sitesini herkes yapabilir. Şimdilik, Juicebox protokolüne erişmek için bu siteden başka hiçbir siteye güvenmeyin).</0><1>Bir Juicebox projesi oluşturmak, size proje üzerindeki mülkiyeti temsil eden bir NFT (ERC-721) basar. Bu NFT'ye sahip olan herkes, oyunun kurallarını ve ödemelerin nasıl dağıtılacağını yapılandırabilir.</1><2>Projenin alınan bir ödeme sonucunda basılan ve dağıtılan token'ları ERC-20 token'lardır. Basılan ve dağıtılan token'ların miktarı, alınan ödemelerin hacmiyle orantılıdır ve projenin zaman içindeki indirim oranıyla ağırlıklandırılır.</2>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "1 ETH katkı karşılığında <0>basılan toplam proje token'ı miktarı</0>. Bu miktar, gelecekteki finansman döngülerinin indirim oranına ve rezerv token miktarına göre zaman içinde değişebilir."
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr "<0>Kullanıcılar, uygulamanızı veya hizmetinizi kullanmak için ödeme yaparak veya bir kullanıcı ya da yatırımcı olarak doğrudan projenizin akıllı sözleşmesine (bu uygulamadaki gibi) ödeme yaparak projenizi finanse eder.</0><1>Uygulamanız aracılığıyla ödeme yapan kullanıcıların karşılığında token almaları için bu fonları Juicebox akıllı sözleşmeleri aracılığıyla yönlendirmelisiniz.</1>"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>Hak talebinde bulunulmamış {tokenSymbol} token'larınız:</0> {0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} ERC-20 adresi:</0> <1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr "@"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "Bir proje sahibi tarafından proje sayfasındaki araçlar menüsünden arşivlenebilir."
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Bir proje, aldığı ödemelerden basılan token'ların belirli bir yüzdesini rezerve edebilir. Rezerve token'lar, herhangi bir zamanda aşağıdaki tahsise göre dağıtılabilir."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "Bir proje, aldığı her ödemeden basılan token'ların belirli bir yüzdesini rezerve edebilir. Rezerve token'lar, herhangi bir zamanda aşağıdaki tahsise göre dağıtılabilir."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr ""
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "Bir projenin ömrü, finansman döngülerinde tanımlanır. Bir finansman hedefi belirlenirse proje döngü süresince hedeften fazlasını çekemez."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr "Yaklaşan bir finansman döngüsü için yeniden yapılandırma, döngü başlamadan en az 3 gün önce sunulmalıdır."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr "Yaklaşan bir finansman döngüsü için yeniden yapılandırma, döngü başlamadan en az 7 gün önce sunulmalıdır."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "%90'ın üzerindeki rezerv oranları, katkıda bulunanlar için risklidir. Katkıda bulunanlar, katkıları karşılığında çok fazla token almazlar."
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr ""
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "ARŞİVLENDİ"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr "MEVCUT"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr "Etkinlik"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "Ödeme ekle"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr "Bu projenin bakiyesine token basmadan fon ekleyin."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr "Resim ekle"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr "Yeni ödeme ekle"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "Ödeme ekle"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr "Bakiyeye Ekle"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr "Bakiyeye ekle"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr "Token tahsisi ekle"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr "Adres"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "Adres:"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "Adres: <0/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "Projenize gelecek ödemeler için teşvikleri ayarlayın."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "Hepsi"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr "Tüm varlıklar"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "Tüm etkinlikler"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr "Tüm fonlar proje tarafından dağıtılabilir ve projede taşma olmaz. (Hedefi sonsuza ayarlamakla aynıdır.)."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr "Hazine tarafından alınan tüm fonlar dağıtılacaktır. Token sahipleri, token'larını yakarken <0>hiç ETH</0> almayacaktır."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr "Tüm {0} proje sahibine gidecek:"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "Projenizin rezerve token'larının bir kısmını diğer Ethereum cüzdanlarına veya Juicebox projelerine tahsis edin."
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr "Token'ların basılmasına izin verin"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "Token basmaya izin ver"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "İzin verildi"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr "Neredeyse kesinlikle."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "Miktar"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "Talep edilecek ERC-20 token miktarı"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr "1 ETH katkı karşılığında <0>proje için rezerve edilmiş</0> yeni basılan proje token'larının miktarı. Rezerve token'lar varsayılan olarak proje sahibi için rezerve edilmiş olsa da proje sahibi tarafından diğer cüzdan adreslerine de tahsis edilebilir."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr "1 ETH katkı karşılığında <0>proje için rezerve edilmiş</0> yeni basılan proje token'larının miktarı. Varsayılan olarak tüm rezerve token'lar proje sahibine tahsis edilmiştir ancak diğer cüzdan adreslerine de tahsis edilebilir."
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr "Ödenen miktar"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "Dağıtılacak miktar"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr "Miktar:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr "Miktarlar"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "Yaptığınız tüm değişiklikler <0>finansman döngüsü #{0}</0> içinde geçerli olacaktır. Mevcut finansman döngüsü (#{currentFCNumber}) değiştirilmeyecektir."
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr "Yaklaşan bir finansman döngüsüne yönelik herhangi bir yeniden yapılandırma, mevcut döngü sona erdiğinde yürürlüğe girecektir. Stratejisi olmayan bir proje, sahibi tarafından e-dolanrıcılığa karşı savunmasız olabilir."
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "Projeyi arşivle"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "Arşivlendi"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "Baştan başlamak istediğinizden emin misiniz?"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr "Finansman döngülerini otomatikleştir"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr "Otomatikleştirilen finansman döngüleri aşağıdaki özellikleri sağlar:"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr "Ücretten sonra kullanılabilir:"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "Mevcut fonlar aşağıdaki ödemelere göre dağıtılır."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr "Mevcut fonlar aşağıdaki ödemelere göre dağıtılabilir{0}."
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr "Mevcut:"
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "Başa dön"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "Bakiye aşıldı"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "Proje sahibinin cüzdan bakiyesi."
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "Faydalanıcı"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "Faydalanıcı adresi"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr "Juicebox'ı mümkün kılan altyapı ve ekonomiyi hazırladığı için Ethereum topluluğuna selamlar."
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "Blok numarası"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "Şunlar için üretildi:"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "Proje token'larını yakın"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "{tokensLabel} token'larınızı yakın. Karşılığında ETH almayacaksınız çünkü bu projede taşma bulunmuyor."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "{0} adet {tokensTextShort} token'ını yak"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "{tokensLabel} token'larını yak"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "{tokensTextLong} yak"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "Aksi istenmediği takdirde, tahsis edilmemiş bütün fonlar proje sahibinin cüzdanına dağıtılabilir."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "Varsayılan olarak, yeni basılan token'lar, adrese fon gönderen cüzdana gider. Token faydalanıcısını özel bir adres olarak belirlemek için bunu etkinleştirebilirsiniz."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "Projemin sözleşmesini oluşturulduktan sonra değiştirebilir miyim?"
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr "Bir projeyi silebilir miyim?"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "Bu projede taşma bulunmadığından ETH için token talep edilemez."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "Proje detaylarında yapılan değişiklikler hemen etkili olacaktır."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "Bu özellikler üzerinde herhangi bir zamanda değişiklik yapılabilir ve projenize hemen uygulanacaktır."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr "Projenizin finansman yapılandırmasında yapılan değişikliklerin yürürlüğe girmesi için topluluk tarafından onaylanmış bir süre gerekir ve bu, dolandırıcılıklara karşı bir koruma görevi görür. Destekçileriniz size güvenmek zorunda değil - zaten güveniyor olsalar bile."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr "Değişiklikler, projenin özel oylama sözleşmesine göre yürürlüğe girecektir."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "Yaptığınız değişiklikler, <0>{0}</0> yeniden yapılandırma kuralınıza göre geçerlilik kazanacaktır (şu andan itibaren <1>{1}</1>'den sonraki ilk finansman döngüsü)."
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "Cüzdanınıza {tokenSymbol} ERC-20 basmak için burayı işaretleyin. Token bakiyenizin Juicebox tarafından takip edilmesini sağlamak için işaretlemeden bırakın ve bu işlemde gazdan tasarruf edin. ERC-20 token'larınızı daha sonra her zaman talep edebilirsiniz."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr "Ödemelerinizi nasıl yapılandırmak istediğinizi seçin."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr "{tokenTextPlural} token'ları talep et"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr "{tokenTextPlural} token'ları ERC-20 olarak talep et"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "{tokenTextShort} Talep et"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "{tokenTextShort} token'ları ERC-20 olarak talep et"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "{tokensLabel} token'larını ERC-20 olarak talep edin"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "{tokenSymbol} token'larını talep etmek, {tokenSymbol} bakiyenizi ERC-20 token'larına dönüştürecek ve bunları cüzdanınıza basacaktır."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "{tokenTextLong} token'larınızı talep etmeniz, {tokenTextShort} bakiyenizi ERC-20 token'larına dönüştürecek ve bunları cüzdanınıza basacaktır."
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "Kapat"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr "Kapat, bunları daha sonra yapacağım"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "Gelirinizin bir kısmını, desteklemek istediğiniz kişilere veya projelere veya ödeme yapmak istediğiniz katkıda bulunanlara gitmesi için taahhüt edin. Siz ödeme aldığınızda, onlar da alsın."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "Projenizin nasıl fon toplayacağını ve harcayacağını yapılandırın."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "Finansman döngüleriniz için kısıtlamaları yapılandırın."
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "Proje token'ınızın dinamiklerini yapılandırın."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr "Projenizi başlattığınız için tebrikler! Sonraki adımlar isteğe bağlıdır ve daha sonra tamamlanabilir."
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr "Cüzdan bağla"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr "Talep etmek için cüzdanınızı bağlayın"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "Başlatmak için cüzdanınızı bağlayın"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr "Dağıtmak için cüzdanınızı bağlayın"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr "Token çıkarmak için cüzdanınızı bağlayın"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "Ödemek için cüzdanınızı bağlayın"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr "Aktarmak için cüzdanınızı bağlayın"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "Varlıklarınızı görmek için cüzdanınızı bağlayın."
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "Projelerinizi görmek için cüzdanınızı bağlayın."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "Bağlı cüzdan yetkili değil"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr "Sözleşme Adresi: {0}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr "Katkıda bulunan oranı"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "Katkıda bulunanlar, katkıda bulundukları ETH başına bu miktarda proje token'ı ile ödüllendirilecektir."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "Katkı sahipleri bu projeye ödeme karşılığında token almayacaktır."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr "Katkı sahipleri, bu finansman döngüsünde yaptıkları katkılar için bir sonraki finansman döngüsüne kıyasla <0>{discountRatePercent}%</0> oranında daha fazla token alacaktır."
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "Katkı sahipleri bu projeye ödeme karşılığında token'ların nispeten küçük bir kısmını alacaktır."
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "Katkıda bulunanlar, projenize ödeme yapmadan önce bu mesajı göreceklerdir."
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr "Kopyalandı!"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr "Bir ödeme adresi oluşturun (isteğe bağlı)"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr "Projeniz için bir Ethereum adresi oluşturun. Projenizin Juicebox sayfasından geçmeden yapılacak doğrudan ödemeleri etkinleştirir."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "Projenize doğrudan ödeme yapmak için kullanılabilecek bir Ethereum adresi oluşturun."
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "Ödeme adresi oluşturun"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr ""
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "Proje oluştur"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "Projenizdeki hisseyi temsil etmek için kendi ERC-20 token'ınızı oluşturun. Katkıda bulunanlar, projenize ödeme yaptıklarında bu token'ları alacaklar."
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr "Güncel"
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "Güncel 3. Taraf Kripto Kurları"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "Güncel sahibi: {ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr "Özel strateji"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "Özel token faydalanıcısı"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr "Projenizin \"Ödeme\" butonunu özelleştirin. Varsayılanı kullanmak için boş bırakın."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "Döngü #{0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr "Koyu tema"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "Tarih"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "Oluşturma tarihi"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "Gün"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr "Ödemeyi sil"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr "Token tahsisini sil"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "Projeyi başlat"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "Projeyi {signerNetwork} üzerinde başlat"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "Projeyi {0} ağında başlat"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "Devreye alınan ERC20 token'ı"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "@{handle} hesabına 1 wei yatırın"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr "Projenizi tasarlayın"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "Detaylar"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr "Bu adrese yapılan ödemelerden token basılıp basılmayacağını belirler."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "Devre dışı"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "Finansman döngüsünün dağıtım sınırı <0>Sınırsız</0> (sonsuz) olduğunda devre dışı kalır"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "Projenizin finansman döngüsü süresi 0 (sıfır) olduğunda devre dışı kalır."
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "Projenizin finansman döngüsünün süresi olmadığında devre dışı kalır."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr "İptal Et"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr "Projenize ödeme yapmadan önce tüm ayrıntıları katkı sahiplerinize açıklayın."
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr "Bağlantıyı kes"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr "Discord"
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr "İndirim oranı"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "Bu proje sahibinin cüzdanında bulunan ERC-20 token'larını ve diğer Juicebox proje token'larını görüntüleyin."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "Uygun fonları diğer Ethereum cüzdanlarına veya Juicebox projelerine ödeme olarak dağıtın. Bunu katılımcılara, yardım kuruluşlarına, bağlı olduğunuz Juicebox projelerine veya başkalarına ödeme yapmak için kullanın. Projelerinizden para çekildiğinde fonlar dağıtılır."
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "Fonları dağıt"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "Rezerve {tokenTextPlural} token'ları dağıt"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "{tokenTextPlural} token'ları dağıt"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "{tokensText} token'ları dağıt"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr "Dağıtıldı"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "Dağıtılmış Fonlar"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr "Dağıtılmış Rezervler"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr "Dağıtılmış Token'lar"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr "Dağıtılmış fonlar"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr "Juicebox projelerine fon dağıtmak ücrete tabi değildir."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr "Dağıtım"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr "Dağıtım Sınırı <0/>:"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "Dağıtım sınırı"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "Dağıtım sınırı 0: Tüm fonlar taşma olarak kabul edilir ve token sahipleri tarafından kullanılabilir."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr "Dağıtım sınırı sonsuzdur. <0>Tüm fonların nasıl dağıtılacağını proje kontrol eder ve fonların hiçbiri, token sahipleri tarafından kullanılamaz.</0>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "Dağıtım sınırı, süre ve ödemeler"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr "Juicebox'ı iş modeli olarak kullanmak için projemi açık kaynak yapmak zorunda mıyım?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr "Dokümanlar"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "V1.1 sözleşmelerine ilişkin belgeler"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr "Bir proje kendi taşmasından faydalanır mı?"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "Tamamlandı"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "CSV'yi indirin"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "Ödemeler CSV'sini indirin"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "Proje Etkinliği CSV'sini indirin"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "{0} sahipleri CSV'sini indirin"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr "Süre"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr "Süre (saniye)"
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "ERC-20 token'ları, yalnızca bu proje için bir ERC-20 token'ı çıkarıldığında basılabilir."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "Her ödeme, finansman döngülerinin her birinde, hazinede yeterli tutar mevcutsa bu toplamdan ona ait olan yüzdeyi alacaktır. Aksi halde, hazinede bulunan tutar ne kadarsa bu tutar üzerinden yüzde alacaktır."
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr "Ödemeyi düzenle"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "Projeyi düzenle"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "Proje ayrıntılarını düzenle"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "Rezerve token tahsisini düzenle"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "Token tahsisini düzenle"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "İzlenen varlıkları düzenleyin"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr ""
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr "Etkin"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr "Bunun etkinleştirilmesi, proje sahibine, herhangi bir miktarda token'ı herhangi bir adrese manuel olarak basma izni verir."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "Bunu etkinleştirmek {tokenSymbol} ERC-20 token'ları basacaktır. Aksi takdirde, talep edilmemiş {tokenSymbol} token'ları basılacak ve bunlar, daha sonra alıcı tarafından ERC-20 olarak talep edilebilecektir."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr "Token basımının etkinleştirilmesi, katkıda bulunanlar açısından riskli görünecektir."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr "Son"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "Sahipler yüklenirken hata oluştu"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "Ödemeler yüklenirken hata oluştu"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "Projeleri keşfedin"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "SSS"
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr "SSS"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr "Proje meta verileri güncellenemedi"
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "Dosya {formattedSize}{unit} değerinden küçük olmalıdır"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr "Herhangi bir şeye fon sağlayın. Birlikte büyüyün."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "Finansman"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr "Finansman döngüsü"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "Finansman döngüsü detayları"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr "Finansman döngüsü süresi"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr "Finansman döngüsü önizlemesi"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr "Finansman döngüsü gerekli."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr "Finansman döngüsü hedefi"
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "Finansman döngüleri, katkı sahiplerini bilgilendirmeden, yeni bir döngü başlangıcından dakikalar önce yeniden yapılandırılabilir."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "Finansman dağılımı"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "Finansman hedefi"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr "Fonlar şunlara dağıtılacaktır:"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr ""
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "Geribildirim verin"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr "Etherscan'e git"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr "Tanıtıcı"
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr "Dikkat"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr "Geçmiş"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr "Sahipler"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "Token'larınız"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr "Saat"
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr "Juicebox ne kadar merkeziyetsiz?"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr "Bir projeyi nasıl arşivlerim?"
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "Nasıl proje oluştururum?"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr "Nasıl karar veririm?"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr "Kullanım oranını nasıl ayarlayabilirim?"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr "Sözleşmeler nasıl test edildi?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "Değişikliklerin yürürlüğe girmesi için bir sonraki finansman döngünüzden ne kadar önce yeniden yapılandırmanız gerektiği."
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "Bir finansman döngüsünün ne kadar süreceğini ifade eder. Finansman döngüsü <0>yeniden yapılandırmaları</0> yalnızca <1>yaklaşan</1> finansman döngüleri için, yani mevcut bir finansman döngüsü sona erdikten sonra geçerli olacaktır."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr "Projenizin rezerve token'larının %{reservedPercentage} kadarının nasıl pay edileceği."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr "Projenizin fonları nasıl dağıtacağı."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "Anladım"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr "Kimlik"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr "Kimlik: {projectId}"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Kilitliyse kilidin süresi dolana veya finansman döngüsü yeniden yapılandırılana kadar düzenlenemez veya kaldırılamaz."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "Kilitliyse, kilidin süresi dolana veya finansman döngüsü yeniden yapılandırılana kadar bu bölüm düzenlenemez veya kaldırılamaz."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr "Bu miktarı toplayamazsanız pay sahipleriniz, toplayabildiğiniz miktardan kendi yüzdelerine orantılı miktarı alacaktır."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "Ödeme adresini devreye aldığınız halde bu adresi kaybettiyseniz lütfen <0>Discord</0> aracılığıyla Juicebox ekibiyle iletişime geçin."
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "Bir proje başlatmak istiyorsanız ama hala çekinceleriniz varsa <0>bu bilgilendirici video</0>'yu izlemelisiniz. Ayrıca bize <1>Juicebox Discord</1>'u üzerinden ulaşabilirsiniz, takım arkadaşlarımız proje fikrinizi hayata geçirirken size yardımcı olmaktan mutluluk duyacaktır!"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "Hak talebinde bulunmanız gerekip gerekmediğinden emin değilseniz muhtemelen gerekli değildir."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr "Juicebox'da"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "Hazinede"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr "Cüzdanda"
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr "Teşvikler"
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr "Bağımsız yaratıcılar ve geliştiriciler"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr "Sonsuz (sınır yok)"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "İlk token çıkarma oranı"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr "İlk basım oranı"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "ERC-20 çıkart"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "ERC-20 token'ı çıkart"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "Bu projenin token'ı olarak kullanılması için bir ERC-20 token'i çıkarın. Çıkarıldıktan sonra, herkes mevcut token bakiyesini yeni token cinsinden talep edebilir."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr "Bir ERC-20 token'ı çıkarın (isteğe bağlı)"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "Token çıkar"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "Bir projenin verilerini blok zincirinden tümüyle kaldırmak mümkün olmasa da Juicebox uygulaması içinde gizleyebilir ve erişime kapatabiliriz. Bunun için bizimle <0>Discord</0> üzerinden iletişime geçmeniz yeterli. Ancak projenizin doğrudan sözleşmeye erişim aracılığıyla kullanıma açık olacağını unutmayın."
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr "Yapsan çok kıyak olur"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr "JBX Ücreti (%{0}):"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "JBX Ücreti (%{feePercentage}):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "Juicebox Proje Kimliği"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "{0} Kimlikli Juicebox V2 projesi"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Juicebox yüklenme animasyonu"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Juicebox projesi"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr "Son ödeme"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "Daha sonra"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "En son"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "Son ödemeler"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr "Finansman döngüsünü başlat"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr "Projenizi başlatın"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr "Hemen başlamak için boş bırakın."
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr "Aydınlık tema"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr "Daha fazla yükle"
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr ""
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "Kilit süresi bitiş tarihi"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "Kilitlendi:"
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr "Logo"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "MAKS"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "Yönet"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "{tokenText} token'ını yönet"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr "Maksimum {MAX_DESCRIPTION_LENGTH} karakter"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "Juicebox V1.1'e geçiş yapın"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "ERC-20 olarak bas"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "Bir hesaba yeni {tokensLabel} token'ı basın. Bir projenin token'larını sadece o prejenin sahibi, belirlenmiş bir operatör veya terminallerinden birinin delegesi basabilir."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "Talep üzerine proje token'larının basılması"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr "Basım oranı"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr "Token'ları ERC-20 olarak bas"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "Token'ları özel bir adrese basın."
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "{tokensLabel} token'larını bas"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "{tokensTokenLower} token'larını bas"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr "Dakika"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr ""
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "{tokensLabel} token'larınızı Juicebox sözleşmesinden cüzdanınıza taşıyın."
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "LİMİT YOK"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr "İsim"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "Yeni"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr "Hazineye katkıda bulundukları ETH başına, <0>katkıda bulunanlar tarafından alınan</0> yeni basılan {tokenSymbolPlural} miktarı."
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "Sonraki: Finansman döngüsü"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "Sonraki: İncele ve başlat"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "Hayır"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr "Aktif finansman döngüsü yok."
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "Henüz etkinlik yok"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "Finansman hedefi yok: Proje, tüm fonların nasıl dağıtılacağını kontrol eder ve hiçbiri token sahipleri tarafından talep edilemez."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "Hazineden para dağıtılamaz. Fonlara yalnızca token'larını kullanan token sahipleri erişebilir."
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "Limit yok (sonsuz)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr "Tek bir finansman döngüsünde proje, finansman döngüsü hedefinden daha fazlasını dağıtamaz."
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "Geçmiş finansman döngüsü yok"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr "Strateji yok"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr "Hedef yok"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr "Hedef belirlenmedi."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr "Ayarlanmadı"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "Not"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "Not: Token'lar, mevcut finansman döngüsünde izin verildiğinde manuel olarak basılabilir. İzin, sonraki döngüler için proje sahibi tarafından değiştirilebilir."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr "{0} tarafından yapılan bildirim:"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr "Bir kez başlatıldığında, ilk finansman döngünüz <0>değiştirilemez</0>. Yaklaşan finansman döngülerini projenin <1>yeniden yapılandırma kurallarına</1> göre yeniden yapılandırabilirsiniz."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "Bu projenin sahibinin cüzdanındaki diğer varlıklar."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr ""
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr "Taşma"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr "Projenizin bakiyesi finansman döngüsü hedefinizi aşarsa taşma oluşur. Taşma, projenizin token sahipleri tarafından talep edilerek kullanılabilir."
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "Proje sahibi, istediği zaman token basabilir."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "Proje sahibinin token basmasına izin verilmez."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr ""
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr ""
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr "<0/> olarak ödendi"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr "Ödemeleri duraklat"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "Alınan ödemeleri duraklat"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr "Duraklatıldı"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr "Ödeme"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr "Ödeme miktarı"
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "Ödeme tutarı 0'dan büyük olmalıdır."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr "Ödeme butonu"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr "Ödeme butonu metni"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr "Ödeme açıklaması"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr "{0} Öde"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "Ödeyen"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "<0>{0}</0> ödemek bir yatırım değil, projeyi desteklemenin bir yoludur. Aldığınız token'ların değeri veya faydası {1} tarafından belirlenir."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr "Bu projeye ödeme şu anda devredışı."
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr ""
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr "Ödeme notu görüntüsü"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr "Ödemeler"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr "Ödemeler duraklatıldı"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr "Ödeme kilitlendi"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "Ödeme alıcıları"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "Ödemeler"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "Ödemeler (isteğe bağlı)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "Ethereum adreslerine yapılan ödemeler için %{feePercentage} ücret alınır. Bunun karşılığında projeniz, mevcut token çıkarma oranında JBX alacaktır."
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "Yüzde"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr "Yüzde tahsisi"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "Yüzde:"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr "Yüzdeler"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "Yüzdelerin toplamı %100 veya daha az olmalıdır"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr "Podcast"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "Potansiyel riskler"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "Önizleme:"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr "Proje Oluşturuldu"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr "Proje kimliği bir sayı olmalıdır."
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "Proje Kimliği:"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "Proje Token'ı"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "Proje proje yapılandırması"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr "Projeyi oluşturan"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr "Proje açıklaması"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr "Proje ayrıntıları"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr "Proje detayları herhangi bir zamanda düzenlenebilir."
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "Proje detaylarını yeniden yapılandırmak, ayrı bir işlem oluşturacaktır."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr "Proje tanıtıcısı"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr "Proje tanıtıcısı eşsiz olmalıdır."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "Proje, bu finansman döngüsünde ödeme kabul ediyor."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "Proje, bu finansman döngüsünde ödeme kabul etmiyor."
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr "Proje başarıyla başlatıldı"
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr "Proje adı"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr "Proje adı, tanıtıcı, bağlantılar ve diğer ayrıntılar."
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr "Proje sahibi"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "Proje sahibi (siz)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "Proje sahipleri, bir gecikme aralığı yapılandırabilir. Bu takdirde, yaklaşan bir finansman döngüsünde yapılmak istenen değişiklikler, döngü başlangıç tarihinin belirlenen gün kadar öncesinde yapılmalıdır. Örneğin, 3 günlük bir gecikme aralığı, değişikliklerin bir sonraki finansman döngüsü başlamadan 3 gün önce yapılması gerektiği anlamına gelir. Gecikme aralığı, token sahiplerine karara tepki vermek için zaman tanır ve dolandırıcılık yapılabilme ihtimalini düşürür."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "Proje token'ı"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr ""
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "{name} yakında burada olacak! Kısa bir süre sonra sayfayı yenilemeyi deneyin."
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr "{projectId} projesi"
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "Proje {projectId} bulunamadı"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr "Projeler"
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "Projeler, isteğe bağlı olarak, erken destekçileri teşvik etmek için tasarlanmış bir indirim oranı ile oluşturulabilir. Projenize ödenen Eth başına ödüllendilen token miktarı, her yeni finansman döngüsünde iskonto oranı kadar azalacaktır. Yüksek bir indirim oranı, destekçileri projenizi daha erken desteklemeye teşvik edecektir."
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr "Juicebox'taki projeler"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "Oluşturduğunuz projeler."
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "Token'larını tuttuğunuz projeler."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "%{reservedRateRiskyMin} veya daha fazla rezerve oranı kullanan projeler, projenize ödeme yapılması karşılığında nispeten az sayıda token alınacağından, katkıda bulunanlar açısından riskli görünecektir."
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "Katkı sayısına ve son {trendingWindow} gün içinde kazanılan hacme dayalı sıralamalar. <0>Kodu gör</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr ""
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "ERC-20 al"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "{receiveText} alın"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr "Alıcı"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "Alıcılar ödemeleri ETH olarak alacaktır."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr "Yeniden yapılandırma"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "Yeniden yapılandırma kuralları"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "Yeniden yapılandırma stratejisi"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "Yeniden yapılandır"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr "Proje ve finansman ayrıntılarını yeniden yapılandırın"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "Proje detaylarını yeniden yapılandır"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "Token'ı yeniden yapılandırın"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "Yaklaşanları yeniden yapılandır"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "Yaklaşan finansman döngülerini yeniden yapılandır"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "{tokensLabel} token'larınızı, projenin taşmasının bir kısmını talep etmek için kullanın. Kullanılan her {tokensLabel} token'ı yakılacaktır."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "{0} adet {tokensTextShort} token'ı ETH için kullan"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "{tokensLabel} token'larını ETH için kullan"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "{tokensTextLong} token'larını ETH için kullan"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "Kullanılan"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "Kullanım oranı"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "Kullanım oranı: <0>%{0}</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "Yenile"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr "Finansman döngünüzü yeni Juicebox V2 sözleşmelerinde yeniden başlatın."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "Gerekli"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr "Projenizin kullanması için yeni basılmış token'ların bir yüzdesini rezerve edin."
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "Rezerve oranı"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "Rezerve oranı %0 ancak rezerve token tahsisi mevcut. Sıfırdan büyük bir rezerve oranı eklemeyi veya token tahsisini kaldırmayı düşünün."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr "Rezerve token tahsisi"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "Rezerve token tahsisi (isteğe bağlı)"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr "Rezerve token tahsisleri"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr "Rezerve token'lar"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr "Rezerve {0}"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "Rezerve {tokenSymbolPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "Rezerve {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "Rezerve {tokensText}"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "Kaynaklar"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "Ödemeleri ve token basımını kısıtlayın."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr "Kısıtlanmış eylemler"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr "İncele ve Dağıt"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr "Finansman döngüsünü gözden geçirin ve başlatın"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr "Projeyi gözden geçir"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr "Belirli topluluk üyelerini token'larla ödüllendirin."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr "Kurallar"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "Finansman döngülerinin nasıl yeniden yapılandırılabileceğini belirleyen kurallar"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr "Projenizde nasıl değişiklik yapılabileceğine ilişkin kurallar."
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr "Bu projenin finansman döngülerinin nasıl yeniden yapılandırılabileceğine ilişkin kurallar."
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "Değişiklikleri kaydet"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr "Finansman yapılandırmasını kaydet"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "Tanıtıcıyı kaydet"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr "Ödemeyi kaydet"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "Ödemeleri kaydet"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr "Proje ayrıntılarını kaydet"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr "Yeniden yapılandırmayı kaydet"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "Kuralları kaydet"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "Token tahsisini kaydet"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "Token yapılandırmasını kaydet"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "İzlenen varlıkları kaydet"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr "Tanıtıcıya göre proje ara"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr "Saniye"
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "İşlemi gör"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr "Bir dağıtım sınırı belirleyin"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr "Bir finansman döngüsü süresi belirleyin"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr "Bir finansman döngüsü hedefi belirleyin"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr "Her finansman döngüsünde toplamak istediğiniz fon miktarını belirleyin. Finansman döngüsü hedefi dahilinde toplanan fonlar proje tarafından dağıtılabilir ve projenizin token sahipleri tarafından talep edilemez."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr "Finansman döngülerinizin süresini belirleyin."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr "Bunu tüm ödemelerinizin toplamı olarak ayarlayın"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr "Juicebox’a katılmalı mısın?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "Bir finansman süresi belirlemediğiniz için bu ayarlarda yapılan değişiklikler hemen uygulanacaktır."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr ""
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "Bir şeyler yanlış gitti."
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr "Harcama"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr "Başlangıç"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr "Baştan Başla"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr "Başlangıç zamanı (saniye, Unix zamanı)"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "Yüzdelerin toplamı %100'ü aşamaz"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "Yüzdelerin toplamı %100'ü aşamaz."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr "Hedef"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "Hedef 0: Tüm fonlar taşma olarak kabul edilecek ve proje token'ları yakılarak kullanılabilecektir."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr "<0>Token çıkarma oranı</0>, ikinci finansman döngünüz için <1>1 ETH başına {0} token</1>, üçüncü finansman döngünüz için <2>1 ETH başına {1} token</2> olacak ve bu şekilde ilerleyecektir."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr "JBX protokolü denetlenmez ve bunun üzerine inşa edilen projeler hatalara veya açıklardan yararlanmaya karşı savunmasız olabilir. Dikkatli olunmalıdır!"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "{0} üzerinde devreye alınan ve <0>bu arayüzü</0> kullanan herhangi bir akıllı sözleşmenin adresi."
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr "Bu projeye ödeme yaparak basılan token'ları alması gereken adres."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "Bu projenin sahip olduğu rezerve token miktarı. Bu token'lar, rezerve token faydalanıcılarına dağıtılabilir."
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "Alıcıya basılacak token miktarı."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "Mevcut dağıtım limitinin dışında, bu finansman döngüsünde Juicebox bakiyesinden dağıtılan miktar. Tek bir finansman döngüsünde dağıtım limitinden fazlası dağıtılamaz; Juicebox'ta kalan tüm ETH, bir sonraki döngü başlayana kadar taşma olarak kabul edilir."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "Mevcut finansman hedefinin dışında, bu finansman döngüsünde Juicebox bakiyesinden dağıtılan miktar. Tek bir finansman döngüsünde finansman hedefinden daha fazlası dağıtılamaz; Juicebox'ta kalan ETH, bir sonraki döngü başlayana kadar taşma durumundadır."
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "Proje sahibinin cüzdan bakiyesi."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "Bu projenin Juicebox sözleşmesindeki bakiyesi."
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Bu finansman döngüsü için dağıtım limiti 0'dır, yani Juicebox'taki tüm fonlar şu anda taşma olarak kabul edilir. Taşma, token sahipleri tarafından kullanılabilir, ancak dağıtılamaz."
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "Gelecek, içerik üreticileri tarafından yönetilecek ve topluluklara ait olacak."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "Her finansman döngüsünde projenin hazinesinden dağıtılmasına izin verilen maksimum fon miktarı."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr "Her finansman döngüsünde hazineden dağıtılabilecek maksimum fon miktarı."
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "Bir finansman döngüsü içinde bu projeden dağıtılabilecek maksimum fon miktarı. Fonlar, hangi para birimini seçerseniz seçin ETH olarak çekilecektir."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr "İlk finansman döngüsüne 1 ETH katkıda bulunulduğunda basılan proje token'larının sayısı."
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "1 ETH katkıda bulunulduğunda basılan proje token'larının sayısı."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "Bu kişinin toplam %{reservedRate} rezerve token tahsisinden aldığı yüzde"
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "Proje sahibi, herhangi bir zamanda herhangi bir miktarda token basarak tüm mevcut katkı sahiplerinin token payını azaltabilir."
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "Proje sahibi, bu finansman döngüsünü, herhangi bir zamanda, bildirimde bulunmadan yeniden yapılandırabilir."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr "Proje token'ı çıkarma oranı, her finansman döngüsünde bu yüzde oranında azalacaktır. Daha yüksek bir indirim oranı, katkıda bulunanları projeye daha erken ödeme yapmaya teşvik edecektir."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr "Ödeme tutarı başına verilen token'ların oranı, her yeni finansman döngüsünde bu yüzde oranında azalacaktır. Daha yüksek bir indirim oranı, destekçileri projenizi daha erken ödemeye teşvik edecektir."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Kullanım oranı, her token'ın herhangi bir zamanda kullanılabilecek taşma miktarını belirler. Daha düşük bir kullanım oranında, bir token kullanmak, kalan her bir token'ın değerini artırır ve token'ları diğer sahiplerden daha uzun süre tutmak için bir teşvik yaratır. %100'lük bir kullanım oranı, ne zaman kullanıldıklarına bakılmaksızın tüm token'ların eşit değere sahip olacağı anlamına gelir."
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr "Kullanım oranı, her token'ın kullanıldığında alabileceği taşma miktarını belirler."
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "Bu finansman döngüsü için hedef 0'dır, yani Juicebox'taki tüm fonlar şu anda taşma olarak kabul edilir. Taşma, token sahipleri tarafından talep edilerek kullanılabilir, ancak dağıtılamaz."
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr "Bu Juicebox projesinin oluşturulduğundan beri aldığı toplam fon."
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr "Bu finansman döngüsü için tanımlanmış ödeme bulunmamaktadır. Proje sahibi mevcut tüm fonları alacaktır."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "Bu finansman döngüsü için tanımlanmış rezerve token bulunmamaktadır. Proje sahibi mevcut tüm token'ları alacaktır."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "Bu nitelikler herhangi bir zamanda değiştirilebilir."
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "Bu ayarlar, bir finansman döngüsü içinde hemen <0>düzenlenemez</0>. Yalnızca <1>yaklaşan</1> finansman döngüleri için değiştirilebilirler."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "Bu adres, tanınmayan bir strateji sözleşmesine aittir. Doğru olduğundan emin olun!"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr "Bu adres, alıcı projeye ödeme yapıldığında basılan tüm token'ları alacaktır."
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr "Bu adres, bu projeyi ödeyerek basılan token'ları alacaktır."
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "Bu finansman döngüsü katkı sahipleri için risk oluşturabilir. Bu projeye ödeme yapmadan önce finansman döngüsü detaylarını kontrol edin."
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr "Her finansman döngüsünde hazineden dağıtılabilecek maksimum fon miktarı."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr "Bu liste deneysel bir veri dizini kullanıyor ve bazı projeler için doğru olmayabilir."
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr "Bu proje arşivlendi ve ödeme yapılamaz."
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "Bu proje şu anda Juicebox V1 terminal sözleşmesini kullanıyor. V1.1'de tanıtılan yeni özellikler, proje sahibinin şunları yapmasına olanak tanır:"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "Bu proje, Juicebox sözleşmelerinin V2 sürümünü kullanır."
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr "Bu projenin Juicebox sözleşmesindeki bakiyesi."
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "Bu oran, her token'ın herhangi bir zamanda kullanılabilecek taşma miktarını belirler. Daha düşük bir bağlılık eğrisinde, bir token'ı kullanmak, kalan her bir token'ın değerini artırır ve token'ları diğerlerinden daha uzun süre tutmak için bir teşvik yaratır. %100'lük bir bağlılık eğrisi, ne zaman kullanıldıklarına bakılmaksızın tüm token'ların eşit değere sahip olacağı anlamına gelir."
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "Yaptığınız tüm değişiklikler silinecektir."
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr "Kime: <0/>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "Token"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "Token adresi: <0/>"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr "Token faydalanıcısı adresi"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr "Token faydalanıcısı:"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr "Token sahipleri, kullanım oranı 0 olduğunda, herhangi bir miktar ETH karşılığında <0>token'larını kullanamaz</0>."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr "Token basımı"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "Token basımı, proje sahibinin herhangi bir zamanda proje token'larını basmasına olanak tanır."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr "Token basımı etkinleştirildi"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "Token basma seçeneği yalnızca V1.1 projelerinde kullanılabilir. Token basma seçeneği, projenin finansman döngüsü yeniden yapılandırılarak etkinleştirilebilir veya devre dışı bırakılabilir."
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "Token adı"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr "Token adı gerekli"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr "Token kullanma değeri"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "Token sembolü"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr "Token sembolü gerekli"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "Token'lar"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr "1 ETH katkıda bulunduklarında <0>katkıda bulunanların alacağı</0> token'lar."
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr "1 ETH katkıda bulunulduğunda <0>proje için rezerve edilen</0> token miktarı."
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr "Token'lar, projenize ödeme yapan herkes tarafından kazanılır ve projenizde bir finansman hedefi belirlendiyse taşma için kullanılabilir."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "Token'lar, bir projenin <0>taşmasının</0> bir kısmı için kullanılarak projenin başarısından yararlanmanıza izin verir. Sonuçta, oraya ulaşmasına yardım eden sizsiniz. Token'lar, size yalnızca üyelere özel ayrıcalıklar tanıyarak topluluk yönetişimine katkıda bulunmanıza olanak da tanıyabilir."
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Token'lar, mevcut finansman döngüsünün bağlılık eğrisi oranına göre bu projenin ETH taşmasının bir kısmı için kullanılabilir. <0>Token'lar, kullanıldıklarında yakılır.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "Token'lar, mevcut finansman döngüsünün kullanım oranına göre bu projenin ETH taşmasının bir kısmı için kullanılabilir. <0>Token'lar, kullanıldıklarında yakılır.</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "Bu proje için herhangi bir ERC-20 token'ı çıkarılmamış olduğundan token'lar talep edilemez. ERC-20 token'ları proje sahibi tarafından çıkarılmalıdır."
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "Token alıcısı"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "Token'lar:"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr "Araçlar"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr "Toplam fon:"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "Toplanan yekün"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr "Toplam arz"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr "Toplam: %{0}"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr "İşlem başarısız"
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "İşlem beklemede..."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr "İşlem başarısız"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr "Mülkiyeti aktar"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "Talep edilmemiş {tokenSymbolShort} token'larını aktar"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "{tokenSymbolShort} token'larını aktar"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "Çok konuşulanlar"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr "Twitter tanıtıcısı"
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "Projeyi arşivden kaldır"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "Mevcut değil"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "Kaydedilmeyen değişiklikler"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr "İsimsiz proje"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "Yaklaşan"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "Bu bölümde yaptığınız güncellemeler yalnızca <0>gelecek</0> finansman döngülerine uygulanacaktır."
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr "Yükle"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "Şuraya yüklendi: <0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr "Bir <0>dağıtım sınırı</0> yapılandırmak istediğinizde <1>Tutarlar</1>'ı kullanın. Dağıtım sınırını aşan hazine fonlarına <2>taşma</2> denir. Token sahipleri, taşmanın bir kısmı için token'larını kullanabilir (yakabilir). <3>Daha fazla bilgi edinin</3>."
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr "Bir <0>sonsuz dağıtım sınırı</0> yapılandırmak istediğinizde <1>Yüzdeler</1>'i kullanın. Sonsuz dağıtım sınırı ile projeniz tüm fonları kendisine rezerve eder. Projenizde taşma olmayacağı için token'lar ETH karşılığında kesinlikle kullanılamacaktır. <2>Daha fazla bilgi edinin</2>."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "Bir süre kullanılması önerilir. Finansman döngülerinin herhangi bir zamanda yeniden yapılandırılmasına izin vermek, katkıda bulunanlar açısından riskli görünecektir."
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "Yeniden yapılandırma stratejisi kullanılması önerilir. Stratejisi olmayan projeler, katkıda bulunanlar açısından riskli görünecektir."
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr "V1"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr "V1.1"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr "V2"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "Bu proje tarafından kullanılan terminal sözleşmesinin sürümü."
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr "Hacim"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr ""
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr "WAGMI!"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "Cüzdan adresi"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr ""
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr "Web sitesi"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr "Otomatik finansman döngüleri nelerdir?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr "Topluluk tokenleri nedir?"
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr "Riskler nelerdir?"
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr "Juicebox'ın maliyeti nedir?"
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr "Taşma nedir?"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr "Bağlılık eğrisi nedir?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr "İndirim oranı nedir?"
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr "Kaputun altında neler oluyor?"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr "İşaretlendiğinde, bu adrese yapılan ödemeler, bu projenin ERC-20 token'larını faydalanıcının cüzdanına basacaktır. Ödemeler daha fazla gas ücretine mal olacaktır. İşaret kaldırılırsa Juicebox, ödeme yaptığında faydalanıcının yeni token'larını takip edecektir. Faydalanıcı, ERC-20 token'larını istediği zaman talep edebilir."
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "Etkinleştirildiğinde, proje sahibi herhangi bir token miktarını herhangi bir adrese manuel olarak basabilir."
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "Etkinleştirildiğinde, projeniz doğrudan ödeme alamaz."
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "Birisi projenize ödeme yaptığında, karşılığında projenizin token'larından alırlar. Token'lar projenizin taşmasından bir miktar talep etmek için kullanılabilir; siz kazandığınızda topluluğunuz da sizinle birlikte kazanır. Projenizin token'ınını yönetişimde oy hakkı, topluluk erişimi veya başka üyelik ayrıcalıkları vermek için kullanabilirsiniz."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "Token basımına izin verildiğinde bu projenin sahibi, kararı kendisine ait olmak üzere, herhangi bir adrese, herhangi bir sayıda token basma iznine sahip olacaktır. Bu, projenin hazine bakiyesini artırmadan tüm mevcut token sahiplerinin etkisini azaltabilir. Proje sahibi bunu, finansman döngüsünün diğer tüm özellikleriyle birlikte yapılandırabilir."
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "Birisi projenize ödeme yaptığında yeni basılan bu token yüzdesi rezerve edilecek ve geri kalanı ödeme yapan kişiye gidecektir. Rezerve token'lar, varsayılan olarak proje sahibi için rezerve edilir ancak proje sahibi tarafından diğer cüzdan adreslerine de tahsis edilebilir. Token'lar rezerve edildikten sonra herkes onları \"basabilir\" ve bu işlem, onları amaçlanan alıcılarına dağıtır."
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr "Juicebox projelerini kim finanse ediyor?"
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "Peel kimdir?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr "Neden Ethereum?"
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr "Neden bir projenin tokenlerine sahip olmak isteyeyim?"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr "<0/>{0} değerine yuvarlanacak"
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr "L2'lerde çalışacak mı?"
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr "Juicebox ile projeler, motive olmuş punklar tarafından şeffaf bir şekilde ödenir ve destekledikleri projeler başarılı oldukça ödüllendirilen bir kullanıcı ve kullanıcı topluluğu tarafından finanse edilir ve sürdürülür."
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr "Finansman döngüsü tanımlanmamışsa, proje sahibi talep üzerine yeni bir finansman döngüsü (2. Finansman Döngüsü) başlatabilir. <0>Daha fazla bilgi edinin.</0>"
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr "Çalışma Alan"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "Bu projenin token'ı olarak kullanılmak üzere bir ERC-20 token'ı çıkartmak ister misiniz?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "Evet"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr "Proje ayrıntılarınızı oluşturduktan sonra istediğiniz zaman düzenleyebilirsiniz, ancak işlem gas maliyeti doğuracaktır."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "{tokenTextLong} token'larınızı hak talebinde bulunmadan taşma için kullanabilirsiniz. Bu projenin sağ üst köşesindeki İngiliz anahtarı simgesinden erişilebilen Araçlar menüsünden talep edilmemiş {tokenTextLong} token'larınızı başka bir adrese aktarabilirsiniz."
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "{tokenSymbol} token'larınızı taşma için talep etmeden de kullanabilir ve talep edilmemiş {tokenSymbol} token'larınızı, bu projenin sağ üst köşesindeki anahtar simgesiyle erişebileceğiniz Araçlar menüsünden başka bir adrese aktarabilirsiniz."
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "Bir finansman döngüsü süreniz yok. Yaptığınız değişiklikler hemen geçerli olacaktır."
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "Herhangi bir Juicebox projesi için token tutmuyorsunuz."
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "Tüm fonları hazineden dağıtılacak şekilde yapılandırdınız. Mevcut ödemeleriniz %100'e ulaşmıyor, bu nedenle geri kalan miktar proje sahibine gidecek."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "Bir finansman döngüsü hedefi belirlediniz."
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr "Kaydedilmemiş değişiklikleriniz mevcut. Değişiklikleri iptal etmek istediğinizden emin misiniz?"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "Henüz herhangi bir proje oluşturmadınız."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "{0}{1} ETH alacaksınız"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "{minReturnedTokensFormatted} ETH alacaksınız"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "Proje sözleşmeniz dağıtıldıktan sonra ERC-20 token'larını çıkarabileceksiniz. O zamana kadar protokol, token bakiyelerini takip ederek destekçilerinizin bu arada token kazanmasına ve onları taşma için kullanmasına izin verecektir."
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr "Juicebox projenizin aktif bir finansman döngüsü yok. Projenizde ödemeleri yeniden etkinleştirmek için bir finansman döngüsü başlatın."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "Bakiyeniz"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr "Finansman döngüsü yapılandırmanız, ilk başlattığınız yapılandırma kullanılarak önceden doldurulmuştur. Özelleştirmeniz gerekiyorsa, bizimle iletişime geçin."
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "Yeni ödeme adresiniz:"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr "Projeniz duraklatıldığında doğrudan ödeme alamaz."
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr "Projeniz finansman döngüleri boyunca finanse edilir. Bir finansman döngüsü, bir finansman hedefine ve süreye sahiptir. Projenizin finansman döngüsü yapılandırması, başlattığınız projenin türüne bağlı olacaktır."
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "Projeniz juicebox.money uygulamasında hemen aktif olarak görünecektir. Projenizin projeler sayfasında, \"aktif projeler\" listesinde görünmesi için lütfen birkaç gün bekleyin."
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr "Projenizin finansman döngüsü hedefi ve süresi."
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "İşleminiz gönderildi ve onay bekliyor."
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr "Talep edilmemiş token bakiyeniz: {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "Talep edilmemiş {tokenTextLong} token'larınız"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr "Sıfır"
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "%{0} JBX ücretinden sonra"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr "gün"
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr "tanıtıcı"
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "saat"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "son {trendingWindowDays} gün"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "yükleniyor"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "Kilit süresi bitiş tarihi {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "\"{searchText}\" ile eşleşen"
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "dakika"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "veya <0><1>borsada {tokenText} satın alın<2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "proje"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "proje sahibi"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "projeler"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "saniye"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "token"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "token'lar"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr "katkıda bulunulan ETH başına token miktarı"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr "kullanılan token'lar"
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr "sonra"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "JBX ücreti sonrası {0}"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr "{0} önce"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{0} token'ları bu projeye ödeme yapan herkese dağıtılır. Proje için bir finansman hedefi belirlenmişse token'lar, talep edilmiş olup olmadıklarına bakılmaksızın proje taşmasının bir miktarı için kullanılabilir."
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr "{0} bakiyesi"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} bakiyesi: <0><1>{1} {tokensTextShort}</1><2>(arzın %{share} kadarı)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr "{0} gün"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr "Size ait {0}"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr "{0} sahipleri"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr "Rezerve {0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr "{0} token/ETH"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr "Toplam {0}"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "{0} çekildi"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr "{0} adet {tokenTextPlural} rezerve edildi"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr "%{0}"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr "Yeni basılan tüm token'ların %{0} kadarı."
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr "%{0} arz"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr "<0/> adresine %{0}"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "{0}/{1} çekildi"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr "toplam {count}"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} borsasının {tokenSymbol} için piyasası yoktur."
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "{formattedTimeLeft} kaldı"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "#{0}'a kadar kalan {formattedTimeLeft}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr "{inflationRate} token/ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr "{issuanceRate} token / ETH"
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} rezerve) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# ödeme} other {# ödeme}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH (%{0})"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "Hazineye ödenen ETH başına alınan {tokenSymbolPluralCap} token'ı. Bu miktar, gelecek finansman döngülerinin indirim oranına ve rezerve token miktarına göre zaman içinde değişebilir."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 addresi"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "{exchangeName} üzerinde {tokenSymbol}/ETH kuru."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "{tokenTextSingular} token'ı alıcıları"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} token'ları bu projeye ödeme yapan herkese dağıtılır. Proje için bir finansman hedefi belirlenmişse token'lar, talep edilmiş olup olmadıklarına bakılmaksızın proje taşmasının bir miktarı için kullanılabilir."
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "Rezerve {tokensText} token'ları"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} token miktarı"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr "talep edilebilir {unclaimedBalanceFormatted} {tokenText}"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "Toplam arzın %{userOwnershipPercentage} kadarı"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -18,4441 +18,3051 @@ msgstr ""
 "X-Crowdin-File: messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "$ve{tokenSymbolDisplayText} Received"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "({0}%)"
 msgstr "({0}%)"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "({realTokenAllocationPercent}% of all newly minted tokens)."
 msgstr "（{realTokenAllocationPercent}% 新铸造的代币）。"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "0% fee"
 msgstr "0% 费率"
 
-#: src/components/VolumeChart/index.tsx
 msgid "1 year"
 msgstr "1 年"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "1. Get funded."
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "1. Project details"
 msgstr "1. 项目详情"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "1. Set ENS name"
 msgstr ""
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "100% overflow"
 msgstr "100% 溢出"
 
-#: src/pages/create/index.page.tsx
 msgid "2. Funding cycle"
 msgstr "2. 筹款周期"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "2. Give ownership"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "2. Set text record"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "24 hours"
 msgstr "24 小时"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "3-day delay"
 msgstr "延迟三天生效"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "3. Manage your funds"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
 msgid "3. Review and deploy"
 msgstr "3. 检查并部署"
 
-#: src/components/VolumeChart/index.tsx
 msgid "30 days"
 msgstr "30 天"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "4. Build trust."
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
 msgid "7 days"
 msgstr "7 天"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "7-day delay"
 msgstr "延迟七天生效"
 
-#: src/components/VolumeChart/index.tsx
 msgid "90 days"
 msgstr "90 天"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "<0/> Archived projects have not been modified or deleted on the blockchain, and can still be interacted with directly through the Juicebox contracts."
 msgstr "<0/> 被存档的项目在区块链上并没有被修改或删除，用户仍然可以直接通过 Juicebox 合约进行交互。"
 
-#: src/pages/projects/index.page.tsx
 msgid "<0/> The Juicebox protocol is open to anyone, and project configurations can vary widely. There are risks associated with interacting with all projects on the protocol. Projects built on the protocol are not endorsed or vetted by JuiceboxDAO or Peel. Do your own research and understand the <1>risks</1> before committing your funds."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "<0/> contributed"
 msgstr ""
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
 msgid "<0/> overflow received"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/> owner balance"
 msgstr "<0/> 项目钱包余额"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "<0/> will go to the project owner: <1/>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "<0/>{0} after {feePercentage}% JBX membership fee"
 msgstr "<0/>{0} 扣除 {feePercentage}% JBX 成员费用之后"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "<0/>{0}{1} distributed"
 msgstr "<0/>{0}{1} 已分发"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr "<0><1/>{netDistributionAmount}</0> 扣除 {feePercentage}% JBX 费用后"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
 msgstr "<0><1>这个项目目前筹集的资金并未溢出</1>，此时燃烧代币将不会收到 ETH。</0>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A bonding curve rewards people who wait longer to redeem your tokens for overflow.</0><1>For example, with a bonding curve of 70%, redeeming 10% of the token supply at any given time will claim around 7% of the total overflow.</1><2>The rest is left to share between token holders.</2>,<3>For more info, check out this <4>short video</4> on bonding curves.</3>"
 msgstr "<0>联合曲线比率奖励较晚赎回项目代币获取溢出的人。</0><1>打个比方，联合曲线比率在70%的情况下，任何时候赎回总供应量10%的代币都将获得总溢出的7%。</1><2>剩余的溢出由其他代币持有人分享。</2>,<3>请观看这个<4>短片</4> 了解更多关于联合曲线比率的信息。</3>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A mechanism like Juicebox where upfront financial commitments should be honored over time is only guaranteed within an ecosystem like Ethereum.</0><1>Ethereum provides a public environment where internet apps like Juicebox can run in a permission-less, trustless, and unstoppable fashion.</1><2>This means that anyone can see the code that they're using, anyone can use the code without asking for permission, and no one can mess with the code or take it down.</2><3>People using Juicebox are interacting with each other through public infrastructure—not a private, profit-seeking corporate service that brokers the exchange.</3><4>Juicebox was built to allow people and projects to get paid for creating public art and infrastructure, as much as or more than they would working towards corporate ends. No more shady business.</4>"
 msgstr "<0>像 Juicebox 这种需要逐步兑现早期财务承诺的机制，只有在类似以太坊这种生态才能得到保证。</0><1>以太坊提供了一种公共的环境，在这种环境下，像 Juicebox 这种互联网应用能够以无需许可、无需信任及不受制约的形式来运行。</1><2>这就意味着任何人都可以看得到这些应用使用的代码，任何人都可以未经许可就使用这些代码，同时没有人能够篡改或者删除这些代码。</2><3>使用 Juicebox 协议的人们通过公共的基础设施—而不是私有化的以盈利为目标的公司服务，来进行相互的交流。</3><4>Juicebox 创建的目的就是为了让人们和各种项目能够通过创造公共艺术和基础设施来获得报酬，这些报酬跟在他们为公司工作时一样甚至还会更多。再没有暗箱操作。</4>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>A project can choose to reserve a percentage of tokens for itself. Instead of being distributed to paying users, this percentage of tokens is instead minted for the project.</0><1>Holding these tokens entitles a project to a portion of its own overflow.</1>"
 msgstr "<0>项目可以选择保留某个百分比的代币。这个百分比的代币会铸造给项目，而不是分发给付费的用户。</0><1>持有这些代币能让项目拥有一部分自己的溢出。</1>"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Add to balance:</0> payments to this contract will fund the project without minting project tokens."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "<0>Auto claim:</0> any minted tokens will automatically be claimed as ERC20 (if this project has issued an ERC20 token)."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Contribution floor:</0> {0} ETH"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Description: </0><1/>"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
 msgstr "<0>折扣率</0>, 以便每个周期降低项目的代币发行比率 (代币每 ETH) 。"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
 msgstr "<0>如果你知道你的项目某个时间段内要赚多少钱才能维持运营，你可以把那个金额设定为筹款目标。要是项目赚取的比这个目标要高，盈余资金就会锁定在溢出池中。任何持有项目代币的人都可以通过赎回他们的代币来获取溢出池的一部分资金。</0><1>更多资讯，请观看这个 <2>短片</2>。</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox has handled tens of thousands of ETH through its protocol, and has so far had 0 security mishaps.</0> <1>However, Juicebox is still experimental software. Although the Juicebox contract team have done their part to shape the smart contracts for public use and have tested the code thoroughly, the risk of exploits is never 0%.</1><2>Due to their public nature, any exploits to the contracts may have irreversible consequences, including loss of funds. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is a governance-minimal protocol. There are only a few levers that can be tuned, none of which impose changes for users without their consent. The Juicebox governance smart contract can adjust these levers.</0><1>The Juicebox protocol is governed by a community of JBX token holders who vote on proposals fortnightly.</1>"
 msgstr "<0>Juicebox 是一个治理最小化的协议。它只有少数几个参数可以调整，不经得同意，这些参数的改变都不能强加到用户身上。Juicebox 的治理智能合约可以对这些参数进行调整。</0><1>Juicebox 协议由 JBX 代币持有人社区每两周投票来进行治理。</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Juicebox is an open protocol on Ethereum that is funded using Juicebox itself. You can check out the contractualized budget specs <1>here</1>.</0><2>Projects building on Juicebox pay a {JB_FEE}% JBX membership fee from withdrawn funds into the JuiceboxDAO treasury. Projects can then use their JBX to participate in the governance of JuiceboxDAO and its collective treasury, as well as redeem from its growing <3>overflow</3>. The fee is also subject to change via JBX member votes.</2>"
 msgstr "<0>Juicebox 是一个以太坊上面的开放协议，由协议自己来提供资金支持。你可以在 <1>这里</1>查看合约化的预算明细。</0><2>Juicebox 协议上运行的项目提取资金时向 JuiceboxDAO 的金库缴纳 {JB_FEE}% JBX 的成员费用。 项目可以用持有的JBX 代币来参与对 JuiceboxDAO及其集体金库的治理，也可以将代币用于赎回其不断增长的<3>溢出</3>。这个费率也会通过 JBX 成员投票进行调整。</2>"
 
-#: src/components/ManageTokensModal.tsx
 msgid "<0>Learn more</0> about burning tokens."
 msgstr "<0>进一步了解</0> 代币的燃烧。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycle duration."
 msgstr "<0>进一步了解</0> 筹款周期持续时间。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about funding cycles."
 msgstr "<0>进一步了解</0> 筹款周期。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Learn more</0> about overflow."
 msgstr "<0>进一步了解</0> 溢出。"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "<0>NOTE:</0> This project has a balance of 0. Projects cannot be migrated without a balance. To migrate this project, first pay it or use the button below to deposit 1 wei (0.000000000000000001 or 10<1>-18</1> ETH)."
 msgstr "<0>注意：</0> 该项目余额为零，无法迁移。如果要迁移该项目，先直接支付或是通过下方按钮存入 1 wei （0.000000000000000001 or 10<1>-18</1> ETH）。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>No duration set.</0>Funding can be reconfigured at any time. Reconfigurations will start a new funding cycle."
 msgstr "<0>未设置筹款周期时长。</0>筹款设置可以随时进行更改。更改设置将开始一个新的筹款周期。"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "<0>Note:</0> These properties will <1>not</1> be editable immediately within a funding cycle. They can only be changed for <2>upcoming</2> funding cycles."
 msgstr "<0>注意：</0> 这些属性<1>不能</1> 在同一个筹款周期内马上进行修改。 更改配置只能在 <2>后面的</2> 筹款周期内完成。"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Note:</0> Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "<0>请注意：</0> 该项目还未发行 ERC-20 形式的代币，因此暂时无法领取代币。ERC-20 形式的代币必须由项目拥有者来发行。"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "<0>On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders.</0> <1>A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed.</1>Learn more in this <2>short video</2>."
 msgstr "<0>赎回比率较低的情况下，每赎回一个代币都会提高剩余代币的价值，形成一种更长期持有的激励机制。</0> <1>100%的赎回率则意味着无论何时赎回，所有代币的价值都是一样的。</1>了解更多，请观看 <2>短视频</2>。"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Peel</0> is the DAO that manages the juicebox.money frontend interface. You can reach out to Peel either through the <1>Peel Discord</1> or the <2>Juicebox Discord</2>."
 msgstr "<0>Peel</0>是一个 DAO，负责管理 juicebox.money 的前端页面。你可以通过<1>Peel</1> 或 <2>Juicebox</2> 的 Discord 服务器来接触 Peel。"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "<0>Recurring funding cycles</0>. For example, distribute funds from your project's treasury every week."
 msgstr "<0>经常性筹款周期</0>。例如，每周从你的项目金库分配资金出去。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "<0>Target is 0.</0> The project's entire balance will be considered overflow. <1>Learn more</1> about overflow."
 msgstr "<0>筹款目标设置为0。</0> 项目的全部余额将被视为溢出。<1>了解更多</1> 关于溢出。"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>That's the plan, but the core Juicebox contracts will first be deployed to Ethereum Mainnet.</0><1>The contract team will soon start working on L2 payment terminals for Juicebox projects.</1>"
 msgstr "<0>有这个计划， 但核心 Juicebox 合约会首先部署到以太坊主网。</0><1>合约团队将很快开始为 Juicebox 项目开发 L2 上面的付款终端。</1>"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>The Juicebox V2 smart contracts have had multiple security audits. <1>Read the audit reports.</1></0><2>While Juicebox has been audited, it is still experimental software, and there are risks. Please use Juicebox with caution.</2><3><4>Learn more</4> about the risks.</3>"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "<0>There are unit tests written for every condition of every function in the contracts, and integration tests for every workflow that the protocol supports.</0><1>There was also a script written to iteratively run the integration tests using a random input generator, prioritizing edge cases. The code has successfully passed over 1 million test cases through this stress-testing script.</1> <2>The code could always use more eyes and more critique to further the community's confidence. Join our <3>Discord</3> and check out the code on <4>GitHub</4> to work with us.</2>"
 msgstr "<0>合约里每个函数的每个条件都有编写单元测试, 同时协议支持的每个工作流都有集成测试。</0><1>之前还编写了一个脚本用于使用随机生成的输入条件来进行迭代集成测试，优先考虑边缘案例。代码通过这个压力测试脚本成功经受了超过一百万次的测试案例。</1> <2>欢迎大家对代码进行进一步的审核和批评，这样可以增强社区的信心。 加入我们的<3>Discord</3> 及查阅 <4>GitHub</4>上的代码，跟我们一起工作。</2>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "<0>This project has no overflow</0>, so you will not receive any ETH for burning tokens."
 msgstr "<0>此项目没有溢出</0>，所以您无法通过燃烧代币来获得 ETH。"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>This website (juicebox.money) connects to the Juicebox protocol's smart contracts, deployed on the Ethereum network. (note: anyone else can make a website that also connects to these same smart contracts. For now, don't trust any site other than this one to access the Juicebox protocol).</0><1>Creating a Juicebox project mints you an NFT (ERC-721) representing ownership over it. Whoever owns this NFT can configure the rules of the game and how payouts are distributed.</1><2>The project's tokens that are minted and distributed as a result of a received payment are ERC-20's. The amount of tokens minted and distributed are proportional to the volume of payments received, weighted by the project's discount rate over time.</2>"
 msgstr "<0>这个网站 (juicebox.moeny)连接 Juicebox 协议各个部署在以太网络上的智能合约。 (注意：任何人都可以建一个连接到相同的智能合约的网站。目前，不要相信这个网站以外的任何站点来访问 Juicebox 协议。)</0><1>创建一个 Juicebox 项目会铸造一个NFT（ERC-721标准）来代表项目的所有权。 任何持有这个NFT都可以配置项目的玩法规则和项目怎样分配支出。</1><2>项目每收到一笔付款后铸造及分发的项目代币属于ERC-20标准。铸造及分发的代币数量与收到付款的金额成正比，这个比例会逐步由项目的折扣率进行加权。</2>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "<0>Total project tokens minted</0> when 1 ETH is contributed. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "收到1 ETH 的捐款时<0>铸造的项目代币总数</0>。这个数量会按照未来筹款周期的折扣率及保留代币数量逐步发生变化。"
 
-#: src/pages/home/QAs.tsx
 msgid "<0>Users fund your project by paying to use your app or service, or as a patron or investor by making a payment directly to your project's smart contract (like on this app).</0><1>For users paying through your app, you should route those funds through the Juicebox smart contracts so they receive tokens in return.</1>"
 msgstr "<0>用户通过付款使用你的应用或者服务来为你的项目提供资金支持，或者作为赞助人或投资人把资金直接打到项目的智能合约里（就像在这个应用上）。</0><1>对于通过你的应用来付款的用户，你应该通过 Juicebox 的智能合约来中转这些资金，这样用户就能相应地获得代币了。</1>"
 
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
 msgstr "<0>你当前未领取的 {tokenSymbol} 代币数量：</0> {0}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
 msgstr "<0>{tokenSymbol} ERC-20 地址：</0><1/>"
 
-#: src/components/formItems/ProjectTwitter.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "@"
 msgstr "@"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "@{handle}"
 msgstr ""
 
-#: src/components/Project404.tsx
 msgid "@{handle} not found"
 msgstr ""
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "A project can be archived by its owner from the tools menu on the project page."
 msgstr "项目所有者可以在项目页面上的“工具菜单”中对项目进行存档。"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "A project can reserve a percentage of the tokens minted from payments it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "项目可以把它收到付款时铸造的代币按一定的百分比保留起来。保留代币可以随时按以下的分配方案进行分配。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "A project can reserve a percentage of tokens minted from every payment it receives. Reserved tokens can be distributed according to the allocation below at any time."
 msgstr "项目每收到一笔付款都会铸造代币，其中某个百分比的代币会保留在项目内。保留代币可随时按以下分配方案进行分发。"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "A project's handle is used in its URL, and allows it to be included in search results on the projects page."
 msgstr ""
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "A project's lifetime is defined in funding cycles. If a funding target is set, the project can withdraw no more than the target for the duration of the cycle."
 msgstr "一个项目的寿命是以筹款周期来定义的。如果设定了筹款目标，那么在周期内，项目的提款不能超过目标。"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 3 days before it starts."
 msgstr "对之后筹款周期的重新配置，至少得提前三天提交。"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "A reconfiguration to an upcoming funding cycle must be submitted at least 7 days before it starts."
 msgstr "对之后筹款周期的重新配置，至少得提前七天提交。"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "A reserved rate of more than 90% is risky for contributors. Contributors won't receive many tokens for their contribution."
 msgstr "代币保留率超过90%对捐款人是有风险的。捐款人能获得的代币数量不多。"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "A veNft can only be redeemed if the project currently has overflow."
 msgstr ""
 
-#: src/components/ProjectCard.tsx
 msgid "ARCHIVED"
 msgstr "已存档"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "AVAILABLE"
 msgstr "可提取"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Activity"
 msgstr "最近动态"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Add Lock Duration Option"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Add NFT reward"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "Add a payout"
 msgstr "添加支出对象"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add an on-chain memo to this payment."
 msgstr "给这笔付款添加一个链上备注"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Add an on-chain memo to this reconfiguration."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add funds to this project's balance without minting tokens."
 msgstr "往项目中添加资金，但不铸造代币。"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Add handle"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Add image"
 msgstr "添加图片"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add lock duration option"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Add new payout"
 msgstr "添加新的支出"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Add payout"
 msgstr "添加支出"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Add reward tier"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Add the V1 Token Payment Terminal to your project."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
 msgid "Add to Balance"
 msgstr "添加到余额"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Add to balance"
 msgstr "添加到余额"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Add token"
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Add token allocation"
 msgstr "添加代币的分配方案"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Address"
 msgstr "地址"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Address required"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Address:"
 msgstr "地址："
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Address: <0/>"
 msgstr "地址： <0/>"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Adjust incentives for paying your project."
 msgstr "调整激励措施，以便鼓励其他人或项目向你的项目付款。"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Advanced (optional)"
 msgstr ""
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "All"
 msgstr "全部"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/index.tsx
 msgid "All assets"
 msgstr "所有资产"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "All events"
 msgstr "所有活动"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "All funds can be distributed by the project. The project will have no overflow (the same as setting the target to infinity)."
 msgstr "所有资金都可以分配给项目，项目将不再会产生溢出（把筹款目标设为无限也是同样结果）。"
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "All funds received by the treasury will be distributed. Token holders will receive <0>no ETH</0> when burning their tokens."
 msgstr "金库收到的所有资金都将进行分配。代币持有者燃烧他们的代币时将 <0>不会收到 ETH</0> 。"
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "All {0} will go to the project owner:"
 msgstr "所有 {0} 会给到项目拥有者："
 
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Allocate a portion of your project's reserved tokens to other Ethereum wallets or Juicebox projects."
 msgstr "把您项目的一部分保留代币分发给其他以太坊钱包或其他Juicebox项目。"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Allow minting tokens"
 msgstr "允许铸造代币"
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow terminal configuration"
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Allow token minting"
 msgstr "允许铸造代币"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Allow your V1 project token holders to swap their tokens for your V2 project tokens."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Allowed"
 msgstr "允许"
 
-#: src/pages/index.page.tsx
 msgid "Almost definitely."
 msgstr "答案是肯定的."
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Amount"
 msgstr "数量"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Amount of ERC-20 tokens to claim"
 msgstr "可领取的 ERC-20 代币数量"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner."
 msgstr "收到 1 ETH的捐款时 <0>保留到项目的</0>新铸项目代币数量。 保留代币默认保留给项目方，但也可以由项目方分配到其他钱包地址。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Amount of newly minted project tokens <0>reserved for the project</0> when 1 ETH is contributed. The project owner is allocated all reserved tokens by default, but they can also be allocated to other wallet addresses."
 msgstr "收到 1 ETH的捐款时 <0>保留到项目的</0>新铸项目代币数量。 保留代币默认全部分配给项目方，但也可以由项目方分配到其他钱包地址。"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Amount paid"
 msgstr "支付数额"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Amount required"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Amount to distribute"
 msgstr "分发数量"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Amount:"
 msgstr "金额："
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Amounts"
 msgstr "金额"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Any changes you make will take effect in <0>funding cycle #{0}</0>. The current funding cycle (#{currentFCNumber}) won't be altered."
 msgstr "你做出的任何变更将会在 <0>筹款周期 #{0}</0>生效。目前的 (#{currentFCNumber}) 筹款周期将不会受到影响。"
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "Any reconfiguration to an upcoming funding cycle will take effect once the current cycle ends. A project with no strategy may be vulnerable to being rug-pulled by its owner."
 msgstr "对之后的筹款周期进行重新配置，更改将在当前周期结束后生效。 没有策略的项目会有项目方跑路的风险。"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Approve token for transaction"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Archive project"
 msgstr "存档项目"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Archived"
 msgstr "已存档"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Are you sure you want to start over?"
 msgstr "你确定要重新开始吗？"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Assets"
 msgstr "资产"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
 msgid "Attach a sticker"
 msgstr "上传一张贴图"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Attach the image to be associated with this NFT."
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Auto claim"
 msgstr ""
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Automate funding cycles"
 msgstr "自动化筹款周期"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "Automated funding cycles enable the following characteristics:"
 msgstr "自动筹款周期具有以下特点："
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Available after fee:"
 msgstr "扣除手续费后可用"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
 msgid "Available funds are distributed according to the payouts below."
 msgstr "可用资金会分发给以下支出对象。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Available funds can be distributed according to the payouts below{0}."
 msgstr "可用资金可以按以下的支出对象 {0} 进行分配。"
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
 msgid "Available:"
 msgstr "可用:"
 
-#: src/components/ScrollToTopButton.tsx
 msgid "Back to top"
 msgstr "回到顶部"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Balance exceeded"
 msgstr "超出余额"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Balance of the project owner's wallet."
 msgstr "项目拥有者钱包的余额"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Beneficiary"
 msgstr "受益人"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Beneficiary address"
 msgstr "受益人钱包地址"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Beneficiary:"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."
 msgstr "依托于以太坊社区精心打造的基础设施和经济生态，Juicebox 才得以实现。"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Block number"
 msgstr "区块数"
 
-#: src/components/Navbar/constants.ts
 msgid "Blog"
 msgstr "博客"
 
-#: src/pages/index.page.tsx
 msgid "Built for:"
 msgstr "服务的对象:"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Burn project tokens"
 msgstr "燃烧项目代币"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no overflow."
 msgstr "燃烧你的 {tokensLabel}。你不会收到 ETH 作为回报，因为这个项目没有溢出的资金。"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Burn {0} {tokensTextShort}"
 msgstr "燃烧 {0} {tokensTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Burn {tokensLabel}"
 msgstr "燃烧 {tokensLabel}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Burn {tokensTextLong}"
 msgstr "燃烧 {tokensTextLong}"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "By default, all unallocated funds can be distributed to the project owner's wallet."
 msgstr "默认的情况下，所有未分配资金可被分发给项目拥有者的钱包。"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "By default, newly minted tokens will go to the wallet who sends funds to the address. You can enable this to set the token beneficiary to a custom address."
 msgstr "默认情况下，新铸造代币会分发给向这个地址付款的钱包地址。打开此选项可以把代币受益人设置为一个自定义地址。"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Can I change my project's contract after it's been created?"
 msgstr "项目合约创建后，我还更改它吗?"
 
-#: src/pages/home/QAs.tsx
 msgid "Can I delete a project?"
 msgstr "我可以删除一个项目吗？"
 
-#: src/components/modals/AttachStickerModal/AttachStickerModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Cancel"
 msgstr "取消"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project has no overflow."
 msgstr "这个项目的筹款没有溢出，无法用代币赎回 ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Cannot redeem tokens for ETH because this project's redemption rate is zero."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change ENS name"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Change project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Changes to payouts will take effect immediately."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Changes to project details will take effect immediately."
 msgstr "对项目详情的更改将立即生效。"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Changes to these attributes can be made at any time and will be applied to your project immediately."
 msgstr "可以随时修改这些属性，并立即应用于你的项目。"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Changes to your project's funding configuration require a community-approved period to take effect, which acts as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr "对项目资金的变动需要经过社区的批准阶段才能生效，这可以作为预防项目方跑路的措施。项目支持者不需要依赖于对你的信任 —— 尽管他们已经这样做了。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Changes to your reserved token allocation will take effect immediately."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes will take effect according to the project's custom ballot contract."
 msgstr "变更的生效将照按项目自定义的选票合约来执行。"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Changes you make will take effect according to your <0>{0}</0> reconfiguration rule (the first funding cycle following <1>{1}</1> from now)."
 msgstr "你作出的变更将按照你的 <0>{0}</0> 重新配置规则生效 (从现在开始<1>{1}</1> 后的第一个完整周期生效)。"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Character"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have your token balance tracked by Juicebox, saving gas on this transaction. You can always claim your ERC-20 tokens later."
 msgstr "勾选此项来铸造{tokenSymbol} ERC-20 代币并领取到你的钱包。不勾选可以降低本次交易的 gas 费用，你的代币余额将交由 Juicebox 托管。 你以后可以随时再来领取你的 ERC-20 代币。"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Choose an ENS name to use as the project's handle. Subdomains are allowed and will be included in the handle. Handles won't include the \".eth\" extension.<0/><1/>juicebox.eth = @juicebox<2/>dao.juicebox.eth = @dao.juicebox"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Choose how you would like to configure your payouts."
 msgstr "选择你想怎样配置你的支出。"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural}"
 msgstr "领取 {tokenTextPlural}"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claim {tokenTextPlural} as ERC-20 tokens"
 msgstr "以 ERC-20 标准代币领取 {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort}"
 msgstr "领取 {tokenTextShort}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claim {tokenTextShort} as ERC-20 tokens"
 msgstr "以 ERC-20 代币形式领取 {tokenTextShort}"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Claim {tokensLabel} as ERC-20"
 msgstr "按 ERC-20 标准来领取{tokensLabel} 代币"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "领取 {tokenSymbol} 代币将会以 ERC-20 标准铸造你的 {tokenSymbol} 代币并发送至你的钱包。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Claiming {tokenTextLong} will convert your {tokenTextShort} balance to ERC-20 tokens and mint them to your wallet."
 msgstr "领取 {tokenTextLong} 代币将会以 ERC-20 格式铸造你的 {tokenTextShort} 代币并发送至你的钱包。"
 
-#: src/components/TransactionModal.tsx
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Close"
 msgstr "关闭"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Close, I'll do these later"
 msgstr "关闭，我晚点再做这些"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection name"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Collection symbol"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Commit portions of your funds to the people or projects you want to support, or the contributors you want to pay. When you get paid, so do they."
 msgstr "提前设定把您资金的一部分自动分拨给您想要支持的人或项目，或者您需要支付的贡献者。您获得收入的同时，他们也会收到相应款项。"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure how your project will collect and spend funds."
 msgstr "设置你的项目接收及使用资金的方式。"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure restrictions for your funding cycles."
 msgstr "对你的筹款周期设置限制条件。"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Configure the dynamics of your project's token."
 msgstr "设置项目代币的各项动能指标。"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Configure which Juicebox V1 project you'd like to accept tokens for. Token holders of this V1 project will be able to swap their V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Confirm Stake"
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
 msgstr "恭喜你成功创建项目！下面这些步骤是可选项，任何时候来完成都可以。"
 
-#: src/components/Navbar/Account.tsx
 msgid "Connect"
 msgstr "连接钱包"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Connect Wallet"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Connect wallet"
 msgstr "连接钱包"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Connect wallet to claim"
 msgstr "连接钱包以领取"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Connect wallet to deploy"
 msgstr "连接钱包以部署"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Connect wallet to distribute"
 msgstr "连接钱包以分配"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Connect wallet to issue"
 msgstr "连接钱包以签发"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Connect wallet to pay"
 msgstr "连接钱包以支付"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Connect wallet to transfer"
 msgstr "连接钱包以转让"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Connect your wallet to see your holdings."
 msgstr "连接钱包查看你的持币明细。"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Connect your wallet to see your projects."
 msgstr "连接钱包查看你的项目。"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Connected wallet not authorized"
 msgstr "已链接钱包未授权"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Contract address: {0}"
 msgstr "合约地址：{0}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contribution threshold"
 msgstr ""
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributor rate"
 msgstr "捐款铸造比率"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/ContributionFloorFormItem.tsx
-#: src/components/veNft/formControls/TokensStakedMinInput.tsx
 msgid "Contributors receive the NFT when they contribute at least this amount."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Contributors who pay this address from a custodial service platform (like Coinbase) <0>won't receive project tokens</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Contributors will be rewarded this amount of your project's tokens per ETH contributed."
 msgstr "捐款人每捐一个 ETH 就可以获得这个数量的项目代币。"
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will not receive any tokens in exchange for paying this project."
 msgstr "捐献者给项目付款将不会获得任何代币。"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Contributors will receive <0>{discountRatePercent}%</0> more tokens for contributions they make this funding cycle compared to the next funding cycle."
 msgstr "捐款人本筹款周期付款会比下一周期付款获得多 <0>{discountRatePercent}%</0> 的代币。"
 
-#: src/constants/fundingWarningText.ts
 msgid "Contributors will receive a relatively small portion of tokens in exchange for paying this project."
 msgstr "捐款者给项目付款将获得相对较低比例的代币。"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Contributors will see this message before they pay your project."
 msgstr "在付款之前，捐款人将会看到这个信息。"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copied!"
 msgstr "已复制！"
 
-#: src/components/CopyTextButton.tsx
 msgid "Copy to clipboard"
 msgstr "复制到剪贴板"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create a payable address (optional)"
 msgstr "创建一个可付款地址（可选）"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
 msgstr "为项目创建一个以太坊地址。支持不经过项目的 Juicebox 页面直接付款。"
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr "创建一个可用于直接支付给你的项目的以太坊地址。"
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "Create payable address"
 msgstr "创建可支付地址"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Create payment address"
 msgstr ""
 
-#: src/hooks/PageTitle.ts
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Create project"
 msgstr "创建项目"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr "创建项目自己的 ERC-20 代币来代表对项目的份额。捐款人向项目付款将会获得这些代币。"
 
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
 msgid "Created ETH-ERC20 payment address"
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Crowdfund your project with ETH. Set a funding target to cover predictable expenses, and any extra funds (<0>overflow</0>) can be claimed by anyone holding your project's tokens alongside you."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Crowdfunding"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Current"
 msgstr "当前"
 
-#: src/components/AMMPrices/index.tsx
 msgid "Current 3rd Party Exchange Rates"
 msgstr "当前第三方交易平台价格"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Current owner: {ownerAddress}"
 msgstr "当前项目方：{ownerAddress}"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Currently worth: <0><1/></0>"
 msgstr ""
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
-#: src/utils/ballot.ts
 msgid "Custom strategy"
 msgstr "自定义策略"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Custom token beneficiary"
 msgstr "自定义代币受益人"
 
-#: src/components/formItems/ProjectPayButton.tsx
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr "定制项目的 \"付款“ 按钮。留空则使用默认值。"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Cycle #{0}"
 msgstr "周期 #{0}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Cycle #{0} -"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "DAOs"
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Dark theme"
 msgstr "深色主题"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Date"
 msgstr "日期"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Date created"
 msgstr "创建日期"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Day"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Days"
 msgstr "天"
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Days to lock tokens"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
-#: src/components/veNft/VeNftVariantCard.tsx
 msgid "Delete NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Delete Option"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Delete payout"
 msgstr "删除支出"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Delete token allocation"
 msgstr "删除代币的分配方案"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Deploy funding cycle configuration"
 msgstr "部署筹款周期配置"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerButton.tsx
 msgid "Deploy payment address"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deploy payment address contract"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project"
 msgstr "部署项目"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Deploy project on {signerNetwork}"
 msgstr "在{signerNetwork} 上部署项目"
 
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
 msgid "Deploy project to {0}"
 msgstr "部署项目至 {0}"
 
-#: src/components/activityEventElems/DeployedERC20EventElem.tsx
 msgid "Deployed ERC20 token"
 msgstr "已部署的 ERC20 标准代币"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Deployed payment addresses can be found in the Tools drawer on the project page."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Deposit 1 wei to @{handle}"
 msgstr "存入 1 wei 给 @{handle}"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Description"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Design how your tokens should work."
 msgstr ""
 
-#: src/pages/home/HowItWorksSection.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Design your project"
 msgstr "设计你的项目"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Details"
 msgstr "详情"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Determines whether tokens will be minted from payments to this address."
 msgstr "决定了向这个地址付款是否会铸造代币。"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Disabled"
 msgstr "已禁用"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Disabled when your funding cycle's distribution limit is <0>No limit</0> (infinite)"
 msgstr "筹款周期的可分配资金的限额为<0>无限额</0> (无上限) 的时候，此项禁用。"
 
-#: src/components/formItems/ProjectDiscountRate.tsx
 msgid "Disabled when your project's funding cycle duration is 0."
 msgstr "项目筹款周期时长设置为0天的时候禁用。"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Disabled when your project's funding cycle has no duration."
 msgstr "未设置项目筹款周期时长时，本项禁用。"
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Discard"
 msgstr "放弃"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
 msgid "Disclose any details to your contributors before they pay your project."
 msgstr "在捐款人向你的项目付款前，向他们披露任意事项。"
 
-#: src/components/Navbar/Mobile/MobileCollapse.tsx
-#: src/components/Navbar/Wallet.tsx
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discord"
 msgstr "Discord"
 
-#: src/components/formItems/ProjectDiscord.tsx
 msgid "Discord link"
 msgstr ""
 
-#: src/components/formItems/ProjectDiscountRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Discount rate"
 msgstr "折扣率"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Display ERC-20 and other Juicebox project tokens that this project owner holds."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr "展示项目方钱包中的 ERC-20 代币及其他 Juicebox 项目代币。"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a percentage of all funds received to entities. Your distribution limit will be <0>infinite</0>."
 msgstr "把资金按百分比分配给各个实体。项目的分配限额将为 <0>无限</0>。"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribute a specific amount of funds to entities each funding cycle. Your distribution limit will equal the <0>sum of all payout amounts.</0>"
 msgstr "每个筹款周期把特定金额的资金分配给各个实体。项目的分配限额将等于<0>所有支出金额的总和。</0>"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Distribute available funds to other Ethereum wallets or Juicebox projects as payouts. Use this to pay contributors, charities, Juicebox projects you depend on, or anyone else. Funds are distributed whenever a withdrawal is made from your project."
 msgstr "把可用资金分发给其他以太坊钱包或者其他Juicebox项目。使用这项功能付款给项目的贡献者、慈善机构、其他帮助你的Juicebox项目、或是任何其他人。无论什么时候从您项目提款，资金都会自动进行发放。"
 
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Distribute funds"
 msgstr "分发资金"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr "分配保留的 {tokenTextPlural} 代币"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Distribute {tokenTextPlural}"
 msgstr "分配 {tokenTextPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Distribute {tokensText}"
 msgstr "分配 {tokensText}"
 
-#: src/components/Project/FundingProgressBar.tsx
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "Distributed"
 msgstr "已分发"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Funds"
 msgstr "分配资金"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
 msgid "Distributed Reserves"
 msgstr "分配保留代币"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Distributed Tokens"
 msgstr "分配代币"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
 msgid "Distributed funds"
 msgstr "分配资金"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "Distributed reserved {0}"
 msgstr "已分配的保留代币 {0}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distributing funds to Juicebox projects won't incur fees."
 msgstr "分配资金给 Juicebox 项目不会产生费用。"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Distribution"
 msgstr "分配"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Distribution Limit <0/>:"
 msgstr "分配限额 <0/>："
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit"
 msgstr "分配上限"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is 0: All funds will be considered overflow and can be redeemed by token holders."
 msgstr "分配限额为0：所有资金将被视为溢出，持币人可以赎回这些资金。"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
 msgstr "分配限额为无限。<0>项目将决定所有资金应该如何分配，没有资金可供持币人赎回。</0>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Distribution limit, duration and payouts"
 msgstr "分配上限、时长及支出"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Distribution limit: <0/>{0}"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr "要把 Juicebox 用作项目的商业模式的话，我必须把项目进行开源吗？"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Do I need this?"
 msgstr ""
 
-#: src/components/formItems/ENSName.tsx
 msgid "Do not include .eth"
 msgstr ""
 
-#: src/components/Navbar/constants.ts
 msgid "Docs"
 msgstr "文档"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Documentation on v1.1 contracts"
 msgstr "v1.1 合约的文档"
 
-#: src/pages/home/QAs.tsx
 msgid "Does a project benefit from its own overflow?"
 msgstr "项目是否能从溢出中获益？"
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
-#: src/components/v2/V2Project/NewDeployModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "Done"
 msgstr "完成"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV"
 msgstr "下载 CSV"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Download CSV of payments"
 msgstr "下载付款记录的 CSV 文件"
 
-#: src/components/v1/V1Project/V1DownloadActivityModal.tsx
-#: src/components/v2/V2Project/V2DownloadActivityModal.tsx
 msgid "Download CSV of project activity"
 msgstr "下载项目活动记录的 CSV 文件"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Download CSV of {0} holders"
 msgstr "下载包含 {0} 持有者的 CSV"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Duration"
 msgstr "持续时间"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Duration (seconds)"
 msgstr "时长（秒）"
 
-#: src/components/formItems/ENSName.tsx
 msgid "ENS Name"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "ERC-20 tokens can only be minted once an ERC-20 token has been issued for this project."
 msgstr "项目签发了 ERC-20 代币合约后，才能铸造 ERC-20 标准的代币。"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ERC20 Deployed"
 msgstr "部署 ERC-20 标准代币"
 
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "ETH-ERC20 Address Created"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "ETH-ERC20 Payment addresses are <0>smart contracts</0>that allow this project to be paid in <1>ETH</1> by sending ETH directly to the contract, or in <2>ERC20 tokens</2> via the contract's <3>pay()</3> function."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Each payout will receive their percent of this total each funding cycle if there is enough in the treasury. Otherwise, they will receive their percent of whatever is in the treasury."
 msgstr "如果金库资金足够，每个支出对象将在每个筹款周期收到自己在这个总额里的对应份额。否则，他们将按各自的占比来分配金库剩余的资金。"
 
-#: src/pages/home/QAs.tsx
 msgid "Each project has its own <0>tokens</0>. Anyone who contributes funds to a project receives that project's tokens in return. Token balances will be tracked by the protocol until ERC-20 tokens are optionally issued by the project owner."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Edit NFT reward"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Edit allocation"
 msgstr ""
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Edit payout"
 msgstr "编辑支出对象"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Edit payouts"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Edit project"
 msgstr "编辑项目"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Edit project details"
 msgstr "编辑项目的细节"
 
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Edit reserved token allocation"
 msgstr "保留代币的分配方案"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
 msgid "Edit token allocation"
 msgstr "编辑代币的分发"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Edit tracked assets"
 msgstr "编辑监测的资产"
 
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Enable veNFT Governance"
 msgstr ""
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "Enable veNFT to Spend Unclaimed Tokens"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Enabled"
 msgstr "已启用"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Enabling this allows the project owner to manually mint any amount of tokens to any address."
 msgstr "允许项目所有者手动铸造并发送任何数量的代币。"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Enabling this will mint {tokenSymbol} ERC-20 tokens. Otherwise, unclaimed {tokenSymbol} tokens will be minted, which can be claimed later as ERC-20 by the receiver."
 msgstr "打开此选项将铸造 {tokenSymbol} ERC-20 标准代币。否则将铸造未领取 {tokenSymbol} 代币，受益人可以以后再来把它领取为 ERC-20 标准代币。"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "Enabling token minting will appear risky to contributors."
 msgstr "允许代币铸造会令捐款人觉得有风险。"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "End"
 msgstr "结束时间"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
 msgid "Error loading holders"
 msgstr "加载持有人错误"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Error loading payments"
 msgstr "加载付款信息错误"
 
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error parsing form"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
-#: src/pages/api/ipfs/logo.page.ts
 msgid "Error uploading file"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Explore projects"
 msgstr "探索项目"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Extend Lock"
 msgstr ""
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Extend lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/Navbar/MenuItems.tsx
 msgid "FAQ"
 msgstr "常见问题解答"
 
-#: src/pages/index.page.tsx
 msgid "FAQs"
 msgstr "常见问题解答"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Failed to update project metadata"
 msgstr "更新项目元数据失败"
 
-#: src/components/activityEventElems/PayEventElem.tsx
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
-#: src/components/inputs/FormImageUploader.tsx
-#: src/components/inputs/ImageUploader.tsx
 msgid "File must be less than {formattedSize}{unit}"
 msgstr "文件大小必须小于 {formattedSize}{unit}"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Fund and operate your thing, your way."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Fund anything. Grow together."
 msgstr "运“筹”帷幄，共创未来。"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/FundingDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Funding"
 msgstr "筹款"
 
-#: src/components/Project/FundingCycleSection.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding cycle"
 msgstr "筹款周期"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Funding cycle details"
 msgstr "筹款周期详情"
 
-#: src/components/formItems/ProjectDuration.tsx
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/DurationInputAndSelect.tsx
 msgid "Funding cycle duration"
 msgstr "筹款周期持续时间"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle preview"
 msgstr "筹款周期预览"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Funding cycle required."
 msgstr "需要筹款周期"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Funding cycle target"
 msgstr "筹款周期目标"
 
-#: src/constants/fundingWarningText.ts
 msgid "Funding cycles can be reconfigured moments before a new cycle begins, without notifying contributors."
 msgstr "新的筹款周期开始前即可重新配置筹款周期参数，无须通知捐款者。"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/Spending.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Funding distribution"
 msgstr "资金分发"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "Funding target"
 msgstr "筹款目标"
 
-#: src/components/Project/SpendingStats.tsx
 msgid "Funds available to distribute in this funding cycle (before the {feePercentage}% JBX fee). This amount won't roll over to the next funding cycle, so funds should be distributed before this funding cycle ends."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "Funds will be distributed to:"
 msgstr "资金将会分发给："
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "General"
 msgstr "通用"
 
-#: src/components/FeedbackFormButton.tsx
-#: src/components/FeedbackFormButton.tsx
 msgid "Give feedback"
 msgstr "提交反馈"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Give this NFT a name."
 msgstr ""
 
-#: src/components/EtherscanLink.tsx
 msgid "Go to Etherscan"
 msgstr "跳转到 Etherscan"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "Grant permission"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Handle"
 msgstr "标识"
 
-#: src/pages/home/QAs.tsx
 msgid "Has Juicebox been audited?"
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "Heads up"
 msgstr "注意"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "History"
 msgstr "历史"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Holders"
 msgstr "持有者"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Holdings"
 msgstr "持有"
 
-#: src/constants/time.ts
 msgid "Hours"
 msgstr "小时"
 
-#: src/pages/home/QAs.tsx
 msgid "How decentralized is Juicebox?"
 msgstr "Juicebox 的去中心化程度如何？"
 
-#: src/pages/projects/ArchivedProjectsMessage.tsx
 msgid "How do I archive a project?"
 msgstr "怎样才能把一个项目存档呢？"
 
-#: src/pages/home/QAs.tsx
 msgid "How do I create a project?"
 msgstr "怎样创建一个项目呢？"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "How do I decide?"
 msgstr "我应该怎样决定？"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "How do I set the redemption rate?"
 msgstr "我怎样设定赎回比率？"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "How does it work?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "How have the contracts been tested?"
 msgstr "这些合约是如何被测试的？"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How long before your next funding cycle must you reconfigure in order for changes to take effect."
 msgstr "你需要在下一筹款周期前多长时间完成重新配置，才能使变更在下一周期生效。"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "How long one funding cycle will last. Funding cycle <0>reconfigurations</0> will only take effect for <1>upcoming</1> funding cycles, i.e. once a current funding cycle has ended."
 msgstr "一个筹款周期的时长是多少。筹款周期 <0>参数设置的更改</0> 只能生效于 <1>后面的</1> 筹款周期，亦即是当前筹款周期终止之后。"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "How the {reservedPercentage}% of your project's reserved tokens will be split."
 msgstr "项目的 {reservedPercentage}% 保留代币怎样进行分配。"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "How to Juice."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "How your project will distribute funds."
 msgstr "您的项目将如何分配资金。"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "I accept this project's <0>risks</0>."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "I have read and accept the <0>Terms of Service</0>."
 msgstr ""
 
-#: src/components/PayWarningModal.tsx
 msgid "I understand"
 msgstr "我明白了"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "ID"
 msgstr "标识"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "ID: {projectId}"
 msgstr "ID: {projectId}"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "如果锁定了，这一项就不能编辑或删除，除非锁定失效或重新配置筹款周期。"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If locked, this split can't be edited or removed until the lock expires or the funding cycle is reconfigured."
 msgstr "如果设置锁定，这个支出收款人将不可编辑或删除，直到锁定期结束或筹款周期重新配置。"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "If you don't raise the sum of all your payouts (<0/>{distributionLimit}), this address will receive {0}% of all the funds you raise."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "If you don't raise this amount, your splits will receive their percentage of whatever you raise."
 msgstr "如果你没有筹集够这个金额，你的收款人按各自的占比来分配你筹得的所有资金。"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "If you have Juicebox project on Juicebox V1 and V2, we recommend you migrate to V2 exclusively."
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/PayableAddressSection.tsx
 msgid "If you have already deployed a payable address and have lost it, please contact the Juicebox team through <0>Discord.</0>"
 msgstr "如果你已经部署过可支付地址但把它弄丢了，请到<0>Discord</0>去联系 Juicebox 团队。"
 
-#: src/pages/home/QAs.tsx
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr "如果你对创建一个项目感兴趣，却不知道该如何开始，可以考虑看看这个<0>教学视频</0>。也可以在 <1>Juicebox Discord</1> 中寻求帮助，我们的团队将很乐意帮助您实现您的项目想法！"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr "如果你不确定你是否需要领取，那么你或许不需要。"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Image file"
 msgstr ""
 
-#: src/components/VolumeChart/index.tsx
-#: src/components/v1/V1Project/Paid.tsx
 msgid "In Juicebox"
 msgstr "项目金库余额"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "In treasury"
 msgstr "金库内"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "In wallet"
 msgstr "项目钱包余额"
 
-#: src/components/forms/IncentivesForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Incentives"
 msgstr "激励措施"
 
-#: src/pages/index.page.tsx
 msgid "Indie creators and builders"
 msgstr "独立创作者和建设者们"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Infinite (no limit)"
 msgstr "无限（无限额）"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial issuance rate"
 msgstr "初始发行比率"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Initial mint rate"
 msgstr "最初铸造比率"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Insufficient token balance"
 msgstr ""
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Invalid address"
 msgstr ""
 
-#: src/components/IssueTokenButton.tsx
 msgid "Issue ERC-20"
 msgstr "签发 ERC-20"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue ERC-20 token"
 msgstr "发行 ERC-20 代币"
 
-#: src/components/IssueTokenButton.tsx
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue an ERC-20 to be used as this project's token. Once issued, anyone can claim their existing token balance in the new token."
 msgstr "发行 ERC-20 合约作为项目代币。一旦发行，任何人都可以将现存的余额铸造为对应代币。"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Issue an ERC-20 token (optional)"
 msgstr "发行一个 ERC-20 标准代币（可选）"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Issue token"
 msgstr "发行代币"
 
-#: src/pages/home/QAs.tsx
 msgid "It isn't possible to remove a project's data from the blockchain, but we can hide it in the app if you'd like to prevent people from seeing or interacting with it — just let us know in <0>Discord</0>. Keep in mind people will still be able to use your project by interacting directly with the contract."
 msgstr "想在区块链上删除项目数据是不可能的，但如果你不想让人们看见它或与它交互，请在 <0>Discord</0> 中告诉我们，我们可以将它在应用程序中隐藏。请记住，人们仍然能够通过直接与合约交互来使用你的项目。"
 
-#: src/pages/home/QAs.tsx
 msgid "It'd be a lot cooler if you did"
 msgstr "如果你这么做了会更好"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "JBX Fee ({0}%):"
 msgstr "JBX 费率（{0}%）："
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "JBX Fee ({feePercentage}%):"
 msgstr "JBX 费率 ({feePercentage}%):"
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox Project ID"
 msgstr "Juicebox 项目标识"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Juicebox V1 project ID"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Juicebox V2 project with ID {0}"
 msgstr "Juicebox V2 上标识为 {0} 的项目"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "Juicebox isn't guaranteed to be free of bugs or exploits. Before spending money, do your own research. <0>Ask questions</0>, check out the <1>code</1>, and understand the <2>risks</2>!"
 msgstr ""
 
-#: src/components/TransactionModal.tsx
 msgid "Juicebox loading animation"
 msgstr "Juicebox加载动画"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Juicebox project"
 msgstr "Juicebox项目"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Juicebox projects use <0>ENS names</0> as handles. Setting a handle involves 2 transactions:"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Juicebox puts the fun back in funding so you can focus on building."
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Last paid"
 msgstr "上次支付"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Later"
 msgstr "以后"
 
-#: src/components/modals/DownloadParticipantsModal.tsx
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Latest"
 msgstr "最近"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Latest payments"
 msgstr "最近付款"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Launch funding cycle"
 msgstr "启动筹款周期"
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Launch veNFT"
 msgstr ""
 
-#: src/pages/create/index.page.tsx
-#: src/pages/index.page.tsx
 msgid "Launch your project"
 msgstr "启动你的项目"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Leave blank to start immediately."
 msgstr "留空以便马上开始。"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
-#: src/components/Navbar/Mobile/ThemePickerMobile.tsx
 msgid "Light theme"
 msgstr "浅色主题"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Link Juicebox V1 project"
 msgstr ""
 
-#: src/components/modals/ParticipantsModal.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Load more"
 msgstr "加载更多"
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Lock ${tokenSymbolDisplayText} for Voting Power"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Lock Duration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Lock Durations ({0} options)"
 msgstr ""
 
-#: src/components/veNft/formControls/LockDurationSelectInput.tsx
 msgid "Lock duration"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Lock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Lock until"
 msgstr "锁定至"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Locked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Locked:"
 msgstr "锁定："
 
-#: src/components/formItems/ProjectLogoUri.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Logo"
 msgstr "标志"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "MAX"
 msgstr "最大值"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "Manage"
 msgstr "管理代币"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Manage your {0}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Manage {tokenText}"
 msgstr "管理 {tokenText}"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
 msgstr "最高 {MAX_DESCRIPTION_LENGTH} 个字符"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Memo (optional)"
 msgstr "备注（可选）"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Memo included on-chain"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Migrate to Juicebox V1.1"
 msgstr "迁移至 Juicebox V1.1"
 
-#: src/components/veNft/formControls/CustomBeneficiaryInput.tsx
 msgid "Mint NFT to a custom address."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint as ERC-20"
 msgstr "铸造成 ERC-20 标准的代币"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint new {tokensLabel} into an account. Only a project's owner, a designated operator, or one of its terminal's delegates can mint its tokens."
 msgstr "铸造新的 {tokensLabel} 代币并转入某个账号。 只有项目拥有者、指定的操作员或者项目终端的授权代表才能进行此项操作。"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Mint project tokens on demand"
 msgstr "按需铸造项目代币"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Mint rate"
 msgstr "铸造比率"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint this project's ERC-20 tokens to your wallet."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Mint tokens as ERC-20"
 msgstr "铸造 ERC-20 标准代币"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Mint tokens to a custom address."
 msgstr "铸造代币并发给自定义地址"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Mint {tokensLabel}"
 msgstr "铸造 {tokensLabel}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Mint {tokensTokenLower}"
 msgstr "铸造 {tokensTokenLower}"
 
-#: src/constants/time.ts
 msgid "Minutes"
 msgstr "分钟"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "More information"
 msgstr ""
 
-#: src/pages/home/TrendingSection.tsx
 msgid "More trending projects"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Move your {tokensLabel} from the Juicebox contract to your wallet."
 msgstr "将你的 {tokensLabel} 从 Juicebox 合约中取到你的钱包里。"
 
-#: src/components/Navbar/Wallet.tsx
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "My projects"
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "NFT projects"
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
 msgid "NFT rewards"
 msgstr ""
 
-#: src/components/Project/SpendingStats.tsx
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "NO LIMIT"
 msgstr "无限额"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Name"
 msgstr "名称"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "New"
 msgstr "新"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Newly minted {tokenSymbolPlural} <0>received by contributors</0> per ETH they contribute to the treasury."
 msgstr "捐款人每向金库捐款 1 ETH<0>获得的</0> 新铸造 {tokenSymbolPlural} 。"
 
-#: src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
 msgid "Next: Funding cycle"
 msgstr "下一页：筹款周期"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Next: Review and deploy"
 msgstr "下一页：概览及部署"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No"
 msgstr "取消"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "No NFT reward tiers"
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/NoFundingCycle.tsx
 msgid "No active funding cycle."
 msgstr "没有活跃的筹款周期。"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "No activity yet"
 msgstr "暂无动态"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "No beneficiary selected. Is your wallet connected?"
 msgstr ""
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."
 msgstr "不设定筹款目标：所有的资金如何分发都由此项目决定，代币持有者无法赎回。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
 msgid "No funds available to distribute."
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
 msgid "No funds can be distributed out of the treasury. Funds can only be accessed by token holders redeeming their tokens."
 msgstr "资金不能从金库分配出去。资金只能由代币持有人通过赎回代币来获得。"
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "No limit (infinite)"
 msgstr "无限额 (无限)"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr "在单个筹款周期中，项目无法提取超出筹款目标的资金。"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "No past funding cycles"
 msgstr "没有历史筹款周期"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "No reserved tokens available to distribute."
 msgstr ""
 
-#: src/constants/v1/ballotStrategies/index.ts
-#: src/constants/v2/ballotStrategies/index.ts
 msgid "No strategy"
 msgstr "暂无策略"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "No target"
 msgstr "没有筹款目标"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "No target set."
 msgstr "不设定筹款目标。"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Not a valid ETH address"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Not set"
 msgstr "未设定"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Note"
 msgstr "请注意："
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Note: Tokens can be minted manually when allowed in the current funding cycle. This can be changed by the project owner for upcoming cycles."
 msgstr "请注意：当前筹款周期允许的情况下，可以手动进行代币铸造。项目方可以在以后的筹款周期变更这一设置。"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Notice from {0}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Notice from {0}:"
 msgstr "通知自{0}:"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
 msgid "Once launched, your first funding cycle <0>can't be changed</0>. You can reconfigure upcoming funding cycles according to the project's <1>reconfiguration rules</1>."
 msgstr "一旦启动，你的第一个筹款周期 <0>不能再更改</0>。 你可以按照项目的 <1>重新配置规则</1>来重新配置后续的筹款周期。"
 
-#: src/components/formItems/ENSName.tsx
 msgid "Only lowercase letters"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Only project tokens claimed as ERC-20 tokens can be staked for NFTs."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Other assets in this project's owner's wallet."
 msgstr "项目拥有者钱包内的其他资产"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Other details"
 msgstr ""
 
-#: src/components/Project/FundingProgressBar.tsx
 msgid "Overflow"
 msgstr "溢出"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr "如果您项目的资金余额超出您的筹款周期目标，就会产生溢出。项目代币持有人可以赎回溢出部分资金。"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Owned by: <0/>"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can mint tokens at any time."
 msgstr "项目方可以随时铸造代币"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner is not allowed to mint tokens."
 msgstr "项目方不能够铸造代币。"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Owner isn't allowed to set the project's payment terminals."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Owner token minting"
 msgstr "项目方的代币铸造"
 
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Owner tools"
 msgstr "项目方工具"
 
-#: src/components/activityEventElems/PayEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Paid"
 msgstr "支付"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Paid as <0/>"
 msgstr "支付 <0/>"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Pause payments"
 msgstr "暂停支付"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "Pause received payments"
 msgstr "暂停接受付款"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay"
 msgstr "支付"
 
-#: src/components/Project/ProjectToolsDrawer/AddToProjectBalanceForm.tsx
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay amount"
 msgstr "支付金额"
 
-#: src/components/inputs/Pay/PayInputGroup.tsx
 msgid "Pay amount must be greater than 0."
 msgstr "支付金额必须大于0 。"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay button"
 msgstr "支付按钮"
 
-#: src/components/formItems/ProjectPayButton.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Pay button text"
 msgstr "支付按钮文本"
 
-#: src/components/formItems/ProjectPayDisclosure.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Pay disclosure"
 msgstr "付款声明"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Pay {0}"
 msgstr "支付 {0}"
 
-#: src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
-#: src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
 msgid "Payer"
 msgstr "付款人"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. <1>{1}</1> determines any value or utility of the tokens you receive."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Paying <0>{0}</0> is not an investment — it's a way to support the project. Any value or utility of the tokens you receive is determined by {1}."
 msgstr "向 <0>{0}</0> 支付并不是投资 —— 而是支持项目的一种方式。你收到代币的价值和效用都由 {1} 决定。"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "Paying this project is currently disabled."
 msgstr "当前项目已暂停接收付款。"
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "Payment address contract:"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Payment equivalent"
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Payment memo"
 msgstr ""
 
-#: src/components/RichImgPreview.tsx
 msgid "Payment memo image"
 msgstr "付款留言图片"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Payment options"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Payments"
 msgstr "支付"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "Payments are paused in this funding cycle."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Payments made"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Payments paused"
 msgstr "付款已暂停"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Payout is locked"
 msgstr "支出被锁定"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Payout recipients"
 msgstr "支出的收款人"
 
-#: src/pages/create/forms/FundingForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Payouts"
 msgstr "支出对象"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
 msgid "Payouts (optional)"
 msgstr "支出 (可选)"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Payouts to Ethereum addresses incur a 2.5% JBX membership fee"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return at the current issuance rate."
 msgstr "项目支出分配到其他以太地址需缴纳一个 {feePercentage}% 的费用。支付费用后，你的项目将按当前的发行比率收到 JBX 代币。"
 
-#: src/components/Navbar/constants.ts
 msgid "Peel"
 msgstr "Peel"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Percent"
 msgstr "百分比"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "Percentage allocation"
 msgstr "分配百分比"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Percentage:"
 msgstr "百分比："
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Percentages"
 msgstr "百分比"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "Percentages must add up to 100% or less"
 msgstr "百分比总数相加必须少于或等于100%"
 
-#: src/components/Navbar/constants.ts
 msgid "Podcast"
 msgstr "播客"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Potential risks"
 msgstr "潜在风险"
 
-#: src/pages/create/ProjectConfigurationFieldsContainer.tsx
 msgid "Preview"
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Preview:"
 msgstr "预览："
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Project Created"
 msgstr "创建项目"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Project ID must be a number."
 msgstr "项目 ID 必须是一个数字。"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Project ID:"
 msgstr "项目标识："
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Links"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project Page Customizations"
 msgstr ""
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Project Token"
 msgstr "项目代币"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project configuration"
 msgstr "项目设置"
 
-#: src/components/activityEventElems/ProjectCreateEventElem.tsx
 msgid "Project created by"
 msgstr "项目创建人是"
 
-#: src/components/formItems/ProjectDescription.tsx
 msgid "Project description"
 msgstr "项目说明"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Project details"
 msgstr "项目详情"
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
 msgid "Project details can be edited at any time."
 msgstr "项目的详情可以随时进行编辑。"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Project details reconfigurations will create a separate transaction."
 msgstr "项目细节的重新配置将会发起一个单独的交易。"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Project handle"
 msgstr "项目标识"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Project handle must be unique."
 msgstr "项目标识必须是唯一的。"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is accepting payments this funding cycle."
 msgstr "项目本筹款周期接受付款。"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Project is not accepting payments this funding cycle."
 msgstr "项目本筹款周期不接受付款。"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Project launch successful"
 msgstr "项目成功启动"
 
-#: src/components/formItems/ProjectName.tsx
 msgid "Project name"
 msgstr "项目名称"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Project name, handle, links, and other details."
 msgstr "项目名称，标识，链接以及其他详细信息。"
 
-#: src/components/Project404.tsx
 msgid "Project not found"
 msgstr ""
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner"
 msgstr "项目拥有者"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project owner (you)"
 msgstr "项目拥有者 (你)"
 
-#: src/pages/home/QAs.tsx
 msgid "Project owners can configure a delay period, meaning reconfigurations to an upcoming funding cycle must be submitted a certain number of days before it starts. For example, a 3-day delay period means reconfigurations must be submitted at least 3 days before the next funding cycle starts. This gives token holders time to react to the decision and reduces the chance of rug-pulls."
 msgstr "项目方可以配置一个延迟期，这意味着对即将到来的筹款周期的重新配置必须在某个时间段内提交。例如，3天的延迟期意味着重新配置必须至少在下一个筹款周期开始前的3天内提交。这给了代币持有者对决策做出反应的时间，并减少了项目方跑路的机会。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project token"
 msgstr "项目代币"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/TokenDrawer.tsx
 msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is <1>optional</1>."
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Project {0}"
 msgstr ""
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr "{name} 项目即将创建完成！请稍后尝试刷新页面。"
 
-#: src/components/v2/shared/V2ProjectHandle.tsx
 msgid "Project {projectId}"
 msgstr "项目 {projectId}"
 
-#: src/components/Project404.tsx
 msgid "Project {projectId} not found"
 msgstr "项目 {projectId} 未找到"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/hooks/PageTitle.ts
 msgid "Projects"
 msgstr "项目"
 
-#: src/pages/home/QAs.tsx
 msgid "Projects can be created with an optional discount rate designed to incentivize supporters to contribute earlier rather than later. The amount of tokens rewarded per amount paid to your project will decrease by the discount rate with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier rather than later."
 msgstr "创建项目时，可选择配置一个折扣率用于激励早期支持者。 每个新的筹款周期，支付给项目的每笔金额所奖励的代币数量将按折扣率递减。更高的折扣率将激励支持者尽早资助你的项目。"
 
-#: src/pages/home/StatsSection.tsx
-#: src/pages/projects/index.page.tsx
 msgid "Projects on Juicebox"
 msgstr "Juicebox 上的项目"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "Projects that you have created."
 msgstr "你已创建的项目"
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "Projects that you hold tokens for."
 msgstr "你持有代币的项目。"
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Projects using a reserved rate of {reservedRateRiskyMin}% or more will appear risky to contributors, as a relatively small number of tokens will be received in exchange for paying your project."
 msgstr "项目使用的代币保留率大于或等于{reservedRateRiskyMin}% 会让捐款人觉得项目不安全，因为这种情况下给您的项目捐款从而获得的代币数量会比较少。"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Projects with a handle:<0/><1/>1. Are included in search results on the projects page<2/>2. Can be accessed via the URL: <3>juicebox.money{0}</3><4/><5/>(The original URL <6>juicebox.money{1}</6> will continue to work.)"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
 msgid "Provide a link to additional information about this NFT."
 msgstr ""
 
-#: src/pages/home/StatsSection.tsx
 msgid "Raised on Juicebox"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "Range"
 msgstr ""
 
-#: src/pages/projects/RankingExplanation.tsx
 msgid "Rankings based on number of contributions and volume gained in the last {trendingWindow} days. <0>See code</0>"
 msgstr "按最近 {trendingWindow} 天的支付次数与数额排行。<0>查看代码</0>"
 
-#: src/components/Paragraph.tsx
 msgid "Read less"
 msgstr ""
 
-#: src/components/Paragraph.tsx
 msgid "Read more"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "Receive ERC-20"
 msgstr "接收 ERC-20 标准代币"
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
 msgstr ""
 
-#: src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
 msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "Receive {receiveText}"
 msgstr "接收 {receiveText}"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Recipient"
 msgstr "收款人"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Recipient Address"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Recipient address"
 msgstr "接收人地址"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Recipients will receive payouts in ETH."
 msgstr "收款人将收到以 ETH 支付的报酬。"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reconfiguration"
 msgstr "重新配置"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Reconfiguration rules"
 msgstr "重新配置的规则"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reconfiguration strategy"
 msgstr "重新配置策略"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure"
 msgstr "重新配置"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Reconfigure payouts as percentages of your distribution limit."
 msgstr ""
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
 msgid "Reconfigure project and funding details"
 msgstr "重新配置项目和筹款详细内容"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureProjectDetailsDrawer.tsx
 msgid "Reconfigure project details"
 msgstr "重新配置项目明细"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/drawers/V2ReconfigureTokenDrawer.tsx
 msgid "Reconfigure token"
 msgstr "重新配置代币"
 
-#: src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Reconfigure upcoming"
 msgstr "重新配置之后的筹款"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Reconfigure upcoming funding cycles"
 msgstr "重新配置以后的筹款周期"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Redeem"
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeem veNFT"
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem your {tokensLabel} for a portion of the project's overflow. Any {tokensLabel} you redeem will be burned."
 msgstr "赎回你的 {tokensLabel} 来获取一部分项目的溢出资金。用于赎回的 {tokensLabel} 将会被燃烧掉。"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redeem {0} {tokensTextShort} for ETH"
 msgstr "燃烧 {0} {tokensTextShort} 来赎回 ETH"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Redeem {tokensLabel} for ETH"
 msgstr "燃烧 {tokensLabel} 来赎回 ETH"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr "燃烧 {tokensTextLong} 来赎回 ETH"
 
-#: src/components/activityEventElems/RedeemEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "Redeemed"
 msgstr "赎回"
 
-#: src/components/veNft/VeNftRedeemModal.tsx
 msgid "Redeeming this NFT will burn the token and return..."
 msgstr ""
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/formItems/ProjectRedemptionRate.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
-#: src/pages/create/forms/TokenForm/index.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Redemption rate"
 msgstr "赎回率"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Redemption rate:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Redemption rate: <0>{0}%</0>"
 msgstr "赎回比率: <0>{0}%</0>"
 
-#: src/components/NewDeployNotAvailable.tsx
 msgid "Refresh"
 msgstr "刷新"
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
 msgstr "在新的 Juicebox 合约上启动项目的筹款周期。"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Required"
 msgstr "必需"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr "保留某个百分比的新铸造代币供项目使用。"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Reserved rate"
 msgstr "保留率"
 
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved rate is 0% but has reserved token allocation. Consider adding a reserved rate that is greater than zero, or remove the token allocation."
 msgstr "代币保留率为0%但又需要分配保留代币。建议增加一个大于零的保留率，或者取消代币分配。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Reserved token allocation"
 msgstr "保留代币的分配方案"
 
-#: src/components/forms/TicketingForm.tsx
-#: src/pages/create/forms/TokenForm/ReservedTokensFormItem.tsx
 msgid "Reserved token allocation (optional)"
 msgstr "保留代币的分配方案（可选）"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Reserved token allocations"
 msgstr "保留代币的分配方案"
 
-#: src/components/formItems/ProjectReserved.tsx
-#: src/components/forms/TicketingForm.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Reserved tokens"
 msgstr "保留代币"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "Reserved {0}"
 msgstr "已保留 {0}"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Reserved {tokenSymbolPlural}"
 msgstr "保留的 {tokenSymbolPlural}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr "保留的 {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "Reserved {tokensText}"
 msgstr "保留的 {tokensText}"
 
-#: src/components/Navbar/MenuItems.tsx
-#: src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
 msgid "Resources"
 msgstr "相关资料"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Restrict payments and printing tokens."
 msgstr "限制付款以及铸造代币。"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Restricted actions"
 msgstr "受限操作"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Review & Deploy"
 msgstr "检查并部署"
 
-#: src/components/veNft/formControls/StakingFormActionButton.tsx
 msgid "Review and confirm stake"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Review and launch funding cycle"
 msgstr "复核及启动筹款周期"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Review project"
 msgstr "检查项目"
 
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Reward contributors with NFT's."
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Reward contributors with NFTs when they meet your configured funding criteria."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Reward specific community members with tokens."
 msgstr "用代币奖励特定的社区成员。"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/RulesDrawer.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
 msgid "Rules"
 msgstr "规则"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Rules for determining how funding cycles can be reconfigured"
 msgstr "决定如何重新配置筹款周期的规则"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Rules for how changes can be made to your project."
 msgstr "项目筹款周期配置的更改规则。"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr "关于如何重新配置该项目筹款周期的规则"
 
-#: src/components/forms/RestrictedActionsForm.tsx
-#: src/components/forms/TicketingForm.tsx
 msgid "Save"
 msgstr "保存"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/components/veNft/VeNftRewardTierModal.tsx
 msgid "Save NFT reward"
 msgstr ""
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Save NFT rewards"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
 msgid "Save Option"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save changes"
 msgstr "保存更改"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "Save funding configuration"
 msgstr "保存筹款设置"
 
-#: src/components/v1/V1Project/modals/EditProjectModal.tsx
 msgid "Save handle"
 msgstr "保存标识"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Save payout"
 msgstr "保存支出对象"
 
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Save payouts"
 msgstr "保存开支配置"
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "Save project details"
 msgstr "保存项目详情"
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
 msgid "Save reconfiguration"
 msgstr "保存新的配置"
 
-#: src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "Save rules"
 msgstr "保存规则"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
-#: src/components/v1/shared/TicketModsList.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditTokenAllocationModal.tsx
 msgid "Save token allocation"
 msgstr "保存代币的分配方案"
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "Save token configuration"
 msgstr "保存代币配置"
 
-#: src/components/v1/V1Project/modals/V1BalancesModal.tsx
-#: src/components/v2/V2Project/V2BalancesModal/V2BalancesModal.tsx
 msgid "Save tracked assets"
 msgstr "保存监测资产项"
 
-#: src/pages/projects/index.page.tsx
 msgid "Search projects by handle"
 msgstr "通过标识搜索项目"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "Second"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
-#: src/constants/time.ts
 msgid "Seconds"
 msgstr "秒"
 
-#: src/components/EtherscanLink.tsx
 msgid "See transaction"
 msgstr "查看交易"
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set ENS name"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "Set Up veNFT Governance"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set a distribution limit"
 msgstr "设置一个分配限额"
 
-#: src/components/formItems/ProjectDuration.tsx
 msgid "Set a funding cycle duration"
 msgstr "设置筹款周期持续时间"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set a funding cycle target"
 msgstr "设定筹款周期目标"
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a project handle (optional)"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-#: src/components/v2/V2Project/NewDeployModal.tsx
 msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set project handle"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Set text record for {0}"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the amount of funds you'd like to raise each funding cycle. Any funds raised within the funding cycle target can be distributed by the project, and can't be redeemed by your project's token holders."
 msgstr "设定你每个筹款周期想要筹款的金额。筹款周期目标以内的金额会分配给项目，项目代币持有人不能通过赎回取得这部分资金。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Set the length of your funding cycles."
 msgstr "设定您的筹款周期时长。"
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "Set this to the sum of all your payouts"
 msgstr "把这个设置为你所有支出对象的总额"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up V1 token migration"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
-#: src/components/veNft/VeNftSetupSection.tsx
 msgid "Set up and launch veNFT governance for your project."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "Set up token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "Set up your Juicebox V2 project for migration from your Juicebox V1 project."
 msgstr ""
 
-#: src/pages/index.page.tsx
 msgid "Should you Juicebox?"
 msgstr "你应该使用Juicebox吗?"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingSummarySection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Since you have not set a funding duration, changes to these settings will be applied immediately."
 msgstr "鉴于你并未设置筹款持续时间，对这些设置的修改将会立即生效。"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "Some funding cycle settings may put project contributors at risk."
 msgstr ""
 
-#: src/components/ProjectRiskNotice.tsx
 msgid "Some of the project's current funding cycle properties may indicate risk for contributors."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Something went wrong."
 msgstr "出错了。"
 
-#: src/components/formItems/ENSName.tsx
 msgid "Spaces are not allowed"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Spending"
 msgstr "资金分配"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake your {tokensLabel} to increase your voting weight and claim Governance NFTs."
 msgstr ""
 
-#: src/components/veNft/VeNftHeaderSection.tsx
 msgid "Stake {tokenName} ({tokenSymbolDisplayText}) tokens in exchange for voting weight. In return, you'll impact {projectName} governance and receive a choice governance NFT."
 msgstr ""
 
-#: src/components/ManageTokensModal.tsx
 msgid "Stake {tokensLabel} for NFT"
 msgstr ""
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Staking Summary:"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Start"
 msgstr "开始时间"
 
-#: src/pages/create/StartOverButton.tsx
-#: src/pages/v1/create/index.page.tsx
-#: src/pages/v1/create/index.page.tsx
 msgid "Start Over"
 msgstr "重新来过"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "Start over"
 msgstr ""
 
-#: src/pages/home/TopProjectsSection.tsx
 msgid "Start raising funds"
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Start time (seconds, Unix time)"
 msgstr "开始时间（秒，Unix时间）"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Step 1. Add V1 token payment terminal"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "Step 2. Link your Juicebox V1 project"
 msgstr ""
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "Successfully approved ERC-20 spending."
 msgstr ""
 
-#: src/components/v1/shared/PayoutModsList.tsx
 msgid "Sum of percentages cannot exceed 100%"
 msgstr "百分比合计不能超过 100%"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v1/shared/forms/PayModsForm.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "Sum of percentages cannot exceed 100%."
 msgstr "百分比合计不能超过 100%."
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap V1 {tokenSymbolFormattedPlural} for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
 msgid "Swap for V2 {tokenSymbolFormattedPlural}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/V1ProjectTokensSection.tsx
 msgid "Swap for V2 {tokenText}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target"
 msgstr "目标"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Target is 0: All funds will be considered overflow and can be redeemed by burning project tokens."
 msgstr "目标为 0 ：所有资金将被视为溢出，可以通过燃烧项目代币来赎回。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Terminal configuration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ReconfigureProjectHandleDrawer.tsx
 msgid "Text record is set"
 msgstr ""
 
-#: src/pages/create/forms/TokenForm/index.tsx
 msgid "The <0>issuance rate</0> of your second funding cycle will be <1>{0} tokens per 1 ETH</1>, then <2>{1} tokens per 1 ETH </2>for your third funding cycle, and so on."
 msgstr "项目第二个筹款的 <0>发行比率/0> 将会是 <1>{0} 个代币每1 ETH</1>， 然后第三个筹款是 <2>{1} 个代币每 1 ETH </2>，以此类推。"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "The JBX protocol is unaudited, and projects built on it may be vulnerable to bugs or exploits. Be smart!"
 msgstr "JBX 协议未经审计，基于它构建的项目可能受到 bug 的影响或漏洞被恶意利用。使用风险请自行承担！"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "The address of any smart contract deployed on {0} that implements <0>this interface</0>."
 msgstr "所有在 {0} 上面部署同时实现<0>这个接口</0>的智能合约地址 。"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr "项目收到付款时，应该接收到新铸造代币的地址。"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "The amount of tokens this project has reserved. These tokens can be distributed to reserved token beneficiaries."
 msgstr "项目保留的代币数量。这些代币可以分配给保留代币受益人。"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "The amount of tokens to mint to the receiver."
 msgstr "铸造给接收人的代币数量。"
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "目前这个筹款周期从 Juicebox 余额中分配出去的金额，未超出分配限额部分。在单个筹款周期里面，分配的资金不能超过分配限额— 剩余 Juicebox 内的所有 ETH 都作为溢出处理，直至下个周期开始。"
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr "当前筹款周期中，从筹款目标中已提取的金额。单个筹款周期中，超出目标的资金不能被分发——Juicebox 中剩余的 ETH 都记为溢出，直到下个周期开始。"
 
-#: src/components/v1/V1Project/Paid.tsx
-#: src/components/v2/V2Project/TreasuryStats/OwnerBalance.tsx
 msgid "The balance of the project owner's wallet."
 msgstr "项目拥有者钱包的余额。"
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The balance of this project in the Juicebox contract."
 msgstr "该项目在Juicebox合约中的余额。"
 
-#: src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
 msgid "The distribution limit for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "当前筹款周期的分配限额为 0, 也就是说 Juicebox 里的所有资金都被视为溢出。溢出可供持币人赎回代币来换取，但不能用于分配。"
 
-#: src/pages/index.page.tsx
 msgid "The future will be led by creators, and owned by communities."
 msgstr "创造者将引领未来, 而社区会拥有未来."
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "The maximum amount of funds allowed to be distributed from the project's treasury each funding cycle."
 msgstr "每个筹款周期允许从项目金库分配出去的最大金额。"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "The maximum amount of funds that can be distributed from the treasury each funding cycle."
 msgstr "每个筹款周期可以从金库分配出去的最大金额。"
 
-#: src/components/formItems/ProjectTarget.tsx
 msgid "The maximum amount of funds that can be distributed from this project in one funding cycle. Funds will be withdrawn in ETH no matter the currency you choose."
 msgstr "单个筹款周期内，可从项目分配出去的资金上限。无论你选择用哪种货币进行分配，都是以 ETH 的形式提取资金。"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed in the first funding cycle."
 msgstr "第一个筹款周期捐款 1 ETH 铸造的项目代币数量。"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "The number of project tokens minted when 1 ETH is contributed."
 msgstr "捐款 1 ETH 铸造的项目代币数量。"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "The onchain memo for each payment made to this address. The project's payment feed will include the memo alongside the payment."
 msgstr ""
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "The percentage this individual receives of the overall {reservedRate}% reserved token allocation"
 msgstr "这个个体收到的全部 {reservedRate}% 保留代币分配方案中的百分比"
 
-#: src/pages/index.page.tsx
 msgid "The programmable funding protocol. Light enough for a group of friends, powerful enough for a global network of anons. <0>Community-owned</0>, on Ethereum."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "The project owner can add and remove payment terminals."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner is using an unverified contract for its reconfiguration strategy."
 msgstr ""
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may mint any supply of tokens at any time, diluting the token share of all existing contributors."
 msgstr "项目方可以随时铸造任意数量的代币，这会稀释所有代币持有者的份额。"
 
-#: src/constants/fundingWarningText.ts
 msgid "The project owner may reconfigure this funding cycle at any time, without notice."
 msgstr "项目方可以随时修改当前筹款周期的配置，不需要事先通知。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The project token's issuance rate will decrease by this percentage every funding cycle. A higher discount rate will incentivize contributors to pay the project earlier."
 msgstr "项目代币的发行比率每个筹款周期都会按这个百分比逐步递减。较高的折扣率会鼓励捐款人尽早向项目付款。"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "The ratio of tokens rewarded per payment amount will decrease by this percentage with each new funding cycle. A higher discount rate will incentivize supporters to pay your project earlier than later."
 msgstr "按付款金额奖励项目代币的比例，会随着进入新的筹款周期不断按这个比率递进减少。较高的折扣率会鼓励您的支持者更早一点给您的项目捐款。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/settingExplanations.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for at any given time. On a lower redemption rate, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than other holders. A redemption rate of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "赎回比率决定了任何时候每赎回一个代币可以换取的溢出金额。赎回比率低的时候，每赎回一个代币都会增加每个剩余代币的价值，形成一个比其他人持有更长时间的激励机制。100%的赎回比率意味着不管什么时候赎回，所有代币都将拥有同样的价值。"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "The redemption rate determines the amount of overflow each token can be redeemed for."
 msgstr "赎回比率决定了每赎回一个代币能获得的溢出金额。"
 
-#: src/components/v1/V1Project/Paid.tsx
 msgid "The target for this funding cycle is 0, meaning all funds in Juicebox are currently considered overflow. Overflow can be redeemed by token holders, but not distributed."
 msgstr "当前筹款周期的目标为零，意味着目前所有资金都视作溢出。代币持有者可以从溢出池中赎回 ETH，但是项目方不能从溢出池中提取资金。"
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
 msgid "The total funds this Juicebox project has received since it was created."
 msgstr "这个 Juicebox 项目创建后总共收到的资金。"
 
-#: src/components/PayWarningModal.tsx
 msgid "The<0>Juicebox contracts</0> may be vulnerable to bugs or hacks. All funds moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses by projects or their supporters."
 msgstr ""
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr "当前筹款周期没有设置支出。项目拥有者将获得所有的可用资金。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "There are no reserved token recipients defined for this funding cycle. The project owner will receive all available tokens."
 msgstr "当前筹款周期没有设置保留代币受益人。项目拥有者将会获得所有可分配代币。"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These attributes can be changed at any time."
 msgstr "任何时候都可以修改这些属性。"
 
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "These settings will <0>not</0> be editable immediately within a funding cycle. They can only be changed for <1>upcoming</1> funding cycles."
 msgstr "这些属性<0>不能</0> 在同一个筹款周期内马上进行修改。 更改的配置只会在 <1>后面的</1> 筹款周期生效。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "This Juicebox V2 project also has a project on Juicebox V1. The project owner is allowing you to swap your V1 tokens for V2 tokens."
 msgstr ""
 
-#: src/utils/ballot.ts
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
 msgstr "此地址是一个未识别的策略合约。请确保这个地址是对的。"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/shared/SplitItem.tsx
 msgid "This address will receive any tokens minted when the recipient project gets paid."
 msgstr "有人给这个项目付款时，此地址会收到保留的代币。"
 
-#: src/components/modals/ReservedTokenReceiverModal.tsx
 msgid "This address will receive the tokens minted from paying this project."
 msgstr "捐款给项目后铸造出来的代币将会发放到这个地址。"
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
 msgstr "当前筹款周期可能存在一定风险。支付前请先检查筹款周期的配置详情。"
 
-#: src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."
 msgstr "这是每个筹款周期可以从金库分配出去的最大资金数量。"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
 msgstr "这个列表是通过实验性的数据索引统计而得到的，对某些项目来说可能并不精确。"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
-#: src/components/v2/V2Project/V2PayButton/index.tsx
 msgid "This project is archived and can't be paid."
 msgstr "项目已被归档，无法收到付款。"
 
-#: src/components/v1/V1Project/modals/MigrateV1Pt1Modal.tsx
 msgid "This project is currently using the Juicebox V1 terminal contract. New features introduced in V1.1 allow the project owner to:"
 msgstr "这个项目正在使用 Juicebox V1 Terminal 合约。V1.1 的新特性使得项目拥有者可以："
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "This project reserves some of the newly minted tokens for itself."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
 msgid "This project uses the V2 version of the Juicebox contracts."
 msgstr "这个项目使用的是 V2 版本的 Juicebox 合约。"
 
-#: src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
 msgid "This project's balance in the Juicebox contract."
 msgstr "这个项目在 Juicebox 合约内的余额。"
 
-#: src/components/Project/BallotStateBadge.tsx
 msgid "This proposed reconfiguration hasn't passed the {0} period. It's not guaranteed to take effect in the upcoming funding cycle."
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "This rate determines the amount of overflow that each token can be redeemed for at any given time. On a lower bonding curve, redeeming a token increases the value of each remaining token, creating an incentive to hold tokens longer than others. A bonding curve of 100% means all tokens will have equal value regardless of when they are redeemed."
 msgstr "这一比率决定了任何特定时间内每赎回一个代币可以获得的溢出金额。联合曲线比率较低的情况下，每赎回一个代币都会相应地提升所有剩余代币的赎回价值，这样就会形成一个代币长期持有的激励机制。联合曲线比率为 100% 时，则意味着无论什么时候赎回代币，每个代币获得的价值都将是相同的。"
 
-#: src/components/veNft/VeNftSetUnclaimedTokensPermissionSection.tsx
 msgid "This will enable your project's veNFT contract to spend unclaimed tokens in addition to project ERC-20 tokens."
 msgstr ""
 
-#: src/pages/v1/create/index.page.tsx
 msgid "This will erase all of your changes."
 msgstr "这将删除你所有的更改。"
 
-#: src/pages/create/StartOverButton.tsx
 msgid "This will reset the data for your new project. All changes will be lost."
 msgstr ""
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Time Remaining"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "Time remaining for changes made to affect the next funding cycle:"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "To do so, you need to give your V1 token holders the ability to exchange their V1 tokens for V2 tokens. Select <0>Set up token migration</0> below to get started."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "To: <0/>"
 msgstr "分配给：<0/>"
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
-#: src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Token"
 msgstr "代币"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "Token address: <0/>"
 msgstr "代币地址：<0/>"
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Token amount"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Token beneficiary address"
 msgstr "代币受益人地址"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "Token beneficiary:"
 msgstr "代币受益人："
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token holders <0>cannot redeem their tokens</0> for any ETH when the redemption rate is 0."
 msgstr "赎回比率为 0 时，代币持有人 <0>不能赎回他们的代币</0> 来获取 ETH。"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "Token holders of your V1 project tokens will swap their V1 tokens for V2 tokens at a 1-to-1 exchange rate."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Token minting"
 msgstr "代币铸造"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "Token minting allows the project owner to mint project tokens at any time."
 msgstr "代币铸造功能允许项目拥有者随时铸造项目代币。"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "Token minting enabled"
 msgstr "代币铸造已允许"
 
-#: src/components/ManageTokensModal.tsx
 msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr "代币铸造功能只在 V1.1 项目中可用。可以通过重新配置项目的筹款周期来启用或禁用这一功能。"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name"
 msgstr "代币名称"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token name is required"
 msgstr "请填写代币名称"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "Token redeem value"
 msgstr "代币赎回价值"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol"
 msgstr "代币符号"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Token symbol is required"
 msgstr "请填写代币简称"
 
-#: src/components/v1/shared/Mod.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
-#: src/utils/tokenSymbolText.ts
 msgid "Tokens"
 msgstr "代币"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>contributors will receive</0> when they contribute 1 ETH."
 msgstr "捐款人捐 1 ETH <0>将会获得的</0> 代币。"
 
-#: src/components/formItems/ProjectReserved.tsx
 msgid "Tokens <0>reserved for the project</0> when 1 ETH is contributed."
 msgstr "捐款 1 ETH 时<0>保留给项目的</0> 代币。"
 
-#: src/components/forms/TicketingForm.tsx
 msgid "Tokens are earned by anyone who pays your project, and can be redeemed for overflow if your project has set a funding target."
 msgstr "当有人对你的项目进行支付时，他们会获得项目代币。在项目设定了筹款目标时, 可以通过赎回项目代币来获得溢出资金。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Tokens are required."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
 msgid "Tokens can be minted manually when allowed in the current funding cycle. The project owner can enable or disable minting for upcoming cycles."
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "Tokens can be redeemed for a portion of a project's <0>overflow</0>, letting you benefit from its success. After all, you helped it get there. The token may also give you exclusive member-only privledges, and allow you to contribute to the governance of the community."
 msgstr "代币可以用来赎回一部分项目的 <0>溢出资金</0>，让你从项目的成功中受益。毕竟，是你帮助它实现的。代币还可以提供专属于成员的特权，并允许你为社区的治理做出贡献。"
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the bonding curve rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "代币可以用于赎回项目溢出的一部分 ETH，基于当前筹款周期的联合曲线率。<0>赎回时代币会被燃烧掉。</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "Tokens can be redeemed for a portion of this project's ETH overflow, according to the redemption rate of the current funding cycle. <0>Tokens are burned when they are redeemed.</0>"
 msgstr "可以通过赎回代币，按当前筹款周期的赎回比率来获取项目的部分溢出。 <0>赎回的代币会被销毁掉。</0>"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Tokens cannot be claimed because no ERC-20 token has been issued for this project. ERC-20 tokens must be issued by the project owner."
 msgstr "因为 ERC-20 代币还没有签发，所以目前还不能领取代币。ERC-20 代币必须由项目方来签发。"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens for you"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/PrintPreminedModal.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "Tokens receiver"
 msgstr "代币接收方"
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "Tokens reserved"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "Tokens:"
 msgstr "代币："
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
-#: src/components/v1/V1Project/V1ProjectToolsDrawer.tsx
-#: src/components/v2/V2Project/V2ProjectHeaderActions.tsx
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "Tools"
 msgstr "工具"
 
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
 msgid "Total funds:"
 msgstr "总资金："
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "Total raised"
 msgstr "总筹款"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked period"
 msgstr ""
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "Total staked {tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Total supply"
 msgstr "总供应量"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
-#: src/components/v1/shared/ProjectTicketMods.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
 msgid "Total: {0}%"
 msgstr "总共：{0}%"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
-#: src/hooks/Transactor.ts
 msgid "Transaction failed"
 msgstr "交易失败"
 
-#: src/components/TransactionModal.tsx
 msgid "Transaction pending..."
 msgstr "交易进行中......"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Transaction unsuccessful"
 msgstr "交易不成功"
 
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
-#: src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
 msgid "Transfer ownership"
 msgstr "所有权转移"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer unclaimed {tokenSymbolShort}"
 msgstr "转账未领取的 {tokenSymbolShort}"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Transfer {tokenSymbolShort}"
 msgstr "转账 {tokenSymbolShort}"
 
-#: src/pages/projects/ProjectsTabs.tsx
 msgid "Trending"
 msgstr "热门"
 
-#: src/pages/home/TrendingSection.tsx
 msgid "Trending projects"
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Twitter"
 msgstr "Twitter"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "Twitter handle"
 msgstr "推特名"
 
-#: src/components/ArchiveProject/index.tsx
-#: src/components/ArchiveProject/index.tsx
 msgid "Unarchive project"
 msgstr "取消项目的存档状态"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "Unavailable"
 msgstr "不可用"
 
-#: src/components/v2/shared/SplitItem.tsx
-#: src/components/veNft/VeNftContent.tsx
 msgid "Unknown Project"
 msgstr ""
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "除非在项目筹款周期设置中将付款暂停，否则项目仍能通过 Juicebox 协议的合约直接收到付款。"
 
-#: src/components/veNft/VeNftOwnedTokenCard.tsx
 msgid "Unlock"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock successful. Results will be indexed in a few moments."
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlock veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftUnlockModal.tsx
 msgid "Unlocking this staking position will burn your NFT and return ${tokenSymbolDisplayText}."
 msgstr ""
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "Unsaved changes"
 msgstr "未保存更改"
 
-#: src/components/Project/ProjectHeader/index.tsx
 msgid "Untitled project"
 msgstr "项目未命名"
 
-#: src/components/v2/V2Project/V2BalancesModal/V2TokenRefs.tsx
 msgid "Untrack token"
 msgstr ""
 
-#: src/components/v1/V1Project/FundingCycles/index.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/index.tsx
 msgid "Upcoming"
 msgstr "未来"
 
-#: src/components/veNft/VeNftExtendLockModal.tsx
 msgid "Update your veNFT's lock duration."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/index.tsx
 msgid "Updates you make to this section will only be applied to <0>upcoming</0> funding cycles."
 msgstr "你对这个部分的改动在 <0>后面的</0> 筹款周期才会生效。"
 
-#: src/components/formItems/ProjectLogoUri.tsx
 msgid "Upload"
 msgstr "上传"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
 msgid "Upload an image"
 msgstr ""
 
-#: src/components/inputs/ImageUploader.tsx
 msgid "Uploaded to: <0>{url}</0>"
 msgstr "已上传至：<0>{url}</0>"
 
-#: src/components/inputs/FormImageUploader.tsx
 msgid "Uploaded to: <0>{value}</0>"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Amounts</0> when you want to configure a <1>distribution limit</1>. Treasury funds that exceed the distribution limit are called <2>overflow</2>. Token holders can redeem (burn) their tokens for a portion of the overflow. <3>Learn more</3>."
 msgstr "使用 <0>金额</0> 来配置 <1>分配限额</1>。金库资金超出分配限额的部分称为<2>溢出</2>。代币持有人可以赎回（燃烧）他们的代币来获取部分溢出。<3>了解更多</3>。"
 
-#: src/components/v2/shared/DistributionSplitsSection/PayoutConfigurationExplainerCollapse.tsx
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr "使用 <0>百分比</0> 来配置 <1>无限分配限额。</1> 分配限额为无限时，所有的资金由项目自身保留。项目不会产生溢出，因此不能通过赎回代币来获取 ETH。 <2>了解更多</2>。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr "推荐设置一个持续时间。对于贡献者来说，可以随时修改配置的筹款周期是具有风险的。"
 
-#: src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
 msgid "Using a reconfiguration strategy is recommended. Projects with no strategy will appear risky to contributors."
 msgstr "推荐设置一个修改配置的策略（延迟生效）。对于贡献者来说，没有策略的项目是具有风险的。"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1"
 msgstr "V1"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupSection.tsx
 msgid "V1 token migration"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "V1 tokens to swap"
 msgstr ""
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V1.1"
 msgstr "V1.1"
 
-#: src/pages/projects/ProjectsFilterAndSort.tsx
 msgid "V2"
 msgstr "V2"
 
-#: src/components/v1/V1Project/V1ProjectHeaderActions.tsx
 msgid "Version of the terminal contract used by this project."
 msgstr "当前项目所使用的 Terminal 版本。"
 
-#: src/components/veNft/VeNftStakingForm.tsx
 msgid "View token ranges"
 msgstr ""
 
-#: src/components/Project/VolumeStatLine/VolumeStatLine.tsx
-#: src/components/VolumeChart/index.tsx
 msgid "Volume"
 msgstr "总收入"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "VotePWR"
 msgstr ""
 
-#: src/components/inputs/Pay/MemoFormInput.tsx
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "WAGMI!"
 msgstr "WAGMI！"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "Wallet address"
 msgstr "钱包地址"
 
-#: src/components/v1/V1Project/V1PayButton.tsx
 msgid "We've disabled payments because the project has opted to reserve 100% of new tokens. You would receive no tokens from your payment."
 msgstr ""
 
-#: src/components/formItems/ProjectLink.tsx
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
-#: src/pages/create/tabs/ReviewDeployTab/ProjectDetailsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Website"
 msgstr "网站"
 
-#: src/pages/create/forms/FundingForm/FundingCycleExplainerCollapse.tsx
 msgid "What are automated funding cycles?"
 msgstr "自动化筹款周期是什么？"
 
-#: src/pages/home/QAs.tsx
 msgid "What are community tokens?"
 msgstr "什么是社区代币？"
 
-#: src/pages/home/QAs.tsx
 msgid "What are the risks?"
 msgstr "有什么风险？"
 
-#: src/pages/home/QAs.tsx
 msgid "What does Juicebox cost?"
 msgstr "Juicebox 平台怎么收费？"
 
-#: src/pages/home/QAs.tsx
 msgid "What is overflow?"
 msgstr "什么是溢出？"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
 msgid "What is the V1 Token Payment Terminal?"
 msgstr ""
 
-#: src/pages/home/QAs.tsx
 msgid "What's a bonding curve?"
 msgstr "什么是联合曲线？"
 
-#: src/pages/home/QAs.tsx
 msgid "What's a discount rate?"
 msgstr "什么是折扣率？"
 
-#: src/pages/home/QAs.tsx
 msgid "What's going on under the hood?"
 msgstr "里面究竟有什么乾坤？"
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "When a payment address is paid, its <0>beneficiary</0> address will receive any minted project tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/LaunchProjectPayer/AdvancedOptionsCollapse.tsx
 msgid "When checked, payments to this address will mint this project's ERC-20 tokens to the beneficiary's wallet. Payments will cost more gas. When unchecked, Juicebox will track the beneficiary's new tokens when they pay. The beneficiary can claim their ERC-20 tokens at any time."
 msgstr "勾选此项，向这个地址付款会把 ERC-20 标准代币铸造到受益人钱包地址。付款的 gas 费用会增加。取消勾选，则付款后受益人的新代币将在 Juicebox 协议内托管。受益人可以随时来提取自己的 ERC-20 代币。"
 
-#: src/components/v2/shared/DistributionSplitsSection/index.tsx
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/TokenMintingExtra.tsx
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
 msgstr "启用此选项，项目拥有者就能够随时手动铸造任意数量的代币。"
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
-#: src/pages/create/forms/RulesForm/index.tsx
 msgid "When enabled, your project cannot receive direct payments."
 msgstr "启用此选项，你的项目将无法收到直接付款。"
 
-#: src/pages/home/HowItWorksSection.tsx
 msgid "When someone pays your project, they'll receive your project's tokens in return. Tokens can be redeemed for a portion of your project's overflow funds; when you win, your community wins with you. Leverage your project's token to grant governance rights, community access, or other membership perks."
 msgstr "当有人向你的项目付款时，他们会收到项目的代币作为回报。 代币可以兑换你项目的部分溢出资金；让你的社区和你共赢。 利用你的项目代币来授予治理权、社区访问权或其他成员福利。"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "When token minting is allowed, the owner of this project has permission to mint any number of tokens to any address at their discretion. This has the effect of diluting all current token holders, without increasing the project's treasury balance. The project owner can reconfigure this along with all other properties of the funding cycle."
 msgstr "当铸造代币功能启用时，该项目方可以铸造任意数量的代币并发送给任意地址。这一操作并不会增加项目金库的余额，所以会稀释所有当前代币持有者的份额。和其他属性一样，也可以在每个筹款周期中重新配置这一项。"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "Whenever someone pays your project, this percentage of the newly minted tokens will be reserved and the rest will go to the payer. Reserve tokens are reserved for the project owner by default, but can also be allocated to other wallet addresses by the owner. Once tokens are reserved, anyone can \"mint\" them, which distributes them to their intended receivers."
 msgstr "有人对你的项目付款时，这一比例的新铸代币将会被保留, 剩余的代币会发送至付款人。保留代币默认会保留给项目方, 但是项目方也可以分配给其他钱包地址。代币保留起来以后，任何人都可以把它们“铸造”出来，亦即把保留代币分发给预先指定的接收人。"
 
-#: src/pages/home/QAs.tsx
 msgid "Who funds Juicebox projects?"
 msgstr "谁会资助 Juicebox 上的这些项目？"
 
-#: src/pages/home/QAs.tsx
 msgid "Who is Peel?"
 msgstr "什么是Peel？"
 
-#: src/pages/home/QAs.tsx
 msgid "Why Ethereum?"
 msgstr "为什么是以太坊？"
 
-#: src/pages/home/QAs.tsx
 msgid "Why should I want to own a project's tokens?"
 msgstr "为什么我会想要持有一个项目的代币？"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
 msgid "Will be rounded to <0/>{0}"
 msgstr "会被四舍五入成 <0/>{0}"
 
-#: src/pages/home/QAs.tsx
 msgid "Will it work on L2s?"
 msgstr "它能在 L2 上运行吗？"
 
-#: src/pages/index.page.tsx
 msgid "With Juicebox, projects are built and maintained by motivated punks getting paid transparently, and funded by a community of users and patrons who are rewarded as the projects they support succeed."
 msgstr "积极进取的朋克们通过 Juicebox 构建和维护项目，并以透明的方式获得报酬。用户和赞助者组成的社区对项目给予资助，而他们则可以在项目成功时获得回报。"
 
-#: src/pages/create/forms/FundingForm/index.tsx
 msgid "With no funding cycles, the project's owner can start a new funding cycle (Funding Cycle #2) on-demand. <0>Learn more.</0>"
 msgstr "没有筹款周期的话，项目方可以按自己需要开始一个新的筹款周期 (第二个筹款周期)。 <0>了解更多。</0>"
 
-#: src/components/Navbar/constants.ts
 msgid "Workspace"
 msgstr "工作空间"
 
-#: src/components/modals/IssueTokenModal.tsx
 msgid "Would you like to issue an ERC-20 token to be used as this project's token?"
 msgstr "你是否要签发一个 ERC-20 标准代币来作为项目代币？"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "Yes"
 msgstr "确定"
 
-#: src/components/veNft/VeNftConfirmStakeModal.tsx
 msgid "You are agreeing to IRREVOCABLY lock your tokens for {formattedLockDuration} in exchange for {votingPower} $ve{tokenSymbolDisplayText}"
 msgstr ""
 
-#: src/components/forms/ProjectDetailsForm.tsx
 msgid "You can edit your project details after creation at any time, but the transaction will cost gas."
 msgstr "创建项目之后，你可以随时修改项目的详细配置，但需要发起链上交易并支付 gas 费用。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "You can redeem your {tokenTextLong} for overflow without claiming them. You can transfer your unclaimed {tokenTextLong} to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "你可以直接赎回你的 {tokenTextLong} 代币来获取溢出，不一定非得先领取出来。点击项目页面右上角的扳手图标进入工具菜单，你还可以把你未领取的 {tokenTextLong} 代币发送给另一个地址。"
 
-#: src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr "未领取的 {tokenSymbol} 代币，依然可以用来赎回溢出池中的 ETH，也可以在工具菜单中把代币直接转给其他地址。点击右上角的扳手按钮可以打开工具菜单。"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureUpcomingMessage.tsx
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr "你的项目未设置筹款周期时长。你做的更改将会立即生效。"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "You don't have enough tokens to stake."
 msgstr ""
 
-#: src/pages/projects/HoldingsProjects.tsx
 msgid "You don't hold tokens for any Juicebox project."
 msgstr "你目前未持有任何 Juicebox 项目的代币。"
 
-#: src/components/veNft/VeNftOwnedTokensSection.tsx
 msgid "You don't own any veNFTs!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/TokenSwapDescription.tsx
 msgid "You have <0>{0}</0> tokens on <1>Juicebox V1</1>. You can swap your <2>{1}</2> V1 tokens for V2 tokens"
 msgstr ""
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
 msgid "You have configured for all funds to be distributed from the treasury. Your current payouts do not sum to 100%, so the remainder will go to the project owner."
 msgstr "你已经配置把金库的所有资金分配出去。你当前的支出总额没有达到所有资金的100%，因此剩余部分将会分配给项目方。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You have exceeded the total token supply of <0>{0}</0>"
 msgstr ""
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "You have set a funding cycle target."
 msgstr "您设定了一个筹款周期目标。"
 
-#: src/components/v2/shared/UnsavedChangesModal.tsx
 msgid "You have unsaved changes. Are you sure you want to discard them?"
 msgstr "你有更改未保存。是否放弃更改？"
 
-#: src/pages/projects/MyProjects.tsx
 msgid "You haven't created any projects yet."
 msgstr "你尚未创建项目。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
 msgid "You must grant permission to swap your tokens."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/SetV1ProjectSection.tsx
 msgid "You must own this V1 project."
 msgstr ""
 
-#: src/pages/create/tabs/ReviewDeployTab/index.tsx
 msgid "You must review and accept the Terms of Service."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
 msgid "You must review and accept the risks."
 msgstr ""
 
-#: src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
 msgid "You receive an NFT for contributing over <0>{0} ETH</0>."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/RedeemModal.tsx
 msgid "You will receive {0}{1} ETH"
 msgstr "你会收到 {0}{1} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You will receive {minReturnedTokensFormatted} ETH"
 msgstr "你将会收到 {minReturnedTokensFormatted} ETH"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive at least {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "You would receive {minReturnedTokensFormatted} ETH"
 msgstr ""
 
-#: src/components/forms/TicketingForm.tsx
 msgid "You'll be able to issue ERC-20 tokens once your project contract has been deployed. Until then, the protocol will track token balances, allowing your supporters to earn tokens and redeem for overflow in the meantime."
 msgstr "项目合约部署上线后，你就可以铸造ERC-20代币了。在此之后，协议就会开始追踪代币余额，同时允许你的支持者获得代币以及赎回代币取得项目溢出资金。"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/V1TokenMigrationSetupModal.tsx
 msgid "You're all set!"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/StepSection.tsx
 msgid "You've completed this step."
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your <0>@{v1ProjectHandle}</0> V1 token balance."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your Juicebox project has no active funding cycle. Launch a funding cycle to re-enable payments on your project."
 msgstr "你的 Juicevox 项目没有活跃的筹款周期。启动筹款周期以便重新允许向项目付款。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your V1 balance"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensForm.tsx
 msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
-#: src/components/v1/V1Project/Rewards/index.tsx
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "Your balance"
 msgstr "你的余额"
 
-#: src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
 msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
-#: src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."
 msgstr "你的筹款周期配置已按你原来启动项目时的配置进行预填。如果你需要自己定制，请联系我们。"
 
-#: src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
 msgid "Your new payable address:"
 msgstr "你的新可支付地址："
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr "项目仍能通过 Juicebox 协议的合约直接收到付款。"
 
-#: src/components/forms/RestrictedActionsForm.tsx
 msgid "Your project cannot receive direct payments while paused."
 msgstr "暂停期间，你的项目不会再收到直接付款。"
 
-#: src/components/v1/shared/forms/BudgetForm.tsx
 msgid "Your project is funded across funding cycles. A funding cycle has a funding target and a duration. Your project's funding cycle configuration will depend on the kind of project you're starting."
 msgstr "您的项目按筹款周期来进行筹款。每个筹款周期都有一个筹款目标和周期时长。您项目的筹款周期配置视您将创建项目的种类而定。"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will appear archived, and won't be able to receive payments through the juicebox.money app. You can unarchive a project at any time. Allow a few days for your project to appear under the \"archived\" filter on the Projects page."
 msgstr "项目将显示已被归档，并将无法通过 juicebox.money 接收付款。你可以随时取消项目的归档。项目仍会在项目页面的“已归档”一项下面显示几天。"
 
-#: src/components/ArchiveProject/index.tsx
 msgid "Your project will immediately appear active on the juicebox.money app. Please allow a few days for it to appear in the \"active\" projects list on the Projects page."
 msgstr "您的项目将立即在 juicebox.money 应用程序上显示为“活动”状态。请留出几天时间，让它显示在\"项目\"页面上的\"活动\"项目列表中。"
 
-#: src/pages/v1/create/index.page.tsx
 msgid "Your project's funding cycle target and duration."
 msgstr "项目筹款周期的目标与持续时间。"
 
-#: src/components/TransactionModal.tsx
 msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr "你的交易已提交，正等待交易确认。"
 
-#: src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
 msgid "Your unclaimed token balance: {0}"
 msgstr "你的未领取代币余额： {0}"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "Your unclaimed {tokenTextLong}"
 msgstr "你的待领取 {tokenTextLong} 代币"
 
-#: src/components/veNft/formControls/VotingPowerDisplayInput.tsx
 msgid "Your voting power"
 msgstr ""
 
-#: src/components/v2/V2Project/DistributionLimit.tsx
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "Zero"
 msgstr "0"
 
-#: src/components/inputs/BudgetTargetInput.tsx
-#: src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
 msgid "after {0}% JBX fee"
 msgstr "计算 {0}% JBX 费用之后"
 
-#: src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
-#: src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
-#: src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
 msgid "called by <0/>"
 msgstr "由 <0/> 调用"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "day"
 msgstr ""
 
-#: src/components/veNft/VeNftAddLockDurationModal.tsx
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
-#: src/utils/formatTime.ts
 msgid "days"
 msgstr "天"
 
-#: src/components/v1/shared/formItems/ProjectHandle/ProjectHandleInput.tsx
 msgid "handle"
 msgstr "标识"
 
-#: src/utils/formatTime.ts
 msgid "hours"
 msgstr "小时"
 
-#: src/components/formItems/ProjectTwitter.tsx
 msgid "juiceboxETH"
 msgstr "juiceboxETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "last {trendingWindowDays} days"
 msgstr "最近 {trendingWindowDays} 天"
 
-#: src/components/VolumeChart/index.tsx
 msgid "loading"
 msgstr "加载中"
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "locked until {lockedUntilFormatted}"
 msgstr "修改权限锁定至 {lockedUntilFormatted}"
 
-#: src/pages/projects/index.page.tsx
 msgid "matching \"{searchText}\""
 msgstr "满足条件 \"{searchText}\""
 
-#: src/utils/formatTime.ts
 msgid "minutes"
 msgstr "分钟"
 
-#: src/components/inputs/Pay/PayInputSubText.tsx
 msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
 msgstr "或是 <0><1>在交易所购买 {tokenText} <2/></1></0>"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "project"
 msgstr "项目"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "project owner"
 msgstr "项目拥有者"
 
-#: src/pages/projects/HoldingsProjects.tsx
-#: src/pages/projects/MyProjects.tsx
-#: src/pages/projects/index.page.tsx
 msgid "projects"
 msgstr "项目"
 
-#: src/utils/formatTime.ts
 msgid "seconds"
 msgstr "秒"
 
-#: src/utils/tokenSymbolText.ts
 msgid "token"
 msgstr "代币"
 
-#: src/utils/tokenSymbolText.ts
 msgid "tokens"
 msgstr "代币"
 
-#: src/pages/create/forms/TokenForm/MintRateFormItem.tsx
 msgid "tokens per ETH contributed"
 msgstr "每捐款 1 ETH 获得的代币"
 
-#: src/components/formItems/ProjectRedemptionRate.tsx
 msgid "tokens redeemed"
 msgstr "代币已赎回"
 
-#: src/components/v1/shared/Mod.tsx
 msgid "until"
 msgstr "直到"
 
-#: src/components/v2/V2Project/V2ProjectToolsDrawer/V2ProjectToolsDrawer.tsx
 msgid "veNFT"
 msgstr ""
 
-#: src/components/veNft/VeNftSetupModal.tsx
 msgid "veNFT Tiers ({0} variants)"
 msgstr ""
 
-#: src/components/Project/ProjectToolsDrawer/ProjectPayersSection.tsx
 msgid "{0, plural, one {# deployed payment address} other {# deployed payment addresses}}"
 msgstr ""
 
-#: src/components/v2/V2Project/ProjectPayersModal.tsx
 msgid "{0, plural, one {# payment address} other {# payment addresses}}"
 msgstr ""
 
-#: src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
-#: src/pages/v1/create/ConfirmDeployProject.tsx
 msgid "{0} after JBX fee"
 msgstr "收取 JBX 费用之后 {0}"
 
-#: src/utils/formatDate.tsx
 msgid "{0} ago"
 msgstr "{0} 之前"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "任何人付款给项目都会得到 {0} 代币 。 只要项目设置了筹款目标，不管是否已经领取代币，都可以通过赎回代币来获得项目的溢出。"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} balance"
 msgstr "{0} 余额"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2RedeemModal.tsx
 msgid "{0} balance: <0><1>{1} {tokensTextShort}</1><2>({share}% of supply)</2></0>"
 msgstr "{0} 余额: <0><1>{1} {tokensTextShort}</1><2>(总发行量的{share}%)</2></0>"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{0} days"
 msgstr "{0} 天"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} for you"
 msgstr "给到你的 {0}"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} holders"
 msgstr "{0} 持有者"
 
-#: src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
 msgid "{0} reserved"
 msgstr "{0} 已保留"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{0} tokens/ETH"
 msgstr "{0} 代币/ETH"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} total"
 msgstr "{0} 总共"
 
-#: src/components/modals/ParticipantsModal.tsx
 msgid "{0} unclaimed"
 msgstr "{0} 未领取"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0} withdrawn"
 msgstr "已提取 {0}"
 
-#: src/components/v1/shared/FundingCycle/ReservedTokens.tsx
 msgid "{0} {tokenTextPlural} reserved"
 msgstr "{0} {tokenTextPlural} 已保留"
 
-#: src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
 msgid "{0}%"
 msgstr ""
 
-#: src/components/v2/shared/SplitItem.tsx
 msgid "{0}% of all newly minted tokens."
 msgstr "所有新铸造代币的 {0}% 。"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}% of supply"
 msgstr "占比 {0}%"
 
-#: src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
 msgid "{0}% to <0/>"
 msgstr "{0}% 分配给 <0/>"
 
-#: src/components/v1/shared/ProjectTicketMods.tsx
 msgid "{0}% to {1}"
 msgstr "{0}% 分配给 {1}"
 
-#: src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
 msgid "{0}/{1} withdrawn"
 msgstr "已提取 {0}/{1}"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
-#: src/components/v1/V1Project/ProjectActivity/index.tsx
-#: src/components/v2/V2Project/ProjectActivity/index.tsx
 msgid "{count} total"
 msgstr "总共 {count}"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{exchangeName} has no market for {tokenSymbol}."
 msgstr "{exchangeName} 不存在 {tokenSymbol} 的兑换市场"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} left"
 msgstr "剩余 {formattedTimeLeft}"
 
-#: src/components/Project/FundingCycleDetailsCard.tsx
 msgid "{formattedTimeLeft} until #{0}"
 msgstr "距离 #{0} 剩余 {formattedTimeLeft}"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{inflationRate} tokens / ETH"
 msgstr "{inflationRate} 代币 / ETH"
 
-#: src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
 msgid "{issuanceRate} tokens / ETH"
 msgstr "{issuanceRate} 个代币 / ETH"
 
-#: src/pages/projects/FilterCheckboxItem.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOptionInDays} {lockDurationOptionInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/VeNftLockDurationOptionCard.tsx
 msgid "{lockDurationOption} {lockDurationOption, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{minTokensAllowedToStake, plural, one {You must stake at least # token.} other {You must stake at least # tokens.}}"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{payerRate} (+ {reservedRate} reserved) {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} (+ {reservedRate} 保留) {tokenSymbolPlural}/ETH"
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{payerRate} {tokenSymbolPlural}/ETH"
 msgstr "{payerRate} {tokenSymbolPlural}/ETH"
 
-#: src/pages/projects/TrendingProjectCard.tsx
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr "{paymentCount, plural, one {# 笔付款} other {# 笔付款}}"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
 msgid "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 msgstr "{reservedRate} {tokenSymbolPlural}/ETH ({0}%)"
 
-#: src/components/veNft/VeNftStakingTokenRangesModal.tsx
 msgid "{tokenSymbolDisplayText} range"
 msgstr ""
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{tokenSymbolDisplayText} to lock"
 msgstr ""
 
-#: src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
 msgid "{tokenSymbolPluralCap} received per ETH paid to the treasury. This can change over time according to the discount rate and reserved tokens amount of future funding cycles."
 msgstr "每向金库捐款 1 ETH 获得的 {tokenSymbolPluralCap} 代币。 这个数量会按照未来筹款周期的折扣率及保留代币数量逐步发生变化。"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2ClaimTokensModal.tsx
 msgid "{tokenSymbol} ERC-20 address"
 msgstr "{tokenSymbol} ERC-20 地址"
 
-#: src/components/AMMPrices/TokenAMMPriceRow.tsx
 msgid "{tokenSymbol}/ETH exchange rate on {exchangeName}."
 msgstr "在 {exchangeName} 的兑换率为 {tokenSymbol}/ETH"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/modals/DistributeReservedTokensModal.tsx
 msgid "{tokenTextSingular} recipients"
 msgstr "{tokenTextSingular} 接收人"
 
-#: src/components/v1/V1Project/Rewards/index.tsx
 msgid "{tokensLabel} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr "{tokensLabel} 会被分配给付款的人。如果项目设置了筹款目标，可以燃烧代币来按比例赎回溢出池中的 ETH。"
 
-#: src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
 msgid "{tokensText} reserved"
 msgstr "{tokensText} 已保留"
 
-#: src/components/v2/V2Project/V2ManageTokensSection/V2MintModal.tsx
 msgid "{tokensTokenUpper} amount"
 msgstr "{tokensTokenUpper} 数量"
 
-#: src/components/veNft/VeNftSummaryStatsSection.tsx
 msgid "{totalStakedPeriodInDays, plural, one {{0}} other {{1}}}"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{unclaimedBalanceFormatted} {tokenText} claimable"
 msgstr "{unclaimedBalanceFormatted} {tokenText} 可领取"
 
-#: src/components/veNft/formControls/TokensStakedInput.tsx
 msgid "{unstakedTokens} {tokenSymbolDisplayText} remaining"
 msgstr ""
 
-#: src/components/v2/V2Project/V2ManageTokensSection/index.tsx
 msgid "{userOwnershipPercentage}% of total supply"
 msgstr "总供应量的 {userOwnershipPercentage}%"
 


### PR DESCRIPTION
As per title!

These origin strings serve no functional purpose. They lead to bigger diffs and higher potential for merge conflicts.

