### PR TITLE
Make FormattedAddress component return an EtherscanLink

### DIFF
--- a/src/components/CopyTextButton.tsx
+++ b/src/components/CopyTextButton.tsx
@@ -29,7 +29,7 @@ export default function CopyTextButton({
       <CopyOutlined
         onClick={copyText}
         className="copyIcon"
-        style={{ ...style, paddingLeft: 10, color: colors.text.primary }}
+        style={{ ...style, color: colors.text.primary }}
       />
     </Tooltip>
   )

--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -1,6 +1,6 @@
 import { LinkOutlined } from '@ant-design/icons'
 import { NetworkName } from 'models/network-name'
-import { CSSProperties } from 'react'
+import { CSSProperties, PropsWithChildren } from 'react'
 import { truncateEthAddress } from 'utils/formatAddress'
 
 import { readNetwork } from 'constants/networks'
@@ -12,13 +12,14 @@ export default function EtherscanLink({
   truncated,
   truncateTo,
   style,
-}: {
+  children,
+}: PropsWithChildren<{
   value: string | undefined
   type: 'tx' | 'address'
   truncated?: boolean
   truncateTo?: number
   style?: CSSProperties
-}) {
+}>) {
   if (!value) return null
   let truncatedValue: string | undefined
   // Return first and last 4 chars of ETH address only
@@ -31,8 +32,9 @@ export default function EtherscanLink({
     subdomain = readNetwork.name + '.'
   }
   const linkProps = {
-    className: 'hover-action',
-    style: { ...style, fontWeight: 400 },
+    className:
+      'hover-text-action-primary hover-text-decoration-underline color-unset',
+    style: { ...style },
     href: `https://${subdomain}etherscan.io/${type}/${value}`,
   }
 
@@ -44,5 +46,9 @@ export default function EtherscanLink({
     )
   }
 
-  return <ExternalLink {...linkProps}>{truncatedValue ?? value}</ExternalLink>
+  return (
+    <ExternalLink {...linkProps}>
+      {children ?? truncatedValue ?? value}
+    </ExternalLink>
+  )
 }

--- a/src/components/FeedbackFormButton.tsx
+++ b/src/components/FeedbackFormButton.tsx
@@ -47,7 +47,10 @@ export default function FeedbackFormButton({
   return (
     <Tooltip
       title={
-        <ExternalLink className="quiet hover-action" href={formUrl}>
+        <ExternalLink
+          className="quiet hover-text-action-primary hover-text-decoration-underline"
+          href={formUrl}
+        >
           <Trans>Give feedback</Trans>
         </ExternalLink>
       }

--- a/src/components/FeedbackFormButton.tsx
+++ b/src/components/FeedbackFormButton.tsx
@@ -35,7 +35,6 @@ export default function FeedbackFormButton({
         <MessageOutlined size={iconSize} />
         <ExternalLink
           style={{ margin: '0 0 2px 12px', fontWeight: 400 }}
-          className="quiet"
           href={formUrl}
         >
           <Trans>Give feedback</Trans>
@@ -48,7 +47,7 @@ export default function FeedbackFormButton({
     <Tooltip
       title={
         <ExternalLink
-          className="quiet hover-text-action-primary hover-text-decoration-underline"
+          className="hover-text-action-primary hover-text-decoration-underline"
           href={formUrl}
         >
           <Trans>Give feedback</Trans>

--- a/src/components/FormattedAddress.tsx
+++ b/src/components/FormattedAddress.tsx
@@ -2,7 +2,7 @@ import { isAddress } from '@ethersproject/address'
 
 import { Tooltip } from 'antd'
 
-import { useEffect, useState } from 'react'
+import { CSSProperties, useEffect, useState } from 'react'
 
 import CopyTextButton from 'components/CopyTextButton'
 import EtherscanLink from 'components/EtherscanLink'
@@ -38,11 +38,13 @@ export default function FormattedAddress({
   label,
   tooltipDisabled,
   truncateTo,
+  style,
 }: {
   address: string | undefined
   label?: string
   tooltipDisabled?: boolean
   truncateTo?: number
+  style?: CSSProperties
 }) {
   const [ensName, setEnsName] = useState<string | null>()
 
@@ -100,23 +102,29 @@ export default function FormattedAddress({
   const formatted =
     ensName ?? label ?? truncateEthAddress({ address, truncateTo })
 
+  const mergedStyle: CSSProperties = {
+    userSelect: 'all',
+    lineHeight: '22px',
+    ...style,
+  }
+
   if (tooltipDisabled) {
-    return (
-      <span style={{ userSelect: 'all', lineHeight: '22px' }}>{formatted}</span>
-    )
+    return <span style={mergedStyle}>{formatted}</span>
   }
 
   return (
     <Tooltip
-      trigger={['hover', 'click']}
       title={
-        <span>
-          <EtherscanLink value={address} type="address" />{' '}
-          <CopyTextButton value={address} />
+        <span style={{ fontSize: '0.8rem' }}>
+          {address} <CopyTextButton value={address} />
         </span>
       }
     >
-      <span style={{ userSelect: 'all', lineHeight: '22px' }}>{formatted}</span>
+      <span>
+        <EtherscanLink type="address" value={address} style={mergedStyle}>
+          {formatted}
+        </EtherscanLink>
+      </span>
     </Tooltip>
   )
 }

--- a/src/components/activityEventElems/PayEventElem.tsx
+++ b/src/components/activityEventElems/PayEventElem.tsx
@@ -110,7 +110,10 @@ export default function PayEventElem({
               lineHeight: contentLineHeight,
             }}
           >
-            <FormattedAddress address={event.beneficiary} />
+            <FormattedAddress
+              address={event.beneficiary}
+              style={{ fontWeight: 400 }}
+            />
           </div>
         </div>
       </div>

--- a/src/components/activityEventElems/ProjectCreateEventElem.tsx
+++ b/src/components/activityEventElems/ProjectCreateEventElem.tsx
@@ -34,7 +34,10 @@ export default function ProjectCreateEventElem({
           }}
         >
           <Trans>Project created by</Trans>{' '}
-          <FormattedAddress address={event.caller} />
+          <FormattedAddress
+            address={event.caller}
+            style={{ fontWeight: 400 }}
+          />
         </div>
       </div>
 

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -85,7 +85,10 @@ export default function RedeemEventElem({
               textAlign: 'right',
             }}
           >
-            <FormattedAddress address={event.beneficiary} />
+            <FormattedAddress
+              address={event.beneficiary}
+              style={{ fontWeight: 400 }}
+            />
           </div>
         </div>
       </div>

--- a/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
@@ -160,7 +160,7 @@ export default function LaunchProjectPayerModal({
           value={projectPayerAddress}
           style={{ fontSize: 15 }}
           type="address"
-        />
+        />{' '}
         <CopyTextButton value={projectPayerAddress} style={{ fontSize: 25 }} />
         <p style={{ marginTop: 30 }}>
           <Trans>

--- a/src/components/v2/V2Project/ProjectPayersModal.tsx
+++ b/src/components/v2/V2Project/ProjectPayersModal.tsx
@@ -78,7 +78,7 @@ export default function ProjectPayersModal({
                       truncated={isMobile ? true : false}
                       truncateTo={isMobile ? 8 : undefined}
                     />
-                  </span>
+                  </span>{' '}
                   <CopyTextButton value={p.address} />
                 </div>
                 <div

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -34,6 +34,7 @@ label {
 a {
   color: var(--text-action-primary);
   font-weight: 500;
+  transition: none;
 
   &:hover {
     color: var(--text-action-highlight);
@@ -46,14 +47,6 @@ a.quiet {
 
   &:hover {
     color: var(--text-primary);
-  }
-}
-
-a.hover-action {
-  color: var(--text-primary);
-  &:hover {
-    color: var(--text-action-primary);
-    text-decoration: underline;
   }
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -41,15 +41,6 @@ a {
   }
 }
 
-a.quiet {
-  color: inherit;
-  font-weight: 500;
-
-  &:hover {
-    color: var(--text-primary);
-  }
-}
-
 input {
   background: var(--background-l0);
   color: var(--text-primary);

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -2,24 +2,17 @@
   color: var(--text-primary);
 }
 
-.hover-text-secondary {
-  &:hover {
-    color: var(--text-secondary) !important;
-    transition: color 250ms;
-  }
+.color-unset {
+  color: unset
 }
 
 .hover-text-action-primary {
-  transition: unset;
-
   &:hover {
     color: var(--text-action-primary);
   }
 }
 
 .hover-text-decoration-underline {
-  transition: unset;
-
   &:hover {
     text-decoration: underline;
   }

--- a/src/utils/formatAddress.ts
+++ b/src/utils/formatAddress.ts
@@ -1,21 +1,25 @@
-// Truncates an ETH address to specific number of characters (truncateTo)
-// e.g. truncateEthAddress({
-//   address: '0xf0FE43a75Ff248FD2E75D33fa1ebde71c6d1abAd,
-//   truncateTo: 4
-// }) = '0xf0FE...abAd'
+const DEFAULT_TRUNCATE_TO = 6
+
+/**
+ * Truncates an ETH address to a given [truncateTo] length.
+ * @example
+ *  truncateEthAddress({
+ *    address: '0xf0FE43a75Ff248FD2E75D33fa1ebde71c6d1abAd,
+ *    truncateTo: 4
+ *  }) = '0xf0FE...abAd'
+ */
 export function truncateEthAddress({
   address,
-  truncateTo,
+  truncateTo = DEFAULT_TRUNCATE_TO,
 }: {
   address: string
   truncateTo?: number
 }) {
-  const effectiveTruncateTo = truncateTo ?? 6
-  const frontTruncate = effectiveTruncateTo + 2 // account for 0x
+  const frontTruncate = truncateTo + 2 // account for 0x
 
   return (
     address.substring(0, frontTruncate) +
     '...' +
-    address.substring(address.length - effectiveTruncateTo, address.length)
+    address.substring(address.length - truncateTo, address.length)
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

FormattedAddress links throughout the app are currently unintuitive. I expect to be able to click any address and open it in Etherscan. Instead, I have to hover, then click the link in the tooltip.

This PR reworks FormattedAddress to return an EtherscanLink.

Other minor things:
- remove transition from `a` elements.
- remove padding from ClipboardButton
- clean up formatAddress util a bit.

## Screenshots or screen recordings

| before | after |
| --- | --- |
| <img width="629" alt="Screen Shot 2022-08-25 at 2 31 27 PM" src="https://user-images.githubusercontent.com/12551741/186578921-db369f3b-d880-461e-80f2-cf3b0701c94b.png"> | <img width="639" alt="Screen Shot 2022-08-25 at 2 30 42 PM" src="https://user-images.githubusercontent.com/12551741/186578837-2b998f4a-688c-4a28-8a84-2ed9947d9391.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
