### PR TITLE
Auto Import Organise - Add prettier import rule (2/n)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -14,5 +14,6 @@
         "printWidth": 600
       }
     }
-  ]
+  ],
+  "organizeImportsSkipDestructiveCodeActions": true
 }

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "husky": "^7.0.0",
     "jest": "^28.1.3",
     "lint-staged": "13.0.0",
+    "prettier-plugin-organize-imports": "^3.1.0",
     "react-error-overlay": "6.0.9",
     "react-test-renderer": "^17",
     "ts-prune": "^0.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13962,6 +13962,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-organize-imports@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.1.0.tgz#00420affd69f21926dbf29bf94a152f37e859d5e"
+  integrity sha512-eufD78FKdkDTyyY9oKxuwEMrfz4/AXrGeyeyjqiRtSBr01DAdGFTq4SgIKvLeqlLkq+ZPJ2H0+BK0e6flRUwJQ==
+
 prettier-plugin-solidity@^1.0.0-beta.19:
   version "1.0.0-beta.19"
   resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz#7c3607fc4028f5e6a425259ff03e45eedf733df3"


### PR DESCRIPTION
## What does this PR do and why?

This PR is part of a greater stack:
- Adding support for a Prettier Plugin that automatically organises imports

This PR:
- Adds new prettier rule to organise code imports automatically.

## Screenshots or screen recordings

N/A

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
