### PR TITLE
Split out FormattedNumberInput from Form.Item in SpecificLimitModal

### DIFF
--- a/src/components/inputs/FormattedNumberInputNew.tsx
+++ b/src/components/inputs/FormattedNumberInputNew.tsx
@@ -1,0 +1,116 @@
+import { InputNumber } from 'antd'
+import { CSSProperties } from 'react'
+import { formattedNum } from 'utils/formatNumber'
+
+import { FormItemExt } from 'components/formItems/formItemExt'
+
+export default function FormattedNumberInputNew({
+  style,
+  min,
+  max,
+  step,
+  value,
+  disabled,
+  placeholder,
+  suffix,
+  prefix,
+  accessory,
+  onChange,
+  onBlur,
+  isInteger,
+}: {
+  style?: CSSProperties
+  min?: number
+  max?: number
+  step?: number
+  value?: string
+  placeholder?: string
+  disabled?: boolean
+  suffix?: string
+  prefix?: string
+  accessory?: JSX.Element
+  onChange?: (val?: string) => void
+  onBlur?: (val?: string) => void
+  isInteger?: boolean
+} & FormItemExt) {
+  const thousandsSeparator = ','
+  const decimalSeparator = '.'
+  const _suffix = suffix ? ` ${suffix}` : ''
+  const _prefix = prefix ? `${prefix}` : ''
+  const allowedValueChars = [
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    thousandsSeparator,
+  ]
+  if (!isInteger) {
+    allowedValueChars.push(decimalSeparator)
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        position: 'relative',
+        ...style,
+      }}
+    >
+      <InputNumber
+        className={accessory ? 'antd-no-number-handler' : ''}
+        min={min}
+        max={max}
+        style={{ width: '100%' }}
+        value={value !== undefined ? parseFloat(value) : undefined}
+        step={step ?? 1}
+        stringMode={true}
+        placeholder={placeholder}
+        formatter={(val?: string | number | undefined) =>
+          _prefix +
+          (val
+            ? formattedNum(val, {
+                thousandsSeparator,
+                decimalSeparator,
+              })
+            : '') +
+          _suffix
+        }
+        parser={(val?: string) =>
+          parseFloat(
+            (val !== undefined ? val : '0')
+              .replace(new RegExp(thousandsSeparator, 'g'), '')
+              .replace(_prefix, '')
+              .replace(_suffix, '')
+              .split('')
+              .filter(char => allowedValueChars.includes(char))
+              .join('') || '0',
+          )
+        }
+        disabled={disabled}
+        onBlur={_value => {
+          onBlur?.(_value?.toString())
+        }}
+        onChange={_value => {
+          onChange?.(_value?.toString())
+        }}
+      />
+      <div
+        style={{
+          zIndex: 1,
+          fontSize: '.8rem',
+          position: 'absolute',
+          right: 5,
+        }}
+      >
+        {accessory && <div>{accessory}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/SpecificLimitModal.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Form, Modal } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import InputAccessoryButton from 'components/InputAccessoryButton'
-import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
+import FormattedNumberInputNew from 'components/inputs/FormattedNumberInputNew'
 import TooltipLabel from 'components/TooltipLabel'
 
 import { CurrencyName } from 'constants/currency'
@@ -51,39 +51,45 @@ export default function SpecificLimitModal({
       onOk={setNewSplitsFromLimit}
     >
       <Form form={form}>
-        <FormattedNumberInput
-          placeholder="0"
-          onChange={distributionLimit =>
-            form.setFieldsValue({
-              distributionLimit,
-            })
-          }
-          name="distributionLimit"
-          formItemProps={{
-            rules: [{ required: true }],
-            extra: (
-              <TooltipLabel
-                label={t`Set this to the sum of all your payouts`}
-                tip={
-                  <Trans>
-                    Each payout will receive their percent of this total each
-                    funding cycle if there is enough in the treasury. Otherwise,
-                    they will receive their percent of whatever is in the
-                    treasury.
-                  </Trans>
-                }
+        <Form.Item name="distributionLimit">
+          <FormattedNumberInputNew
+            placeholder="0"
+            name="distributionLimit"
+            formItemProps={{
+              rules: [
+                {
+                  required: true,
+                  validator: (rule, value: string) => {
+                    if (!value.match(/^[\d,]+$/g)) {
+                      return Promise.reject()
+                    }
+                  },
+                },
+              ],
+              extra: (
+                <TooltipLabel
+                  label={t`Set this to the sum of all your payouts`}
+                  tip={
+                    <Trans>
+                      Each payout will receive their percent of this total each
+                      funding cycle if there is enough in the treasury.
+                      Otherwise, they will receive their percent of whatever is
+                      in the treasury.
+                    </Trans>
+                  }
+                />
+              ),
+            }}
+            min={0}
+            accessory={
+              <InputAccessoryButton
+                withArrow
+                content={currencyName}
+                onClick={toggleCurrency}
               />
-            ),
-          }}
-          min={0}
-          accessory={
-            <InputAccessoryButton
-              withArrow
-              content={currencyName}
-              onClick={toggleCurrency}
-            />
-          }
-        />
+            }
+          />
+        </Form.Item>
       </Form>
     </Modal>
   )


### PR DESCRIPTION
## What does this PR do and why?

This splits out the form into the desired format, ready to be used in code changes.

This also fixes a bug where you can submit and break the form with non numeric characters (doesn't update fast enough to catch in validation)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
