### PR TITLE
Move V2 Project dashboard state to hook

### DIFF
--- a/src/hooks/v2/V2ProjectState.ts
+++ b/src/hooks/v2/V2ProjectState.ts
@@ -1,0 +1,269 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import * as constants from '@ethersproject/constants'
+import { V2ArchivedProjectIds } from 'constants/v2/archivedProjects'
+import {
+  ETH_PAYOUT_SPLIT_GROUP,
+  RESERVED_TOKEN_SPLIT_GROUP,
+} from 'constants/v2/splits'
+import { V2ProjectContextType } from 'contexts/v2/projectContext'
+import { useCurrencyConverter } from 'hooks/CurrencyConverter'
+import useNameOfERC20 from 'hooks/NameOfERC20'
+import { useProjectsQuery } from 'hooks/Projects'
+import useSymbolOfERC20 from 'hooks/SymbolOfERC20'
+import { useBallotState } from 'hooks/v2/contractReader/BallotState'
+import { useNftRewardTiersOf } from 'hooks/v2/contractReader/NftRewardTiersOf'
+import { usePaymentTerminalBalance } from 'hooks/v2/contractReader/PaymentTerminalBalance'
+import useProjectCurrentFundingCycle from 'hooks/v2/contractReader/ProjectCurrentFundingCycle'
+import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
+import useProjectHandle from 'hooks/v2/contractReader/ProjectHandle'
+import useProjectOwner from 'hooks/v2/contractReader/ProjectOwner'
+import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
+import useProjectTerminals from 'hooks/v2/contractReader/ProjectTerminals'
+import useProjectToken from 'hooks/v2/contractReader/ProjectToken'
+import useProjectTokenTotalSupply from 'hooks/v2/contractReader/ProjectTokenTotalSupply'
+import useTerminalCurrentOverflow from 'hooks/v2/contractReader/TerminalCurrentOverflow'
+import useUsedDistributionLimit from 'hooks/v2/contractReader/UsedDistributionLimit'
+import useNftRewards from 'hooks/v2/NftRewards'
+import { useVeNftContractForProject } from 'hooks/veNft/VeNftContractForProject'
+import { first } from 'lodash'
+import { ProjectMetadataV4 } from 'models/project-metadata'
+import { V2CurrencyOption } from 'models/v2/currencyOption'
+import { useMemo } from 'react'
+import { NO_CURRENCY, V2CurrencyName, V2_CURRENCY_ETH } from 'utils/v2/currency'
+import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
+
+const useBalanceInDistributionLimitCurrency = ({
+  ETHBalanceLoading,
+  ETHBalance,
+  distributionLimitCurrency,
+}: {
+  ETHBalanceLoading: boolean
+  ETHBalance: BigNumber | undefined
+  distributionLimitCurrency: BigNumber
+}) => {
+  const converter = useCurrencyConverter()
+
+  return useMemo(() => {
+    if (ETHBalanceLoading) return { loading: true }
+
+    // if ETH, no conversion necessary
+    if (
+      distributionLimitCurrency?.eq(V2_CURRENCY_ETH) ||
+      distributionLimitCurrency?.eq(NO_CURRENCY)
+    ) {
+      return { data: ETHBalance, loading: false }
+    }
+
+    return {
+      data: converter.wadToCurrency(
+        ETHBalance,
+        V2CurrencyName(
+          distributionLimitCurrency?.toNumber() as V2CurrencyOption,
+        ),
+        V2CurrencyName(V2_CURRENCY_ETH),
+      ),
+      loading: false,
+    }
+  }, [ETHBalance, ETHBalanceLoading, converter, distributionLimitCurrency])
+}
+
+export function useV2ProjectState({
+  projectId,
+  metadata: projectMetadata,
+}: {
+  projectId: number
+  metadata: ProjectMetadataV4
+}) {
+  /**
+   * Load additional project metadata
+   */
+  const { data: handle } = useProjectHandle({
+    projectId,
+  })
+  const { data: projectOwnerAddress } = useProjectOwner(projectId)
+  const isArchived = projectId
+    ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived
+    : false
+
+  /**
+   * Load project stats
+   */
+  const { data: projects } = useProjectsQuery({
+    projectId,
+    keys: ['createdAt', 'totalPaid'],
+    cv: ['2'],
+  })
+  const createdAt = first(projects)?.createdAt
+  const totalVolume = first(projects)?.totalPaid
+
+  /**
+   * Load funding cyle data
+   */
+  const { data: fundingCycleResponse, loading: fundingCycleLoading } =
+    useProjectCurrentFundingCycle({
+      projectId,
+    })
+  const [fundingCycle, fundingCycleMetadata] = fundingCycleResponse ?? []
+  const { data: ballotState } = useBallotState(projectId)
+
+  /**
+   * Load splits data
+   */
+  const { data: reservedTokensSplits } = useProjectSplits({
+    projectId,
+    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
+    domain: fundingCycle?.configuration?.toString(),
+  })
+  const { data: payoutSplits } = useProjectSplits({
+    projectId,
+    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
+    domain: fundingCycle?.configuration?.toString(),
+  })
+
+  /**
+   * Load payment terminal data
+   */
+  const { data: terminals } = useProjectTerminals({
+    projectId,
+  })
+  const primaryTerminal = terminals?.[0] // TODO: make primaryTerminalOf hook and use it
+  const { data: ETHBalance, loading: ETHBalanceLoading } =
+    usePaymentTerminalBalance({
+      terminal: primaryTerminal,
+      projectId,
+    })
+  const { data: primaryTerminalCurrentOverflow } = useTerminalCurrentOverflow({
+    projectId,
+    terminal: primaryTerminal,
+  })
+
+  /**
+   * Load distribution limit data
+   */
+  const { data: distributionLimitData, loading: distributionLimitLoading } =
+    useProjectDistributionLimit({
+      projectId,
+      configuration: fundingCycle?.configuration?.toString(),
+      terminal: primaryTerminal,
+    })
+  const { data: usedDistributionLimit, loading: usedDistributionLimitLoading } =
+    useUsedDistributionLimit({
+      projectId,
+      terminal: primaryTerminal,
+      fundingCycleNumber: fundingCycle?.number,
+    })
+  const [distributionLimit, distributionLimitCurrency] =
+    distributionLimitData ?? []
+  const {
+    data: balanceInDistributionLimitCurrency,
+    loading: balanceInDistributionLimitCurrencyLoading,
+  } = useBalanceInDistributionLimitCurrency({
+    ETHBalanceLoading,
+    ETHBalance,
+    distributionLimitCurrency,
+  })
+
+  /**
+   * Load token data
+   */
+  const { data: tokenAddress } = useProjectToken({
+    projectId,
+  })
+  const tokenSymbol = useSymbolOfERC20(tokenAddress)
+  const tokenName = useNameOfERC20(tokenAddress)
+  const { data: totalTokenSupply } = useProjectTokenTotalSupply(projectId)
+
+  /**
+   * Load NFT Rewards data
+   */
+  const { data: nftRewardTiersResponse, loading: nftRewardsCIDsLoading } =
+    useNftRewardTiersOf(fundingCycleMetadata?.dataSource)
+  let nftRewardsCIDs: string[] = []
+  if (nftRewardTiersResponse) {
+    nftRewardsCIDs = CIDsOfNftRewardTiersResponse(nftRewardTiersResponse)
+  }
+  const { data: nftRewardTiers, isLoading: nftRewardTiersLoading } =
+    useNftRewards(nftRewardTiersResponse ?? [])
+  // Assumes having `dataSource` means there are NFTs initially
+  // In worst case, if has `dataSource` but isn't for NFTs:
+  //    - loading will be true briefly
+  //    - will resolve false when `useNftRewardTiersOf` fails
+  const nftsLoading = Boolean(
+    fundingCycleMetadata?.dataSource &&
+      fundingCycleMetadata.dataSource !== constants.AddressZero &&
+      (nftRewardTiersLoading || nftRewardsCIDsLoading),
+  )
+
+  /**
+   * Load veNFT data
+   */
+  const { data: veNftInfo } = useVeNftContractForProject(projectId)
+  const veNftContractAddress = first(veNftInfo)?.address
+  const veNftUriResolver = first(veNftInfo)?.uriResolver
+
+  const project: V2ProjectContextType = {
+    cv: '2',
+
+    // project metadata
+    projectId,
+    handle,
+    projectOwnerAddress,
+    projectMetadata,
+    isArchived,
+
+    // stats
+    createdAt,
+    totalVolume,
+
+    // funding cycle data
+    fundingCycle,
+    fundingCycleMetadata,
+    ballotState,
+
+    // splits data
+    payoutSplits,
+    reservedTokensSplits,
+
+    // payment terminal data
+    terminals,
+    ETHBalance,
+    primaryTerminal,
+    primaryTerminalCurrentOverflow,
+
+    // distribution limit data
+    distributionLimit,
+    usedDistributionLimit,
+    distributionLimitCurrency,
+    balanceInDistributionLimitCurrency,
+
+    // token data
+    tokenAddress,
+    tokenSymbol,
+    tokenName,
+    totalTokenSupply,
+
+    // NFT Rewards data
+    nftRewards: {
+      CIDs: nftRewardsCIDs,
+      rewardTiers: nftRewardTiers ?? [],
+      loading: nftsLoading,
+    },
+
+    // veNFT data
+    veNft: {
+      contractAddress: veNftContractAddress,
+      uriResolver: veNftUriResolver,
+    },
+
+    // loading states
+    loading: {
+      ETHBalanceLoading,
+      balanceInDistributionLimitCurrencyLoading,
+      distributionLimitLoading,
+      fundingCycleLoading,
+      usedDistributionLimitLoading,
+    },
+  }
+
+  return project
+}

