### PR TITLE
Ensure z-indexes of Drawers and modals are correctly set

### DIFF
--- a/src/styles/antd-overrides/drawer.scss
+++ b/src/styles/antd-overrides/drawer.scss
@@ -9,3 +9,7 @@
 .ant-drawer-header {
   background: var(--background-l0);
 }
+
+.ant-drawer {
+  z-index: 1;
+}

--- a/src/styles/antd-overrides/modal.scss
+++ b/src/styles/antd-overrides/modal.scss
@@ -20,3 +20,8 @@
     border-color: transparent;
   }
 }
+
+.ant-modal-wrap,
+.ant-modal-mask {
+  z-index: 1;
+}

--- a/src/styles/web3-onboard-overrides/onboard/color.scss
+++ b/src/styles/web3-onboard-overrides/onboard/color.scss
@@ -1,4 +1,3 @@
 :root {
-  --onboard-success-100: var(--background-success);
   --onboard-shadow-2: inset 0px -1px 0px var(--stroke-tertiary);
 }


### PR DESCRIPTION
## What does this PR do and why?

Due to changes for web3-onboard, we had to change the way that zIndexes are applied to modals. This ensures that the modal and drawers are layered correctly.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
