### PR TITLE
Remove call to user address check as the transactor handles it already

### DIFF
--- a/src/hooks/v1/transactor/TapProjectTx.ts
+++ b/src/hooks/v1/transactor/TapProjectTx.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { V1UserContext } from 'contexts/v1/userContext'
-import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
 
 import { V1CurrencyOption } from 'models/v1/currencyOption'
@@ -14,13 +13,11 @@ export function useTapProjectTx(): TransactorInstance<{
   currency: V1CurrencyOption
 }> {
   const { transactor, contracts } = useContext(V1UserContext)
-  const { userAddress } = useWallet()
   const { projectId, terminal } = useContext(V1ProjectContext)
 
   return ({ tapAmount, minAmount, currency }, txOpts) => {
     if (
       !transactor ||
-      !userAddress ||
       !projectId ||
       !contracts?.Projects ||
       !terminal?.version


### PR DESCRIPTION
## What does this PR do and why?

Removes the call to `userAddress` check in `useTapProjectTx` as this is already handled by the transactor itself.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
