### PR TITLE
Strip out commas in distribution limit to avoid crashing big number up stack

### DIFF
--- a/src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
@@ -25,7 +25,11 @@ export default function SpecificLimitModal({
   function setNewSplitsFromLimit() {
     form.validateFields()
 
-    setDistributionLimit(form.getFieldValue('distributionLimit'))
+    const distributionLimit = form
+      .getFieldValue('distributionLimit')
+      // Remove all commas from distribution limit
+      .replace(/,/g, '')
+    setDistributionLimit(distributionLimit)
     onClose()
   }
 


### PR DESCRIPTION
## What does this PR do and why?

Strip out commas in distribu tion limit to avoid crashing big number up stack.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
