### PR TITLE
Hide edit payouts when distribution limit is 0 or non-exist

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/PayoutSplitsCard.tsx
@@ -165,7 +165,7 @@ export default function PayoutSplitsCard({
                 </Trans>
               }
             />
-            {canEditPayouts && (
+            {canEditPayouts && effectiveDistributionLimit.gt(0) && (
               <Button
                 size="small"
                 onClick={() => setEditPayoutModalVisible(true)}


### PR DESCRIPTION
## What does this PR do and why?

To be more in line with token allocations, this PR hides the button when a project has no distribution limit.

Effectively, a user cannot really add distributions without a dist limit so I think it makes sense.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
