### PR TITLE
CSV upload for V2 payouts

### DIFF
--- a/src/components/SplitCsvUpload/SplitCsvUpload.tsx
+++ b/src/components/SplitCsvUpload/SplitCsvUpload.tsx
@@ -1,0 +1,93 @@
+import { UploadOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
+import { Split } from 'models/v2/splits'
+import { ChangeEventHandler } from 'react'
+import { splitPercentFrom } from 'utils/v2/math'
+
+// https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
+const READY_STATE_DONE = 2
+
+const readCsvFile = async (file: File): Promise<string | null> => {
+  const reader = new FileReader()
+
+  return new Promise((resolve, reject) => {
+    reader.onload = function (evt) {
+      if (evt?.target?.readyState != READY_STATE_DONE) return resolve(null)
+      if (evt?.target.error) {
+        reject(evt.target.error)
+        return
+      }
+
+      const content = evt.target.result as string | null
+
+      resolve(content)
+    }
+
+    reader.readAsText(file)
+  })
+}
+
+const parseCsvFile = (csvContent: string) => {
+  const [, ...rows] = csvContent.split('\n')
+
+  const splits: Split[] = rows.map(row => {
+    const [
+      beneficiary,
+      percent,
+      preferClaimed,
+      lockedUntil,
+      projectId,
+      allocator,
+    ] = row.split(',')
+
+    return {
+      beneficiary,
+      percent: splitPercentFrom(parseFloat(percent) * 100).toNumber(),
+      preferClaimed: Boolean(preferClaimed),
+      lockedUntil: lockedUntil ? parseInt(lockedUntil) : undefined,
+      projectId: projectId || undefined,
+      allocator: allocator || undefined,
+    }
+  })
+
+  return splits
+}
+
+export function SplitCsvUpload({
+  onChange,
+}: {
+  onChange: (splits: Split[]) => void
+}) {
+  const onUploadChange: ChangeEventHandler<HTMLInputElement> = async e => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const { files } = e.target
+    const file = files?.[0]
+    if (!file) return
+
+    const csvContent = await readCsvFile(file)
+    if (!csvContent) return
+
+    const splits = parseCsvFile(csvContent)
+    onChange(splits)
+  }
+
+  return (
+    <label
+      style={{ cursor: 'pointer', fontWeight: 400 }}
+      role="button"
+      htmlFor="csv-upload"
+    >
+      <UploadOutlined /> <Trans>Upload CSV</Trans>
+      <input
+        type="file"
+        hidden
+        id="csv-upload"
+        onChange={onUploadChange}
+        // Never set the value. This allows a file of the same name to be uploaded repeatedly.
+        value=""
+      />
+    </label>
+  )
+}

