### PR TITLE
Remove delete button from remainder owner payout split card

### DIFF
--- a/src/components/v2/shared/DistributionSplitsSection/index.tsx
+++ b/src/components/v2/shared/DistributionSplitsSection/index.tsx
@@ -150,7 +150,7 @@ export default function DistributionSplitsSection({
         onSplitsChanged={onSplitsChanged}
         onCurrencyChange={onCurrencyChange}
         currencyName={currencyName}
-        isLocked={distributionLimitIsInfinite}
+        isLocked
         isProjectOwner
       />
     )


### PR DESCRIPTION
## What does this PR do and why?

Fixes #1786 

This happens in some cases it shouldn't due to rounding fidelity, but this fixes a pretty simple and obviously broken part of it. 

BEFORE:
<img width="596" alt="Screen Shot 2022-08-29 at 3 25 46 pm" src="https://user-images.githubusercontent.com/96150256/187129534-fa245c38-fafd-45c2-a225-ad9c8cc882c5.png">

AFTER:
<img width="578" alt="Screen Shot 2022-08-29 at 3 25 33 pm" src="https://user-images.githubusercontent.com/96150256/187129523-93c8db10-8c14-47db-bf40-acd18628f0eb.png">


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
