### PR TITLE
Remove scrollbar in FC history section if there is enough space

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
@@ -290,7 +290,7 @@ export default function FundingCycleHistory() {
     <Space
       direction="vertical"
       size="large"
-      style={{ width: '100%', maxHeight: '80vh', overflow: 'scroll' }}
+      style={{ width: '100%', maxHeight: '80vh', overflow: 'auto' }}
     >
       {pastFundingCycles.length ? (
         pastFundingCycles.map((fundingCycle: V2FundingCycle, i) => (


### PR DESCRIPTION
## What does this PR do and why?

Fixes - https://github.com/jbx-protocol/juice-interface/issues/1838

The intention is to remove the scrollbar when there is enough space, it is a smol fix.

## Screenshots or screen recordings
**Before**
![image](https://user-images.githubusercontent.com/18723426/186871696-fab2f762-b896-4aba-8f05-505d405cb68b.png)
**After**
![image](https://user-images.githubusercontent.com/18723426/186871831-446bc1b7-0033-4f57-806a-8edb127edf61.png)

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
