### PR TITLE
[8/x] add advanced controls section and allow public lock extension

### DIFF
--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -36,8 +36,11 @@ import { VeNftContext } from 'contexts/v2/veNftContext'
 
 import useUserUnclaimedTokenBalance from 'hooks/v2/contractReader/UserUnclaimedTokenBalance'
 
+import { MinimalCollapse } from 'components/MinimalCollapse'
+
 import { shadowCard } from 'constants/styles/shadowCard'
 import VeNftTokenSelectInput from './formControls/VeNftTokenSelectInput'
+import AllowPublicExtensionInput from './formControls/AllowPublicExtensionInput'
 
 export interface StakingFormProps {
   tokensStaked: number
@@ -70,7 +73,7 @@ const VeNftStakingForm = ({
   const tokensStaked = useWatch('tokensStaked', form) || 1
   const lockDuration = useWatch('lockDuration', form) || 0
   const beneficiary = useWatch('beneficiary', form) || ''
-  const useJbToken = useWatch('useJbToken', form)
+  const useJbToken = useWatch('useJbToken', form) || false
 
   const { data: nftTokenUri } = useVeNftResolverTokenUri(
     parseWad(tokensStaked),
@@ -198,7 +201,16 @@ const VeNftStakingForm = ({
               <VotingPowerDisplayInput votingPower={votingPower} />
             </div>
 
-            <CustomBeneficiaryInput form={form} />
+            <MinimalCollapse
+              header={
+                <h3 style={{ margin: 0 }}>
+                  <Trans>Advanced Options</Trans>
+                </h3>
+              }
+            >
+              <CustomBeneficiaryInput form={form} />
+              <AllowPublicExtensionInput form={form} />
+            </MinimalCollapse>
 
             {variants && baseImagesHash && (
               <VeNftCarousel

--- a/src/components/veNft/formControls/AllowPublicExtensionInput.tsx
+++ b/src/components/veNft/formControls/AllowPublicExtensionInput.tsx
@@ -1,0 +1,33 @@
+import { t, Trans } from '@lingui/macro'
+import { Form, FormInstance, Space, Switch } from 'antd'
+import { ThemeContext } from 'contexts/themeContext'
+import React, { useContext } from 'react'
+
+interface AllowPublicExtensionInputProps {
+  form: FormInstance
+}
+
+const AllowPublicExtensionInput = ({
+  form,
+}: AllowPublicExtensionInputProps) => {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+  return (
+    <Form.Item
+      name="allowPublicExtension"
+      extra={t`Allows anyone to extend your lock position.`}
+    >
+      <Space>
+        <Switch
+          onChange={val => form.setFieldsValue({ allowPublicExtension: val })}
+        />
+        <span style={{ color: colors.text.primary, fontWeight: 500 }}>
+          <Trans>Allow public lock extension</Trans>
+        </span>
+      </Space>
+    </Form.Item>
+  )
+}
+
+export default AllowPublicExtensionInput

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -338,6 +338,9 @@ msgstr ""
 msgid "Advanced (optional)"
 msgstr ""
 
+msgid "Advanced Options"
+msgstr ""
+
 msgid "All"
 msgstr ""
 
@@ -362,6 +365,9 @@ msgstr ""
 msgid "Allow minting tokens"
 msgstr ""
 
+msgid "Allow public lock extension"
+msgstr ""
+
 msgid "Allow terminal configuration"
 msgstr ""
 
@@ -372,6 +378,9 @@ msgid "Allow your V1 project token holders to swap their tokens for your V2 proj
 msgstr ""
 
 msgid "Allowed"
+msgstr ""
+
+msgid "Allows anyone to extend your lock position."
 msgstr ""
 
 msgid "Almost definitely."


### PR DESCRIPTION
## What does this PR do and why?

Add a control for allowing public extension on a locked position, and move that input plus custom beneficiary input into an advanced options section in the staking form.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
