### PR TITLE
NFT form refactor and add collection description input

### DIFF
--- a/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/AddRewardTierButton.tsx
+++ b/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/AddRewardTierButton.tsx
@@ -1,0 +1,36 @@
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+
+import { PlusCircleOutlined } from '@ant-design/icons'
+import { CSSProperties } from 'react'
+
+export function AddRewardTierButton({
+  onClick,
+  disabled,
+  style,
+}: {
+  onClick: VoidFunction
+  disabled?: boolean
+  style?: CSSProperties
+}) {
+  const buttonStyle: CSSProperties = {
+    ...style,
+    marginTop: 15,
+  }
+
+  return (
+    <Button
+      type="dashed"
+      onClick={onClick}
+      style={buttonStyle}
+      disabled={disabled}
+      block
+      size="large"
+      icon={<PlusCircleOutlined />}
+    >
+      <span>
+        <Trans>Add reward tier</Trans>
+      </span>
+    </Button>
+  )
+}

--- a/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftMarketplaceCustomizationForm.tsx
+++ b/src/components/v2/shared/FundingCycleConfigurationDrawers/NftDrawer/NftMarketplaceCustomizationForm.tsx
@@ -1,0 +1,61 @@
+import { t } from '@lingui/macro'
+import { Form, FormInstance, Input } from 'antd'
+import { useAppSelector } from 'hooks/AppSelector'
+import {
+  defaultNftCollectionDescription,
+  defaultNftCollectionName,
+} from 'utils/v2/nftRewards'
+
+import { MarketplaceFormFields } from '.'
+
+export function NftMarketplaceCustomizationForm({
+  form,
+}: {
+  form: FormInstance<MarketplaceFormFields>
+}) {
+  const {
+    nftRewards: {
+      collectionMetadata: { name, description, symbol },
+    },
+    projectMetadata: { name: projectName },
+  } = useAppSelector(state => state.editingV2Project)
+
+  const initialValues = {
+    collectionName: name,
+    collectionDescription: description,
+    collectionSymbol: symbol,
+  }
+  return (
+    <Form layout="vertical" form={form} initialValues={initialValues}>
+      <Form.Item
+        requiredMark="optional"
+        name="collectionName"
+        label={t`Collection name`}
+      >
+        <Input
+          type="string"
+          autoComplete="off"
+          placeholder={defaultNftCollectionName(projectName)}
+        />
+      </Form.Item>
+      <Form.Item
+        requiredMark="optional"
+        name="collectionSymbol"
+        label={t`Collection symbol`}
+      >
+        <Input type="string" autoComplete="off" />
+      </Form.Item>
+      <Form.Item
+        requiredMark="optional"
+        name="collectionDescription"
+        label={t`Collection description`}
+      >
+        <Input
+          type="string"
+          autoComplete="off"
+          placeholder={defaultNftCollectionDescription(projectName)}
+        />
+      </Form.Item>
+    </Form>
+  )
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -596,6 +596,9 @@ msgstr ""
 msgid "Close, I'll do these later"
 msgstr ""
 
+msgid "Collection description"
+msgstr ""
+
 msgid "Collection name"
 msgstr ""
 
@@ -744,6 +747,9 @@ msgid "Custom strategy"
 msgstr ""
 
 msgid "Custom token beneficiary"
+msgstr ""
+
+msgid "Customize how your NFT collection will appear on NFT marketplaces (like OpenSea)."
 msgstr ""
 
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
@@ -1407,6 +1413,9 @@ msgid "Manage your {0}"
 msgstr ""
 
 msgid "Manage {tokenText}"
+msgstr ""
+
+msgid "Marketplace customizations"
 msgstr ""
 
 msgid "Maximum {MAX_DESCRIPTION_LENGTH} characters"
@@ -2813,9 +2822,6 @@ msgstr ""
 msgid "You can still redeem your {tokenSymbol} tokens for overflow without claiming them, and you can transfer your unclaimed {tokenSymbol} tokens to another address from the Tools menu, which can be accessed from the wrench icon in the upper right hand corner of this project."
 msgstr ""
 
-msgid "You collection's symbol will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
-msgstr ""
-
 msgid "You don't have a funding cycle duration. Changes you make will take effect immediately."
 msgstr ""
 
@@ -2895,9 +2901,6 @@ msgid "Your V1 {tokenSymbolFormatted} balance"
 msgstr ""
 
 msgid "Your balance"
-msgstr ""
-
-msgid "Your collection's name will apply to the whole collection of reward tiers on NFT marketplaces (like OpenSea)."
 msgstr ""
 
 msgid "Your funding cycle configuration has been pre-populated using the configuration you originally launched with. If you need to customize it, contact us."

--- a/src/models/v2/nftRewardTier.ts
+++ b/src/models/v2/nftRewardTier.ts
@@ -57,3 +57,10 @@ export type IpfsNftCollectionMetadata = {
   seller_fee_basis_points: number | undefined
   fee_recipient: string | undefined
 }
+
+export type NftCollectionMetadata = {
+  symbol: string | undefined
+  name: string | undefined
+  CID: string | undefined
+  description: string | undefined
+}

--- a/src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
@@ -72,9 +72,11 @@ export function DeployProjectWithNftsButton({ form }: { form: FormInstance }) {
     nftRewards: {
       CIDs,
       rewardTiers,
-      collectionName,
-      collectionSymbol,
-      collectionCID,
+      collectionMetadata: {
+        name: collectionName,
+        symbol: collectionSymbol,
+        CID: collectionCID,
+      },
     },
   } = useAppSelector(state => state.editingV2Project)
   const fundingCycleMetadata = useEditingV2FundingCycleMetadataSelector()

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -17,7 +17,7 @@ import {
   serializeV2FundingCycleMetadata,
 } from 'utils/v2/serializers'
 
-import { NftRewardTier } from 'models/v2/nftRewardTier'
+import { NftCollectionMetadata, NftRewardTier } from 'models/v2/nftRewardTier'
 import {
   DEFAULT_MINT_RATE,
   issuanceRateFrom,
@@ -40,9 +40,7 @@ interface V2ProjectState {
   nftRewards: {
     rewardTiers: NftRewardTier[]
     CIDs: string[] | undefined // points to locations of the NFTs' json on IPFS
-    collectionSymbol: string | undefined
-    collectionName: string | undefined
-    collectionCID: string | undefined
+    collectionMetadata: NftCollectionMetadata
   }
 }
 
@@ -115,9 +113,12 @@ export const defaultProjectState: V2ProjectState = {
   nftRewards: {
     rewardTiers: [],
     CIDs: undefined,
-    collectionSymbol: undefined,
-    collectionName: undefined,
-    collectionCID: undefined,
+    collectionMetadata: {
+      symbol: undefined,
+      name: undefined,
+      CID: undefined,
+      description: undefined,
+    },
   },
 }
 
@@ -224,17 +225,29 @@ const editingV2ProjectSlice = createSlice({
     setNftRewardsCIDs: (state, action: PayloadAction<string[]>) => {
       state.nftRewards.CIDs = action.payload
     },
+    setNftRewardsCollectionMetadata: (
+      state,
+      action: PayloadAction<NftCollectionMetadata>,
+    ) => {
+      state.nftRewards.collectionMetadata = action.payload
+    },
     setNftRewardsCollectionMetadataCID: (
       state,
       action: PayloadAction<string | undefined>,
     ) => {
-      state.nftRewards.collectionCID = action.payload
+      state.nftRewards.collectionMetadata.CID = action.payload
     },
     setNftRewardsSymbol: (state, action: PayloadAction<string | undefined>) => {
-      state.nftRewards.collectionSymbol = action.payload
+      state.nftRewards.collectionMetadata.symbol = action.payload
+    },
+    setNftRewardsCollectionDescription: (
+      state,
+      action: PayloadAction<string | undefined>,
+    ) => {
+      state.nftRewards.collectionMetadata.description = action.payload
     },
     setNftRewardsName: (state, action: PayloadAction<string | undefined>) => {
-      state.nftRewards.collectionName = action.payload
+      state.nftRewards.collectionMetadata.name = action.payload
     },
     setAllowSetTerminals: (state, action: PayloadAction<boolean>) => {
       state.fundingCycleMetadata.global.allowSetTerminals = action.payload

--- a/src/utils/v2/nftRewards.ts
+++ b/src/utils/v2/nftRewards.ts
@@ -71,3 +71,15 @@ export function CIDsOfNftRewardTiersResponse(
     .filter(cid => cid.length > 0)
   return cids
 }
+
+// Default name for NFT collections on NFT marketplaces
+export const defaultNftCollectionName = (projectName: string | undefined) =>
+  `${projectName?.length ? projectName : "Your project's"} NFT rewards`
+
+// Default description for NFT collections on NFT marketplaces
+export const defaultNftCollectionDescription = (
+  projectName: string | undefined,
+) =>
+  `NFTs rewarded to ${
+    projectName?.length ? projectName : 'your project'
+  }'s Juicebox contributors.`


### PR DESCRIPTION
## What does this PR do and why?

Tidies code around the NFT form and adds a field for collection description

<img width="619" alt="Screen Shot 2022-09-08 at 10 05 37 pm" src="https://user-images.githubusercontent.com/96150256/189118978-159cc594-f721-40c7-a0db-61b572aef36e.png">

<img width="608" alt="Screen Shot 2022-09-08 at 10 05 51 pm" src="https://user-images.githubusercontent.com/96150256/189118984-de1a47d5-a45b-4851-8302-15e1b2e9a969.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
