### PR TITLE
Remove etherscan link tooltip

### DIFF
--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -1,6 +1,4 @@
 import { LinkOutlined } from '@ant-design/icons'
-import { t } from '@lingui/macro'
-import { Tooltip } from 'antd'
 import { NetworkName } from 'models/network-name'
 import { CSSProperties } from 'react'
 import { truncateEthAddress } from 'utils/formatAddress'
@@ -13,14 +11,12 @@ export default function EtherscanLink({
   type,
   truncated,
   truncateTo,
-  hideTooltip,
   style,
 }: {
   value: string | undefined
   type: 'tx' | 'address'
   truncated?: boolean
   truncateTo?: number
-  hideTooltip?: boolean
   style?: CSSProperties
 }) {
   if (!value) return null
@@ -42,23 +38,11 @@ export default function EtherscanLink({
 
   if (type === 'tx') {
     return (
-      <Tooltip
-        title={t`See transaction`}
-        visible={hideTooltip ? !hideTooltip : undefined}
-      >
-        <ExternalLink {...linkProps}>
-          <LinkOutlined />
-        </ExternalLink>
-      </Tooltip>
+      <ExternalLink {...linkProps}>
+        <LinkOutlined />
+      </ExternalLink>
     )
   }
 
-  return (
-    <Tooltip
-      title={t`Go to Etherscan`}
-      visible={hideTooltip ? !hideTooltip : undefined}
-    >
-      <ExternalLink {...linkProps}>{truncatedValue ?? value}</ExternalLink>
-    </Tooltip>
-  )
+  return <ExternalLink {...linkProps}>{truncatedValue ?? value}</ExternalLink>
 }

--- a/src/components/Navbar/Wallet.tsx
+++ b/src/components/Navbar/Wallet.tsx
@@ -25,12 +25,7 @@ export default function Wallet({ userAddress }: { userAddress: string }) {
 
   const CopyableAddress = () => (
     <>
-      <EtherscanLink
-        value={userAddress}
-        type="address"
-        truncated={true}
-        hideTooltip
-      />{' '}
+      <EtherscanLink value={userAddress} type="address" truncated />{' '}
       <CopyTextButton value={userAddress} style={{ zIndex: 1 }} />
     </>
   )

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1109,9 +1109,6 @@ msgstr ""
 msgid "Give this NFT a name."
 msgstr ""
 
-msgid "Go to Etherscan"
-msgstr ""
-
 msgid "Grant permission"
 msgstr ""
 
@@ -2061,9 +2058,6 @@ msgid "Second"
 msgstr ""
 
 msgid "Seconds"
-msgstr ""
-
-msgid "See transaction"
 msgstr ""
 
 msgid "Set ENS name"


### PR DESCRIPTION
## What does this PR do and why?

Remove tooltips on etherscan links. They aren't really adding to the experience and are distracting. The user should expect that links for addresses and transactions should direct to etherscan, as this is a common pattern throughout web3.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
