### PR TITLE
Some font optimisations

### DIFF
--- a/src/components/common/Head/Head.tsx
+++ b/src/components/common/Head/Head.tsx
@@ -15,9 +15,11 @@ export const Head: VFC = () => {
       <link rel="apple-touch-icon" href="/assets/juice_logo-ol.png" />
       <link rel="icon" href="/favicon.ico" />
       <link rel="manifest" href="/manifest.json" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" />
+
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
       <link
-        href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap"
+        href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap"
         rel="stylesheet"
       />
 
@@ -25,11 +27,14 @@ export const Head: VFC = () => {
         async
         src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"
       ></script>
-      <script
-        src="https://learned-hearty.juicebox.money/script.js"
-        data-site="ERYRRJSV"
-        defer
-      ></script>
+
+      {process.env.NODE_ENV === 'production' && (
+        <script
+          src="https://learned-hearty.juicebox.money/script.js"
+          data-site="ERYRRJSV"
+          defer
+        ></script>
+      )}
       {process.env.NODE_ENV === 'production' && (
         <script
           defer

--- a/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2/V2Project/V2PayButton/V2ConfirmPayModal/index.tsx
@@ -198,7 +198,7 @@ export function V2ConfirmPayModal({
             </strong>
             <Paragraph
               description={projectMetadata.payDisclosure}
-              style={{ fontStyle: 'italic', fontSize: '0.8rem' }}
+              style={{ fontSize: '0.8rem' }}
             />
           </Callout>
         )}

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -83,11 +83,7 @@ function Landing() {
         t`NFT projects`,
         t`Indie creators and builders`,
       ].map((data, i) => (
-        <Space
-          style={{ fontStyle: 'italic', paddingLeft: 8 }}
-          key={i}
-          size="middle"
-        >
+        <Space style={{ paddingLeft: 8 }} key={i} size="middle">
           <img src="/assets/bolt.svg" alt="⚡️" />
           {data}
         </Space>

--- a/src/styles/web3-onboard-overrides/onboard/font.scss
+++ b/src/styles/web3-onboard-overrides/onboard/font.scss
@@ -1,0 +1,5 @@
+:root {
+  --onboard-font-family-normal: 'DM Mono', monospace;
+  --onboard-font-family-semibold: 'DM Mono', monospace;
+  --onboard-font-family-light: 'DM Mono', monospace;
+}

--- a/src/styles/web3-onboard-overrides/onboard/index.scss
+++ b/src/styles/web3-onboard-overrides/onboard/index.scss
@@ -1,2 +1,3 @@
 @import './color.scss';
 @import './connect.scss';
+@import './font.scss';


### PR DESCRIPTION
- Remove DM Mono weight 300 font. We don't use this anywhere.
- Remove DM Mono italic variant. We used this in 2 spots, but I think performance cost outweighs the stylistic benefit.
- Use DM Mono in web3-onboard, for both performance and vibes. Closes https://github.com/jbx-protocol/juice-interface/issues/1872

<img width="798" alt="Screen Shot 2022-08-30 at 10 19 27 AM" src="https://user-images.githubusercontent.com/12551741/187324012-54f07557-662a-4e0d-823b-1f58b9c3e9f0.png">
