### PR TITLE
[1/4] Create downloadCsvFile util

### DIFF
--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -10,6 +10,7 @@ import { querySubgraphExhaustive } from 'utils/graph'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import { readProvider } from 'constants/readProvider'
+import { downloadCsvFile } from 'utils/csv'
 
 export default function DownloadParticipantsModal({
   projectId,
@@ -91,18 +92,7 @@ export default function DownloadParticipantsModal({
         ])
       })
 
-      const csvContent =
-        'data:text/csv;charset=utf-8,' + rows.map(e => e.join(',')).join('\n')
-      const encodedUri = encodeURI(csvContent)
-      const link = document.createElement('a')
-      link.setAttribute('href', encodedUri)
-      link.setAttribute(
-        'download',
-        `@${projectName}_holders-block${blockNumber}.csv`,
-      )
-      document.body.appendChild(link)
-
-      link.click()
+      downloadCsvFile(`@${projectName}_holders-block${blockNumber}.csv`, rows)
 
       setLoading(false)
     } catch (e) {

--- a/src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
+++ b/src/components/v1/V1Project/V1DownloadPaymentsModal.tsx
@@ -11,6 +11,7 @@ import { querySubgraphExhaustive } from 'utils/graph'
 import { emitErrorNotification } from 'utils/notifications'
 
 import { readProvider } from 'constants/readProvider'
+import { downloadCsvFile } from 'utils/csv'
 
 export default function V1DownloadPaymentsModal({
   visible,
@@ -74,18 +75,7 @@ export default function V1DownloadPaymentsModal({
         rows.push([fromWad(p.amount), date, p.caller, p.beneficiary, p.note])
       })
 
-      const csvContent =
-        'data:text/csv;charset=utf-8,' + rows.map(e => e.join(',')).join('\n')
-      const encodedUri = encodeURI(csvContent)
-      const link = document.createElement('a')
-      link.setAttribute('href', encodedUri)
-      link.setAttribute(
-        'download',
-        `@${handle}_payments-block${blockNumber}.csv`,
-      )
-      document.body.appendChild(link)
-
-      link.click()
+      downloadCsvFile(`@${handle}_payments-block${blockNumber}.csv`, rows)
 
       setLoading(false)
     } catch (e) {

--- a/src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
+++ b/src/components/v2/V2Project/V2DownloadPaymentsModal.tsx
@@ -10,6 +10,7 @@ import { fromWad } from 'utils/formatNumber'
 import { querySubgraphExhaustive } from 'utils/graph'
 
 import { readProvider } from 'constants/readProvider'
+import { downloadCsvFile } from 'utils/csv'
 
 export default function V2DownloadPaymentsModal({
   visible,
@@ -73,18 +74,10 @@ export default function V2DownloadPaymentsModal({
         rows.push([fromWad(p.amount), date, p.caller, p.beneficiary, p.note])
       })
 
-      const csvContent =
-        'data:text/csv;charset=utf-8,' + rows.map(e => e.join(',')).join('\n')
-      const encodedUri = encodeURI(csvContent)
-      const link = document.createElement('a')
-      link.setAttribute('href', encodedUri)
-      link.setAttribute(
-        'download',
+      downloadCsvFile(
         `project-${projectId}_payments-block${blockNumber}.csv`,
+        rows,
       )
-      document.body.appendChild(link)
-
-      link.click()
 
       setLoading(false)
     } catch (e) {

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,13 @@
+export function downloadCsvFile(filename: string, rows: string[][]) {
+  const csvContent =
+    'data:text/csv;charset=utf-8,' + rows.map(e => e.join(',')).join('\n')
+  const encodedUri = encodeURI(csvContent)
+
+  const link = document.createElement('a')
+  link.setAttribute('href', encodedUri)
+  link.setAttribute('download', `${filename}.csv`)
+
+  document.body.appendChild(link)
+
+  link.click()
+}


### PR DESCRIPTION
## What does this PR do and why?

In prep for export payouts/reserved tokens as csv. This pr adds a util and uses it where possible.

## Screenshots or screen recordings

No user-facing change.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
