### PR TITLE
Fix Mobile content nav padding

### DIFF
--- a/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
+++ b/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
@@ -60,7 +60,7 @@ const _Wrapper: React.FC = ({ children }) => {
         }}
       >
         <Navbar />
-        <Content style={isMobile ? { paddingTop: 40 } : {}}>{children}</Content>
+        <Content style={isMobile ? { paddingTop: 64 } : {}}>{children}</Content>
       </Layout>
     </>
   )


### PR DESCRIPTION
## What does this PR do and why?

Currently the nav is cut off by 40 being too low. 64 fixes this

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
