### PR TITLE
Fix erc20 onClose redirect

### DIFF
--- a/src/components/IssueTokenButton.tsx
+++ b/src/components/IssueTokenButton.tsx
@@ -67,7 +67,7 @@ export default function IssueTokenButton({
     setModalVisible(false)
 
     // remove newDeploy=true query parameter
-    router.replace({
+    router.replace(router.pathname, {
       search: '',
     })
   }


### PR DESCRIPTION
## What does this PR do and why?

Currently when erc-20 modal is closed, there's a redirect bug.

<img width="503" alt="Screen Shot 2022-08-22 at 11 21 54 AM" src="https://user-images.githubusercontent.com/12551741/185823507-1468b941-e199-4d49-ab64-3e12a640915e.png">.

This pr fixes that

