### PR TITLE
fix Cancelling transfer tx keeps loading state

### DIFF
--- a/src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
+++ b/src/components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm.tsx
@@ -45,6 +45,9 @@ export function TransferUnclaimedTokensForm({
           transferTokensForm.resetFields()
           setLoadingTransferTokens(false)
         },
+        onError: () => {
+          setLoadingTransferTokens(false)
+        },
       },
     )
   }

--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -173,9 +173,9 @@ export function useTransactor({
           description = JSON.parse(json).message || message
         } catch (_) {
           description = message
+          options?.onError?.(new DOMException(description))
+          emitErrorNotification(t`Transaction failed`, { description })
         }
-
-        emitErrorNotification(t`Transaction failed`, { description })
 
         options?.onDone?.()
 

--- a/src/hooks/v1/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/v1/transactor/SafeTransferFromTx.ts
@@ -13,6 +13,24 @@ export function useSafeTransferFromTx(): TransactorInstance<{
 
   return ({ newOwnerAddress }, txOpts) => {
     if (!transactor || !projectId || !contracts?.Projects) {
+      const missingParam = !transactor
+        ? 'transactor'
+        : !projectId
+        ? 'projectId'
+        : !contracts?.Projects
+        ? 'contracts.Projects'
+        : !newOwnerAddress
+        ? 'newOwnerAddress'
+        : null
+
+      txOpts?.onError?.(
+        new DOMException(
+          `Missing ${
+            missingParam ?? 'parameter` not found'
+          } in v1 SafeTransferFromTx`,
+        ),
+      )
+
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }

--- a/src/hooks/v2/transactor/TransferUnclaimedTokensTx.ts
+++ b/src/hooks/v2/transactor/TransferUnclaimedTokensTx.ts
@@ -16,6 +16,26 @@ export function useTransferUnclaimedTokensTx(): TransactorInstance<{
 
   return ({ amount, to }, txOpts) => {
     if (!transactor || !projectId || !contracts?.JBTokenStore) {
+      const missingParam = !transactor
+        ? 'transactor'
+        : !projectId
+        ? 'projectId'
+        : !contracts?.JBTokenStore
+        ? 'contracts.JBTokenStore'
+        : !amount
+        ? 'amount'
+        : !to
+        ? 'to'
+        : null
+
+      txOpts?.onError?.(
+        new DOMException(
+          `Missing ${
+            missingParam ?? 'parameter` not found'
+          } in v2 TransferUnclaimedTokensTx`,
+        ),
+      )
+
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }


### PR DESCRIPTION
## What does this PR do and why?
fixes #1581, additionally, any other exceptions thrown during a pending request now just need the `onErorr` callback defined at their callsite, screen shot to follow

Test in vercel preview, both v1 and v2 projects.
## Screenshots or screen recordings
![CleanShot 2022-08-11 at 12 07 11](https://user-images.githubusercontent.com/2502947/184179134-40b48521-11c0-414a-ba1f-42f363cddf75.gif)


_If applicable, provide screenshots or screen recordings to demonstrate the changes.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
