### PR TITLE
Hide v1 token migration in settings page

### DIFF
--- a/src/components/v2/V2Project/V2ProjectSettings/V2ProjectSettings.tsx
+++ b/src/components/v2/V2Project/V2ProjectSettings/V2ProjectSettings.tsx
@@ -70,12 +70,14 @@ const items: MenuItem[] = [
     'Manage',
     'manage',
     [
-      menuItem('V1 token migration', 'v1tokenmigration'),
+      menuItem('Transfer ownership', 'transferownership'),
+      menuItem('Archive project', 'archiveproject'),
       featureFlagEnabled(FEATURE_FLAGS.VENFT)
         ? menuItem('veNFT governance', 'venft')
         : null,
-      menuItem('Transfer ownership', 'transferownership'),
-      menuItem('Archive project', 'archiveproject'),
+      featureFlagEnabled(FEATURE_FLAGS.V1_TOKEN_SWAP)
+        ? menuItem('V1 token migration', 'v1tokenmigration')
+        : null,
     ],
     'group',
   ),


### PR DESCRIPTION
Causing confusion and this will probably change. lets hide it for now.