### PR TITLE
Load project handles in payout cards v2

### DIFF
--- a/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/DistributionSplitCard.tsx
@@ -23,6 +23,7 @@ import {
 } from 'utils/v2/math'
 
 import { CurrencyName } from 'constants/currency'
+import V2ProjectHandle from '../V2ProjectHandle'
 import DistributionSplitModal from './DistributionSplitModal'
 
 const Parens = ({
@@ -61,6 +62,7 @@ export default function DistributionSplitCard({
   const {
     theme: { colors, radii },
   } = useContext(ThemeContext)
+
   const { projectOwnerAddress } = useContext(V2ProjectContext)
 
   const [editSplitModalOpen, setEditSplitModalOpen] = useState<boolean>(false)
@@ -111,7 +113,7 @@ export default function DistributionSplitCard({
           <Row gutter={gutter} style={{ width: '100%' }} align="middle">
             <Col span={labelColSpan}>
               <label style={{ cursor }}>
-                <Trans>Project ID:</Trans>
+                <Trans>Project:</Trans>
               </label>{' '}
             </Col>
             <Col span={dataColSpan}>
@@ -122,7 +124,7 @@ export default function DistributionSplitCard({
                   justifyContent: 'space-between',
                 }}
               >
-                <span style={{ cursor }}>{parseInt(split.projectId)}</span>
+                <V2ProjectHandle projectId={parseInt(split.projectId)} />
               </div>
             </Col>
           </Row>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1706,9 +1706,6 @@ msgstr ""
 msgid "Project ID must be a number."
 msgstr ""
 
-msgid "Project ID:"
-msgstr ""
-
 msgid "Project Token"
 msgstr ""
 
@@ -1788,6 +1785,9 @@ msgid "Project {projectId}"
 msgstr ""
 
 msgid "Project {projectId} not found"
+msgstr ""
+
+msgid "Project:"
 msgstr ""
 
 msgid "Projects"


### PR DESCRIPTION
## What does this PR do and why?

Fixes - https://github.com/jbx-protocol/juice-interface/issues/1781

I've just got one UI / UX dilemma here, I'm utilizing `V2ProjectHandle` shared func in `DistributionSplitCard`

I've renamed the label in the first row, instead of `Project ID` it is now `Project` since sometimes we get the handle back, only small issue I see here is that if the project has no handle then in the first row it is like this `Project: Project 13`  ( since shared func is structured like that but it will be clear to you what I mean in screenshots )

I can either change our shared func to return a boolean if there is a handle so I can manipulate with labels outside of it or I can repeat logic from the shared func inside `DistributionSplitCard` but I think that is not good since we want to utilize shared func as much as we can.
## Screenshots or screen recordings
![image](https://user-images.githubusercontent.com/18723426/186418120-8a412752-0faa-4521-bfee-bd4b5c02fa67.png)
![image](https://user-images.githubusercontent.com/18723426/186418320-548afe1a-410d-4f01-b488-fa7b6d0e3ce3.png)


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
