### PR TITLE
enhance etherscanlink and ethamount to allow ability to hide tooltips

### DIFF
--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -11,11 +11,13 @@ export default function EtherscanLink({
   value,
   type,
   truncated,
+  hideTooltip,
   style,
 }: {
   value: string | undefined
   type: 'tx' | 'address'
   truncated?: boolean
+  hideTooltip?: boolean
   style?: CSSProperties
 }) {
   if (!value) return null
@@ -38,7 +40,10 @@ export default function EtherscanLink({
 
   if (type === 'tx') {
     return (
-      <Tooltip title={t`See transaction`}>
+      <Tooltip
+        title={t`See transaction`}
+        visible={hideTooltip ? !hideTooltip : undefined}
+      >
         <ExternalLink {...linkProps}>
           <LinkOutlined />
         </ExternalLink>
@@ -47,7 +52,10 @@ export default function EtherscanLink({
   }
 
   return (
-    <Tooltip title={t`Go to Etherscan`}>
+    <Tooltip
+      title={t`Go to Etherscan`}
+      visible={hideTooltip ? !hideTooltip : undefined}
+    >
       <ExternalLink {...linkProps}>{truncatedValue ?? value}</ExternalLink>
     </Tooltip>
   )

--- a/src/components/Navbar/Balance.tsx
+++ b/src/components/Navbar/Balance.tsx
@@ -9,9 +9,11 @@ import ETHAmount from 'components/currency/ETHAmount'
 export default function Balance({
   address,
   showEthPrice,
+  hideTooltip,
 }: {
   address: string | undefined
   showEthPrice?: boolean
+  hideTooltip?: boolean
 }) {
   const {
     theme: { colors },
@@ -27,7 +29,7 @@ export default function Balance({
         color: colors.text.tertiary,
       }}
     >
-      <ETHAmount amount={balance} fallback="--" />
+      <ETHAmount amount={balance} fallback="--" hideTooltip={hideTooltip} />
 
       {showEthPrice && (
         <div style={{ color: colors.text.tertiary }}>

--- a/src/components/Navbar/Wallet.tsx
+++ b/src/components/Navbar/Wallet.tsx
@@ -30,7 +30,12 @@ export default function Wallet({ userAddress }: { userAddress: string }) {
   const menu = (
     <Menu>
       <Menu.Item style={{ padding: menuItemPadding }} key={0}>
-        <EtherscanLink value={userAddress} type="address" truncated={true} />{' '}
+        <EtherscanLink
+          value={userAddress}
+          type="address"
+          truncated={true}
+          hideTooltip
+        />{' '}
         <CopyTextButton value={userAddress} style={{ zIndex: 1 }} />
       </Menu.Item>
       <Menu.Item
@@ -87,7 +92,7 @@ export default function Wallet({ userAddress }: { userAddress: string }) {
         }}
       >
         <FormattedAddress address={userAddress} tooltipDisabled={true} />
-        <Balance address={userAddress} />
+        <Balance address={userAddress} hideTooltip />
       </div>
     </Dropdown>
   )

--- a/src/components/currency/ETHAmount.tsx
+++ b/src/components/currency/ETHAmount.tsx
@@ -19,11 +19,13 @@ export default function ETHAmount({
   precision = PRECISION_ETH,
   padEnd = false,
   fallback,
+  hideTooltip,
 }: {
   amount: BigNumber | undefined // in wad (18 decimals)
   precision?: number
   padEnd?: boolean
   fallback?: string
+  hideTooltip?: boolean
 }) {
   if (amount === undefined) return fallback ? <span>{fallback}</span> : null
 
@@ -50,6 +52,7 @@ export default function ETHAmount({
             {formatWad(amount, { precision: 8 })}
           </span>
         }
+        visible={hideTooltip ? !hideTooltip : undefined}
       >
         <CurrencySymbol currency="ETH" />
         ~0
@@ -63,7 +66,10 @@ export default function ETHAmount({
   })
 
   return (
-    <Tooltip title={<ETHToUSD ethAmount={amount} />}>
+    <Tooltip
+      title={<ETHToUSD ethAmount={amount} />}
+      visible={hideTooltip ? !hideTooltip : undefined}
+    >
       <CurrencySymbol currency="ETH" />
       {formattedETHAmount}
     </Tooltip>


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/1736.

## Screenshots or screen recordings

### Before

https://user-images.githubusercontent.com/104132113/184570944-65ca7fc5-920e-4f0c-801f-dc193329abd7.mov

### After

https://user-images.githubusercontent.com/104132113/184570947-3da1cd50-1114-4707-9987-246b626e2a05.mov



## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
