### PR TITLE
[3/4] Add CSV payout export to V1 projects

### DIFF
--- a/src/components/v1/V1Project/V1ProjectHeaderActions.tsx
+++ b/src/components/v1/V1Project/V1ProjectHeaderActions.tsx
@@ -7,7 +7,7 @@ import { useV1ConnectedWalletHasPermission } from 'hooks/v1/contractReader/V1Con
 import { V1OperatorPermission } from 'models/v1/permissions'
 import { useContext, useState } from 'react'
 
-import { V1ProjectToolsDrawer } from 'components/v1/V1Project/V1ProjectToolsDrawer'
+import { V1ProjectToolsDrawer } from 'components/v1/V1Project/V1ProjectToolsDrawer/V1ProjectToolsDrawer'
 import { useIsUserAddress } from 'hooks/IsUserAddress'
 
 import EditProjectModal from './modals/EditProjectModal'

--- a/src/components/v1/V1Project/V1ProjectToolsDrawer/ExportPayoutModsButton.tsx
+++ b/src/components/v1/V1Project/V1ProjectToolsDrawer/ExportPayoutModsButton.tsx
@@ -1,0 +1,69 @@
+import { DownloadOutlined } from '@ant-design/icons'
+import { t, Trans } from '@lingui/macro'
+import { Button } from 'antd'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { PayoutMod } from 'models/mods'
+import { useContext, useState } from 'react'
+import { downloadCsvFile } from 'utils/csv'
+import { permyriadToPercent } from 'utils/formatNumber'
+import { emitErrorNotification } from 'utils/notifications'
+
+const CSV_HEADER: (keyof PayoutMod)[] = [
+  'beneficiary',
+  'percent',
+  'preferUnstaked',
+  'lockedUntil',
+  'projectId',
+  'allocator',
+]
+
+const preparePayoutModsCsv = (mods: PayoutMod[]): (string | undefined)[][] => {
+  const csvContent = mods.map(mod => {
+    return [
+      mod.beneficiary,
+      `${parseFloat(permyriadToPercent(`${mod.percent}`)) / 100}`,
+      `${mod.preferUnstaked}`,
+      `${mod.lockedUntil}`,
+      mod.projectId?.toString(),
+      mod.allocator,
+    ]
+  })
+
+  return [CSV_HEADER, ...csvContent]
+}
+
+export function ExportPayoutModsButton() {
+  const { handle, currentFC, currentPayoutMods } = useContext(V1ProjectContext)
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const onExportSplitsButtonClick = () => {
+    if (!currentFC || !currentPayoutMods) return
+
+    setLoading(true)
+
+    try {
+      const csvContent = preparePayoutModsCsv(currentPayoutMods)
+      const filename = `@${handle}_payouts_fc-${currentFC.number}`
+
+      downloadCsvFile(filename, csvContent)
+    } catch (e) {
+      console.error(e)
+      emitErrorNotification(t`CSV download failed.`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Button
+      icon={<DownloadOutlined />}
+      size="small"
+      onClick={onExportSplitsButtonClick}
+      loading={loading}
+    >
+      <span>
+        <Trans>Export payouts CSV</Trans>
+      </span>
+    </Button>
+  )
+}

--- a/src/components/v1/V1Project/V1ProjectToolsDrawer/ExportTicketModsButton.tsx
+++ b/src/components/v1/V1Project/V1ProjectToolsDrawer/ExportTicketModsButton.tsx
@@ -2,58 +2,54 @@ import { DownloadOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
-import { PayoutMod } from 'models/mods'
+import { TicketMod } from 'models/mods'
 import { useContext, useState } from 'react'
 import { downloadCsvFile } from 'utils/csv'
 import { permyriadToPercent } from 'utils/formatNumber'
 import { emitErrorNotification } from 'utils/notifications'
-import { getProjectOwnerRemainderPayoutMod } from 'utils/v1/mods'
+import { getProjectOwnerRemainderTicketMod } from 'utils/v1/mods'
 
-const CSV_HEADER: (keyof PayoutMod)[] = [
+const CSV_HEADER: (keyof TicketMod)[] = [
   'beneficiary',
   'percent',
   'preferUnstaked',
   'lockedUntil',
-  'projectId',
-  'allocator',
 ]
 
-const payoutModToCsvRow = (mod: PayoutMod) => {
+const ticketModToCsvRow = (mod: TicketMod) => {
   return [
     mod.beneficiary,
     `${parseFloat(permyriadToPercent(`${mod.percent}`)) / 100}`,
     `${mod.preferUnstaked}`,
     `${mod.lockedUntil}`,
-    mod.projectId?.toString(),
-    mod.allocator,
   ]
 }
 
-const preparePayoutModsCsv = (
-  mods: PayoutMod[],
+const prepareTicketModsCsv = (
+  mods: TicketMod[],
   projectOwnerAddress: string,
 ): (string | undefined)[][] => {
-  const csvContent = mods.map(payoutModToCsvRow)
+  const csvContent = mods.map(ticketModToCsvRow)
   const rows = [CSV_HEADER, ...csvContent]
 
-  const projectOwnerMod = getProjectOwnerRemainderPayoutMod(
+  const projectOwnerMod = getProjectOwnerRemainderTicketMod(
     projectOwnerAddress,
     mods,
   )
   if (projectOwnerMod.percent > 0) {
-    rows.push(payoutModToCsvRow(projectOwnerMod))
+    rows.push(ticketModToCsvRow(projectOwnerMod))
   }
 
   return rows
 }
 
-export function ExportPayoutModsButton() {
-  const { handle, currentFC, currentPayoutMods, owner } =
+export function ExportTicketModsButton() {
+  const { handle, currentFC, currentTicketMods, owner } =
     useContext(V1ProjectContext)
   const [loading, setLoading] = useState<boolean>(false)
 
   const onExportSplitsButtonClick = () => {
-    if (!currentFC || !currentPayoutMods || !owner) {
+    if (!currentFC || !currentTicketMods || !owner) {
       emitErrorNotification(
         t`CSV data wasn't ready for export. Wait a few seconds and try again.`,
       )
@@ -63,8 +59,8 @@ export function ExportPayoutModsButton() {
     setLoading(true)
 
     try {
-      const csvContent = preparePayoutModsCsv(currentPayoutMods, owner)
-      const filename = `@${handle}_payouts_fc-${currentFC.number}`
+      const csvContent = prepareTicketModsCsv(currentTicketMods, owner)
+      const filename = `@${handle}_reserved-tokens_fc-${currentFC.number}`
 
       downloadCsvFile(filename, csvContent)
     } catch (e) {
@@ -83,7 +79,7 @@ export function ExportPayoutModsButton() {
       loading={loading}
     >
       <span>
-        <Trans>Export payouts CSV</Trans>
+        <Trans>Export token allocation CSV</Trans>
       </span>
     </Button>
   )

--- a/src/components/v1/V1Project/V1ProjectToolsDrawer/V1ProjectToolsDrawer.tsx
+++ b/src/components/v1/V1Project/V1ProjectToolsDrawer/V1ProjectToolsDrawer.tsx
@@ -11,9 +11,11 @@ import { useSafeTransferFromTx } from 'hooks/v1/transactor/SafeTransferFromTx'
 import { useSetProjectUriTx } from 'hooks/v1/transactor/SetProjectUriTx'
 import { useTransferTokensTx } from 'hooks/v1/transactor/TransferTokensTx'
 
-import { AddToProjectBalanceForm } from '../../Project/ProjectToolsDrawer/AddToProjectBalanceForm'
-import { TransferOwnershipForm } from '../../Project/ProjectToolsDrawer/TransferOwnershipForm'
-import { TransferUnclaimedTokensForm } from '../../Project/ProjectToolsDrawer/TransferUnclaimedTokensForm'
+import { AddToProjectBalanceForm } from 'components/Project/ProjectToolsDrawer/AddToProjectBalanceForm'
+import { ExportSection } from 'components/Project/ProjectToolsDrawer/ExportSection'
+import { TransferOwnershipForm } from 'components/Project/ProjectToolsDrawer/TransferOwnershipForm'
+import { TransferUnclaimedTokensForm } from 'components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm'
+import { ExportPayoutModsButton } from './ExportPayoutModsButton'
 
 const { TabPane } = Tabs
 
@@ -72,6 +74,11 @@ export function V1ProjectToolsDrawer({
             <section>
               <AddToProjectBalanceForm useAddToBalanceTx={useAddToBalanceTx} />
             </section>
+
+            <ExportSection
+              exportPayoutsButton={<ExportPayoutModsButton />}
+              exportReservedTokensButton={undefined}
+            />
           </Space>
         </TabPane>
         {isOwnerWallet && (

--- a/src/components/v1/V1Project/V1ProjectToolsDrawer/V1ProjectToolsDrawer.tsx
+++ b/src/components/v1/V1Project/V1ProjectToolsDrawer/V1ProjectToolsDrawer.tsx
@@ -16,6 +16,7 @@ import { ExportSection } from 'components/Project/ProjectToolsDrawer/ExportSecti
 import { TransferOwnershipForm } from 'components/Project/ProjectToolsDrawer/TransferOwnershipForm'
 import { TransferUnclaimedTokensForm } from 'components/Project/ProjectToolsDrawer/TransferUnclaimedTokensForm'
 import { ExportPayoutModsButton } from './ExportPayoutModsButton'
+import { ExportTicketModsButton } from './ExportTicketModsButton'
 
 const { TabPane } = Tabs
 
@@ -77,7 +78,7 @@ export function V1ProjectToolsDrawer({
 
             <ExportSection
               exportPayoutsButton={<ExportPayoutModsButton />}
-              exportReservedTokensButton={undefined}
+              exportReservedTokensButton={<ExportTicketModsButton />}
             />
           </Space>
         </TabPane>

--- a/src/components/v1/V1Project/V1ProjectToolsDrawer/index.tsx
+++ b/src/components/v1/V1Project/V1ProjectToolsDrawer/index.tsx
@@ -1,0 +1,1 @@
+export { V1ProjectToolsDrawer } from './V1ProjectToolsDrawer'

--- a/src/components/v1/shared/PayoutModsList.tsx
+++ b/src/components/v1/shared/PayoutModsList.tsx
@@ -26,6 +26,7 @@ import { amountSubFee } from 'utils/math'
 import { V1CurrencyName } from 'utils/v1/currency'
 
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
+import { MODS_TOTAL_PERCENT } from 'utils/v1/mods'
 import ProjectPayoutMods from './ProjectPayMods/ProjectPayoutMods'
 
 export default function PayoutModsList({
@@ -91,7 +92,7 @@ export default function PayoutModsList({
   }
 
   const modsTotal = mods?.reduce((acc, curr) => acc + curr.percent, 0)
-  const ownerPercent = 10000 - (modsTotal ?? 0)
+  const ownerPercent = MODS_TOTAL_PERCENT - (modsTotal ?? 0)
 
   const baseTotal = total ?? amountSubFee(fundingCycle?.target, feePerbicent)
 

--- a/src/components/v1/shared/TicketModsList.tsx
+++ b/src/components/v1/shared/TicketModsList.tsx
@@ -12,6 +12,7 @@ import { V1OperatorPermission } from 'models/v1/permissions'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 import { formatWad, permyriadToPercent } from 'utils/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
+import { MODS_TOTAL_PERCENT } from 'utils/v1/mods'
 export default function TicketModsList({
   total,
   mods,
@@ -64,7 +65,7 @@ export default function TicketModsList({
   }
 
   const modsTotal = mods?.reduce((acc, curr) => acc + curr.percent, 0)
-  const ownerPercent = 10000 - (modsTotal ?? 0)
+  const ownerPercent = MODS_TOTAL_PERCENT - (modsTotal ?? 0)
 
   const hasEditPermission = useV1ConnectedWalletHasPermission(
     V1OperatorPermission.SetTicketMods,

--- a/src/components/v2/V2Project/V2ProjectToolsDrawer/ExportSplitsButton.tsx
+++ b/src/components/v2/V2Project/V2ProjectToolsDrawer/ExportSplitsButton.tsx
@@ -9,6 +9,7 @@ import { PropsWithChildren, useContext, useState } from 'react'
 import { downloadCsvFile } from 'utils/csv'
 import { emitErrorNotification } from 'utils/notifications'
 import { formatSplitPercent } from 'utils/v2/math'
+import { getProjectOwnerRemainderSplit } from 'utils/v2/splits'
 
 const CSV_HEADER = [
   'beneficiary',
@@ -19,40 +20,64 @@ const CSV_HEADER = [
   'allocator',
 ]
 
-const prepareSplitsCsv = (splits: Split[]): (string | undefined)[][] => {
-  const csvContent = splits.map(split => {
-    return [
-      split.beneficiary,
-      `${parseFloat(formatSplitPercent(BigNumber.from(split.percent))) / 100}`,
-      `${split.preferClaimed}`,
-      `${split.lockedUntil}`,
-      split.projectId,
-      split.allocator,
-    ]
-  })
+const splitToCsvRow = (split: Split) => {
+  return [
+    split.beneficiary,
+    `${parseFloat(formatSplitPercent(BigNumber.from(split.percent))) / 100}`,
+    `${split.preferClaimed}`,
+    `${split.lockedUntil}`,
+    split.projectId,
+    split.allocator,
+  ]
+}
 
-  return [CSV_HEADER, ...csvContent]
+const prepareSplitsCsv = (
+  splits: Split[],
+  projectOwnerAddress: string,
+): (string | undefined)[][] => {
+  const csvContent = splits.map(splitToCsvRow)
+
+  const rows = [CSV_HEADER, ...csvContent]
+
+  const projectOwnerSplit = getProjectOwnerRemainderSplit(
+    projectOwnerAddress,
+    splits,
+  )
+  if (projectOwnerSplit.percent > 0) {
+    rows.push(splitToCsvRow(projectOwnerSplit))
+  }
+
+  return rows
 }
 
 export function ExportSplitsButton<G extends SplitGroup>({
   children,
   groupedSplits,
 }: PropsWithChildren<{ groupedSplits: GroupedSplits<G> }>) {
-  const { handle, projectId, fundingCycle } = useContext(V2ProjectContext)
+  const { handle, projectId, fundingCycle, projectOwnerAddress } =
+    useContext(V2ProjectContext)
   const [loading, setLoading] = useState<boolean>(false)
 
   const onExportSplitsButtonClick = () => {
-    if (!groupedSplits || !fundingCycle) return
+    if (!groupedSplits || !fundingCycle || !projectOwnerAddress) {
+      emitErrorNotification(
+        t`CSV data wasn't ready for export. Wait a few seconds and try again.`,
+      )
+      return
+    }
 
     setLoading(true)
 
     try {
-      const csvContent = prepareSplitsCsv(groupedSplits.splits)
+      const csvContent = prepareSplitsCsv(
+        groupedSplits.splits,
+        projectOwnerAddress,
+      )
       const projectIdentifier = handle ? `@${handle}` : `project-${projectId}`
       const splitType =
         groupedSplits.group === ETH_PAYOUT_SPLIT_GROUP
           ? 'payouts'
-          : 'reserved_tokens'
+          : 'reserved-tokens'
       const filename = `${projectIdentifier}_${splitType}_fc-${fundingCycle.number}`
 
       downloadCsvFile(filename, csvContent)

--- a/src/components/v2/shared/SplitList.tsx
+++ b/src/components/v2/shared/SplitList.tsx
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Split } from 'models/v2/splits'
-import { SPLITS_TOTAL_PERCENT } from 'utils/v2/math'
+import { getProjectOwnerRemainderSplit } from 'utils/v2/splits'
 
 import SplitItem from './SplitItem'
 
@@ -23,9 +23,9 @@ export default function SplitList({
   valueFormatProps?: { precision?: number }
   reservedRate?: number
 }) {
-  const totalSplitPercentage =
-    splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
-  const ownerPercentage = SPLITS_TOTAL_PERCENT - totalSplitPercentage
+  const ownerSplit = projectOwnerAddress
+    ? getProjectOwnerRemainderSplit(projectOwnerAddress, splits)
+    : undefined
 
   return (
     <div>
@@ -48,16 +48,9 @@ export default function SplitList({
             />
           </div>
         ))}
-      {ownerPercentage && reservedRate ? (
+      {ownerSplit && reservedRate ? (
         <SplitItem
-          split={{
-            beneficiary: projectOwnerAddress,
-            percent: ownerPercentage,
-            preferClaimed: undefined,
-            lockedUntil: undefined,
-            projectId: undefined,
-            allocator: undefined,
-          }}
+          split={ownerSplit}
           showSplitValue={showSplitValues}
           currency={currency}
           totalValue={totalValue}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -494,6 +494,9 @@ msgstr ""
 msgid "By default, the payer will receive any project tokens minted from the payment."
 msgstr ""
 
+msgid "CSV data wasn't ready for export. Wait a few seconds and try again."
+msgstr ""
+
 msgid "CSV download failed."
 msgstr ""
 

--- a/src/utils/v1/mods.ts
+++ b/src/utils/v1/mods.ts
@@ -1,0 +1,52 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import * as constants from '@ethersproject/constants'
+import { TEN_THOUSAND } from 'constants/numbers'
+import { PayoutMod, TicketMod } from 'models/mods'
+
+export const MODS_TOTAL_PERCENT = TEN_THOUSAND // = 100%
+
+/**
+ * Return a PayoutMod object that represents the remaining percentage allocated to the project owner.
+ *
+ * In the Juicebox protocol, if the sum of the payout mod percentages is less than 100%,
+ * the remainder gets allocated to the project owner.
+ */
+export const getProjectOwnerRemainderPayoutMod = (
+  projectOwnerAddress: string,
+  splits: PayoutMod[],
+): PayoutMod => {
+  const totalSplitPercentage =
+    splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
+  const ownerPercentage = MODS_TOTAL_PERCENT - totalSplitPercentage
+
+  return {
+    beneficiary: projectOwnerAddress,
+    percent: ownerPercentage,
+    preferUnstaked: false,
+    lockedUntil: 0,
+    projectId: BigNumber.from(0),
+    allocator: constants.AddressZero,
+  }
+}
+
+/**
+ * Return a TicketMod object that represents the remaining percentage allocated to the project owner.
+ *
+ * In the Juicebox protocol, if the sum of the ticket mod percentages is less than 100%,
+ * the remainder gets allocated to the project owner.
+ */
+export const getProjectOwnerRemainderTicketMod = (
+  projectOwnerAddress: string,
+  splits: TicketMod[],
+): TicketMod => {
+  const totalSplitPercentage =
+    splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
+  const ownerPercentage = MODS_TOTAL_PERCENT - totalSplitPercentage
+
+  return {
+    beneficiary: projectOwnerAddress,
+    percent: ownerPercentage,
+    preferUnstaked: false,
+    lockedUntil: 0,
+  }
+}

--- a/src/utils/v2/splits.ts
+++ b/src/utils/v2/splits.ts
@@ -4,7 +4,11 @@ import { PayoutMod } from 'models/mods'
 import { Split } from 'models/v2/splits'
 import { percentToPermyriad, permyriadToPercent } from 'utils/formatNumber'
 
-import { formatSplitPercent, splitPercentFrom } from './math'
+import {
+  formatSplitPercent,
+  splitPercentFrom,
+  SPLITS_TOTAL_PERCENT,
+} from './math'
 
 export const toSplit = (mod: PayoutMod): Split => {
   return {
@@ -44,5 +48,29 @@ export const sanitizeSplit = (split: Split): Split => {
     allocator: constants.AddressZero,
     preferClaimed: false,
     percent: split.percent,
+  }
+}
+
+/**
+ * Return a Split object that represents the remaining percentage allocated to the project owner.
+ *
+ * In the Juicebox protocol, if the sum of the split percentages is less than 100%,
+ * the remainder gets allocated to the project owner.
+ */
+export const getProjectOwnerRemainderSplit = (
+  projectOwnerAddress: string,
+  splits: Split[],
+): Split => {
+  const totalSplitPercentage =
+    splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
+  const ownerPercentage = SPLITS_TOTAL_PERCENT - totalSplitPercentage
+
+  return {
+    beneficiary: projectOwnerAddress,
+    percent: ownerPercentage,
+    preferClaimed: false,
+    lockedUntil: 0,
+    projectId: BigNumber.from(0).toHexString(),
+    allocator: constants.AddressZero,
   }
 }


### PR DESCRIPTION
## What does this PR do and why?

Payout export for V1 projects. Reserved token allocation export coming in the next pr. 

## Screenshots or screen recordings

<img width="624" alt="Screen Shot 2022-08-25 at 12 06 26 PM" src="https://user-images.githubusercontent.com/12551741/186561459-94b67604-4f63-40af-a5f3-802df377341b.png">

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
