### PR TITLE
Add Desmos calculator.js to source

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ build
 node_modules
 .eslintrc.json
 .vscode
+public/vendor

--- a/src/components/common/Head/Head.tsx
+++ b/src/components/common/Head/Head.tsx
@@ -23,7 +23,7 @@ export const Head: VFC = () => {
 
       <script
         async
-        src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"
+        src="/vendor/desmos/calculator.min.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"
       ></script>
       <script
         src="https://learned-hearty.juicebox.money/script.js"


### PR DESCRIPTION
A step towards this: https://github.com/jbx-protocol/juice-interface/issues/531

- move desmos into our source code, so it's served from our domain
- minify it
- remove the font loading code in the script.

### how to test
- open the token tab in create flow
- scroll to **redemption rate**
- play with the graph. it should still work