### PR TITLE
Use ipfs get fallback on project metadata

### DIFF
--- a/src/hooks/ProjectMetadata.ts
+++ b/src/hooks/ProjectMetadata.ts
@@ -1,6 +1,5 @@
-import axios from 'axios'
 import { consolidateMetadata } from 'models/project-metadata'
-import { ipfsCidUrl } from 'utils/ipfs'
+import { ipfsGetWithFallback } from 'utils/ipfs'
 import { useQuery } from 'react-query'
 
 export function useProjectMetadata(uri: string | undefined) {
@@ -10,8 +9,8 @@ export function useProjectMetadata(uri: string | undefined) {
       if (!uri) {
         throw new Error('Project URI not specified.')
       }
-      const url = ipfsCidUrl(uri)
-      const response = await axios.get(url)
+
+      const response = await ipfsGetWithFallback(uri)
       return consolidateMetadata(response.data)
     },
     {


### PR DESCRIPTION
## What does this PR do and why?

Fall back to a public gateway to fetch project metadata.

For example:

https://juice-interface-rinkeby-5bbhxtuy9-peel.vercel.app/v2/p/4535

but this one doesn't work:

https://rinkeby.juicebox.money/v2/p/4535

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
