### PR TITLE
dry up transactor try catch

### DIFF
--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -17,7 +17,7 @@ import { windowOpen } from 'utils/windowUtils'
 
 type TransactorCallback = (e?: TransactionEvent, signer?: JsonRpcSigner) => void
 
-type TransactorOptions = {
+export type TransactorOptions = {
   value?: BigNumberish
   onDone?: VoidFunction
   onConfirmed?: TransactorCallback
@@ -36,6 +36,22 @@ export type TransactorInstance<T = undefined> = (
   args: T,
   txOpts?: Omit<TransactorOptions, 'value'>,
 ) => ReturnType<Transactor>
+
+export function onCatch(
+  missingParam: string | undefined,
+  txOpts?: Omit<TransactorOptions, 'value'>,
+) {
+  txOpts?.onError?.(
+    new DOMException(
+      `Missing ${
+        missingParam ?? 'parameter` not found'
+      } in v1 SafeTransferFromTx`,
+    ),
+  )
+
+  txOpts?.onDone?.()
+  return Promise.resolve(false)
+}
 
 // wrapper around BlockNative's Notify.js
 // https://docs.blocknative.com/notify

--- a/src/hooks/Transactor.ts
+++ b/src/hooks/Transactor.ts
@@ -39,13 +39,15 @@ export type TransactorInstance<T = undefined> = (
 
 export function onCatch(
   missingParam: string | undefined,
+  fnName: string,
+  version: 'v1' | 'v2',
   txOpts?: Omit<TransactorOptions, 'value'>,
 ) {
   txOpts?.onError?.(
     new DOMException(
       `Missing ${
         missingParam ?? 'parameter` not found'
-      } in v1 SafeTransferFromTx`,
+      } in ${version} ${fnName}`,
     ),
   )
 

--- a/src/hooks/v1/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/v1/transactor/SafeTransferFromTx.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
-import { isDefined } from 'utils/isDefined'
+import invariant from 'tiny-invariant'
 
 import { onCatch, TransactorInstance } from '../../Transactor'
 
@@ -13,7 +13,7 @@ export function useSafeTransferFromTx(): TransactorInstance<{
   const { projectId, owner } = useContext(V1ProjectContext)
 
   return ({ newOwnerAddress }, txOpts) => {
-    isDefined(transactor && contracts?.Projects && projectId && owner)
+    invariant(transactor && contracts?.Projects && projectId && owner)
     try {
       return transactor(
         contracts.Projects,

--- a/src/hooks/v1/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/v1/transactor/SafeTransferFromTx.ts
@@ -2,8 +2,9 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { V1UserContext } from 'contexts/v1/userContext'
 import { useContext } from 'react'
+import { isDefined } from 'utils/isDefined'
 
-import { TransactorInstance } from '../../Transactor'
+import { onCatch, TransactorInstance } from '../../Transactor'
 
 export function useSafeTransferFromTx(): TransactorInstance<{
   newOwnerAddress: string
@@ -12,7 +13,15 @@ export function useSafeTransferFromTx(): TransactorInstance<{
   const { projectId, owner } = useContext(V1ProjectContext)
 
   return ({ newOwnerAddress }, txOpts) => {
-    if (!transactor || !projectId || !contracts?.Projects) {
+    isDefined(transactor && contracts?.Projects && projectId && owner)
+    try {
+      return transactor(
+        contracts.Projects,
+        'safeTransferFrom(address,address,uint256)',
+        [owner, newOwnerAddress, BigNumber.from(projectId).toHexString()],
+        txOpts,
+      )
+    } catch (_) {
       const missingParam = !transactor
         ? 'transactor'
         : !projectId
@@ -21,25 +30,9 @@ export function useSafeTransferFromTx(): TransactorInstance<{
         ? 'contracts.Projects'
         : !newOwnerAddress
         ? 'newOwnerAddress'
-        : null
+        : undefined
 
-      txOpts?.onError?.(
-        new DOMException(
-          `Missing ${
-            missingParam ?? 'parameter` not found'
-          } in v1 SafeTransferFromTx`,
-        ),
-      )
-
-      txOpts?.onDone?.()
-      return Promise.resolve(false)
+      return onCatch(missingParam, txOpts)
     }
-
-    return transactor(
-      contracts.Projects,
-      'safeTransferFrom(address,address,uint256)',
-      [owner, newOwnerAddress, BigNumber.from(projectId).toHexString()],
-      txOpts,
-    )
   }
 }

--- a/src/hooks/v1/transactor/SafeTransferFromTx.ts
+++ b/src/hooks/v1/transactor/SafeTransferFromTx.ts
@@ -32,7 +32,7 @@ export function useSafeTransferFromTx(): TransactorInstance<{
         ? 'newOwnerAddress'
         : undefined
 
-      return onCatch(missingParam, txOpts)
+      return onCatch(missingParam, 'safeTransferFrom', 'v1', txOpts)
     }
   }
 }

--- a/src/utils/isDefined.ts
+++ b/src/utils/isDefined.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isDefined(condition: any): asserts condition {
+  if (condition === undefined || condition === null || condition === false) {
+    throw new Error(
+      `Expected 'condition' to be defined, but received ${condition}`,
+    )
+  }
+}

--- a/src/utils/isDefined.ts
+++ b/src/utils/isDefined.ts
@@ -1,8 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isDefined(condition: any): asserts condition {
-  if (condition === undefined || condition === null || condition === false) {
-    throw new Error(
-      `Expected 'condition' to be defined, but received ${condition}`,
-    )
-  }
-}


### PR DESCRIPTION
## What does this PR do and why?

fixes: #1728 the initial start of adding error and loading handlers to all transaction hooks. 

I thought using a try catch with an assertion was a little easier to grok, as well as putting the error callback in a function.

I'll move foward, with adding error and loading states to transactor hooks with this try catch pattern after/if this PR gets approved.



## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
