### PR TITLE
Ignore note parsing on paragraph usage

### DIFF
--- a/src/components/Paragraph.tsx
+++ b/src/components/Paragraph.tsx
@@ -35,6 +35,7 @@ export default function Paragraph({
         note={
           !expanded && CHARACTER_LIMIT_EXCEEDED ? shortDescription : description
         }
+        ignoreMediaLinks
       >
         {CHARACTER_LIMIT_EXCEEDED && (
           <Button

--- a/src/components/Project/ProjectHeader/index.tsx
+++ b/src/components/Project/ProjectHeader/index.tsx
@@ -145,11 +145,11 @@ export default function ProjectHeader({
             />
           )}
           {owner && (
-            <span style={{ color: colors.text.secondary }}>
+            <div style={{ color: colors.text.secondary, marginTop: '0.4rem' }}>
               <Trans>
-                Owned by: <FormattedAddress address={owner} />
+                Owned by <FormattedAddress address={owner} />
               </Trans>
-            </span>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/RichNote.tsx
+++ b/src/components/RichNote.tsx
@@ -5,28 +5,32 @@ import { useProcessedRichNote } from 'hooks/ProcessedRichNote'
 
 type RichNoteProps = {
   note: string | undefined
+  ignoreMediaLinks?: boolean
   style?: React.CSSProperties | undefined
 }
 
 export default function RichNote({
   note,
   style,
+  ignoreMediaLinks,
   children,
 }: React.PropsWithChildren<RichNoteProps>) {
   const { trimmedNote, formattedMediaLinks } = useProcessedRichNote(note)
 
-  if (trimmedNote === undefined) return null
+  const noteToRender = ignoreMediaLinks ? note : trimmedNote
+
+  if (noteToRender === undefined) return null
 
   return (
     <div style={{ marginTop: 5, ...style }}>
-      {trimmedNote.length ? (
+      {noteToRender.length ? (
         <span
           style={{
             overflowWrap: 'break-word',
             paddingRight: '0.5rem',
           }}
           dangerouslySetInnerHTML={{
-            __html: Autolinker.link(trimmedNote, {
+            __html: Autolinker.link(noteToRender, {
               sanitizeHtml: true,
               truncate: {
                 length: 30,
@@ -39,7 +43,7 @@ export default function RichNote({
 
       {children}
 
-      {formattedMediaLinks?.length ? (
+      {!ignoreMediaLinks && formattedMediaLinks?.length ? (
         <div style={{ display: 'block' }}>
           <Space size="middle">
             {formattedMediaLinks.map((link, i) => (

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1559,7 +1559,7 @@ msgstr ""
 msgid "Overflow is created if your project's balance exceeds your funding cycle target. Overflow can be redeemed by your project's token holders."
 msgstr ""
 
-msgid "Owned by: <0/>"
+msgid "Owned by <0/>"
 msgstr ""
 
 msgid "Owner can mint tokens at any time."


### PR DESCRIPTION
## What does this PR do and why?

Fixes https://github.com/jbx-protocol/juice-interface/issues/1738.

Ensures newlines get rendered in `Paragraph`s.

This isn't an amazing solution. I feared breaking stuff by messing with the RichNote internals too much. So i think this PR is a net positive.

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="982" alt="Screen Shot 2022-08-21 at 4 59 14 PM" src="https://user-images.githubusercontent.com/12551741/185780545-0e53b513-d48d-4e92-93b4-a621eefd5989.png"> | <img width="948" alt="Screen Shot 2022-08-21 at 5 00 34 PM" src="https://user-images.githubusercontent.com/12551741/185780594-f9e31677-6cf7-4657-aedb-8af75871111d.png"> |
| <img width="859" alt="Screen Shot 2022-08-21 at 5 01 23 PM" src="https://user-images.githubusercontent.com/12551741/185780621-4424fbc7-ebdc-4b24-8b1f-0944cbfcfefa.png"> | <img width="940" alt="Screen Shot 2022-08-21 at 5 00 39 PM" src="https://user-images.githubusercontent.com/12551741/185780601-0455f91d-aac6-47c8-98f1-ae1350ee6a79.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