--- a/src/pages/v2/p/components/V2Dashboard.tsx
+++ b/src/pages/v2/p/components/V2Dashboard.tsx
@@ -1,242 +1,24 @@
 import ScrollToTopButton from 'components/ScrollToTopButton'
-
-import * as constants from '@ethersproject/constants'
-import {
-  V2ProjectContext,
-  V2ProjectContextType,
-} from 'contexts/v2/projectContext'
-import { useCurrencyConverter } from 'hooks/CurrencyConverter'
-import { useProjectsQuery } from 'hooks/Projects'
-import useSymbolOfERC20 from 'hooks/SymbolOfERC20'
-import { useBallotState } from 'hooks/v2/contractReader/BallotState'
-import { useNftRewardTiersOf } from 'hooks/v2/contractReader/NftRewardTiersOf'
-import { usePaymentTerminalBalance } from 'hooks/v2/contractReader/PaymentTerminalBalance'
-import useProjectCurrentFundingCycle from 'hooks/v2/contractReader/ProjectCurrentFundingCycle'
-import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
-import useProjectHandle from 'hooks/v2/contractReader/ProjectHandle'
-import useProjectOwner from 'hooks/v2/contractReader/ProjectOwner'
-import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
-import useProjectTerminals from 'hooks/v2/contractReader/ProjectTerminals'
-import useProjectToken from 'hooks/v2/contractReader/ProjectToken'
-import useProjectTokenTotalSupply from 'hooks/v2/contractReader/ProjectTokenTotalSupply'
-import useTerminalCurrentOverflow from 'hooks/v2/contractReader/TerminalCurrentOverflow'
-import useUsedDistributionLimit from 'hooks/v2/contractReader/UsedDistributionLimit'
-import { first } from 'lodash'
-import { V2CurrencyOption } from 'models/v2/currencyOption'
-import { useMemo } from 'react'
-import { NO_CURRENCY, V2CurrencyName, V2_CURRENCY_ETH } from 'utils/v2/currency'
-
-import useNftRewards from 'hooks/v2/NftRewards'
-import { CIDsOfNftRewardTiersResponse } from 'utils/v2/nftRewards'
-
-import useNameOfERC20 from 'hooks/NameOfERC20'
-import { ProjectMetadataV4 } from 'models/project-metadata'
-
-import { useVeNftContractForProject } from 'hooks/veNft/VeNftContractForProject'
-
+import V2Project from 'components/v2/V2Project'
 import { layouts } from 'constants/styles/layouts'
