### PR TITLE
Add hook to supply contract read value hook [2/n]

### DIFF
--- a/src/hooks/ContractReadValue.ts
+++ b/src/hooks/ContractReadValue.ts
@@ -1,0 +1,97 @@
+import { Contract } from '@ethersproject/contracts'
+import { useCallback, useState } from 'react'
+import useDeepCompareEffect from 'use-deep-compare-effect'
+import { callContractRead } from 'utils/callContractRead'
+import { contractToRead } from 'utils/contractToRead'
+
+/**
+ * Reads a `contract` value from `contracts`, using the `functionName`.
+ *
+ * Upon load, the contract is initially read. From there, `refetchValue` must be
+ * called.
+ *
+ * @returns refetchValue - Call to refetch and hydrate the `value`.
+ * @returns value - Value returned from the contract.
+ * @returns loading - Whether the contract is currently being read.
+ */
+export function useContractReadValue<C extends string, V>({
+  contract,
+  contracts,
+  functionName,
+  args,
+  version,
+  formatter,
+  valueDidChange,
+}: {
+  version: string
+  contract: C | Contract | undefined
+  contracts: Record<C, Contract> | undefined
+  functionName: string | undefined
+  args: unknown[] | null | undefined
+  formatter?: (val?: any) => V | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
+  valueDidChange?: (oldVal?: V, newVal?: V) => boolean
+}) {
+  const [value, setValue] = useState<V | undefined>()
+  const [loading, setLoading] = useState<boolean>(true)
+
+  const _formatter = useCallback(
+    (val: any) => (formatter ? formatter(val) : val), // eslint-disable-line @typescript-eslint/no-explicit-any
+    [formatter],
+  )
+  const _valueDidChange = useCallback(
+    (a?: any, b?: any) => (valueDidChange ? valueDidChange(a, b) : a !== b), // eslint-disable-line @typescript-eslint/no-explicit-any
+    [valueDidChange],
+  )
+
+  const fetchValue = useCallback(async () => {
+    const readContract = contractToRead(contract, contracts)
+    try {
+      setLoading(true)
+      const result = await callContractRead({
+        readContract,
+        contracts,
+        functionName,
+        args,
+        version,
+      })
+      const newValue = _formatter(result)
+
+      if (_valueDidChange(value, newValue)) {
+        console.info(
+          `📗 [${version}] New >`,
+          functionName,
+          { args },
+          { newValue },
+          { contract: readContract?.address },
+        )
+        setValue(newValue)
+      }
+    } catch (err) {
+      setValue(_formatter(undefined))
+    } finally {
+      setLoading(false)
+    }
+  }, [
+    _formatter,
+    _valueDidChange,
+    args,
+    contract,
+    contracts,
+    functionName,
+    value,
+    version,
+  ])
+
+  // Fetch the value on load or when args change.
+  useDeepCompareEffect(() => {
+    fetchValue()
+
+    // WARNING: This is kind of a hack in order to get it working.
+    // Only is called when args has changed.
+    // Most likely case is when args go from null -> defined
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [{ args }])
+
+  return { refetchValue: fetchValue, value, loading }
+}

--- a/src/hooks/ContractReadValue.ts
+++ b/src/hooks/ContractReadValue.ts
@@ -2,7 +2,7 @@ import { Contract } from '@ethersproject/contracts'
 import { useCallback, useState } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { callContractRead } from 'utils/callContractRead'
-import { contractToRead } from 'utils/contractToRead'
+import { getContract } from 'utils/getContract'
 
 /**
  * Reads a `contract` value from `contracts`, using the `functionName`.
@@ -19,11 +19,9 @@ export function useContractReadValue<C extends string, V>({
   contracts,
   functionName,
   args,
-  version,
   formatter,
   valueDidChange,
 }: {
-  version: string
   contract: C | Contract | undefined
   contracts: Record<C, Contract> | undefined
   functionName: string | undefined
@@ -44,7 +42,7 @@ export function useContractReadValue<C extends string, V>({
   )
 
   const fetchValue = useCallback(async () => {
-    const readContract = contractToRead(contract, contracts)
+    const readContract = getContract(contract, contracts)
     try {
       setLoading(true)
       const result = await callContractRead({
@@ -52,13 +50,12 @@ export function useContractReadValue<C extends string, V>({
         contracts,
         functionName,
         args,
-        version,
       })
       const newValue = _formatter(result)
 
       if (_valueDidChange(value, newValue)) {
         console.info(
-          `📗 [${version}] New >`,
+          `📗 New >`,
           functionName,
           { args },
           { newValue },
@@ -79,7 +76,6 @@ export function useContractReadValue<C extends string, V>({
     contracts,
     functionName,
     value,
-    version,
   ])
 
   // Fetch the value on load or when args change.

--- a/src/hooks/v1/contractReader/ContractReader.ts
+++ b/src/hooks/v1/contractReader/ContractReader.ts
@@ -1,9 +1,10 @@
 import { Contract, EventFilter } from '@ethersproject/contracts'
 import * as Sentry from '@sentry/browser'
 import { V1UserContext } from 'contexts/v1/userContext'
-import { V1ContractName, V1Contracts } from 'models/v1/contracts'
+import { V1ContractName } from 'models/v1/contracts'
 import { useCallback, useContext, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
+import { contractToRead } from 'utils/contractToRead'
 
 type ContractUpdateOn = {
   contract?: ContractConfig
@@ -138,15 +139,4 @@ export default function useContractReader<V>({
   ])
 
   return value
-}
-
-function contractToRead(
-  contractConfig?: ContractConfig,
-  contracts?: V1Contracts,
-): Contract | undefined {
-  if (!contractConfig) return
-
-  if (typeof contractConfig === 'string') {
-    return contracts ? contracts[contractConfig] : undefined
-  } else return contractConfig
 }

--- a/src/hooks/v1/contractReader/ContractReader.ts
+++ b/src/hooks/v1/contractReader/ContractReader.ts
@@ -4,7 +4,7 @@ import { V1UserContext } from 'contexts/v1/userContext'
 import { V1ContractName } from 'models/v1/contracts'
 import { useCallback, useContext, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
-import { contractToRead } from 'utils/contractToRead'
+import { getContract } from 'utils/getContract'
 
 type ContractUpdateOn = {
   contract?: ContractConfig
@@ -50,7 +50,7 @@ export default function useContractReader<V>({
 
   useDeepCompareEffectNoCheck(() => {
     async function getValue() {
-      const readContract = contractToRead(contract, contracts)
+      const readContract = getContract(contract, contracts)
 
       if (!readContract || !functionName || args === null) return
 
@@ -107,7 +107,7 @@ export default function useContractReader<V>({
       try {
         // Subscribe listener to updateOn events
         updateOn.forEach(u => {
-          const _contract = contractToRead(u.contract, contracts)
+          const _contract = getContract(u.contract, contracts)
 
           if (!u.eventName || !_contract) return
 

--- a/src/hooks/v2/contractReader/V2ContractReader.ts
+++ b/src/hooks/v2/contractReader/V2ContractReader.ts
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/browser'
 import { V2ContractName } from 'models/v2/contracts'
 import { useCallback, useContext, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
-import { contractToRead } from 'utils/contractToRead'
+import { getContract } from 'utils/getContract'
 
 type ContractUpdateOn = {
   contract?: ContractConfig
@@ -54,7 +54,7 @@ export default function useV2ContractReader<V>({
 
   useDeepCompareEffectNoCheck(() => {
     async function getValue() {
-      const readContract = contractToRead(contract, contracts)
+      const readContract = getContract(contract, contracts)
 
       console.info(readContract, functionName, args, contract, contracts)
 
@@ -116,7 +116,7 @@ export default function useV2ContractReader<V>({
       try {
         // Subscribe listener to updateOn events
         updateOn.forEach(u => {
-          const _contract = contractToRead(u.contract, contracts)
+          const _contract = getContract(u.contract, contracts)
 
           if (!u.eventName || !_contract) return
 

--- a/src/hooks/v2/contractReader/V2ContractReader.ts
+++ b/src/hooks/v2/contractReader/V2ContractReader.ts
@@ -2,9 +2,10 @@ import { Contract, EventFilter } from '@ethersproject/contracts'
 import { V2UserContext } from 'contexts/v2/userContext'
 
 import * as Sentry from '@sentry/browser'
-import { V2ContractName, V2Contracts } from 'models/v2/contracts'
+import { V2ContractName } from 'models/v2/contracts'
 import { useCallback, useContext, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
+import { contractToRead } from 'utils/contractToRead'
 
 type ContractUpdateOn = {
   contract?: ContractConfig
@@ -147,15 +148,4 @@ export default function useV2ContractReader<V>({
   ])
 
   return { data: value, loading }
-}
-
-function contractToRead(
-  contractConfig?: ContractConfig,
-  contracts?: V2Contracts,
-): Contract | undefined {
-  if (!contractConfig) return
-
-  if (typeof contractConfig === 'string') {
-    return contracts ? contracts[contractConfig] : undefined
-  } else return contractConfig
 }

--- a/src/utils/callContractRead.ts
+++ b/src/utils/callContractRead.ts
@@ -11,9 +11,7 @@ export async function callContractRead<T extends string>({
   contracts,
   functionName,
   args,
-  version,
 }: {
-  version: string
   readContract: Contract | undefined
   contracts: Record<T, Contract> | undefined
   functionName: string | undefined
@@ -22,11 +20,11 @@ export async function callContractRead<T extends string>({
   if (!readContract || !functionName || args === null) return
 
   try {
-    console.info(`📚 [${version}] Read >`, functionName)
+    console.info(`📚 Read >`, functionName)
     return await readContract[functionName](...(args ?? []))
   } catch (err) {
     console.error(
-      `📕 [${version}] Read error >`,
+      `📕 Read error >`,
       functionName,
       { args },
       { err },

--- a/src/utils/callContractRead.ts
+++ b/src/utils/callContractRead.ts
@@ -1,0 +1,45 @@
+import { Contract } from '@ethersproject/contracts'
+import * as Sentry from '@sentry/browser'
+
+/**
+ * Calls the `readContract` to be read from `contracts` in `functionName`.
+ *
+ * This is done in pureJS.
+ */
+export async function callContractRead<T extends string>({
+  readContract,
+  contracts,
+  functionName,
+  args,
+  version,
+}: {
+  version: string
+  readContract: Contract | undefined
+  contracts: Record<T, Contract> | undefined
+  functionName: string | undefined
+  args: unknown[] | null | undefined
+}) {
+  if (!readContract || !functionName || args === null) return
+
+  try {
+    console.info(`📚 [${version}] Read >`, functionName)
+    return await readContract[functionName](...(args ?? []))
+  } catch (err) {
+    console.error(
+      `📕 [${version}] Read error >`,
+      functionName,
+      { args },
+      { err },
+      { contract: readContract.address },
+      contracts,
+    )
+
+    Sentry.captureException(err, {
+      tags: {
+        contract: typeof readContract === 'string' ? readContract : undefined,
+        contract_function: functionName,
+      },
+    })
+    throw err
+  }
+}

--- a/src/utils/contractToRead.ts
+++ b/src/utils/contractToRead.ts
@@ -1,0 +1,14 @@
+import { Contract } from '@ethersproject/contracts'
+
+type ContractConfig<T> = T | Contract | undefined
+
+export function contractToRead<T extends string>(
+  contractConfig?: ContractConfig<T>,
+  contracts?: Record<T, Contract>,
+): Contract | undefined {
+  if (!contractConfig) return
+
+  if (typeof contractConfig === 'string') {
+    return contracts ? contracts[contractConfig] : undefined
+  } else return contractConfig
+}

--- a/src/utils/getContract.ts
+++ b/src/utils/getContract.ts
@@ -2,7 +2,7 @@ import { Contract } from '@ethersproject/contracts'
 
 type ContractConfig<T> = T | Contract | undefined
 
-export function contractToRead<T extends string>(
+export function getContract<T extends string>(
   contractConfig?: ContractConfig<T>,
   contracts?: Record<T, Contract>,
 ): Contract | undefined {


### PR DESCRIPTION
## What does this PR do and why?

Add a hook to allow flexible updating of a contract read value.

This code will allow the combining of code from v1 and v2 read contracts.

This code is mostly taken from v1 and v2 ContractReader's and supplied now in a shared way. See next item in stack for application.

The rationale here is that `useContractReadValue` can be used anywhere a contract needs to be read. It will also allow the ability to poll contract read values via the `refetchValue` method returned from the hook.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
