### PR TITLE
add yarn cache clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "i18n:lint": "./scripts/lint-translations.sh",
     "postinstall": "yarn i18n:compile",
     "format": "prettier --write './**/*.{js,jsx,ts,tsx}'",
-    "pristine": "rm -Rf node_modules && yarn install",
+    "pristine": "rm -Rf node_modules && yarn cache clean --all && yarn install",
     "find-deadcode": "ts-prune"
   },
   "browser": {


### PR DESCRIPTION
## What does this PR do and why?

in addition to deleting node_modules, cleaning out the yarn cache is helpful when getting the project back to a pristine state, removing the likelihood of an old dep breaking a local environment.


https://yarnpkg.com/cli/cache/clean

to test run:
`yarn run pristine`


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
