### PR TITLE
Auto Import Organise - Remove import order eslint plugin rule (1/n)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,13 +45,6 @@
         "format": ["PascalCase"]
       }
     ],
-    "import/order": [
-      "error",
-      {
-        "groups": ["external", "internal"],
-        "newlines-between": "always-and-inside-groups"
-      }
-    ],
     "no-console": ["error", { "allow": ["warn", "error", "info"] }],
     "no-restricted-imports": [
       "error",


### PR DESCRIPTION
## What does this PR do and why?

This PR is part of a greater stack:
- Adding support for a Prettier Plugin that automatically organises imports

This PR:
- Removes import rules from eslint.

## Screenshots or screen recordings

N/A

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
