### PR TITLE
Use readProvider for all provider calls

### DIFF
--- a/src/hooks/Wallet/hooks/Provider.ts
+++ b/src/hooks/Wallet/hooks/Provider.ts
@@ -1,5 +1,4 @@
-import { JsonRpcBatchProvider, Web3Provider } from '@ethersproject/providers'
-import { useConnectWallet } from '@web3-onboard/react'
+import { JsonRpcBatchProvider } from '@ethersproject/providers'
 import { readNetwork } from 'constants/networks'
 import { useMemo } from 'react'
 
@@ -8,12 +7,5 @@ export function useProvider() {
     () => new JsonRpcBatchProvider(readNetwork.rpcUrl),
     [],
   )
-  const [{ wallet }] = useConnectWallet()
-  const provider = useMemo(() => {
-    if (wallet) {
-      return new Web3Provider(wallet.provider, 'any')
-    }
-    return readProvider
-  }, [readProvider, wallet])
-  return provider
+  return readProvider
 }

--- a/src/hooks/Wallet/hooks/Signer.ts
+++ b/src/hooks/Wallet/hooks/Signer.ts
@@ -1,20 +1,18 @@
-import { JsonRpcBatchProvider, Web3Provider } from '@ethersproject/providers'
+import { Web3Provider } from '@ethersproject/providers'
+import { useConnectWallet } from '@web3-onboard/react'
 import { useMemo } from 'react'
 
-import { useProvider } from './Provider'
-
 export function useSigner() {
-  const provider = useProvider()
-  const signer = useMemo(() => {
-    if (provider instanceof JsonRpcBatchProvider) {
-      return undefined
-    }
-    if (provider instanceof Web3Provider) {
-      return provider?.getSigner()
-    }
+  const [{ wallet }] = useConnectWallet()
+  const signerProvider = useMemo(() => {
+    if (!wallet) return undefined
+    return new Web3Provider(wallet.provider, 'any')
+  }, [wallet])
 
-    console.error('FATAL: unexpected lack of provider found')
-    throw new Error('FATAL: unexpected lack of provider found')
-  }, [provider])
+  const signer = useMemo(() => {
+    if (!signerProvider) return undefined
+    return signerProvider.getSigner()
+  }, [signerProvider])
+
   return signer
 }

--- a/src/hooks/Wallet/hooks/Signer.ts
+++ b/src/hooks/Wallet/hooks/Signer.ts
@@ -1,18 +1,22 @@
 import { Web3Provider } from '@ethersproject/providers'
 import { useConnectWallet } from '@web3-onboard/react'
 import { useMemo } from 'react'
+import { useChainUnsupported } from './ChainUnsupported'
 
 export function useSigner() {
   const [{ wallet }] = useConnectWallet()
+  const chainUnsupported = useChainUnsupported()
   const signerProvider = useMemo(() => {
     if (!wallet) return undefined
     return new Web3Provider(wallet.provider, 'any')
   }, [wallet])
 
   const signer = useMemo(() => {
-    if (!signerProvider) return undefined
+    // If the provider is not available or the chain is unsupported, we
+    // shouldn't attempt to do anything
+    if (!signerProvider || chainUnsupported) return undefined
     return signerProvider.getSigner()
-  }, [signerProvider])
+  }, [chainUnsupported, signerProvider])
 
   return signer
 }


### PR DESCRIPTION
## What does this PR do and why?

Changes the wallet's Provider hook to use only read provider of the expected network to ensure all calls work, irrespective of chosen network by user

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
