### PR TITLE
[6/4]  Include owner remainder mod in V1 mod CSV exports

### DIFF
--- a/src/components/v1/shared/PayoutModsList.tsx
+++ b/src/components/v1/shared/PayoutModsList.tsx
@@ -26,6 +26,7 @@ import { amountSubFee } from 'utils/math'
 import { V1CurrencyName } from 'utils/v1/currency'
 
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
+import { MODS_TOTAL_PERCENT } from 'utils/v1/mods'
 import ProjectPayoutMods from './ProjectPayMods/ProjectPayoutMods'
 
 export default function PayoutModsList({
@@ -91,7 +92,7 @@ export default function PayoutModsList({
   }
 
   const modsTotal = mods?.reduce((acc, curr) => acc + curr.percent, 0)
-  const ownerPercent = 10000 - (modsTotal ?? 0)
+  const ownerPercent = MODS_TOTAL_PERCENT - (modsTotal ?? 0)
 
   const baseTotal = total ?? amountSubFee(fundingCycle?.target, feePerbicent)
 

--- a/src/components/v1/shared/TicketModsList.tsx
+++ b/src/components/v1/shared/TicketModsList.tsx
@@ -12,6 +12,7 @@ import { V1OperatorPermission } from 'models/v1/permissions'
 import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 import { formatWad, permyriadToPercent } from 'utils/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
+import { MODS_TOTAL_PERCENT } from 'utils/v1/mods'
 export default function TicketModsList({
   total,
   mods,
@@ -64,7 +65,7 @@ export default function TicketModsList({
   }
 
   const modsTotal = mods?.reduce((acc, curr) => acc + curr.percent, 0)
-  const ownerPercent = 10000 - (modsTotal ?? 0)
+  const ownerPercent = MODS_TOTAL_PERCENT - (modsTotal ?? 0)
 
   const hasEditPermission = useV1ConnectedWalletHasPermission(
     V1OperatorPermission.SetTicketMods,

--- a/src/utils/v1/mods.ts
+++ b/src/utils/v1/mods.ts
@@ -1,0 +1,52 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import * as constants from '@ethersproject/constants'
+import { TEN_THOUSAND } from 'constants/numbers'
+import { PayoutMod, TicketMod } from 'models/mods'
+
+export const MODS_TOTAL_PERCENT = TEN_THOUSAND // = 100%
+
+/**
+ * Return a PayoutMod object that represents the remaining percentage allocated to the project owner.
+ *
+ * In the Juicebox protocol, if the sum of the payout mod percentages is less than 100%,
+ * the remainder gets allocated to the project owner.
+ */
+export const getProjectOwnerRemainderPayoutMod = (
+  projectOwnerAddress: string,
+  splits: PayoutMod[],
+): PayoutMod => {
+  const totalSplitPercentage =
+    splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
+  const ownerPercentage = MODS_TOTAL_PERCENT - totalSplitPercentage
+
+  return {
+    beneficiary: projectOwnerAddress,
+    percent: ownerPercentage,
+    preferUnstaked: false,
+    lockedUntil: 0,
+    projectId: BigNumber.from(0),
+    allocator: constants.AddressZero,
+  }
+}
+
+/**
+ * Return a TicketMod object that represents the remaining percentage allocated to the project owner.
+ *
+ * In the Juicebox protocol, if the sum of the ticket mod percentages is less than 100%,
+ * the remainder gets allocated to the project owner.
+ */
+export const getProjectOwnerRemainderTicketMod = (
+  projectOwnerAddress: string,
+  splits: TicketMod[],
+): TicketMod => {
+  const totalSplitPercentage =
+    splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
+  const ownerPercentage = MODS_TOTAL_PERCENT - totalSplitPercentage
+
+  return {
+    beneficiary: projectOwnerAddress,
+    percent: ownerPercentage,
+    preferUnstaked: false,
+    lockedUntil: 0,
+  }
+}


### PR DESCRIPTION
Includes the project owner's remainder "mod" in the V1 payout + ticket mods CSV file.