### PR TITLE
Show upcoming fc tab with no duration, if reconfig

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/UpcomingFundingCycle.tsx
@@ -1,72 +1,19 @@
 import { LoadingOutlined } from '@ant-design/icons'
 import { CardSection } from 'components/CardSection'
 import FundingCycleDetailsCard from 'components/Project/FundingCycleDetailsCard'
-import { V2ProjectContext } from 'contexts/v2/projectContext'
-import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
-import { useProjectLatestConfiguredFundingCycle } from 'hooks/v2/contractReader/ProjectLatestConfiguredFundingCycle'
-import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
-import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
-import {
-  BallotState,
-  V2FundingCycle,
-  V2FundingCycleMetadata,
-} from 'models/v2/fundingCycle'
-import { useContext } from 'react'
-import { V2FundingCycleRiskCount } from 'utils/v2/fundingCycle'
-
-import FundingCycleDetails from './FundingCycleDetails'
-import PayoutSplitsCard from './PayoutSplitsCard'
-import ReservedTokensSplitsCard from './ReservedTokensSplitsCard'
-
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
 } from 'constants/v2/splits'
-
-const useUpcomingFundingCycle = (): [
-  V2FundingCycle | undefined,
-  V2FundingCycleMetadata | undefined,
-  BallotState?,
-] => {
-  const { projectId, fundingCycle } = useContext(V2ProjectContext)
-
-  const { data: latestConfiguredFundingCycleResponse } =
-    useProjectLatestConfiguredFundingCycle({
-      projectId,
-    })
-  const [
-    latestConfiguredFundingCycle,
-    latestConfiguredFundingCycleMetadata,
-    latestConfiguredFundingCycleBallotState,
-  ] = latestConfiguredFundingCycleResponse ?? []
-
-  const isCurrentFundingCycleLatest =
-    latestConfiguredFundingCycle &&
-    fundingCycle &&
-    fundingCycle.number.eq(latestConfiguredFundingCycle.number)
-
-  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
-    projectId: isCurrentFundingCycleLatest ? projectId : undefined,
-  })
-  const [queuedFundingCycle, queuedFundingCycleMetadata] =
-    queuedFundingCycleResponse ?? []
-
-  const hasLatestBallotFailed =
-    latestConfiguredFundingCycleBallotState === BallotState.failed
-
-  if (
-    (isCurrentFundingCycleLatest || hasLatestBallotFailed) &&
-    queuedFundingCycle
-  ) {
-    return [queuedFundingCycle, queuedFundingCycleMetadata]
-  }
-
-  return [
-    latestConfiguredFundingCycle,
-    latestConfiguredFundingCycleMetadata,
-    latestConfiguredFundingCycleBallotState,
-  ]
-}
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
+import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
+import { useProjectUpcomingFundingCycle } from 'hooks/v2/contractReader/ProjectUpcomingFundingCycle'
+import { useContext } from 'react'
+import { V2FundingCycleRiskCount } from 'utils/v2/fundingCycle'
+import FundingCycleDetails from './FundingCycleDetails'
+import PayoutSplitsCard from './PayoutSplitsCard'
+import ReservedTokensSplitsCard from './ReservedTokensSplitsCard'
 
 export default function UpcomingFundingCycle({
   expandCard,
@@ -76,7 +23,7 @@ export default function UpcomingFundingCycle({
   const { projectId, primaryTerminal } = useContext(V2ProjectContext)
 
   const [upcomingFundingCycle, upcomingFundingCycleMetadata, ballotState] =
-    useUpcomingFundingCycle()
+    useProjectUpcomingFundingCycle()
 
   const { data: queuedPayoutSplits } = useProjectSplits({
     projectId,

--- a/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/index.tsx
@@ -23,6 +23,7 @@ import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
 
+import { useProjectUpcomingFundingCycle } from 'hooks/v2/contractReader/ProjectUpcomingFundingCycle'
 import V2ReconfigureFundingModalTrigger from '../V2ProjectReconfigureModal/V2ReconfigureModalTrigger'
 import CurrentFundingCycle from './CurrentFundingCycle'
 import FundingCycleHistory from './FundingCycleHistory'
@@ -54,7 +55,7 @@ export default function V2FundingCycleSection({
   } = useProjectQueuedFundingCycle({
     projectId,
   })
-
+  const [upcomingFundingCycle] = useProjectUpcomingFundingCycle()
   const [queuedFundingCycle] = queuedFundingCycleResponse || []
 
   if (
@@ -113,7 +114,7 @@ export default function V2FundingCycleSection({
       content: <CurrentFundingCycle expandCard={expandCard} />,
     },
     !isPreviewMode &&
-      (hasFundingDuration(fundingCycleData) || fundingCycle.number.eq(0)) && {
+      !upcomingFundingCycle?.number.eq(0) && {
         key: 'upcoming',
         label: tabText({ text: t`Upcoming` }),
         content: <UpcomingFundingCycle expandCard={expandCard} />,

--- a/src/hooks/v2/contractReader/ProjectUpcomingFundingCycle.ts
+++ b/src/hooks/v2/contractReader/ProjectUpcomingFundingCycle.ts
@@ -1,0 +1,54 @@
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import {
+  BallotState,
+  V2FundingCycle,
+  V2FundingCycleMetadata,
+} from 'models/v2/fundingCycle'
+import { useContext } from 'react'
+import { useProjectLatestConfiguredFundingCycle } from './ProjectLatestConfiguredFundingCycle'
+import useProjectQueuedFundingCycle from './ProjectQueuedFundingCycle'
+
+export function useProjectUpcomingFundingCycle(): [
+  V2FundingCycle | undefined,
+  V2FundingCycleMetadata | undefined,
+  BallotState?,
+] {
+  const { projectId, fundingCycle } = useContext(V2ProjectContext)
+
+  const { data: latestConfiguredFundingCycleResponse } =
+    useProjectLatestConfiguredFundingCycle({
+      projectId,
+    })
+  const [
+    latestConfiguredFundingCycle,
+    latestConfiguredFundingCycleMetadata,
+    latestConfiguredFundingCycleBallotState,
+  ] = latestConfiguredFundingCycleResponse ?? []
+
+  const isCurrentFundingCycleLatest =
+    latestConfiguredFundingCycle &&
+    fundingCycle &&
+    fundingCycle.number.eq(latestConfiguredFundingCycle.number)
+
+  const { data: queuedFundingCycleResponse } = useProjectQueuedFundingCycle({
+    projectId: isCurrentFundingCycleLatest ? projectId : undefined,
+  })
+  const [queuedFundingCycle, queuedFundingCycleMetadata] =
+    queuedFundingCycleResponse ?? []
+
+  const hasLatestBallotFailed =
+    latestConfiguredFundingCycleBallotState === BallotState.failed
+
+  if (
+    (isCurrentFundingCycleLatest || hasLatestBallotFailed) &&
+    queuedFundingCycle
+  ) {
+    return [queuedFundingCycle, queuedFundingCycleMetadata]
+  }
+
+  return [
+    latestConfiguredFundingCycle,
+    latestConfiguredFundingCycleMetadata,
+    latestConfiguredFundingCycleBallotState,
+  ]
+}


### PR DESCRIPTION
## What does this PR do and why?

Fixes the case where:
- a project has a 0 FC duration and a n-day ballot
- They submit a reconfiguration
- The upcoming tab isn't shown, when it should be.

This PR ensures the upcoming tab is show if there is a valid upcoming funding cycle.

Examples:

| scenario | screenshot |
| --- | --- |
| 0 day duration, 3 day ballot, and  a pending reconfiguration: https://rinkeby.juicebox.money/v2/p/4648 | <img width="553" alt="Screen Shot 2022-08-26 at 11 49 49 AM" src="https://user-images.githubusercontent.com/12551741/186803176-9b967151-1a1e-441a-a79e-8be5cac2ef4e.png"> |
| 0 day duration, 3 day ballot, and no pending reconfiguration: https://rinkeby.juicebox.money/v2/p/4649 |  <img width="557" alt="Screen Shot 2022-08-26 at 11 49 55 AM" src="https://user-images.githubusercontent.com/12551741/186803194-a60dea1d-c450-4c10-ba3f-9314d75d92fb.png"> |

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
