### PR TITLE
Remove duplicated code in Reconfigure modal

### DIFF
--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/V2ReconfigureModalTrigger.tsx
@@ -1,23 +1,14 @@
 import { Button, Tooltip } from 'antd'
-import { useContext, useEffect, useRef, useState } from 'react'
-import { Provider, useDispatch } from 'react-redux'
+import { useRef, useState } from 'react'
+import { Provider } from 'react-redux'
 import store, { createStore } from 'redux/store'
 
 import { SettingOutlined } from '@ant-design/icons'
-
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
-import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
-import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
-import { V2FundingCycle } from 'models/v2/fundingCycle'
-import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
-import { fromWad } from 'utils/formatNumber'
 
 import { t } from '@lingui/macro'
 
 import { reloadWindow } from 'utils/windowUtils'
 
-import { ETH_PAYOUT_SPLIT_GROUP } from 'constants/v2/splits'
 import V2ProjectReconfigureModal from './index'
 
 // This component uses a local version of the entire Redux store
@@ -32,10 +23,6 @@ export default function V2ReconfigureFundingModalTrigger({
   hideProjectDetails?: boolean
   triggerButton?: (onClick: VoidFunction) => JSX.Element
 }) {
-  const dispatch = useDispatch()
-  const { projectId, fundingCycle, primaryTerminal } =
-    useContext(V2ProjectContext)
-
   const [reconfigureModalVisible, setReconfigureModalVisible] =
     useState<boolean>(false)
 
@@ -50,68 +37,6 @@ export default function V2ReconfigureFundingModalTrigger({
     setReconfigureModalVisible(false)
     reloadWindow()
   }
-
-  // Load queued FC data of project
-  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
-    projectId,
-  })
-
-  const [queuedFundingCycle] = queuedFundingCycleResponse ?? []
-
-  let effectiveFundingCycle: V2FundingCycle | undefined
-  // If duration is 0, use current FC (not queued)
-  if (!fundingCycle?.duration || fundingCycle?.duration.eq(0)) {
-    effectiveFundingCycle = fundingCycle
-  } else {
-    effectiveFundingCycle = queuedFundingCycle
-  }
-
-  const { data: queuedDistributionLimitData } = useProjectDistributionLimit({
-    projectId,
-    configuration: effectiveFundingCycle?.configuration.toString(),
-    terminal: primaryTerminal,
-  })
-  const [queuedDistributionLimit, queuedDistributionLimitCurrency] =
-    queuedDistributionLimitData ?? []
-
-  const { data: queuedPayoutSplits } = useProjectSplits({
-    projectId,
-    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
-    domain: effectiveFundingCycle?.configuration?.toString(),
-  })
-
-  // Load queued FC data (if it exists) into redux
-  useEffect(() => {
-    if (queuedDistributionLimitData) {
-      dispatch(
-        editingV2ProjectActions.setDistributionLimit(
-          fromWad(queuedDistributionLimit),
-        ),
-      )
-      dispatch(
-        editingV2ProjectActions.setDistributionLimitCurrency(
-          queuedDistributionLimitCurrency.toNumber().toString(),
-        ),
-      )
-    }
-    if (effectiveFundingCycle?.duration) {
-      dispatch(
-        editingV2ProjectActions.setDuration(
-          effectiveFundingCycle?.duration.toNumber().toString(),
-        ),
-      )
-    }
-    if (queuedPayoutSplits) {
-      dispatch(editingV2ProjectActions.setPayoutSplits(queuedPayoutSplits))
-    }
-  }, [
-    queuedDistributionLimitData,
-    dispatch,
-    effectiveFundingCycle,
-    queuedDistributionLimit,
-    queuedDistributionLimitCurrency,
-    queuedPayoutSplits,
-  ])
 
   return (
     <div style={{ textAlign: 'right' }}>

--- a/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/initialEditingData.ts
+++ b/src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/initialEditingData.ts
@@ -116,7 +116,7 @@ export const useInitialEditingData = (visible: boolean) => {
     effectiveDistributionLimitCurrency = queuedDistributionLimitCurrency
   }
 
-  // Creates the local redux state from V2ProjectContext values
+  // Populates the local redux state from V2ProjectContext values
   useEffect(() => {
     if (!visible || !effectiveFundingCycle) return
 


### PR DESCRIPTION
## What does this PR do and why?

This deleted code appears to be a subset of what's already executing in `src/components/v2/V2Project/V2ProjectReconfigureModal/hooks/initialEditingData.ts`.

I think we can just remove it. Seems legit after a few tests.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
