### PR TITLE
Default to 0 ballot if no duration set

### DIFF
--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -24,7 +24,6 @@ import {
   redemptionRateFrom,
 } from 'utils/v2/math'
 
-import { DEFAULT_BALLOT_STRATEGY } from 'constants/v2/ballotStrategies'
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
@@ -49,7 +48,7 @@ interface V2ProjectState {
 // Increment this version by 1 when making breaking changes.
 // When users return to the site and their local version is less than
 // this number, their state will be reset.
-export const REDUX_STORE_V2_PROJECT_VERSION = 6
+export const REDUX_STORE_V2_PROJECT_VERSION = 7
 
 const defaultProjectMetadataState: ProjectMetadataV4 = {
   name: '',
@@ -67,7 +66,7 @@ export const defaultFundingCycleData: SerializedV2FundingCycleData =
     duration: BigNumber.from(0),
     weight: BigNumber.from(issuanceRateFrom(DEFAULT_MINT_RATE.toString())), // 1e24, resulting in 1,000,000 tokens per ETH
     discountRate: BigNumber.from(0), // A number from 0-1,000,000,000
-    ballot: DEFAULT_BALLOT_STRATEGY.address,
+    ballot: constants.AddressZero,
   })
 
 export const defaultFundingCycleMetadata: SerializedV2FundingCycleMetadata =


### PR DESCRIPTION
## What does this PR do and why?

People set 0 fc duration, expecting their project to be reconfigurable instantly. Because we default to a 3-day delay, users skim over this. They end up with a 0fc duration but a 3-day delay.

This PR defaults projects to a 0x00 delay (ballot). If they set an FC duration, we'll auto-set a 3-day delay.

## Screenshots or screen recordings

-

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
