### PR TITLE
NFT skeleton loaders

### DIFF
--- a/src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
+++ b/src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
@@ -1,24 +1,67 @@
 import { Trans } from '@lingui/macro'
-import { Tooltip } from 'antd'
+import { Skeleton, Tooltip } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { NftRewardTier } from 'models/v2/nftRewardTier'
 import { CSSProperties, MouseEventHandler, useContext, useState } from 'react'
 
-import { CheckOutlined } from '@ant-design/icons'
+import { CheckOutlined, LoadingOutlined } from '@ant-design/icons'
 
 import { NftPreview } from './NftPreview'
 
+const rewardTierContainerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  cursor: 'pointer',
+  transition: 'box-shadow 0.25s',
+  height: '100%',
+}
+
+const loadingImageContainerStyle: CSSProperties = {
+  width: '100%',
+  height: '151px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const imageStyle: CSSProperties = {
+  objectFit: 'cover',
+  width: '100%',
+  position: 'absolute',
+  top: 0,
+  height: '100%',
+}
+
+const nftTitleSectionStyle: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center,',
+}
+
+const imageContainerStyle: CSSProperties = {
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  position: 'relative',
+}
+
 // The clickable cards on the project page
 export function RewardTier({
+  loading,
   rewardTier,
   rewardTierUpperLimit,
   isSelected,
   onClick,
 }: {
-  rewardTier: NftRewardTier
-  rewardTierUpperLimit: number | undefined
-  isSelected: boolean
-  onClick: MouseEventHandler<HTMLDivElement>
+  loading?: boolean
+  rewardTier?: NftRewardTier
+  rewardTierUpperLimit?: number | undefined
+  isSelected?: boolean
+  onClick?: MouseEventHandler<HTMLDivElement>
 }) {
   const {
     theme: { colors, radii },
@@ -55,13 +98,13 @@ export function RewardTier({
             {rewardTierUpperLimit ? (
               <Trans>
                 Receive this NFT when you contribute{' '}
-                <strong>{rewardTier.contributionFloor}</strong> - {'<'}
+                <strong>{rewardTier?.contributionFloor}</strong> - {'<'}
                 <strong>{rewardTierUpperLimit} ETH</strong>.
               </Trans>
             ) : (
               <Trans>
                 Receive this NFT when you contribute at least{' '}
-                <strong>{rewardTier.contributionFloor} ETH</strong>.
+                <strong>{rewardTier?.contributionFloor} ETH</strong>.
               </Trans>
             )}
           </span>
@@ -87,16 +130,11 @@ export function RewardTier({
           isSelected ? 'selected-box-shadow' : ''
         } hover-box-shadow`}
         style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          cursor: 'pointer',
+          ...rewardTierContainerStyle,
           outline: isSelected
             ? `2px solid ${colors.stroke.action.primary}`
             : 'rgba(0,0,0,0)',
-          transition: 'box-shadow 0.25s',
           borderRadius: radii.sm,
-          height: '100%',
         }}
         onClick={!isSelected ? onClick : () => setPreviewVisible(true)}
         role="button"
@@ -104,65 +142,81 @@ export function RewardTier({
         {/* Image container */}
         <div
           style={{
+            ...imageContainerStyle,
+            paddingTop: !loading ? '100%' : 'unset',
             backgroundColor,
-            width: '100%',
-            display: 'flex',
-            paddingTop: '100%',
-            justifyContent: 'center',
-            alignItems: 'center',
-            position: 'relative',
           }}
         >
-          <img
-            alt={rewardTier.name}
-            src={rewardTier.imageUrl}
-            style={{
-              objectFit: 'cover',
-              width: '100%',
-              position: 'absolute',
-              top: 0,
-              height: '100%',
-              filter: isSelected ? 'unset' : 'brightness(50%)',
-            }}
-          />
+          {loading ? (
+            <div
+              style={{
+                ...loadingImageContainerStyle,
+                borderBottom: `1px solid ${colors.stroke.tertiary}`,
+              }}
+            >
+              <LoadingOutlined />
+            </div>
+          ) : (
+            <img
+              alt={rewardTier?.name}
+              src={rewardTier?.imageUrl}
+              style={{
+                ...imageStyle,
+                filter: isSelected ? 'unset' : 'brightness(50%)',
+              }}
+            />
+          )}
           {isSelected ? <RewardIcon /> : null}
         </div>
         {/* Details section below image */}
         <div
           style={{
+            ...nftTitleSectionStyle,
             backgroundColor,
-            width: '100%',
-            padding: '8px 10px 5px',
-            height: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center,',
+            padding: `${!loading ? 8 : 4}px 10px 5px`,
           }}
         >
-          <h5
-            style={{
-              color: isSelected ? colors.text.primary : colors.text.tertiary,
-              marginBottom: 0,
-              lineHeight: '13px',
-            }}
+          <Skeleton
+            loading={loading}
+            active
+            title={false}
+            paragraph={{ rows: 1, width: ['100%'] }}
           >
-            {rewardTier.name}
-          </h5>
-          <span
-            style={{
-              color: colors.text.secondary,
-              fontSize: '0.7rem',
-            }}
+            <h5
+              style={{
+                color: isSelected ? colors.text.primary : colors.text.tertiary,
+                marginBottom: 0,
+                lineHeight: '13px',
+              }}
+            >
+              {rewardTier?.name}
+            </h5>
+          </Skeleton>
+          <Skeleton
+            loading={loading}
+            active
+            title={false}
+            paragraph={{ rows: 1, width: ['50%'] }}
+            style={{ marginTop: '3px' }}
           >
-            {rewardTier.contributionFloor} ETH
-          </span>
+            <span
+              style={{
+                color: colors.text.secondary,
+                fontSize: '0.7rem',
+              }}
+            >
+              {rewardTier?.contributionFloor} ETH
+            </span>
+          </Skeleton>
         </div>
       </div>
-      <NftPreview
-        visible={previewVisible}
-        rewardTier={rewardTier}
-        onClose={() => setPreviewVisible(false)}
-      />
+      {rewardTier ? (
+        <NftPreview
+          visible={previewVisible}
+          rewardTier={rewardTier}
+          onClose={() => setPreviewVisible(false)}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/components/v2/V2Project/NftRewardsSection/index.tsx
+++ b/src/components/v2/V2Project/NftRewardsSection/index.tsx
@@ -1,4 +1,3 @@
-import { LoadingOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Col, Row } from 'antd'
 import SectionHeader from 'components/SectionHeader'
@@ -10,6 +9,7 @@ import { useContext, useEffect, useState } from 'react'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { getNftRewardTier } from 'utils/v2/nftRewards'
 
+import { MAX_NFT_REWARD_TIERS } from 'components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { RewardTier } from './RewardTier'
 
@@ -48,9 +48,11 @@ export function NftRewardsSection({
 
   const nftRewardsEnabled = featureFlagEnabled(FEATURE_FLAGS.NFT_REWARDS)
 
-  if (!CIDs || CIDs.length < 1 || !nftRewardsEnabled) return null
+  const hasCIDs = Boolean(CIDs?.length)
 
-  const loading = nftsLoading || (CIDs.length && !rewardTiers?.length)
+  if ((!hasCIDs && !nftsLoading) || !nftRewardsEnabled) {
+    return null
+  }
 
   const renderRewardTier = (rewardTier: NftRewardTier, index: number) => {
     const isSelected = index === selectedIndex
@@ -64,22 +66,30 @@ export function NftRewardsSection({
         xs={8}
         key={`${rewardTier.contributionFloor}-${rewardTier.name}`}
       >
-        {!loading ? (
-          <RewardTier
-            rewardTier={rewardTier}
-            rewardTierUpperLimit={nextRewardTier?.contributionFloor}
-            isSelected={isSelected}
-            onClick={() => {
-              setSelectedIndex(isSelected ? undefined : index)
-              onPayAmountChange(
-                isSelected ? '0' : rewardTier.contributionFloor.toString(),
-              )
-            }}
-          />
-        ) : (
-          <LoadingOutlined />
-        )}
+        <RewardTier
+          rewardTier={rewardTier}
+          rewardTierUpperLimit={nextRewardTier?.contributionFloor}
+          isSelected={isSelected}
+          onClick={() => {
+            setSelectedIndex(isSelected ? undefined : index)
+            onPayAmountChange(
+              isSelected ? '0' : rewardTier.contributionFloor.toString(),
+            )
+          }}
+        />
       </Col>
+    )
+  }
+
+  function RewardTiersLoadingSkeleton() {
+    return (
+      <Row style={{ marginTop: '15px' }} gutter={isMobile ? 8 : 24}>
+        {[...Array(MAX_NFT_REWARD_TIERS)]?.map(index => (
+          <Col md={8} xs={8} key={index}>
+            <RewardTier loading />
+          </Col>
+        ))}
+      </Row>
     )
   }
 
@@ -97,11 +107,13 @@ export function NftRewardsSection({
       >
         <Trans>Contribute to unlock an NFT reward.</Trans>
       </span>
-      {rewardTiers ? (
+      {!nftsLoading ? (
         <Row style={{ marginTop: '15px' }} gutter={isMobile ? 8 : 24}>
-          {rewardTiers.map(renderRewardTier)}
+          {rewardTiers?.map(renderRewardTier)}
         </Row>
-      ) : null}
+      ) : (
+        <RewardTiersLoadingSkeleton />
+      )}
     </div>
   )
 }

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -171,7 +171,14 @@ export default function V2Dashboard({
     ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived
     : false
 
-  const nftsLoading = nftRewardTiersLoading || nftRewardsCIDsLoading
+  // Assumes having `dataSource` means there are NFTs initially
+  // In worst case, if has `dataSource` but isn't for NFTs:
+  //    - loading will be true briefly
+  //    - will resolve false when `useNftRewardTiersOf` fails
+  const nftsLoading = Boolean(
+    fundingCycleMetadata?.dataSource &&
+      (nftRewardTiersLoading || nftRewardsCIDsLoading),
+  )
 
   const project: V2ProjectContextType = {
     cv: '2',


### PR DESCRIPTION
## What does this PR do and why?

**Full loading process:**
1. Waits for `fundingCycleMetadata` to load -> **NFT section hidden**
2. When `fundingCycleMetadata` loads and it has a `dataSource` ->  **Show NFT section with loading cards** 
4. When `rewardTiers` load from IPFS, show cards

https://user-images.githubusercontent.com/96150256/186423364-05b729ef-956f-4798-b4cc-f2628ee508b7.mp4

(excuse my horrid internet^)

https://user-images.githubusercontent.com/96150256/186423378-07c013ea-a656-4982-aef2-0a619d2eb3db.mp4



## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
