### PR TITLE
Only import Desmos when we need it

### DIFF
--- a/src/components/common/Head/Head.tsx
+++ b/src/components/common/Head/Head.tsx
@@ -1,6 +1,8 @@
 import { VFC } from 'react'
 
 import { SEO } from '../SEO'
+import { FathomScript } from './scripts/FathomScript'
+import { HotjarScript } from './scripts/HotjarScript'
 
 export const Head: VFC = () => {
   return (
@@ -23,34 +25,11 @@ export const Head: VFC = () => {
         rel="stylesheet"
       />
 
-      <script
-        async
-        src="/vendor/desmos/calculator.min.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"
-      ></script>
-
       {process.env.NODE_ENV === 'production' && (
-        <script
-          src="https://learned-hearty.juicebox.money/script.js"
-          data-site="ERYRRJSV"
-          defer
-        ></script>
-      )}
-      {process.env.NODE_ENV === 'production' && (
-        <script
-          defer
-          dangerouslySetInnerHTML={{
-            __html: `
-    (function(h,o,t,j,a,r){
-      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-      h._hjSettings={hjid:3077427,hjsv:6};
-      a=o.getElementsByTagName('head')[0];
-      r=o.createElement('script');r.async=1;
-      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-      a.appendChild(r);
-  })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-  `,
-          }}
-        ></script>
+        <>
+          <FathomScript />
+          <HotjarScript />
+        </>
       )}
     </SEO>
   )

--- a/src/components/common/Head/scripts/DesmosScript.tsx
+++ b/src/components/common/Head/scripts/DesmosScript.tsx
@@ -1,0 +1,8 @@
+export function DesmosScript() {
+  return (
+    <script
+      async
+      src="/vendor/desmos/calculator.min.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"
+    ></script>
+  )
+}

--- a/src/components/common/Head/scripts/FathomScript.tsx
+++ b/src/components/common/Head/scripts/FathomScript.tsx
@@ -1,0 +1,9 @@
+export function FathomScript() {
+  return (
+    <script
+      src="https://learned-hearty.juicebox.money/script.js"
+      data-site="ERYRRJSV"
+      defer
+    ></script>
+  )
+}

--- a/src/components/common/Head/scripts/HotjarScript.tsx
+++ b/src/components/common/Head/scripts/HotjarScript.tsx
@@ -1,0 +1,19 @@
+export function HotjarScript() {
+  return (
+    <script
+      defer
+      dangerouslySetInnerHTML={{
+        __html: `
+(function(h,o,t,j,a,r){
+h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+h._hjSettings={hjid:3077427,hjsv:6};
+a=o.getElementsByTagName('head')[0];
+r=o.createElement('script');r.async=1;
+r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+a.appendChild(r);
+})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+`,
+      }}
+    ></script>
+  )
+}

--- a/src/components/common/SEO/SEO.tsx
+++ b/src/components/common/SEO/SEO.tsx
@@ -46,10 +46,6 @@ export const SEO: FC<Props> = ({
           name="googlebot"
           content={robots ?? 'index,follow'}
         ></meta>
-        <meta
-          name="google-site-verification"
-          content="0Jp7zERBL5i76DiM-bODvBGgbjuVMEQGSuwOchP_ZnE"
-        />
       </Head>
 
       <TwitterMetaTags

--- a/src/pages/create/index.page.tsx
+++ b/src/pages/create/index.page.tsx
@@ -1,8 +1,10 @@
 import { t, Trans } from '@lingui/macro'
 import { Tabs } from 'antd'
 import { AppWrapper } from 'components/common'
+import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { ThemeContext } from 'contexts/themeContext'
 import useMobile from 'hooks/Mobile'
+import Head from 'next/head'
 import { V2UserProvider } from 'providers/v2/UserProvider'
 import { V2CurrencyProvider } from 'providers/v2/V2CurrencyProvider'
 import { useContext, useState } from 'react'
@@ -15,9 +17,15 @@ import ReviewDeployTab from './tabs/ReviewDeployTab'
 
 export default function V2CreatePage() {
   return (
-    <AppWrapper>
-      <V2Create />
-    </AppWrapper>
+    <>
+      <Head>
+        <DesmosScript />
+      </Head>
+
+      <AppWrapper>
+        <V2Create />
+      </AppWrapper>
+    </>
   )
 }
 

--- a/src/pages/p/[handle].page.tsx
+++ b/src/pages/p/[handle].page.tsx
@@ -1,4 +1,5 @@
 import { AppWrapper, SEO } from 'components/common'
+import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import FeedbackFormButton from 'components/FeedbackFormButton'
 import NewDeployNotAvailable from 'components/NewDeployNotAvailable'
 import Project404 from 'components/Project404'
@@ -111,7 +112,9 @@ export default function V1HandlePage({
             image: metadata.logoUri,
             site: metadata.twitter,
           }}
-        />
+        >
+          <DesmosScript />
+        </SEO>
       ) : null}
       <AppWrapper>
         {metadata ? <V1Dashboard metadata={metadata} /> : <Loading />}

--- a/src/pages/v1/create/index.page.tsx
+++ b/src/pages/v1/create/index.page.tsx
@@ -71,16 +71,23 @@ import { BallotStrategy } from 'models/ballot'
 
 import ConfirmDeployProject from './ConfirmDeployProject'
 
+import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { drawerStyle } from 'constants/styles/drawerStyle'
 import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
+import Head from 'next/head'
 
 const terminalVersion: V1TerminalVersion = '1.1'
 
 export default function V1CreatePage() {
   return (
-    <AppWrapper>
-      <V1Create />
-    </AppWrapper>
+    <>
+      <Head>
+        <DesmosScript />
+      </Head>
+      <AppWrapper>
+        <V1Create />
+      </AppWrapper>
+    </>
   )
 }
 

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -1,4 +1,5 @@
 import { AppWrapper, SEO } from 'components/common'
+import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import Loading from 'components/Loading'
 import { V2_PROJECT_IDS } from 'constants/v2/projectIds'
 import {
@@ -58,7 +59,9 @@ export default function V2ProjectPage({
             image: metadata.logoUri,
             site: metadata.twitter,
           }}
-        />
+        >
+          <DesmosScript />
+        </SEO>
       ) : null}
       <AppWrapper>
         <V2UserProvider>


### PR DESCRIPTION
## What does this PR do and why?

- Move all `script` tags to own components
- Remove Desmos from the default head
- Add Desmos script to v1 + v2 create, and v1 + v2 project pages