### PR TITLE
Fix trending project cards on home page Mobile

### DIFF
--- a/src/pages/home/TopProjectsSection.tsx
+++ b/src/pages/home/TopProjectsSection.tsx
@@ -38,62 +38,60 @@ const SmallProjectCardMobile = ({
           : `/p/${project?.handle}`
       }
     >
-      <a>
+      <a
+        className="clickable-border"
+        style={{
+          cursor: 'pointer',
+          overflow: 'hidden',
+          width: '100%',
+          padding: '0.5rem 1rem',
+          textAlign: 'center',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+        }}
+      >
         <div
-          className="clickable-border"
           style={{
-            cursor: 'pointer',
-            overflow: 'hidden',
-            width: '100%',
-            padding: '0.5rem 1rem',
-            textAlign: 'center',
             display: 'flex',
-            alignItems: 'center',
-            gap: 10,
+            justifyContent: 'center',
           }}
         >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-            }}
-          >
-            <ProjectLogo
-              uri={metadata?.logoUri}
-              name={metadata?.name}
-              size={60}
-            />
-          </div>
+          <ProjectLogo
+            uri={metadata?.logoUri}
+            name={metadata?.name}
+            size={60}
+          />
+        </div>
 
-          <div
-            style={{
-              fontWeight: 400,
-              width: '100%',
-            }}
-          >
-            {metadata ? (
-              <span
-                style={{
-                  color: colors.text.primary,
-                  margin: 0,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {metadata.name}
-              </span>
-            ) : (
-              <Skeleton paragraph={false} title={{ width: 120 }} active />
-            )}
-
-            <div
+        <div
+          style={{
+            fontWeight: 400,
+            width: '100%',
+          }}
+        >
+          {metadata ? (
+            <span
               style={{
                 color: colors.text.primary,
-                fontWeight: 500,
+                margin: 0,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
               }}
             >
-              <ETHAmount amount={project?.totalPaid} precision={0} /> raised
-            </div>
+              {metadata.name}
+            </span>
+          ) : (
+            <Skeleton paragraph={false} title={{ width: 120 }} active />
+          )}
+
+          <div
+            style={{
+              color: colors.text.primary,
+              fontWeight: 500,
+            }}
+          >
+            <ETHAmount amount={project?.totalPaid} precision={0} /> raised
           </div>
         </div>
       </a>
@@ -118,6 +116,7 @@ const SmallProjectCard = ({ project }: { project: ProjectCardProject }) => {
     >
       <a>
         <div
+          className="clickable-border"
           style={{
             cursor: 'pointer',
             overflow: 'hidden',
@@ -125,7 +124,6 @@ const SmallProjectCard = ({ project }: { project: ProjectCardProject }) => {
             padding: '1rem',
             textAlign: 'center',
           }}
-          className="clickable-border"
         >
           <div
             style={{


### PR DESCRIPTION

## Screenshots or screen recordings

### Before

<img width="352" alt="Screen Shot 2022-08-17 at 10 48 52 am" src="https://user-images.githubusercontent.com/104132113/185009821-a0cde422-6c88-499b-8b94-135e868284a0.png">

### After

<img width="373" alt="Screen Shot 2022-08-17 at 10 48 58 am" src="https://user-images.githubusercontent.com/104132113/185009830-55dff1b1-408e-4e56-ae8c-4f13e0d9132f.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