--- a/src/components/SplitCsvUpload/SplitCsvUpload.tsx
+++ b/src/components/SplitCsvUpload/SplitCsvUpload.tsx
@@ -1,7 +1,9 @@
 import { UploadOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
+import TooltipIcon from 'components/TooltipIcon'
+import { ThemeContext } from 'contexts/themeContext'
 import { Split } from 'models/v2/splits'
-import { ChangeEventHandler } from 'react'
+import { ChangeEventHandler, useContext } from 'react'
 import { splitPercentFrom } from 'utils/v2/math'
 
 // https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
@@ -58,6 +60,10 @@ export function SplitCsvUpload({
 }: {
   onChange: (splits: Split[]) => void
 }) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
   const onUploadChange: ChangeEventHandler<HTMLInputElement> = async e => {
     e.preventDefault()
     e.stopPropagation()
@@ -75,11 +81,16 @@ export function SplitCsvUpload({
 
   return (
     <label
-      style={{ cursor: 'pointer', fontWeight: 400 }}
+      style={{ cursor: 'pointer', fontWeight: 400, color: colors.text.primary }}
       role="button"
       htmlFor="csv-upload"
     >
-      <UploadOutlined /> <Trans>Upload CSV</Trans>
+      <UploadOutlined /> <Trans>Upload CSV</Trans>{' '}
+      <TooltipIcon
+        tip={
+          'CSV format:\nbeneficiary, percent, preferClaimed, lockedUntil, projectId, allocator'
+        }
+      />
       <input
         type="file"
         hidden

--- a/src/components/v1/shared/PayoutModsList.tsx
+++ b/src/components/v1/shared/PayoutModsList.tsx
@@ -1,4 +1,4 @@
-import { t } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { Button, Form, Input, Modal } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import CurrencySymbol from 'components/CurrencySymbol'
@@ -185,8 +185,12 @@ export default function PayoutModsList({
         >
           <Modal
             visible={modalVisible}
-            title="Edit payouts"
-            okText="Save payouts"
+            title={<Trans>Edit payouts</Trans>}
+            okText={
+              <span>
+                <Trans>Save payouts</Trans>
+              </span>
+            }
             onOk={() => setMods()}
             onCancel={() => {
               setModalVisible(false)

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -21,6 +21,8 @@ import { NetworkContext } from 'contexts/networkContext'
 import { MAX_DISTRIBUTION_LIMIT, splitPercentFrom } from 'utils/v2/math'
 import { formatWad } from 'utils/formatNumber'
 import Callout from 'components/Callout'
+import { UploadOutlined } from '@ant-design/icons'
+import TooltipLabel from 'components/TooltipLabel'
 
 import CurrencySymbol from 'components/CurrencySymbol'
 
@@ -90,19 +92,26 @@ const DistributionLimitHeader = ({
         title={false}
         active
       >
-        <b>
-          <Trans>Cycle #{fundingCycle?.number.toString()} -</Trans>{' '}
-          {distributionLimitIsInfinite ? (
-            t`No limit (infinite)`
-          ) : (
+        <TooltipLabel
+          tip={<Trans>Funding Cycle #{fundingCycle?.number.toString()} </Trans>}
+          label={
             <>
-              <Trans>
-                Distribution limit: <CurrencySymbol currency={currency} />
-                {formatWad(distributionLimit)}
-              </Trans>
+              {distributionLimitIsInfinite ? (
+                <Trans>No limit (infinite)</Trans>
+              ) : distributionLimit?.eq(0) ? (
+                <Trans>Zero Distribution Limit</Trans>
+              ) : (
+                <Trans>
+                  <CurrencySymbol currency={currency} />
+
+                  <Trans>
+                    {formatWad(distributionLimit)} Distribution Limit
+                  </Trans>
+                </Trans>
+              )}
             </>
-          )}
-        </b>
+          }
+        />
       </Skeleton>
     </div>
   )
@@ -269,7 +278,11 @@ export const EditPayoutsModal = ({
         onCancel={onCancel}
         width={720}
       >
-        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Space
+          direction="vertical"
+          size="middle"
+          style={{ width: '100%', marginBottom: '2rem' }}
+        >
           <div>
             <Trans>
               Reconfigure payouts as percentages of your distribution limit.
@@ -279,12 +292,19 @@ export const EditPayoutsModal = ({
             <Trans>Changes to payouts will take effect immediately.</Trans>
           </Callout>
         </Space>
-        <DistributionLimitHeader style={{ marginTop: 32, marginBottom: 16 }} />
+
         <Space
           direction="vertical"
           style={{ width: '100%', minHeight: 0 }}
-          size="large"
+          size="middle"
         >
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <DistributionLimitHeader />
+
+            <a>
+              <UploadOutlined /> Upload CSV
+            </a>
+          </div>
           <Space style={{ width: '100%' }} direction="vertical" size="small">
             {editableSplits.map((split, index) =>
               renderSplitCard(split, index),
@@ -305,6 +325,7 @@ export const EditPayoutsModal = ({
               <Trans>Sum of percentages cannot exceed 100%.</Trans>
             </span>
           )}
+
           <div
             style={{
               display: 'flex',
@@ -323,6 +344,7 @@ export const EditPayoutsModal = ({
               <Trans>Total: {totalSplitsPercentage.toFixed(2)}%</Trans>
             </div>
           </div>
+
           <Button
             type="dashed"
             onClick={() => {

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -21,7 +21,7 @@ import { NetworkContext } from 'contexts/networkContext'
 import { MAX_DISTRIBUTION_LIMIT, splitPercentFrom } from 'utils/v2/math'
 import { formatWad } from 'utils/formatNumber'
 import Callout from 'components/Callout'
-import { UploadOutlined } from '@ant-design/icons'
+import { SplitCsvUpload } from 'components/SplitCsvUpload/SplitCsvUpload'
 import TooltipLabel from 'components/TooltipLabel'
 
 import CurrencySymbol from 'components/CurrencySymbol'
@@ -99,14 +99,16 @@ const DistributionLimitHeader = ({
               {distributionLimitIsInfinite ? (
                 <Trans>No limit (infinite)</Trans>
               ) : distributionLimit?.eq(0) ? (
-                <Trans>Zero Distribution Limit</Trans>
+                <Trans>
+                  <strong>Zero</strong> Distribution Limit
+                </Trans>
               ) : (
                 <Trans>
-                  <CurrencySymbol currency={currency} />
-
-                  <Trans>
-                    {formatWad(distributionLimit)} Distribution Limit
-                  </Trans>
+                  <strong>
+                    <CurrencySymbol currency={currency} />
+                    {formatWad(distributionLimit)}
+                  </strong>{' '}
+                  Distribution Limit
                 </Trans>
               )}
             </>
@@ -272,11 +274,16 @@ export const EditPayoutsModal = ({
         visible={visible}
         confirmLoading={modalLoading}
         title={<Trans>Edit payouts</Trans>}
-        okText={<Trans>Save payouts</Trans>}
+        okText={
+          <span>
+            <Trans>Save payouts</Trans>
+          </span>
+        }
         cancelText={modalLoading ? t`Close` : t`Cancel`}
         onOk={() => onSplitsConfirmed(editingSplits)}
         onCancel={onCancel}
         width={720}
+        destroyOnClose
       >
         <Space
           direction="vertical"
@@ -301,9 +308,7 @@ export const EditPayoutsModal = ({
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
             <DistributionLimitHeader />
 
-            <a>
-              <UploadOutlined /> Upload CSV
-            </a>
+            <SplitCsvUpload onChange={onSplitsChanged} />
           </div>
           <Space style={{ width: '100%' }} direction="vertical" size="small">
             {editableSplits.map((split, index) =>

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -70,7 +70,6 @@ const DistributionLimitHeader = ({
   style?: React.CSSProperties
 }) => {
   const {
-    fundingCycle,
     distributionLimit,
     distributionLimitCurrency,
     loading: { distributionLimitLoading, fundingCycleLoading },
@@ -93,7 +92,7 @@ const DistributionLimitHeader = ({
         active
       >
         <TooltipLabel
-          tip={<Trans>Funding Cycle #{fundingCycle?.number.toString()} </Trans>}
+          tip={<Trans>This funding cycle's distribution limit.</Trans>}
           label={
             <>
               {distributionLimitIsInfinite ? (

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1064,7 +1064,13 @@ msgstr ""
 msgid "Fee from <0><1/></0>"
 msgstr ""
 
+msgid "File empty or corrupt. Try again."
+msgstr ""
+
 msgid "File must be less than {formattedSize}{unit}"
+msgstr ""
+
+msgid "File upload failed. Try again."
 msgstr ""
 
 msgid "Fund and operate your thing, your way."
@@ -1494,6 +1500,9 @@ msgid "No activity yet"
 msgstr ""
 
 msgid "No beneficiary selected. Is your wallet connected?"
+msgstr ""
+
+msgid "No file uploaded."
 msgstr ""
 
 msgid "No funding target: The project will control how all funds are distributed, and none can be redeemed by token holders."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1076,9 +1076,6 @@ msgstr ""
 msgid "Funding"
 msgstr ""
 
-msgid "Funding Cycle #{0}"
-msgstr ""
-
 msgid "Funding cycle"
 msgstr ""
 
@@ -2346,6 +2343,9 @@ msgid "This address will receive the tokens minted from paying this project."
 msgstr ""
 
 msgid "This funding cycle may pose risks to contributors. Check the funding cycle details before paying this project."
+msgstr ""
+
+msgid "This funding cycle's distribution limit."
 msgstr ""
 
 msgid "This is the maximum amount of funds that can leave the treasury each funding cycle."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -98,6 +98,9 @@ msgstr ""
 msgid "<0/>{0}{1} distributed"
 msgstr ""
 
+msgid "<0><1/>{0}</0> Distribution Limit"
+msgstr ""
+
 msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
 msgstr ""
 
@@ -210,6 +213,9 @@ msgid "<0>Website:</0> <1>{0}</1>"
 msgstr ""
 
 msgid "<0>Your unclaimed {tokenSymbol} tokens:</0> {0}"
+msgstr ""
+
+msgid "<0>Zero</0> Distribution Limit"
 msgstr ""
 
 msgid "<0>{tokenSymbol} ERC-20 address:</0> <1/>"
@@ -740,9 +746,6 @@ msgstr ""
 msgid "Cycle #{0}"
 msgstr ""
 
-msgid "Cycle #{0} -"
-msgstr ""
-
 msgid "DAOs"
 msgstr ""
 
@@ -911,9 +914,6 @@ msgstr ""
 msgid "Distribution limit, duration and payouts"
 msgstr ""
 
-msgid "Distribution limit: <0/>{0}"
-msgstr ""
-
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
 msgstr ""
 
@@ -1074,6 +1074,9 @@ msgid "Fund anything."
 msgstr ""
 
 msgid "Funding"
+msgstr ""
+
+msgid "Funding Cycle #{0}"
 msgstr ""
 
 msgid "Funding cycle"
@@ -2586,6 +2589,9 @@ msgid "Updates you make to this section will only be applied to <0>upcoming</0> 
 msgstr ""
 
 msgid "Upload"
+msgstr ""
+
+msgid "Upload CSV"
 msgstr ""
 
 msgid "Upload an image"

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,27 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
+const READY_STATE_DONE = 2
+
+/**
+ * Read a given file and return its contents as a string.
+ * @param file the File object to read.
+ * @returns Promise, which resolves to a string containing the file contents.
+ */
+export const readFile = async (file: File): Promise<string | null> => {
+  const reader = new FileReader()
+
+  return new Promise((resolve, reject) => {
+    reader.onload = function (evt) {
+      if (evt?.target?.readyState != READY_STATE_DONE) return resolve(null)
+      if (evt?.target.error) {
+        reject(evt.target.error)
+        return
+      }
+
+      const content = evt.target.result as string | null
+
+      resolve(content)
+    }
+
+    reader.readAsText(file)
+  })
+}


### PR DESCRIPTION
## What does this PR do and why?

Add ability to upload CSV of payouts in V2 Edit Payouts modal.

Will add to V1 in a follow-up PR.

We can def make this more fault-tolerant and give better error messages for invalid csv files. But, think this is a good MVP.

Partly towards https://github.com/jbx-protocol/juice-interface/issues/1274.

## Screenshots or screen recordings

https://user-images.githubusercontent.com/12551741/183411970-b79ffdc3-0902-44b7-bae5-11008fd572af.mp4

| before | after |
| --- | --- |
| <img width="740" alt="Screen Shot 2022-08-08 at 9 28 31 PM" src="https://user-images.githubusercontent.com/12551741/183412938-abef87bc-ea6d-44ac-8d54-bb09f04486fb.png"> | <img width="757" alt="Screen Shot 2022-08-08 at 9 28 18 PM" src="https://user-images.githubusercontent.com/12551741/183412964-0240e199-187d-4735-b232-d843847a796e.png"> | 


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
