### PR TITLE
Move amm price below issuance rate

### DIFF
--- a/src/components/AMMPrices/TokenAMMPriceRow.tsx
+++ b/src/components/AMMPrices/TokenAMMPriceRow.tsx
@@ -1,4 +1,4 @@
-import { LinkOutlined, LoadingOutlined } from '@ant-design/icons'
+import { LoadingOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
 import SushiswapLogo from 'components/icons/Sushiswap'
@@ -83,7 +83,6 @@ export default function TokenAMMPriceRow({
           >
             <ExternalLink href={exchangeLink} style={{ fontWeight: 400 }}>
               {`${formattedNum(WETHPrice)} ${tokenSymbol}/1 ETH`}
-              <LinkOutlined style={{ marginLeft: '0.2rem' }} />
             </ExternalLink>
           </Tooltip>
         ) : (

--- a/src/components/inputs/Pay/PayInputSubText.tsx
+++ b/src/components/inputs/Pay/PayInputSubText.tsx
@@ -11,7 +11,6 @@ import { CurrencyContext } from 'contexts/currencyContext'
 import { Tooltip } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import AMMPrices from 'components/AMMPrices'
-import TooltipIcon from 'components/TooltipIcon'
 
 import useWeiConverter from 'hooks/WeiConverter'
 import { CurrencyOption } from 'models/currencyOption'
@@ -125,10 +124,9 @@ export default function PayInputSubText({
   return (
     <div
       style={{
+        marginTop: '0.3rem',
         fontSize: '.65rem',
         width: '100%',
-        display: 'flex',
-        justifyContent: 'space-between',
         color: colors.text.secondary,
       }}
     >
@@ -152,14 +150,13 @@ export default function PayInputSubText({
             >
               <span
                 style={{
-                  color: colors.text.action.primary,
-                  cursor: 'pointer',
-                  padding: '0.5rem 0',
-                  fontWeight: 500,
+                  cursor: 'default',
+                  paddingTop: '0.5rem',
+                  paddingBottom: '1px',
+                  borderBottom: '1px dashed' + colors.stroke.secondary,
                 }}
               >
-                buy {tokenText} on exchange
-                <TooltipIcon iconStyle={{ marginLeft: '0.2rem' }} />
+                buy {tokenText} on exchange.
               </span>
             </Tooltip>
           </Trans>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2915,7 +2915,7 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "or <0><1>buy {tokenText} on exchange<2/></1></0>"
+msgid "or <0><1>buy {tokenText} on exchange.</1></0>"
 msgstr ""
 
 msgid "project"


### PR DESCRIPTION
## What does this PR do and why?

Move it back. Removed the blue color, because blue should be reserved for links only.

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="500" alt="Screen Shot 2022-08-21 at 4 33 15 PM" src="https://user-images.githubusercontent.com/12551741/185779712-fd07cbdb-71c7-45ff-8ec8-dfe5c60d9df6.png"> | <img width="533" alt="Screen Shot 2022-08-21 at 4 29 01 PM" src="https://user-images.githubusercontent.com/12551741/185779718-ec65cf7f-0079-44ce-95af-ccb58f01bde1.png"> |
| <img width="339" alt="Screen Shot 2022-08-21 at 4 33 18 PM" src="https://user-images.githubusercontent.com/12551741/185779728-42bae98d-91e5-47c4-a13a-10cd117a6599.png"> | <img width="542" alt="Screen Shot 2022-08-21 at 4 29 13 PM" src="https://user-images.githubusercontent.com/12551741/185779732-54d9d6a5-36cb-4fb0-af9c-ddc304220f19.png"> |





## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
