### PR TITLE
show issue with modal

### DIFF
--- a/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
+++ b/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
@@ -24,20 +24,20 @@ export const AppWrapper: React.FC<React.PropsWithChildren<unknown>> = ({
   children,
 }) => {
   return (
-    <React.StrictMode>
-      <ReactQueryProvider>
-        <Provider store={store}>
-          <LanguageProvider>
-            <ThemeProvider>
-              {/* TODO: Remove v1 provider */}
-              <V1UserProvider>
-                <_Wrapper>{children}</_Wrapper>
-              </V1UserProvider>
-            </ThemeProvider>
-          </LanguageProvider>
-        </Provider>
-      </ReactQueryProvider>
-    </React.StrictMode>
+    // <React.StrictMode>
+    <ReactQueryProvider>
+      <Provider store={store}>
+        <LanguageProvider>
+          <ThemeProvider>
+            {/* TODO: Remove v1 provider */}
+            <V1UserProvider>
+              <_Wrapper>{children}</_Wrapper>
+            </V1UserProvider>
+          </ThemeProvider>
+        </LanguageProvider>
+      </Provider>
+    </ReactQueryProvider>
+    // </React.StrictMode>
   )
 }
 


### PR DESCRIPTION
## What does this PR do and why?
Investigation into antd and modal issues:

This issue can't be closed until antd hits v5 release.

Antd is using `findDomNode`, you can see the error in the dev console today.

https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage

when we bump up to react 18, `findDomNode` will break with concurrent mode. You'll see if you run this branch, the modal will close then open and then won't be able to close again. This double render is leveling up the issue in development. This is the exact functionality outlined here:

https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage

> Strict mode can’t automatically detect side effects for you, but it can help you spot them by making them a little more deterministic. This is done by intentionally double-invoking the following functions:

Which happens with `StrictMode` on. If we remove or comment out strict mode, the bug where the modal closes and then re-opens goes away.

I think the options are:
- wait for v5
- use our own modal
cc: @jbx-protocol/frontend-core - what do y'all think?

If the answer is wait 1, I can close this stack of PR's and re-open them once antd, hits v5.
If 2. I can start to look into using a modal, and also double check that other components aren't using the depricated `findDomNode` method.

Additionally, I looked through antd's documentation for a destroy method or prop that would address this issue but it didn't exist.

### More info:
The real tell is if you use the react dev tools, you'll see the modal `visibility` state is `false` after closing, then the forced rerender opening of the modal.


## Screenshots or screen recordings
<todo>

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
