### PR TITLE
Added tooltip to show ETH to USD amount in payout splits card

### DIFF
--- a/src/components/Project/SpendingStats.tsx
+++ b/src/components/Project/SpendingStats.tsx
@@ -12,6 +12,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2/math'
 
 import { CurrencyName } from 'constants/currency'
+import ETHToUSD from 'components/currency/ETHToUSD'
 
 export default function SpendingStats({
   currency,
@@ -48,15 +49,23 @@ export default function SpendingStats({
   return (
     <div>
       <div>
-        <span
-          style={{
-            fontSize: '1rem',
-            fontWeight: 500,
-          }}
+        <Tooltip
+          title={
+            currency === 'ETH' ? (
+              <ETHToUSD ethAmount={distributableAmount ?? ''} />
+            ) : undefined
+          }
         >
-          <CurrencySymbol currency={currency} />
-          {formatWad(distributableAmount, { precision: 4 }) || '0'}{' '}
-        </span>
+          <span
+            style={{
+              fontSize: '1rem',
+              fontWeight: 500,
+            }}
+          >
+            <CurrencySymbol currency={currency} />
+            {formatWad(distributableAmount, { precision: 4 }) || '0'}{' '}
+          </span>
+        </Tooltip>
         <TooltipLabel
           style={smallHeaderStyle}
           label={<Trans>AVAILABLE</Trans>}

--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -2,6 +2,7 @@ import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
+import ETHToUSD from 'components/currency/ETHToUSD'
 import CurrencySymbol from 'components/CurrencySymbol'
 import FormattedAddress from 'components/FormattedAddress'
 import TooltipIcon from 'components/TooltipIcon'
@@ -149,18 +150,21 @@ export default function SplitItem({
   const SplitValue = () => {
     const splitValue = totalValue?.mul(split.percent).div(SPLITS_TOTAL_PERCENT)
     const splitValueFormatted = formatWad(splitValue, { ...valueFormatProps })
+    const curr = V2CurrencyName(
+      currency?.toNumber() as V2CurrencyOption | undefined,
+    )
+    const tooltipTitle =
+      curr === 'ETH' ? <ETHToUSD ethAmount={splitValue ?? ''} /> : undefined
 
     return (
-      <span style={{ fontSize: itemFontSize }}>
-        (
-        <CurrencySymbol
-          currency={V2CurrencyName(
-            currency?.toNumber() as V2CurrencyOption | undefined,
-          )}
-        />
-        {splitValueFormatted}
-        {valueSuffix ? <span> {valueSuffix}</span> : null})
-      </span>
+      <Tooltip title={tooltipTitle}>
+        <span style={{ fontSize: itemFontSize }}>
+          (
+          <CurrencySymbol currency={curr} />
+          {splitValueFormatted}
+          {valueSuffix ? <span> {valueSuffix}</span> : null})
+        </span>
+      </Tooltip>
     )
   }
 


### PR DESCRIPTION
## What does this PR do and why?

Fixes - https://github.com/jbx-protocol/juice-interface/issues/1944

The intention of this PR is to show ETH value in USD when the user hovers over areas in the current funding cycle card.

## Screenshots or screen recordings

**Before**

https://user-images.githubusercontent.com/18723426/189524460-e009429e-f8d9-4e12-9969-3cb94f25fcfa.mov

**After**


https://user-images.githubusercontent.com/18723426/189524467-93f429e3-173d-44fe-b221-e5fe2fe772ac.mov


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
