### PR TITLE
Fix for V2 edit payouts - amount missing when distribution is fixed

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -226,7 +226,6 @@ export const EditPayoutsModal = ({
       return (
         <DistributionSplitCard
           key={split.beneficiary ?? index}
-          editInputMode="Percentage" // Required for edit payouts
           split={split}
           splits={editingSplits}
           distributionLimit={

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -1,6 +1,14 @@
 import { t, Trans } from '@lingui/macro'
 import { Button, Modal, Skeleton, Space } from 'antd'
+import Callout from 'components/Callout'
 import DistributionSplitCard from 'components/v2/shared/DistributionSplitsSection/DistributionSplitCard'
+import DistributionSplitModal from 'components/v2/shared/DistributionSplitsSection/DistributionSplitModal'
+import { NetworkContext } from 'contexts/networkContext'
+import { ThemeContext } from 'contexts/themeContext'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { useSetProjectSplits } from 'hooks/v2/transactor/SetProjectSplits'
+import { filter, isEqual } from 'lodash'
+import { V2CurrencyOption } from 'models/v2/currencyOption'
 import { defaultSplit, Split } from 'models/v2/splits'
 import React, {
   useCallback,
@@ -9,18 +17,10 @@ import React, {
   useMemo,
   useState,
 } from 'react'
-import { getTotalSplitsPercentage } from 'utils/v2/distributions'
-import { ThemeContext } from 'contexts/themeContext'
-import DistributionSplitModal from 'components/v2/shared/DistributionSplitsSection/DistributionSplitModal'
-import { filter, isEqual } from 'lodash'
-import { V2CurrencyOption } from 'models/v2/currencyOption'
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2CurrencyName } from 'utils/v2/currency'
-import { useSetProjectSplits } from 'hooks/v2/transactor/SetProjectSplits'
-import { NetworkContext } from 'contexts/networkContext'
-import { MAX_DISTRIBUTION_LIMIT, splitPercentFrom } from 'utils/v2/math'
 import { formatWad } from 'utils/formatNumber'
-import Callout from 'components/Callout'
+import { V2CurrencyName } from 'utils/v2/currency'
+import { getTotalSplitsPercentage } from 'utils/v2/distributions'
+import { MAX_DISTRIBUTION_LIMIT, splitPercentFrom } from 'utils/v2/math'
 
 import CurrencySymbol from 'components/CurrencySymbol'
 
@@ -336,6 +336,11 @@ export const EditPayoutsModal = ({
       <DistributionSplitModal
         visible={addSplitModalVisible}
         onSplitsChanged={onSplitsChanged}
+        distributionLimit={
+          distributionLimit?.eq(MAX_DISTRIBUTION_LIMIT)
+            ? undefined
+            : formatWad(distributionLimit, { thousandsSeparator: '' })
+        }
         mode={'Add'}
         splits={editingSplits}
         currencyName={currencyName}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
@@ -40,7 +40,6 @@ export default function DistributionSplitCard({
   currencyName,
   isLocked,
   isProjectOwner,
-  editInputMode,
   onSplitsChanged,
   onSplitDelete,
   setDistributionLimit,
@@ -52,7 +51,6 @@ export default function DistributionSplitCard({
   currencyName: CurrencyName
   isLocked?: boolean
   isProjectOwner?: boolean
-  editInputMode?: 'Distribution' | 'Percentage'
   onSplitsChanged?: (splits: Split[]) => void
   onSplitDelete?: (split: Split) => void
   setDistributionLimit?: (distributionLimit: string) => void
@@ -277,7 +275,6 @@ export default function DistributionSplitCard({
       {!isLocked ? (
         <DistributionSplitModal
           visible={editSplitModalOpen}
-          overrideDistTypeWithPercentage={editInputMode === 'Percentage'}
           onSplitsChanged={onSplitsChanged}
           mode={'Edit'}
           splits={splits}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -490,7 +490,7 @@ export default function DistributionSplitModal({
                 onChange={(percentage: number | undefined) => {
                   if (!percentage) return
 
-                  // Only trigger amount logic if we distribution limit exists since Percentage input is available in both cases
+                  // Only trigger amount logic if distribution limit exists since Percentage input is available in both cases
                   if (distributionLimit) {
                     const newAmount = amountFromPercent({
                       percent: percentage,

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -1,16 +1,17 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import * as constants from '@ethersproject/constants'
 import { t, Trans } from '@lingui/macro'
 import { DatePicker, Form, InputNumber, Modal, Radio } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import CurrencySwitch from 'components/CurrencySwitch'
 import CurrencySymbol from 'components/CurrencySymbol'
-import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import {
   ModalMode,
   validateEthAddress,
   validatePercentage,
 } from 'components/formItems/formHelpers'
 import InputAccessoryButton from 'components/InputAccessoryButton'
+import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import NumberSlider from 'components/inputs/NumberSlider'
 import TooltipIcon from 'components/TooltipIcon'
@@ -35,7 +36,6 @@ import {
   preciseFormatSplitPercent,
   splitPercentFrom,
 } from 'utils/v2/math'
-import * as constants from '@ethersproject/constants'
 
 import { CurrencyName } from 'constants/currency'
 
@@ -263,7 +263,11 @@ export default function DistributionSplitModal({
   // Validates new payout receiving address
   const validatePayoutAddress = () => {
     const beneficiary = form.getFieldValue('beneficiary')
-    if (editingSplit?.beneficiary === beneficiary) {
+
+    if (
+      editingSplit?.beneficiary &&
+      editingSplit?.beneficiary === beneficiary
+    ) {
       return Promise.resolve()
     }
     return validateEthAddress(
@@ -406,7 +410,7 @@ export default function DistributionSplitModal({
         ) : null}
 
         {/* Only show amount input if project distribution limit is not infinite */}
-        {distributionLimit && distributionType === 'both' ? (
+        {distributionLimit || distributionType === 'both' ? (
           <Form.Item
             className="ant-form-item-extra-only"
             label={t`Distribution`}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -406,7 +406,7 @@ export default function DistributionSplitModal({
         ) : null}
 
         {/* Only show amount input if project distribution limit is not infinite */}
-        {!distributionLimitIsInfinite && distributionType === 'both' ? (
+        {distributionLimit && distributionType === 'both' ? (
           <Form.Item
             className="ant-form-item-extra-only"
             label={t`Distribution`}
@@ -490,13 +490,16 @@ export default function DistributionSplitModal({
                 onChange={(percentage: number | undefined) => {
                   if (!percentage) return
 
-                  const newAmount = amountFromPercent({
-                    percent: percentage,
-                    amount: distributionLimit || '',
-                  })
+                  // Only trigger amount logic if we distribution limit exists since Percentage input is available in both cases
+                  if (distributionLimit) {
+                    const newAmount = amountFromPercent({
+                      percent: percentage,
+                      amount: distributionLimit || '',
+                    })
+                    setAmount(newAmount)
+                  }
 
                   form.setFieldsValue({ percent: percentage })
-                  setAmount(newAmount)
                 }}
                 step={0.01}
                 defaultValue={0}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -410,7 +410,7 @@ export default function DistributionSplitModal({
         ) : null}
 
         {/* Only show amount input if project distribution limit is not infinite */}
-        {distributionLimit || distributionType === 'both' ? (
+        {distributionLimit && distributionType === 'both' ? (
           <Form.Item
             className="ant-form-item-extra-only"
             label={t`Distribution`}

--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitModal.tsx
@@ -478,7 +478,7 @@ export default function DistributionSplitModal({
             </div>
           </Form.Item>
         ) : null}
-        <Form.Item label="Percent">
+        <Form.Item>
           <div
             style={{
               display: 'flex',


### PR DESCRIPTION
## What does this PR do and why?

Link to an issue - https://github.com/jbx-protocol/juice-interface/issues/1620

The intention of this PR is to show amount input field in edit payouts for v2 projects when there is distribution limit.

Please be careful while reviewing since I've deleted some code that I thought is not necessary. I may be right or wrong but is my second PR in this repository and much more serious than the previous one :)

I'm here for all additional improvements / questions 

## Screenshots or screen recordings


https://user-images.githubusercontent.com/18723426/182964768-2d4dd4d0-8b9d-4908-b386-7218fa2873e2.mov



## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
