### PR TITLE
Add font size utilities.

### DIFF
--- a/src/components/AMMPrices/TokenAMMPriceRow.tsx
+++ b/src/components/AMMPrices/TokenAMMPriceRow.tsx
@@ -27,7 +27,6 @@ type Props = {
 }
 
 const fontStyle = {
-  fontSize: '0.7rem',
   fontWeight: 400,
 }
 
@@ -48,7 +47,7 @@ export default function TokenAMMPriceRow({
 
     return (
       <Tooltip title={tooltip} overlayInnerStyle={{ ...fontStyle }}>
-        <span style={{ cursor: 'default' }}>
+        <span style={{ cursor: 'default' }} className="text-xs">
           {!WETHPrice ? <Trans>Unavailable</Trans> : null}
           <TooltipIcon iconStyle={{ marginLeft: '0.2rem' }} />
         </span>
@@ -65,6 +64,7 @@ export default function TokenAMMPriceRow({
         justifyContent: 'space-between',
         ...style,
       }}
+      className="text-xs"
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <span style={{ marginRight: '0.5rem', width: '1rem' }}>

--- a/src/components/AMMPrices/index.tsx
+++ b/src/components/AMMPrices/index.tsx
@@ -33,7 +33,7 @@ export default function AMMPrices({
 
   return (
     <div style={{ ...style }}>
-      <p style={{ fontSize: '0.7rem' }}>
+      <p className="text-xs">
         <Trans>Current 3rd Party Exchange Rates</Trans>
       </p>
       <TokenAMMPriceRow

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -40,12 +40,12 @@ export function Badge({
     <span
       style={{
         padding: '0.1rem 0.5rem',
-        fontSize: 12,
         fontWeight: 400,
         borderRadius: 12,
         ...variantStyle[variant],
         ...style,
       }}
+      className="text-xs"
     >
       {children}
     </span>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -26,7 +26,10 @@ export default function Banner({
         style={{ position: 'absolute', left: 20, top: 18 }}
       />
 
-      <h2 style={{ color: colors.text.primary, fontSize: 14, fontWeight: 600 }}>
+      <h2
+        style={{ color: colors.text.primary, fontWeight: 600 }}
+        className="text-sm"
+      >
         {title}
       </h2>
       <p>{body}</p>

--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -12,12 +12,14 @@ export default function EtherscanLink({
   truncated,
   truncateTo,
   style,
+  className,
 }: {
   value: string | undefined
   type: 'tx' | 'address'
   truncated?: boolean
   truncateTo?: number
   style?: CSSProperties
+  className?: string
 }) {
   if (!value) return null
   let truncatedValue: string | undefined
@@ -31,7 +33,7 @@ export default function EtherscanLink({
     subdomain = readNetwork.name + '.'
   }
   const linkProps = {
-    className: 'hover-action',
+    className: 'hover-action' + className,
     style: { ...style, fontWeight: 400 },
     href: `https://${subdomain}etherscan.io/${type}/${value}`,
   }

--- a/src/components/FormattedAddress.tsx
+++ b/src/components/FormattedAddress.tsx
@@ -110,7 +110,7 @@ export default function FormattedAddress({
     <Tooltip
       trigger={['hover', 'click']}
       title={
-        <span>
+        <span className="text-sm">
           <EtherscanLink value={address} type="address" />{' '}
           <CopyTextButton value={address} />
         </span>

--- a/src/components/InputAccessoryButton.tsx
+++ b/src/components/InputAccessoryButton.tsx
@@ -41,7 +41,7 @@ export default function InputAccessoryButton({
     >
       {content}
       {withArrow && (
-        <CaretDownOutlined style={{ fontSize: 10, marginLeft: 4 }} />
+        <CaretDownOutlined style={{ marginLeft: 4 }} className="text-xs" />
       )}
     </div>
   ) : null

--- a/src/components/InputAccessoryButton.tsx
+++ b/src/components/InputAccessoryButton.tsx
@@ -32,17 +32,16 @@ export default function InputAccessoryButton({
             : colors.background.l1,
         fontWeight: 500,
         whiteSpace: 'nowrap',
-        padding: '1px 6px',
+        padding: '3px 6px',
         marginLeft: placement === 'suffix' ? 8 : 0,
         marginRight: placement === 'prefix' ? 8 : 0,
         borderRadius: radii.sm,
       }}
+      className="text-xs"
       onClick={onClick}
     >
       {content}
-      {withArrow && (
-        <CaretDownOutlined style={{ marginLeft: 4 }} className="text-xs" />
-      )}
+      {withArrow && <CaretDownOutlined style={{ marginLeft: 4 }} />}
     </div>
   ) : null
 }

--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -91,7 +91,6 @@ export function TopLeftNavItems({
   const router = useRouter()
   const [resourcesOpen, setResourcesOpen] = useState<boolean>(false)
   const dropdownIconStyle: CSSProperties = {
-    fontSize: 13,
     marginLeft: 7,
   }
 
@@ -153,9 +152,9 @@ export function TopLeftNavItems({
           >
             <Trans>Resources</Trans>
             {resourcesOpen ? (
-              <UpOutlined style={dropdownIconStyle} />
+              <UpOutlined style={dropdownIconStyle} className="text-xs" />
             ) : (
-              <DownOutlined style={dropdownIconStyle} />
+              <DownOutlined style={dropdownIconStyle} className="text-xs" />
             )}
           </div>
         </Dropdown>

--- a/src/components/Paragraph.tsx
+++ b/src/components/Paragraph.tsx
@@ -9,10 +9,12 @@ export default function Paragraph({
   description,
   characterLimit,
   style,
+  className,
 }: {
   description: string
   characterLimit?: number
   style?: CSSProperties
+  className?: string
 }) {
   const CHARACTER_LIMIT_EXCEEDED =
     (characterLimit && description.length > characterLimit) ||
@@ -29,7 +31,7 @@ export default function Paragraph({
   }, [characterLimit, description])
 
   return (
-    <div>
+    <div className={className}>
       <RichNote
         style={{ maxWidth: '700px', display: 'inline', ...style }} // good line length for reading
         note={

--- a/src/components/Project/FundingCycleSection.tsx
+++ b/src/components/Project/FundingCycleSection.tsx
@@ -55,7 +55,7 @@ export default function FundingCycleSection({
         {reconfigureButton}
       </div>
 
-      <Space style={{ fontSize: '.8rem', marginBottom: 12 }} size="middle">
+      <Space style={{ marginBottom: 12 }} size="middle" className="text-xs">
         {tabs.map(tab => (
           <div
             key={tab.key}

--- a/src/components/Project/ProjectHeader/index.tsx
+++ b/src/components/Project/ProjectHeader/index.tsx
@@ -100,10 +100,10 @@ export default function ProjectHeader({
             {isArchived && (
               <span
                 style={{
-                  fontSize: '0.8rem',
                   color: colors.text.disabled,
                   textTransform: 'uppercase',
                 }}
+                className="text-xs"
               >
                 (archived)
               </span>

--- a/src/components/Project/SpendingStats.tsx
+++ b/src/components/Project/SpendingStats.tsx
@@ -35,7 +35,6 @@ export default function SpendingStats({
   } = useContext(ThemeContext)
 
   const smallHeaderStyle: CSSProperties = {
-    fontSize: '.7rem',
     fontWeight: 500,
     cursor: 'default',
     color: colors.text.secondary,
@@ -68,10 +67,14 @@ export default function SpendingStats({
               cycle ends.
             </Trans>
           }
+          className="text-xs"
         />
       </div>
 
-      <div style={{ ...smallHeaderStyle, color: colors.text.tertiary }}>
+      <div
+        style={{ ...smallHeaderStyle, color: colors.text.tertiary }}
+        className="text-xs"
+      >
         <div>
           <Trans>
             <CurrencySymbol currency={currency} />

--- a/src/components/Project/StatLine.tsx
+++ b/src/components/Project/StatLine.tsx
@@ -31,7 +31,7 @@ export default function StatLine({
         ...style,
       }}
     >
-      <div style={textSecondary(theme)}>
+      <div style={textSecondary(theme)} className="text-xs">
         <TooltipLabel label={statLabel} tip={statLabelTip} />
       </div>
 

--- a/src/components/Project/VolumeStatLine/VolumeStatLine.tsx
+++ b/src/components/Project/VolumeStatLine/VolumeStatLine.tsx
@@ -47,7 +47,7 @@ export const VolumeStatLine = ({
       statValue={
         <span style={textPrimary}>
           {convertedVolume && convertToCurrency ? (
-            <span style={secondaryTextStyle}>
+            <span style={secondaryTextStyle} className="text-xs">
               <CurrencySymbol currency={convertToCurrency} />
               {convertedVolume}{' '}
             </span>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -170,9 +170,9 @@ export default function ProjectCard({
               <span
                 style={{
                   color: colors.text.tertiary,
-                  fontSize: '0.7rem',
                   fontWeight: 500,
                 }}
+                className="text-xs"
               >
                 V{terminalVersion ?? _project.cv}
               </span>
@@ -213,10 +213,10 @@ export default function ProjectCard({
                 right: 0,
                 padding: '2px 4px',
                 background: colors.background.l1,
-                fontSize: '0.7rem',
                 color: colors.text.tertiary,
                 fontWeight: 500,
               }}
+              className="text-xs"
             >
               <Trans>ARCHIVED</Trans>
             </div>

--- a/src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
+++ b/src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
@@ -89,7 +89,7 @@ export default function ReconfigurationStrategySelector({
           content={
             <div>
               <p>{strategy.description}</p>
-              <p style={{ fontSize: '0.7rem', color: colors.text.tertiary }}>
+              <p style={{ color: colors.text.tertiary }} className="text-xs">
                 <Trans>Contract address: {strategy.address}</Trans>
               </p>
             </div>

--- a/src/components/RichButton.tsx
+++ b/src/components/RichButton.tsx
@@ -82,8 +82,8 @@ export default function RichButton({
             style={{
               color: subheadingColor,
               margin: 0,
-              fontSize: 12,
             }}
+            className="text-xs"
           >
             {description}
           </p>

--- a/src/components/TextButton.tsx
+++ b/src/components/TextButton.tsx
@@ -12,11 +12,11 @@ export function TextButton({ style, ...props }: ButtonProps) {
       {...props}
       style={{
         color: colors.text.tertiary,
-        fontSize: '0.8rem',
         textTransform: 'uppercase',
         padding: 0,
         ...style,
       }}
+      className="text-xs"
       type="text"
       size="small"
     >

--- a/src/components/TooltipLabel.tsx
+++ b/src/components/TooltipLabel.tsx
@@ -8,14 +8,16 @@ export default function TooltipLabel({
   tip,
   placement,
   style,
+  className,
 }: {
   label: string | JSX.Element
   tip?: string | JSX.Element
   placement?: TooltipProps['placement']
   style?: CSSProperties
+  className?: string
 }) {
   return (
-    <span style={style}>
+    <span style={style} className={className}>
       <span style={{ marginRight: tip ? 5 : 0 }}>{label}</span>
       {tip && <TooltipIcon tip={tip} placement={placement} />}
     </span>

--- a/src/components/VolumeChart/index.tsx
+++ b/src/components/VolumeChart/index.tsx
@@ -276,11 +276,6 @@ export default function VolumeChart({
               interval={2}
             />
             <Tooltip
-              contentStyle={{
-                background: colors.background.l0,
-                border: '1px solid ' + colors.stroke.secondary,
-              }}
-              className="text-xs"
               cursor={{ stroke: colors.stroke.secondary }}
               content={({ active, payload }) => {
                 if (!active || !payload?.length) return null
@@ -290,8 +285,9 @@ export default function VolumeChart({
                     style={{
                       padding: 10,
                       background: colors.background.l0,
-                      border: '1px solid ' + colors.stroke.tertiary,
+                      border: '1px solid ' + colors.stroke.secondary,
                     }}
+                    className="text-xs"
                   >
                     <div
                       style={{

--- a/src/components/VolumeChart/index.tsx
+++ b/src/components/VolumeChart/index.tsx
@@ -101,6 +101,7 @@ export default function VolumeChart({
   }
 
   const axisStyle: SVGProps<SVGTextElement> = {
+    fontSize: '0.75rem',
     fill: colors.text.tertiary,
     visibility: events?.length ? 'visible' : 'hidden',
   }
@@ -250,7 +251,6 @@ export default function VolumeChart({
               tickSize={2}
               tickCount={4}
               tick={axisStyle}
-              className="text-xs"
               mirror
             />
             <XAxis

--- a/src/components/VolumeChart/index.tsx
+++ b/src/components/VolumeChart/index.tsx
@@ -97,12 +97,10 @@ export default function VolumeChart({
   }, [cv, duration, projectId, showGraph])
 
   const buttonStyle: CSSProperties = {
-    fontSize: '0.7rem',
     textTransform: 'uppercase',
   }
 
   const axisStyle: SVGProps<SVGTextElement> = {
-    fontSize: 11,
     fill: colors.text.tertiary,
     visibility: events?.length ? 'visible' : 'hidden',
   }
@@ -141,11 +139,11 @@ export default function VolumeChart({
       <div
         style={{
           textTransform: 'uppercase',
-          fontSize: '0.8rem',
           fontWeight: selected ? 600 : 400,
           color: selected ? colors.text.secondary : colors.text.tertiary,
           cursor: 'pointer',
         }}
+        className="text-xs"
         onClick={() => setShowGraph(tab)}
       >
         {text}
@@ -170,7 +168,7 @@ export default function VolumeChart({
         </div>
 
         <Select
-          className="small"
+          className="small text-xs"
           style={{
             ...buttonStyle,
             width: 100,
@@ -252,6 +250,7 @@ export default function VolumeChart({
               tickSize={2}
               tickCount={4}
               tick={axisStyle}
+              className="text-xs"
               mirror
             />
             <XAxis
@@ -280,8 +279,8 @@ export default function VolumeChart({
               contentStyle={{
                 background: colors.background.l0,
                 border: '1px solid ' + colors.stroke.secondary,
-                fontSize: '0.8rem',
               }}
+              className="text-xs"
               cursor={{ stroke: colors.stroke.secondary }}
               content={({ active, payload }) => {
                 if (!active || !payload?.length) return null
@@ -296,9 +295,9 @@ export default function VolumeChart({
                   >
                     <div
                       style={{
-                        fontSize: '0.7rem',
                         color: colors.text.tertiary,
                       }}
+                      className="text-xs"
                     >
                       {dateStringForBlockTime(payload[0].payload.timestamp)}
                     </div>
@@ -308,10 +307,10 @@ export default function VolumeChart({
                         {payload[0].payload.tapped}
                         <div
                           style={{
-                            fontSize: '0.7rem',
                             fontWeight: 500,
                             color: colors.text.secondary,
                           }}
+                          className="text-xs"
                         >
                           withdraw
                         </div>

--- a/src/components/activityEventElems/DeployedERC20EventElem.tsx
+++ b/src/components/activityEventElems/DeployedERC20EventElem.tsx
@@ -33,7 +33,7 @@ export default function DeployedERC20EventElem({
       }}
     >
       <div>
-        <div style={smallHeaderStyle(colors)}>
+        <div style={smallHeaderStyle(colors)} className="text-xs">
           <Trans>Deployed ERC20 token</Trans>
         </div>
         <div
@@ -48,7 +48,7 @@ export default function DeployedERC20EventElem({
 
       <div style={{ textAlign: 'right' }}>
         {event.timestamp && (
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             {formatHistoricalDate(event.timestamp * 1000)}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>

--- a/src/components/activityEventElems/PayEventElem.tsx
+++ b/src/components/activityEventElems/PayEventElem.tsx
@@ -84,7 +84,7 @@ export default function PayEventElem({
         }}
       >
         <div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>Paid</Trans>
           </div>
           <div
@@ -99,7 +99,7 @@ export default function PayEventElem({
 
         <div style={{ textAlign: 'right' }}>
           {event.timestamp && (
-            <div style={smallHeaderStyle(colors)}>
+            <div style={smallHeaderStyle(colors)} className="text-xs">
               {formatHistoricalDate(event.timestamp * 1000)}{' '}
               <EtherscanLink value={event.txHash} type="tx" />
             </div>
@@ -109,6 +109,7 @@ export default function PayEventElem({
               ...smallHeaderStyle(colors),
               lineHeight: contentLineHeight,
             }}
+            className="text-xs"
           >
             <FormattedAddress address={event.beneficiary} />
           </div>

--- a/src/components/activityEventElems/ProjectCreateEventElem.tsx
+++ b/src/components/activityEventElems/ProjectCreateEventElem.tsx
@@ -27,7 +27,9 @@ export default function ProjectCreateEventElem({
       }}
     >
       <div>
-        <div style={smallHeaderStyle(colors)}>Created</div>
+        <div style={smallHeaderStyle(colors)} className="text-xs">
+          Created
+        </div>
         <div
           style={{
             lineHeight: contentLineHeight,
@@ -40,7 +42,7 @@ export default function ProjectCreateEventElem({
 
       <div style={{ textAlign: 'right' }}>
         {event.timestamp && (
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             {formatHistoricalDate(event.timestamp * 1000)}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -48,7 +48,7 @@ export default function RedeemEventElem({
         }}
       >
         <div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>Redeemed</Trans>
           </div>
           <div
@@ -72,6 +72,7 @@ export default function RedeemEventElem({
               ...smallHeaderStyle(colors),
               textAlign: 'right',
             }}
+            className="text-xs"
           >
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
@@ -84,6 +85,7 @@ export default function RedeemEventElem({
               lineHeight: contentLineHeight,
               textAlign: 'right',
             }}
+            className="text-xs"
           >
             <FormattedAddress address={event.beneficiary} />
           </div>

--- a/src/components/activityEventElems/styles.ts
+++ b/src/components/activityEventElems/styles.ts
@@ -2,7 +2,6 @@ import { SemanticColors } from 'models/semantic-theme/colors'
 import { CSSProperties } from 'react'
 
 export const smallHeaderStyle = (colors: SemanticColors) => ({
-  fontSize: '.7rem',
   color: colors.text.tertiary,
 })
 

--- a/src/components/formItems/ProjectRedemptionRate.tsx
+++ b/src/components/formItems/ProjectRedemptionRate.tsx
@@ -35,7 +35,7 @@ function BondingCurveRateExtra({
   } = useContext(ThemeContext)
 
   return (
-    <Space style={{ fontSize: '0.9rem' }} direction="vertical" size="large">
+    <Space className="text-sm" direction="vertical" size="large">
       <p style={{ margin: 0 }}>
         <Trans>
           The redemption rate determines the amount of overflow each token can
@@ -110,7 +110,6 @@ export function ProjectRedemptionRate({
   } = useContext(ThemeContext)
 
   const labelStyle: CSSProperties = {
-    fontSize: '.9rem',
     fontWeight: 500,
     textAlign: 'center',
     position: 'absolute',
@@ -292,6 +291,7 @@ export function ProjectRedemptionRate({
               left: 0,
               right: 0,
             }}
+            className="text-sm"
           >
             % <Trans>tokens redeemed</Trans>
           </div>
@@ -305,6 +305,7 @@ export function ProjectRedemptionRate({
               left: 0,
               width: graphSize,
             }}
+            className="text-sm"
           >
             <Trans>Token redeem value</Trans>
           </div>

--- a/src/components/formItems/ProjectReserved.tsx
+++ b/src/components/formItems/ProjectReserved.tsx
@@ -68,7 +68,7 @@ export default function ProjectReserved({
   return (
     <Form.Item
       extra={
-        <div style={{ fontSize: '0.9rem' }}>
+        <div className="text-sm">
           <p>
             <Trans>
               Reserve a percentage of freshly minted tokens for your project to

--- a/src/components/inputs/EthAddressInput.tsx
+++ b/src/components/inputs/EthAddressInput.tsx
@@ -94,7 +94,7 @@ export function EthAddressInput({
         onChange={onInputChange}
       />
       {extraText ? (
-        <div style={{ fontSize: '0.7rem', color: colors.text.secondary }}>
+        <div style={{ color: colors.text.secondary }} className="text-xs">
           <CheckCircleFilled /> {extraText}
         </div>
       ) : null}

--- a/src/components/inputs/FormImageUploader.tsx
+++ b/src/components/inputs/FormImageUploader.tsx
@@ -100,10 +100,10 @@ export const FormImageUploader = ({
         {value?.length ? (
           <span
             style={{
-              fontSize: '.7rem',
               wordBreak: 'break-all',
               textOverflow: 'ellipsis',
             }}
+            className="text-xs"
           >
             <Trans>
               Uploaded to: <ExternalLink href={value}>{value}</ExternalLink>

--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -112,10 +112,10 @@ export default function FormattedNumberInput({
         <div
           style={{
             zIndex: 1,
-            fontSize: '.8rem',
             position: 'absolute',
             right: 5,
           }}
+          className="text-xs"
         >
           {accessory && <div>{accessory}</div>}
         </div>

--- a/src/components/inputs/ImageUploader.tsx
+++ b/src/components/inputs/ImageUploader.tsx
@@ -107,10 +107,10 @@ export default function ImageUploader({
         {url?.length ? (
           <span
             style={{
-              fontSize: '.7rem',
               wordBreak: 'break-all',
               textOverflow: 'ellipsis',
             }}
+            className="text-xs"
           >
             <Trans>
               Uploaded to: <ExternalLink href={url}>{url}</ExternalLink>

--- a/src/components/inputs/Pay/MemoFormInput.tsx
+++ b/src/components/inputs/Pay/MemoFormInput.tsx
@@ -40,11 +40,11 @@ export function MemoFormInput({
           size={20}
           style={{
             color: colors.text.secondary,
-            fontSize: '.8rem',
             position: 'absolute',
             right: 5,
             top: 7,
           }}
+          className="text-xs"
         />
       </div>
       <AttachStickerModal

--- a/src/components/inputs/Pay/PayInputGroup.tsx
+++ b/src/components/inputs/Pay/PayInputGroup.tsx
@@ -68,7 +68,7 @@ export default function PayInputGroup({
     <>
       <div style={{ height: '22px' }}>
         {isErrorField ? (
-          <span style={{ color: colors.text.failure, fontSize: '0.7rem' }}>
+          <span style={{ color: colors.text.failure }} className="text-xs">
             <Trans>Pay amount must be greater than 0.</Trans>
           </span>
         ) : null}

--- a/src/components/inputs/Pay/PayInputSubText.tsx
+++ b/src/components/inputs/Pay/PayInputSubText.tsx
@@ -125,10 +125,10 @@ export default function PayInputSubText({
     <div
       style={{
         marginTop: '0.3rem',
-        fontSize: '.65rem',
         width: '100%',
         color: colors.text.secondary,
       }}
+      className="text-xs"
     >
       <span>
         <Trans>Receive {receiveText}</Trans>

--- a/src/components/inputs/Pay/PayInputSubText.tsx
+++ b/src/components/inputs/Pay/PayInputSubText.tsx
@@ -134,7 +134,7 @@ export default function PayInputSubText({
         <Trans>Receive {receiveText}</Trans>
       </span>
       {tokenSymbol && tokenAddress && (
-        <div>
+        <div style={{ marginTop: '0.2rem' }}>
           <Trans>
             or{' '}
             <Tooltip

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -120,7 +120,6 @@ export default function ParticipantsModal({
 
   const list = useMemo(() => {
     const smallHeaderStyle = {
-      fontSize: '.7rem',
       color: colors.text.tertiary,
     }
 
@@ -207,7 +206,7 @@ export default function ParticipantsModal({
                 >
                   <FormattedAddress address={p.wallet} />
                 </div>
-                <div style={smallHeaderStyle}>
+                <div style={smallHeaderStyle} className="text-xs">
                   <Trans>
                     <ETHAmount amount={p.totalPaid} /> contributed
                   </Trans>
@@ -228,7 +227,7 @@ export default function ParticipantsModal({
                   })}{' '}
                   ({formatPercent(p.balance, totalTokenSupply)}%)
                 </div>
-                <div style={smallHeaderStyle}>
+                <div style={smallHeaderStyle} className="text-xs">
                   {formatWad(p.stakedBalance, { precision: 0 })}{' '}
                   <Trans>
                     {tokenSymbolText({

--- a/src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
+++ b/src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
@@ -90,7 +90,7 @@ export default function FundingHistory({
             <Space align="baseline">
               <h3>#{cycle.number.toString()}</h3>
 
-              <div style={{ fontSize: '.8rem', marginLeft: 10 }}>
+              <div style={{ marginLeft: 10 }} className="text-xs">
                 <CurrencySymbol
                   currency={V1CurrencyName(
                     cycle.currency.toNumber() as V1CurrencyOption,
@@ -115,7 +115,7 @@ export default function FundingHistory({
 
             <div style={{ flex: 1 }}></div>
 
-            <Space align="baseline" style={{ fontSize: '.8rem' }}>
+            <Space align="baseline" className="text-xs">
               {formatHistoricalDate(
                 cycle.start.add(cycle.duration).mul(1000).toNumber(),
               )}

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -21,6 +21,7 @@ import { V1CurrencyName } from 'utils/v1/currency'
 
 import { VolumeStatLine } from 'components/Project/VolumeStatLine'
 
+import { Space } from 'antd'
 import { readNetwork } from 'constants/networks'
 import { textPrimary, textSecondary } from 'constants/styles/text'
 import { V1_CURRENCY_ETH, V1_CURRENCY_USD } from 'constants/v1/currency'
@@ -55,9 +56,6 @@ export default function Paid() {
 
   if (!currentFC) return null
 
-  const spacing =
-    hasFundingTarget(currentFC) && currentFC.target.gt(0) ? 15 : 10
-
   const formatCurrencyAmount = (amt: BigNumber | undefined) => {
     if (!amt) return null
 
@@ -77,7 +75,7 @@ export default function Paid() {
     projectId === V1_PROJECT_IDS.CONSTITUTION_DAO
 
   return (
-    <>
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
       <VolumeStatLine
         totalVolume={earned}
         color={
@@ -85,7 +83,8 @@ export default function Paid() {
         }
         convertToCurrency={isConstitutionDAO ? 'USD' : undefined}
       />
-      <div style={{ marginTop: spacing, marginBottom: spacing }}>
+
+      <Space direction="vertical" style={{ width: '100%' }}>
         <StatLine
           statLabel={<Trans>In Juicebox</Trans>}
           statLabelTip={
@@ -102,7 +101,7 @@ export default function Paid() {
               }}
             >
               {currentFC.currency.eq(V1_CURRENCY_USD) ? (
-                <span style={secondaryTextStyle} className="text-xs">
+                <span style={secondaryTextStyle} className="text-sm">
                   <ETHAmount amount={balance} precision={2} padEnd={true} />{' '}
                 </span>
               ) : (
@@ -159,62 +158,65 @@ export default function Paid() {
               />
             </div>
           ))}
+      </Space>
 
-        {hasFundingTarget(currentFC) && currentFC.target.gt(0) && (
-          <FundingProgressBar
-            targetAmount={currentFC.target}
-            overflowAmountInTargetCurrency={overflowInCurrency}
-            balanceInTargetCurrency={balanceInCurrency}
-          />
-        )}
-      </div>
+      {hasFundingTarget(currentFC) && currentFC.target.gt(0) && (
+        <FundingProgressBar
+          targetAmount={currentFC.target}
+          overflowAmountInTargetCurrency={overflowInCurrency}
+          balanceInTargetCurrency={balanceInCurrency}
+        />
+      )}
 
-      <StatLine
-        statLabel={<Trans>In wallet</Trans>}
-        statLabelTip={
-          <>
-            <p>
-              <Trans>The balance of the project owner's wallet.</Trans>
-            </p>{' '}
-            <EtherscanLink value={owner} type="address" />
-          </>
-        }
-        statValue={
-          <span>
-            <span style={secondaryTextStyle}>
-              <V1ProjectTokenBalance
-                style={{ display: 'inline-block' }}
-                wallet={owner}
-                projectId={V1_PROJECT_IDS.JUICEBOX_DAO}
-                hideHandle
-              />{' '}
-              +{' '}
+      <div>
+        <StatLine
+          statLabel={<Trans>In wallet</Trans>}
+          statLabelTip={
+            <>
+              <p>
+                <Trans>The balance of the project owner's wallet.</Trans>
+              </p>{' '}
+              <EtherscanLink value={owner} type="address" />
+            </>
+          }
+          statValue={
+            <span>
+              <span style={secondaryTextStyle}>
+                <V1ProjectTokenBalance
+                  style={{ display: 'inline-block' }}
+                  wallet={owner}
+                  projectId={V1_PROJECT_IDS.JUICEBOX_DAO}
+                  hideHandle
+                />{' '}
+                +{' '}
+              </span>
+              <span style={textPrimary}>
+                <ETHAmount amount={ownerBalance} precision={2} padEnd={true} />
+              </span>
             </span>
-            <span style={textPrimary}>
-              <ETHAmount amount={ownerBalance} precision={2} padEnd={true} />
-            </span>
-          </span>
-        }
-      />
+          }
+        />
 
-      <div
-        style={{
-          textAlign: 'right',
-        }}
-      >
-        <span
-          style={{ ...secondaryTextStyle, cursor: 'pointer' }}
-          onClick={() => setBalancesModalVisible(true)}
-          role="button"
+        <div
+          style={{
+            textAlign: 'right',
+          }}
         >
-          <Trans>All assets</Trans> <RightCircleOutlined />
-        </span>
+          <span
+            style={{ ...secondaryTextStyle, cursor: 'pointer' }}
+            onClick={() => setBalancesModalVisible(true)}
+            role="button"
+            className="text-xs"
+          >
+            <Trans>All assets</Trans> <RightCircleOutlined />
+          </span>
+        </div>
       </div>
 
       <V1BalancesModal
         visible={balancesModalVisible}
         onCancel={() => setBalancesModalVisible(false)}
       />
-    </>
+    </Space>
   )
 }

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -102,7 +102,7 @@ export default function Paid() {
               }}
             >
               {currentFC.currency.eq(V1_CURRENCY_USD) ? (
-                <span style={secondaryTextStyle}>
+                <span style={secondaryTextStyle} className="text-xs">
                   <ETHAmount amount={balance} precision={2} padEnd={true} />{' '}
                 </span>
               ) : (
@@ -132,6 +132,7 @@ export default function Paid() {
                     ...secondaryTextStyle,
                     color: colors.text.primary,
                   }}
+                  className="text-xs"
                 >
                   {formatCurrencyAmount(currentFC.tapped)} /{' '}
                   {formatCurrencyAmount(currentFC.target)}
@@ -144,6 +145,7 @@ export default function Paid() {
                 ...secondaryTextStyle,
                 textAlign: 'right',
               }}
+              className="text-xs"
             >
               <TooltipLabel
                 tip={

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
@@ -59,7 +59,7 @@ export default function ReservesEventElem({
         }}
       >
         <div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               Distributed reserved{' '}
               {tokenSymbolText({
@@ -87,13 +87,13 @@ export default function ReservesEventElem({
         </div>
 
         <div style={{ textAlign: 'right' }}>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
             )}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               called by <FormattedAddress address={event.caller} />
             </Trans>
@@ -111,16 +111,17 @@ export default function ReservesEventElem({
               alignItems: 'baseline',
             }}
           >
-            <div style={{ fontWeight: 500, fontSize: '0.8rem' }}>
+            <div style={{ fontWeight: 500 }} className="text-xs">
               <FormattedAddress address={e.modBeneficiary} />:
             </div>
 
             <div
               style={
                 distributeEvents.length > 1
-                  ? { color: colors.text.secondary, fontSize: '0.8rem' }
+                  ? { color: colors.text.secondary }
                   : { fontWeight: 500 }
               }
+              className="text-xs"
             >
               {formatWad(e.modCut, { precision: 0 })}
             </div>

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
@@ -70,7 +70,7 @@ export default function TapEventElem({
         }}
       >
         <div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>Distributed funds</Trans>
           </div>
           {payoutEvents?.length ? (
@@ -90,13 +90,13 @@ export default function TapEventElem({
             textAlign: 'right',
           }}
         >
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
             )}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               called by <FormattedAddress address={event.caller} />
             </Trans>
@@ -112,8 +112,8 @@ export default function TapEventElem({
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'baseline',
-              fontSize: '0.8rem',
             }}
+            className="text-xs"
           >
             <div style={{ fontWeight: 500 }}>
               {e.modProjectId?.gt(0) ? (

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -179,10 +179,10 @@ export default function Rewards() {
                       <div
                         style={{
                           cursor: 'default',
-                          fontSize: '0.8rem',
                           fontWeight: 500,
                           color: colors.text.tertiary,
                         }}
+                        className="text-xs"
                       >
                         <Trans>{share || 0}% of supply</Trans>
                       </div>

--- a/src/components/v1/V1Project/V1PayButton.tsx
+++ b/src/components/v1/V1Project/V1PayButton.tsx
@@ -102,7 +102,7 @@ export default function V1PayButton({
         </Button>
       </Tooltip>
       {payInCurrency === V1_CURRENCY_USD && (
-        <div style={{ fontSize: '.7rem' }}>
+        <div className="text-xs">
           <Trans>
             Paid as <ETHAmount amount={weiPayAmt} />
           </Trans>

--- a/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal.tsx
@@ -476,7 +476,7 @@ export default function ReconfigureFCModal({
                   <span>
                     <CurrencySymbol currency={editingFCCurrency} />
                     {formatWad(editingFC.target)}{' '}
-                    <span style={{ fontSize: '0.8rem' }}>
+                    <span className="text-xs">
                       (
                       {terminalFee?.gt(0) ? (
                         <span>
@@ -534,8 +534,7 @@ export default function ReconfigureFCModal({
               const ballot = getBallotStrategyByAddress(editingFC.ballot)
               return (
                 <div>
-                  {ballot.name}{' '}
-                  <div style={{ fontSize: '0.7rem' }}>{ballot.address}</div>
+                  {ballot.name} <div className="text-xs">{ballot.address}</div>
                 </div>
               )
             }}

--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
@@ -268,11 +268,11 @@ export default function V1ConfirmPayOwnerModal({
             {/* Sticker select icon (right side of memo input) */}
             <div
               style={{
-                fontSize: '.8rem',
                 position: 'absolute',
                 right: 7,
                 top: 36,
               }}
+              className="text-xs"
             >
               {
                 <Sticker

--- a/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -318,7 +318,7 @@ export default function FundingCycleDetails({
           {ballotStrategy.name}
         </FundingCycleDetailWarning>
         <div style={{ color: colors.text.secondary }}>
-          <div style={{ fontSize: '0.7rem' }}>
+          <div className="text-xs">
             <Trans>
               Address:{' '}
               <EtherscanLink value={ballotStrategy.address} type="address" />

--- a/src/components/v1/shared/Mod.tsx
+++ b/src/components/v1/shared/Mod.tsx
@@ -52,10 +52,10 @@ export default function Mod({
               </div>
               <div
                 style={{
-                  fontSize: '.8rem',
                   color: colors.text.secondary,
                   marginLeft: 10,
                 }}
+                className="text-xs"
               >
                 <TooltipLabel
                   label={t`Tokens` + ':'}
@@ -90,7 +90,7 @@ export default function Mod({
           )}
         </div>
         {mod.lockedUntil ? (
-          <div style={{ fontSize: '.8rem', color: colors.text.secondary }}>
+          <div style={{ color: colors.text.secondary }} className="text-xs">
             <LockOutlined /> <Trans>until</Trans>{' '}
             {mod.lockedUntil
               ? formatDate(mod.lockedUntil * 1000, 'yyyy-MM-DD')

--- a/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
+++ b/src/components/v2/V2Project/LaunchProjectPayer/LaunchProjectPayerModal.tsx
@@ -158,8 +158,8 @@ export default function LaunchProjectPayerModal({
         </h4>
         <EtherscanLink
           value={projectPayerAddress}
-          style={{ fontSize: 15 }}
           type="address"
+          className="text-sm"
         />
         <CopyTextButton value={projectPayerAddress} style={{ fontSize: 25 }} />
         <p style={{ marginTop: 30 }}>

--- a/src/components/v2/V2Project/NftRewardsSection/NftPreview.tsx
+++ b/src/components/v2/V2Project/NftRewardsSection/NftPreview.tsx
@@ -48,7 +48,6 @@ const linkStyle: CSSProperties = {
 const bodyTextStyle: CSSProperties = {
   display: 'flex',
   marginTop: '20px',
-  fontSize: '0.75rem',
   color: darkColors.light0,
 }
 
@@ -105,7 +104,7 @@ export function NftPreview({
           {rewardTier.description}
         </p>
         {hasLimitedSupply || rewardTier.externalLink ? (
-          <div style={bodyTextStyle}>
+          <div style={bodyTextStyle} className="text-xs">
             {hasLimitedSupply ? (
               <div>
                 <Trans>

--- a/src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
+++ b/src/components/v2/V2Project/NftRewardsSection/RewardTier.tsx
@@ -78,7 +78,6 @@ export function RewardTier({
       position: 'absolute',
       right: 10,
       top: 10,
-      fontSize: 15,
       color: isSelected ? colors.background.l0 : colors.text.secondary,
       backgroundColor: isSelected
         ? colors.background.action.primary
@@ -94,7 +93,7 @@ export function RewardTier({
     return (
       <Tooltip
         title={
-          <span style={{ fontSize: '0.7rem' }}>
+          <span className="text-xs">
             {rewardTierUpperLimit ? (
               <Trans>
                 Receive this NFT when you contribute{' '}
@@ -116,7 +115,7 @@ export function RewardTier({
         }}
         placement={'bottom'}
       >
-        <div style={iconStyle}>
+        <div style={iconStyle} className="text-sm">
           <CheckOutlined />
         </div>
       </Tooltip>
@@ -202,8 +201,8 @@ export function RewardTier({
             <span
               style={{
                 color: colors.text.secondary,
-                fontSize: '0.7rem',
               }}
+              className="text-xs"
             >
               {rewardTier?.contributionFloor} ETH
             </span>

--- a/src/components/v2/V2Project/NftRewardsSection/index.tsx
+++ b/src/components/v2/V2Project/NftRewardsSection/index.tsx
@@ -102,8 +102,8 @@ export function NftRewardsSection({
       <span
         style={{
           color: colors.text.tertiary,
-          fontSize: '0.69rem',
         }}
+        className="text-xs"
       >
         <Trans>Contribute to unlock an NFT reward.</Trans>
       </span>

--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
@@ -32,18 +32,18 @@ export default function DeployETHERC20ProjectPayerEventElem({
           justifyContent: 'space-between',
         }}
       >
-        <div style={smallHeaderStyle(colors)}>
+        <div style={smallHeaderStyle(colors)} className="text-xs">
           <Trans>Created Payment Address</Trans>
         </div>
 
         <div style={{ textAlign: 'right' }}>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
             )}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               called by <FormattedAddress address={event.caller} />
             </Trans>

--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
@@ -68,7 +68,7 @@ export default function DistributePayoutsElem({
         }}
       >
         <div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>Distributed funds</Trans>
           </div>
           {distributePayoutsEvents?.length ? (
@@ -88,13 +88,13 @@ export default function DistributePayoutsElem({
             textAlign: 'right',
           }}
         >
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
             )}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               called by <FormattedAddress address={event.caller} />
             </Trans>
@@ -110,8 +110,8 @@ export default function DistributePayoutsElem({
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'baseline',
-              fontSize: '0.8rem',
             }}
+            className="text-xs"
           >
             <div style={{ fontWeight: 500 }}>
               {e.splitProjectId ? (

--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
@@ -71,7 +71,7 @@ export default function DistributeReservedTokensEventElem({
         }}
       >
         <div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               Distributed reserved{' '}
               {tokenSymbolText({
@@ -99,13 +99,16 @@ export default function DistributeReservedTokensEventElem({
         </div>
 
         <div>
-          <div style={{ ...smallHeaderStyle(colors), textAlign: 'right' }}>
+          <div
+            style={{ ...smallHeaderStyle(colors), textAlign: 'right' }}
+            className="text-xs"
+          >
             {event.timestamp && (
               <span>{formatHistoricalDate(event.timestamp * 1000)}</span>
             )}{' '}
             <EtherscanLink value={event.txHash} type="tx" />
           </div>
-          <div style={smallHeaderStyle(colors)}>
+          <div style={smallHeaderStyle(colors)} className="text-xs">
             <Trans>
               called by <FormattedAddress address={event.caller} />
             </Trans>
@@ -123,16 +126,17 @@ export default function DistributeReservedTokensEventElem({
               alignItems: 'baseline',
             }}
           >
-            <div style={{ fontWeight: 500, fontSize: '0.8rem' }}>
+            <div style={{ fontWeight: 500 }} className="text-xs">
               <FormattedAddress address={e.beneficiary} />:
             </div>
 
             <div
               style={
                 distributeEvents.length > 1
-                  ? { color: colors.text.secondary, fontSize: '0.8rem' }
+                  ? { color: colors.text.secondary }
                   : { fontWeight: 500 }
               }
+              className="text-xs"
             >
               {formatWad(e.tokenCount, { precision: 0 })}
             </div>

--- a/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
@@ -68,6 +68,7 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
               ...secondaryTextStyle,
               textAlign: 'right',
             }}
+            className="text-xs"
           >
             <TooltipLabel
               tip={

--- a/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/DistributedRatio.tsx
@@ -44,6 +44,7 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
               ...secondaryTextStyle,
               color: colors.text.primary,
             }}
+            className="text-xs"
           >
             <V2CurrencyAmount
               amount={usedDistributionLimit}

--- a/src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
@@ -37,7 +37,7 @@ export default function ProjectBalance({ style }: { style?: CSSProperties }) {
           }}
         >
           {distributionLimitCurrency?.eq(V2_CURRENCY_USD) && (
-            <span style={textSecondary(theme)} className="text-xs">
+            <span style={textSecondary(theme)} className="text-sm">
               <ETHAmount amount={ETHBalance} padEnd />{' '}
             </span>
           )}

--- a/src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/ProjectBalance.tsx
@@ -37,7 +37,7 @@ export default function ProjectBalance({ style }: { style?: CSSProperties }) {
           }}
         >
           {distributionLimitCurrency?.eq(V2_CURRENCY_USD) && (
-            <span style={textSecondary(theme)}>
+            <span style={textSecondary(theme)} className="text-xs">
               <ETHAmount amount={ETHBalance} padEnd />{' '}
             </span>
           )}

--- a/src/components/v2/V2Project/TreasuryStats/index.tsx
+++ b/src/components/v2/V2Project/TreasuryStats/index.tsx
@@ -37,10 +37,14 @@ export default function TreasuryStats() {
     (!isPreviewMode && overflowLoading) || distributionLimitLoading
 
   return (
-    <Space direction="vertical" style={{ display: 'flex' }}>
+    <Space direction="vertical" style={{ display: 'flex' }} size="middle">
       <VolumeStatLine totalVolume={totalVolume} color={colors.text.primary} />
-      <ProjectBalance />
-      <DistributedRatio />
+
+      <Space direction="vertical" style={{ width: '100%' }}>
+        <ProjectBalance />
+        <DistributedRatio />
+      </Space>
+
       <Skeleton
         loading={fundingProgressBarLoading}
         title={false}

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails.tsx
@@ -342,7 +342,7 @@ export default function FundingCycleDetails({
           {ballotStrategy.name}
         </FundingCycleDetailWarning>
         <div style={{ color: colors.text.secondary }}>
-          <div style={{ fontSize: '0.7rem' }}>
+          <div className="text-xs">
             <Trans>
               Address:{' '}
               <EtherscanLink value={ballotStrategy.address} type="address" />

--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
@@ -172,7 +172,7 @@ function HistoricalFundingCycle({
       <Space align="baseline">
         <h3>#{fundingCycle.number.toString()}</h3>
 
-        <div style={{ fontSize: '.8rem', marginLeft: 10 }}>
+        <div style={{ marginLeft: 10 }} className="text-xs">
           <CurrencySymbol
             currency={V2CurrencyName(
               distributionLimitCurrency?.toNumber() as V2CurrencyOption,
@@ -195,7 +195,7 @@ function HistoricalFundingCycle({
         </div>
       </Space>
 
-      <Space align="baseline" style={{ fontSize: '.8rem' }}>
+      <Space align="baseline" className="text-xs">
         {formatHistoricalDate(
           fundingCycle.start.add(fundingCycle.duration).mul(1000).toNumber(),
         )}

--- a/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/ReservedTokensSplitsCard.tsx
@@ -53,7 +53,6 @@ export default function ReservedTokensSplitsCard({
   )
 
   const smallHeaderStyle: CSSProperties = {
-    fontSize: '.7rem',
     fontWeight: 500,
     cursor: 'default',
     color: colors.text.secondary,
@@ -114,6 +113,7 @@ export default function ReservedTokensSplitsCard({
                   ...smallHeaderStyle,
                   whiteSpace: 'nowrap',
                 }}
+                className="text-xs"
                 label={
                   <span style={{ textTransform: 'uppercase' }}>
                     <Trans>{tokensText} reserved</Trans>

--- a/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/modals/DistributePayoutsModal.tsx
@@ -256,7 +256,7 @@ export default function DistributePayoutsModal({
             showSplitValues
           />
         </div>
-        <p style={{ fontSize: '0.8rem' }}>
+        <p className="text-xs">
           <ExclamationCircleOutlined />{' '}
           <Trans>Recipients will receive payouts in ETH.</Trans>
         </p>

--- a/src/components/v2/V2Project/V2ManageTokensSection/index.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/index.tsx
@@ -221,10 +221,10 @@ export default function V2ManageTokensSection() {
                         <div
                           style={{
                             cursor: 'default',
-                            fontSize: '0.8rem',
                             fontWeight: 500,
                             color: colors.text.tertiary,
                           }}
+                          className="text-xs"
                         >
                           <Trans>
                             {userOwnershipPercentage}% of total supply

--- a/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -198,7 +198,8 @@ export function V2ConfirmPayModal({
             </strong>
             <Paragraph
               description={projectMetadata.payDisclosure}
-              style={{ fontStyle: 'italic', fontSize: '0.8rem' }}
+              style={{ fontStyle: 'italic' }}
+              className="text-xs"
             />
           </Callout>
         )}
@@ -215,7 +216,7 @@ export function V2ConfirmPayModal({
             <div>
               {formatWad(receivedTickets, { precision: 0 })} {tokenText}
             </div>
-            <div style={{ fontSize: '0.7rem' }}>
+            <div className="text-xs">
               {userAddress ? (
                 <Trans>
                   To: <FormattedAddress address={userAddress} />

--- a/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2PayForm/V2PayForm.tsx
@@ -108,11 +108,11 @@ export const V2PayForm = ({
               </Form.Item>
               <div
                 style={{
-                  fontSize: '.8rem',
                   position: 'absolute',
                   right: 7,
                   top: 7,
                 }}
+                className="text-xs"
               >
                 {
                   <Sticker

--- a/src/components/v2/V2Project/V2PayButton/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/index.tsx
@@ -71,7 +71,7 @@ export default function V2PayButton({
         </Button>
       </Tooltip>
       {payInCurrency === V2_CURRENCY_USD && (
-        <div style={{ fontSize: '.7rem' }}>
+        <div className="text-xs">
           <Trans>
             Paid as <ETHAmount amount={weiPayAmt} />
           </Trans>

--- a/src/components/v2/V2Project/index.tsx
+++ b/src/components/v2/V2Project/index.tsx
@@ -48,7 +48,8 @@ const AllAssetsButton = ({ onClick }: { onClick: VoidFunction }) => {
   return (
     <TextButton
       onClick={onClick}
-      style={{ fontWeight: 400, fontSize: '0.8rem' }}
+      style={{ fontWeight: 400 }}
+      className="text-xs"
     >
       <Trans>All assets</Trans>
     </TextButton>

--- a/src/components/v2/shared/DistributionSplitsSection/index.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/index.tsx
@@ -206,7 +206,7 @@ export default function DistributionSplitsSection({
             <Space direction="vertical">
               <Radio value="amount">
                 <Trans>Amounts</Trans>
-                <p style={{ fontWeight: 400, fontSize: '0.8rem' }}>
+                <p style={{ fontWeight: 400 }} className="text-xs">
                   <Trans>
                     Distribute a specific amount of funds to entities each
                     funding cycle. Your distribution limit will equal the{' '}
@@ -216,7 +216,7 @@ export default function DistributionSplitsSection({
               </Radio>
               <Radio value="percent">
                 <Trans>Percentages</Trans>
-                <p style={{ fontWeight: 400, fontSize: '0.8rem' }}>
+                <p style={{ fontWeight: 400 }} className="text-xs">
                   <Trans>
                     Distribute a percentage of all funds received to entities.
                     Your distribution limit will be <strong>infinite</strong>.

--- a/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
+++ b/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
@@ -89,7 +89,7 @@ export default function NftRewardTierCard({
             </Col>
           </Row>
           {rewardTier.description && (
-            <div style={{ fontSize: 13, marginTop: 15 }}>
+            <div style={{ marginTop: 15 }} className="text-xs">
               <Trans>
                 <strong>Description:</strong>
                 <Paragraph
@@ -100,7 +100,7 @@ export default function NftRewardTierCard({
             </div>
           )}
           {rewardTier.maxSupply && (
-            <div style={{ fontSize: 13, marginTop: 15 }}>
+            <div style={{ marginTop: 15 }} className="text-xs">
               <Trans>
                 <strong>Max. supply:</strong>{' '}
                 <span>{rewardTier.maxSupply}</span>

--- a/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
+++ b/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload.tsx
@@ -72,12 +72,12 @@ export default function NftUpload({ form }: { form: FormInstance }) {
           width: '100%',
         }}
       >
-        <div style={{ fontSize: 14 }}>
+        <div className="text-sm">
           <strong>
             <Trans>Upload an image</Trans>
           </strong>
         </div>
-        <div style={{ color: colors.text.secondary, fontSize: 12 }}>
+        <div style={{ color: colors.text.secondary }} className="text-xs">
           JPG, PNG, GIF
         </div>
       </div>

--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -56,7 +56,7 @@ export default function SplitItem({
     const lockedUntilFormatted = formatDate(lockedUntil * 1000, 'yyyy-MM-DD')
 
     return (
-      <div style={{ fontSize: '.8rem', color: colors.text.secondary }}>
+      <div className="text-xs" style={{ color: colors.text.secondary }}>
         <LockOutlined /> <Trans>locked until {lockedUntilFormatted}</Trans>
       </div>
     )
@@ -103,10 +103,10 @@ export default function SplitItem({
 
         <div
           style={{
-            fontSize: '.8rem',
             color: colors.text.secondary,
             marginLeft: 10,
           }}
+          className="text-xs"
         >
           <TooltipLabel
             label={<Trans>Tokens:</Trans>}

--- a/src/constants/styles/text.ts
+++ b/src/constants/styles/text.ts
@@ -4,7 +4,6 @@ import { CSSProperties } from 'react'
 export const textSecondary = (theme: SemanticTheme): CSSProperties => ({
   textTransform: 'uppercase',
   color: theme.colors.text.tertiary,
-  fontSize: '0.8rem',
   fontWeight: 500,
 })
 

--- a/src/pages/create/forms/TokenForm/index.tsx
+++ b/src/pages/create/forms/TokenForm/index.tsx
@@ -94,7 +94,7 @@ function DiscountRateExtra({
   )
 
   return (
-    <div style={{ fontSize: '0.9rem' }}>
+    <div className="text-sm">
       {!hasDuration && (
         <FormItemWarningText>
           <Trans>

--- a/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/FundingAttributes.tsx
@@ -333,8 +333,7 @@ export function ReconfigurationStatistic({
             tooltipTitle={ballotWarningText}
           >
             <div>
-              {ballot.name}{' '}
-              <div style={{ fontSize: '0.7rem' }}>{ballot.address}</div>
+              {ballot.name} <div className="text-xs">{ballot.address}</div>
             </div>
           </FundingCycleDetailWarning>
         )
@@ -378,7 +377,7 @@ export function DistributionSplitsStatistic({
         />
       }
       valueRender={() => (
-        <div style={{ fontSize: '0.9rem' }}>
+        <div className="text-sm">
           <SplitList
             splits={splits}
             currency={currency}
@@ -411,7 +410,7 @@ export function ReservedSplitsStatistic({
         />
       }
       valueRender={() => (
-        <div style={{ fontSize: '0.9rem' }}>
+        <div className="text-sm">
           <SplitList
             splits={splits}
             projectOwnerAddress={projectOwnerAddress}

--- a/src/pages/home/Footer.tsx
+++ b/src/pages/home/Footer.tsx
@@ -81,7 +81,7 @@ export default function Footer() {
       {gitCommit ? (
         <span style={{ color: 'white' }}>
           Version:{' '}
-          <ExternalLink href={gitCommitLink} style={{ fontSize: '0.8rem' }}>
+          <ExternalLink href={gitCommitLink} className="text-xs">
             #{gitCommit}
           </ExternalLink>
         </span>

--- a/src/pages/home/Payments.tsx
+++ b/src/pages/home/Payments.tsx
@@ -72,7 +72,8 @@ export default function Payments() {
                 <ProjectHandle project={e.project} />
 
                 <div
-                  style={{ fontSize: '.7rem', color: colors.text.secondary }}
+                  style={{ color: colors.text.secondary }}
+                  className="text-xs"
                 >
                   {e.timestamp && formatHistoricalDate(e.timestamp * 1000)}
                 </div>

--- a/src/pages/home/TopProjectsSection.tsx
+++ b/src/pages/home/TopProjectsSection.tsx
@@ -261,11 +261,10 @@ export function TopProjectsSection() {
               <div
                 role="button"
                 style={{
-                  fontSize: '0.9rem',
                   color: colors.text.secondary,
                   cursor: 'pointer',
                 }}
-                className="hover-text-decoration-underline"
+                className="hover-text-decoration-underline text-sm"
                 onClick={() => {
                   document
                     .getElementById('how-it-works')

--- a/src/pages/projects/TrendingProjectCard.tsx
+++ b/src/pages/projects/TrendingProjectCard.tsx
@@ -167,9 +167,9 @@ export default function TrendingProjectCard({
                   <span
                     style={{
                       color: colors.text.tertiary,
-                      fontSize: '0.7rem',
                       fontWeight: 500,
                     }}
+                    className="text-xs"
                   >
                     V{terminalVersion ?? project.cv}
                   </span>
@@ -212,9 +212,9 @@ export default function TrendingProjectCard({
                 style={{
                   fontWeight: 400,
                   color: colors.text.secondary,
-                  fontSize: 13,
                   marginTop: 2,
                 }}
+                className="text-xs"
               >
                 <Plural
                   value={paymentCount}

--- a/src/pages/v1/create/ConfirmDeployProject.tsx
+++ b/src/pages/v1/create/ConfirmDeployProject.tsx
@@ -179,7 +179,7 @@ export default function ConfirmDeployProject() {
                     <CurrencySymbol currency={editingFCCurrency} />
                     {formatWad(editingFC?.target)}{' '}
                     {editingFC.fee?.gt(0) && (
-                      <span style={{ fontSize: '0.8rem' }}>
+                      <span className="text-xs">
                         (
                         <CurrencySymbol currency={editingFCCurrency} />
                         <Trans>
@@ -292,7 +292,7 @@ export default function ConfirmDeployProject() {
                 return (
                   <div>
                     {ballot.name}{' '}
-                    <div style={{ fontSize: '0.7rem' }}>{ballot.address}</div>
+                    <div className="text-xs">{ballot.address}</div>
                   </div>
                 )
               }}

--- a/src/pages/v1/create/index.page.tsx
+++ b/src/pages/v1/create/index.page.tsx
@@ -426,8 +426,8 @@ function V1Create() {
                   style={{
                     color: colors.text.secondary,
                     fontWeight: 400,
-                    fontSize: '0.75rem',
                   }}
+                  className="text-xs"
                 >
                   {step.description}
                 </div>

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -44,3 +44,57 @@
 .selected-box-shadow {
   box-shadow: 2px 0px 10px 0px var(--boxShadow-primary)
 }
+
+/* FONT SIZES */
+.text-xs {	
+  font-size: 0.75rem; 
+  line-height: 1rem; 
+}
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem; 
+}
+.text-base {
+  font-size: 1rem; 
+  line-height: 1.5rem; 
+}
+.text-lg {
+  font-size: 1.125rem; 
+  line-height: 1.75rem; 
+}
+.text-xl {
+  font-size: 1.25rem; 
+  line-height: 1.75rem; 
+}
+.text-2xl {
+  font-size: 1.5rem; 
+  line-height: 2rem; 
+}
+.text-3xl {
+  font-size: 1.875rem; 
+  line-height: 2.25rem; 
+}
+.text-4xl {
+  font-size: 2.25rem; 
+  line-height: 2.5rem; 
+}
+.text-5xl {
+  font-size: 3rem; 
+  line-height: 1;
+}
+.text-6xl {
+  font-size: 3.75rem; 
+  line-height: 1;
+}
+.text-7xl {
+  font-size: 4.5rem; 
+  line-height: 1;
+}
+.text-8xl {
+  font-size: 6rem; 
+  line-height: 1;
+}
+.text-9xl {
+  font-size: 8rem; 
+  line-height: 1;
+}


### PR DESCRIPTION
## What does this PR do and why?

Utility classes are the wei. Why?

- more performant than inline styles
- more composable
- less dev mental overhead
- keeps the UI more consistent (limited choice of values for things)

Need more convincing? see https://johnpolacek.github.io/the-case-for-atomic-css/ and https://tailwindcss.com/docs/utility-first#maintainability-concerns

Anyways, this PR:
- adds utility classes for font size. Classes stolen from https://tailwindcss.com/docs/font-size
- replaces any small fontSize inline style (below 1rem) with either `text-sm` or `text-xs`

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
