### PR TITLE
remove unneeded react imports

### DIFF
--- a/src/components/Navbar/Mobile/ThemePickerMobile.tsx
+++ b/src/components/Navbar/Mobile/ThemePickerMobile.tsx
@@ -3,7 +3,7 @@ import Sun from 'components/icons/Sun'
 import { Trans } from '@lingui/macro'
 
 import { ThemeContext } from 'contexts/themeContext'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { ThemeOption } from 'constants/theme/theme-option'
 
@@ -22,19 +22,19 @@ export default function ThemePickerMobile() {
       }
     >
       {themeOption === ThemeOption.dark ? (
-        <React.Fragment>
+        <>
           <Sun size={16} />
           <div style={{ margin: '0 0 2px 10px' }}>
             <Trans>Light theme</Trans>
           </div>
-        </React.Fragment>
+        </>
       ) : (
-        <React.Fragment>
+        <>
           <Moon size={16} />
           <div style={{ margin: '0 0 2px 10px' }}>
             <Trans>Dark theme</Trans>
           </div>
-        </React.Fragment>
+        </>
       )}
     </div>
   )

--- a/src/components/Navbar/ThemePicker.tsx
+++ b/src/components/Navbar/ThemePicker.tsx
@@ -2,7 +2,7 @@ import Moon from 'components/icons/Moon'
 import Sun from 'components/icons/Sun'
 
 import { ThemeContext } from 'contexts/themeContext'
-import React, { CSSProperties, useContext } from 'react'
+import { CSSProperties, useContext } from 'react'
 
 import { ThemeOption } from 'constants/theme/theme-option'
 

--- a/src/components/icons/Sticker.tsx
+++ b/src/components/icons/Sticker.tsx
@@ -1,4 +1,4 @@
-import React, { SVGAttributes } from 'react'
+import { SVGAttributes } from 'react'
 
 export default function Sticker({
   size,

--- a/src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
+++ b/src/components/v1/V1Project/FundingCycles/ReconfigureFundingModalTrigger.tsx
@@ -1,6 +1,6 @@
 import { Button, Tooltip } from 'antd'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
-import React, { useContext, useRef, useState } from 'react'
+import { useContext, useRef, useState } from 'react'
 import { Provider } from 'react-redux'
 import store, { createStore } from 'redux/store'
 import { Trans } from '@lingui/macro'

--- a/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
@@ -22,12 +22,7 @@ import { useConfigureProjectTx } from 'hooks/v1/transactor/ConfigureProjectTx'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { V1FundingCycle, V1FundingCycleMetadata } from 'models/v1/fundingCycle'
 import { PayoutMod, TicketMod } from 'models/mods'
-import React, {
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useState,
-} from 'react'
+import { useCallback, useContext, useLayoutEffect, useState } from 'react'
 import { editingProjectActions } from 'redux/slices/editingProject'
 import {
   formattedNum,

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/EditPayoutsModal.tsx
@@ -2,13 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Modal, Skeleton, Space } from 'antd'
 import DistributionSplitCard from 'components/v2/shared/DistributionSplitsSection/DistributionSplitCard'
 import { defaultSplit, Split } from 'models/v2/splits'
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { getTotalSplitsPercentage } from 'utils/v2/distributions'
 import { ThemeContext } from 'contexts/themeContext'
 import DistributionSplitModal from 'components/v2/shared/DistributionSplitsSection/DistributionSplitModal'

--- a/src/components/veNft/VeNftContent.tsx
+++ b/src/components/veNft/VeNftContent.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { Space } from 'antd'
 
 import { tokenSymbolText } from 'utils/tokenSymbolText'

--- a/src/components/veNft/VeNftSummaryStatsSection.tsx
+++ b/src/components/veNft/VeNftSummaryStatsSection.tsx
@@ -2,7 +2,7 @@ import { Plural, t, Trans } from '@lingui/macro'
 import { Descriptions } from 'antd'
 
 import { ThemeContext } from 'contexts/themeContext'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { useVeNftSummaryStats } from 'hooks/veNft/VeNftSummaryStats'
 import { VeNftToken } from 'models/subgraph-entities/v2/venft-token'

--- a/src/components/veNft/formControls/AllowPublicExtensionInput.tsx
+++ b/src/components/veNft/formControls/AllowPublicExtensionInput.tsx
@@ -1,7 +1,7 @@
 import { t, Trans } from '@lingui/macro'
 import { Form, FormInstance, Space, Switch } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 interface AllowPublicExtensionInputProps {
   form: FormInstance

--- a/src/components/veNft/formControls/VeNftTokenSelectInput.tsx
+++ b/src/components/veNft/formControls/VeNftTokenSelectInput.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { Form, FormInstance, Select } from 'antd'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 interface VeNftTokenSelectInputProps {
   form: FormInstance

--- a/src/pages/home/QAs.tsx
+++ b/src/pages/home/QAs.tsx
@@ -1,10 +1,10 @@
 import { t, Trans } from '@lingui/macro'
 import ExternalLink from 'components/ExternalLink'
-import React, { ReactNode } from 'react'
+import { ReactNode, FC } from 'react'
 import Link from 'next/link'
 import { helpPagePath } from 'utils/helpPageHelper'
 
-export const OverflowVideoLink: React.FC = ({ children }) => (
+export const OverflowVideoLink: FC = ({ children }) => (
   <ExternalLink href="https://youtu.be/9Mq5oDh0aBY">{children}</ExternalLink>
 )
 

--- a/src/pages/projects/HoldingsProjects.tsx
+++ b/src/pages/projects/HoldingsProjects.tsx
@@ -5,7 +5,7 @@ import ProjectCard from 'components/ProjectCard'
 import { NetworkContext } from 'contexts/networkContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useHoldingsProjectsQuery } from 'hooks/Projects'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { InfoCircleOutlined } from '@ant-design/icons'
 
 export default function HoldingsProjects() {

--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -7,7 +7,7 @@ import Loading from 'components/Loading'
 import { AppWrapper } from 'components/common'
 
 import { ProjectCategory } from 'models/project-visibility'
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import Grid from 'components/Grid'
 import ProjectCard, { ProjectCardProject } from 'components/ProjectCard'
@@ -224,7 +224,7 @@ function Projects() {
       </div>
 
       {selectedTab === 'all' ? (
-        <React.Fragment>
+        <>
           {concatenatedPages && (
             <Grid>
               {concatenatedPages.map(p => (
@@ -273,7 +273,7 @@ function Projects() {
               </div>
             )
           )}
-        </React.Fragment>
+        </>
       ) : selectedTab === 'holdings' ? (
         <div style={{ paddingBottom: 50 }}>
           <HoldingsProjects />


### PR DESCRIPTION
## What does this PR do and why?

chore: saw a bunch of React imports that aren't needed anymore since
we're using next.js now and it's a react 17 thing too: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#whats-different-in-the-new-transform
## Screenshots or screen recordings


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
