### PR TITLE
Show v2 handles in payment feed

### DIFF
--- a/src/components/v1/shared/V1ProjectHandle.tsx
+++ b/src/components/v1/shared/V1ProjectHandle.tsx
@@ -5,20 +5,23 @@ import { CSSProperties } from 'react'
 
 export default function V1ProjectHandle({
   projectId,
+  handle,
   style,
 }: {
   projectId: BigNumberish
+  handle?: string | null
   style?: CSSProperties
 }) {
-  const handle = useHandleForProjectId(projectId)
+  const _handle = useHandleForProjectId(!handle ? projectId : undefined)
+  const handleToRender = handle ?? _handle
 
   return (
-    <Link href={`/p/${handle}`}>
+    <Link href={`/p/${handleToRender}`}>
       <a
         className="text-primary hover-text-action-primary hover-text-decoration-underline"
         style={{ fontWeight: 500, ...style }}
       >
-        @{handle}
+        @{handleToRender}
       </a>
     </Link>
   )

--- a/src/components/v2/shared/V2ProjectHandle.tsx
+++ b/src/components/v2/shared/V2ProjectHandle.tsx
@@ -6,20 +6,29 @@ import { v2ProjectRoute } from 'utils/routes'
 
 export default function V2ProjectHandle({
   projectId,
+  handle,
   style,
 }: {
   projectId: number
+  handle?: string | null
   style?: CSSProperties
 }) {
-  const { data: handle } = useProjectHandle({ projectId })
+  const { data: _handle } = useProjectHandle({
+    projectId: !handle ? projectId : undefined,
+  })
+  const handleToRender = handle ?? _handle
 
   return (
-    <Link href={v2ProjectRoute({ projectId, handle })}>
+    <Link href={v2ProjectRoute({ projectId, handle: handleToRender })}>
       <a
         style={{ fontWeight: 500, marginRight: '0.5rem', ...style }}
         className="text-primary hover-text-action-primary hover-text-decoration-underline"
       >
-        {handle ? `@${handle}` : <Trans>Project #{projectId}</Trans>}
+        {handleToRender ? (
+          `@${handleToRender}`
+        ) : (
+          <Trans>Project #{projectId}</Trans>
+        )}
       </a>
     </Link>
   )

--- a/src/models/subgraph-entities/vX/project.ts
+++ b/src/models/subgraph-entities/vX/project.ts
@@ -67,20 +67,19 @@ type BaseProject = {
   distributeToTicketModEvents: Partial<DistributeToTicketModEvent>[]
   deployedERC20Events: Partial<DeployedERC20Event>[]
   veNftContract: Partial<VeNftContract>
+  metadataUri: string
 }
 
 type ProjectV1 = {
   terminal: string
-  metadataUri: string
   metadataDomain: null
   handle: string
 } & BaseProject
 
 type ProjectV2 = {
   terminal: null
-  metadataUri: string
   metadataDomain: BigNumber
-  handle: null
+  handle: string | null
 } & BaseProject
 
 export type Project = ProjectV1 | ProjectV2 // Separate entity used for testing

--- a/src/pages/home/Payments.tsx
+++ b/src/pages/home/Payments.tsx
@@ -24,7 +24,7 @@ export default function Payments() {
       'note',
       'timestamp',
       'id',
-      { entity: 'project', keys: ['id', 'projectId', 'cv'] },
+      { entity: 'project', keys: ['id', 'projectId', 'handle', 'cv'] },
     ],
     first: 20,
     orderDirection: 'desc',
@@ -38,11 +38,17 @@ export default function Payments() {
       <div style={{ color: colors.text.action.primary, fontWeight: 500 }}>
         {project.cv === '2' ? (
           <div style={{ display: 'flex', alignItems: 'baseline' }}>
-            <V2ProjectHandle projectId={project.projectId} />
+            <V2ProjectHandle
+              projectId={project.projectId}
+              handle={project.handle}
+            />
             <ProjectVersionBadge versionText="V2" size="small" />
           </div>
         ) : (
-          <V1ProjectHandle projectId={project.projectId} />
+          <V1ProjectHandle
+            projectId={project.projectId}
+            handle={project.handle}
+          />
         )}
       </div>
     )

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -18,6 +18,7 @@ import { StatsSection } from './home/StatsSection'
 import { HeroHeading, HeroSubheading } from './home/strings'
 import { TopProjectsSection } from './home/TopProjectsSection'
 import TrendingSection from './home/TrendingSection'
+import { V2UserProvider } from 'providers/v2/UserProvider'
 
 export default function LandingPage() {
   return (
@@ -204,7 +205,9 @@ function Landing() {
 
       <StatsSection />
 
-      <TrendingSection />
+      <V2UserProvider>
+        <TrendingSection />
+      </V2UserProvider>
 
       <HowItWorksSection />
 

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -18,15 +18,6 @@ import { StatsSection } from './home/StatsSection'
 import { HeroHeading, HeroSubheading } from './home/strings'
 import { TopProjectsSection } from './home/TopProjectsSection'
 import TrendingSection from './home/TrendingSection'
-import { V2UserProvider } from 'providers/v2/UserProvider'
-
-export default function LandingPage() {
-  return (
-    <AppWrapper>
-      <Landing />
-    </AppWrapper>
-  )
-}
 
 const BigHeader = ({
   text,
@@ -205,9 +196,7 @@ function Landing() {
 
       <StatsSection />
 
-      <V2UserProvider>
-        <TrendingSection />
-      </V2UserProvider>
+      <TrendingSection />
 
       <HowItWorksSection />
 
@@ -328,5 +317,13 @@ function Landing() {
       <FeedbackFormButton />
       <Footer />
     </div>
+  )
+}
+
+export default function LandingPage() {
+  return (
+    <AppWrapper>
+      <Landing />
+    </AppWrapper>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Fixes https://github.com/jbx-protocol/juice-interface/issues/1912 https://github.com/jbx-protocol/juice-interface/issues/1939

The issue here was that in `useV2ContractReader` there was no context from `V2UserContext` returning back from `Payments` component,  therefore we need to wrap the parent component with `V2UserProvider`

I wrapped `TrendingSection` with `V2UserProvider` but I'm not sure if it is the right place to wrap.

## Screenshots or screen recordings

**Before**
![image](https://user-images.githubusercontent.com/18723426/189527162-414d1ef3-78fc-4ce4-bf36-580ba253003b.png)

**After**
![image](https://user-images.githubusercontent.com/18723426/189527193-27daf6d5-982d-4c18-a9be-0c28a6b729d2.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