-import { V2ArchivedProjectIds } from 'constants/v2/archivedProjects'
-import {
-  ETH_PAYOUT_SPLIT_GROUP,
-  RESERVED_TOKEN_SPLIT_GROUP,
-} from 'constants/v2/splits'
-
-import V2Project from '../../../../components/v2/V2Project'
+import { ProjectMetadataV4 } from 'models/project-metadata'
+import V2ProjectProvider from 'providers/v2/V2ProjectProvider'
 
 export default function V2Dashboard({
   projectId,
-  metadata: projectMetadata,
+  metadata,
 }: {
   projectId: number
   metadata: ProjectMetadataV4
 }) {
-  const { data: projects } = useProjectsQuery({
-    projectId,
-    keys: ['createdAt', 'totalPaid'],
-    cv: ['2'],
-  })
-  const createdAt = first(projects)?.createdAt
-  const totalVolume = first(projects)?.totalPaid
-
-  const { data: veNftInfo } = useVeNftContractForProject(projectId)
-  const veNftContractAddress = first(veNftInfo)?.address
-  const veNftUriResolver = first(veNftInfo)?.uriResolver
-
-  const { data: fundingCycleResponse, loading: fundingCycleLoading } =
-    useProjectCurrentFundingCycle({
-      projectId,
-    })
-  const [fundingCycle, fundingCycleMetadata] = fundingCycleResponse ?? []
-
-  const { data: payoutSplits } = useProjectSplits({
-    projectId,
-    splitGroup: ETH_PAYOUT_SPLIT_GROUP,
-    domain: fundingCycle?.configuration?.toString(),
-  })
-
-  const { data: terminals } = useProjectTerminals({
-    projectId,
-  })
-
-  const primaryTerminal = terminals?.[0] // TODO: make primaryTerminalOf hook and use it
-
-  const { data: distributionLimitData, loading: distributionLimitLoading } =
-    useProjectDistributionLimit({
-      projectId,
-      configuration: fundingCycle?.configuration?.toString(),
-      terminal: primaryTerminal,
-    })
-
-  const { data: usedDistributionLimit, loading: usedDistributionLimitLoading } =
-    useUsedDistributionLimit({
-      projectId,
-      terminal: primaryTerminal,
-      fundingCycleNumber: fundingCycle?.number,
-    })
-
-  const [distributionLimit, distributionLimitCurrency] =
-    distributionLimitData ?? []
-
-  const { data: reservedTokensSplits } = useProjectSplits({
-    projectId,
-    splitGroup: RESERVED_TOKEN_SPLIT_GROUP,
-    domain: fundingCycle?.configuration?.toString(),
-  })
-
-  const { data: ETHBalance, loading: ETHBalanceLoading } =
-    usePaymentTerminalBalance({
-      terminal: primaryTerminal,
-      projectId,
-    })
-
-  const { data: tokenAddress } = useProjectToken({
-    projectId,
-  })
-
-  const { data: handle } = useProjectHandle({
-    projectId,
-  })
-
-  const tokenSymbol = useSymbolOfERC20(tokenAddress)
-  const tokenName = useNameOfERC20(tokenAddress)
-
-  const { data: primaryTerminalCurrentOverflow } = useTerminalCurrentOverflow({
-    projectId,
-    terminal: primaryTerminal,
-  })
-
-  const converter = useCurrencyConverter()
-  const {
-    data: balanceInDistributionLimitCurrency,
-    loading: balanceInDistributionLimitCurrencyLoading,
-  } = useMemo(() => {
-    if (ETHBalanceLoading) return { loading: true }
-
-    // if ETH, no conversion necessary
-    if (
-      distributionLimitCurrency?.eq(V2_CURRENCY_ETH) ||
-      distributionLimitCurrency?.eq(NO_CURRENCY)
-    ) {
-      return { data: ETHBalance, loading: false }
-    }
-
-    return {
-      data: converter.wadToCurrency(
-        ETHBalance,
-        V2CurrencyName(
-          distributionLimitCurrency?.toNumber() as V2CurrencyOption,
-        ),
-        V2CurrencyName(V2_CURRENCY_ETH),
-      ),
-      loading: false,
-    }
-  }, [ETHBalance, ETHBalanceLoading, converter, distributionLimitCurrency])
-
-  const { data: projectOwnerAddress } = useProjectOwner(projectId)
-
-  const { data: totalTokenSupply } = useProjectTokenTotalSupply(projectId)
-
-  const { data: ballotState } = useBallotState(projectId)
-
-  const { data: nftRewardTiersResponse, loading: nftRewardsCIDsLoading } =
-    useNftRewardTiersOf(fundingCycleMetadata?.dataSource)
-
-  let nftRewardsCIDs: string[] = []
-  if (nftRewardTiersResponse) {
-    nftRewardsCIDs = CIDsOfNftRewardTiersResponse(nftRewardTiersResponse)
-  }
-  const { data: nftRewardTiers, isLoading: nftRewardTiersLoading } =
-    useNftRewards(nftRewardTiersResponse ?? [])
-
-  const isArchived = projectId
-    ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived
-    : false
-
-  // Assumes having `dataSource` means there are NFTs initially
-  // In worst case, if has `dataSource` but isn't for NFTs:
-  //    - loading will be true briefly
-  //    - will resolve false when `useNftRewardTiersOf` fails
-  const nftsLoading = Boolean(
-    fundingCycleMetadata?.dataSource &&
-      fundingCycleMetadata.dataSource !== constants.AddressZero &&
-      (nftRewardTiersLoading || nftRewardsCIDsLoading),
-  )
-
-  const project: V2ProjectContextType = {
-    cv: '2',
-    handle,
-    projectId,
-    createdAt,
-    projectMetadata,
-    fundingCycle,
-    fundingCycleMetadata,
-    distributionLimit,
-    usedDistributionLimit,
-    payoutSplits,
-    reservedTokensSplits,
-    tokenAddress,
-    terminals,
-    primaryTerminal,
-    ETHBalance,
-    totalVolume,
-    distributionLimitCurrency,
-    balanceInDistributionLimitCurrency,
-    tokenSymbol,
-    tokenName,
-    projectOwnerAddress,
-    primaryTerminalCurrentOverflow,
-    totalTokenSupply,
-    ballotState,
-    isArchived,
-
-    nftRewards: {
-      CIDs: nftRewardsCIDs,
-      rewardTiers: nftRewardTiers ?? [],
-      loading: nftsLoading,
-    },
-
-    veNft: {
-      contractAddress: veNftContractAddress,
-      uriResolver: veNftUriResolver,
-    },
-
-    loading: {
-      ETHBalanceLoading,
-      balanceInDistributionLimitCurrencyLoading,
-      distributionLimitLoading,
-      fundingCycleLoading,
-      usedDistributionLimitLoading,
-    },
-  }
-
   return (
-    <V2ProjectContext.Provider value={project}>
+    <V2ProjectProvider projectId={projectId} metadata={metadata}>
       <div style={layouts.maxWidth}>
         <V2Project />
         <div style={{ textAlign: 'center', marginTop: '3rem' }}>
           <ScrollToTopButton />
         </div>
       </div>
-    </V2ProjectContext.Provider>
+    </V2ProjectProvider>
   )
 }

--- a/src/providers/v2/V2ProjectProvider.tsx
+++ b/src/providers/v2/V2ProjectProvider.tsx
@@ -1,0 +1,21 @@
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import { useV2ProjectState } from 'hooks/v2/V2ProjectState'
+import { ProjectMetadataV4 } from 'models/project-metadata'
+import { PropsWithChildren } from 'react'
+
+export default function V2ProjectProvider({
+  projectId,
+  metadata,
+  children,
+}: PropsWithChildren<{
+  projectId: number
+  metadata: ProjectMetadataV4
+}>) {
+  const project = useV2ProjectState({ projectId, metadata })
+
+  return (
+    <V2ProjectContext.Provider value={project}>
+      {children}
+    </V2ProjectContext.Provider>
+  )
+}


### PR DESCRIPTION
## What does this PR do and why?

In preparation for the Settings page, this PR abstracts all the project dashboard state loading code into a single hook. It's then used in a new V2ProjectProvider. This provider is finally used back in V2ProjectDashboard, to provide the context.

I'm imagining the settings page will pretty much follow the same pattern

## Screenshots or screen recordings

No user-facing changes

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
