### PR TITLE
Make read only provider more stable

### DIFF
--- a/src/hooks/Wallet/hooks/Provider.ts
+++ b/src/hooks/Wallet/hooks/Provider.ts
@@ -1,13 +1,19 @@
-import { Web3Provider } from '@ethersproject/providers'
+import { JsonRpcBatchProvider, Web3Provider } from '@ethersproject/providers'
 import { useConnectWallet } from '@web3-onboard/react'
+import { readNetwork } from 'constants/networks'
 import { useMemo } from 'react'
 
 export function useProvider() {
-  const [{ wallet }] = useConnectWallet()
-  const provider = useMemo(
-    () =>
-      wallet?.provider ? new Web3Provider(wallet.provider, 'any') : undefined,
-    [wallet],
+  const readProvider = useMemo(
+    () => new JsonRpcBatchProvider(readNetwork.rpcUrl),
+    [],
   )
+  const [{ wallet }] = useConnectWallet()
+  const provider = useMemo(() => {
+    if (wallet) {
+      return new Web3Provider(wallet.provider, 'any')
+    }
+    return readProvider
+  }, [readProvider, wallet])
   return provider
 }

--- a/src/hooks/Wallet/hooks/Signer.ts
+++ b/src/hooks/Wallet/hooks/Signer.ts
@@ -1,9 +1,20 @@
+import { JsonRpcBatchProvider, Web3Provider } from '@ethersproject/providers'
 import { useMemo } from 'react'
 
 import { useProvider } from './Provider'
 
 export function useSigner() {
   const provider = useProvider()
-  const signer = useMemo(() => provider?.getSigner(), [provider])
+  const signer = useMemo(() => {
+    if (provider instanceof JsonRpcBatchProvider) {
+      return undefined
+    }
+    if (provider instanceof Web3Provider) {
+      return provider?.getSigner()
+    }
+
+    console.error('FATAL: unexpected lack of provider found')
+    throw new Error('FATAL: unexpected lack of provider found')
+  }, [provider])
   return signer
 }


### PR DESCRIPTION
## What does this PR do and why?

I accidentally erased the readonly provider and misunderstood what that actually meant with the new web3-onboard stuff. This fixes it and stops error flooding when not connected.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
