### PR TITLE
Use V2ProjectHandle in more places

### DIFF
--- a/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
+++ b/src/components/v2/V2Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
@@ -13,6 +13,7 @@ import {
   smallHeaderStyle,
 } from 'components/activityEventElems/styles'
 import ETHAmount from 'components/currency/ETHAmount'
+import V2ProjectHandle from 'components/v2/shared/V2ProjectHandle'
 import { DistributePayoutsEvent } from 'models/subgraph-entities/v2/distribute-payouts-event'
 
 export default function DistributePayoutsElem({
@@ -115,7 +116,7 @@ export default function DistributePayoutsElem({
           >
             <div style={{ fontWeight: 500 }}>
               {e.splitProjectId ? (
-                <span>Project {e.splitProjectId}</span>
+                <V2ProjectHandle projectId={e.splitProjectId} />
               ) : (
                 <FormattedAddress address={e.beneficiary} />
               )}

--- a/src/components/v2/shared/SplitItem.tsx
+++ b/src/components/v2/shared/SplitItem.tsx
@@ -1,6 +1,6 @@
 import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
-import { t, Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
 import ETHToUSD from 'components/currency/ETHToUSD'
 import CurrencySymbol from 'components/CurrencySymbol'
@@ -8,22 +8,20 @@ import FormattedAddress from 'components/FormattedAddress'
 import TooltipIcon from 'components/TooltipIcon'
 import TooltipLabel from 'components/TooltipLabel'
 import { ThemeContext } from 'contexts/themeContext'
-import useMobile from 'hooks/Mobile'
-import useProjectHandle from 'hooks/v2/contractReader/ProjectHandle'
 import { Split } from 'models/splits'
 import { V2CurrencyOption } from 'models/v2/currencyOption'
-import Link from 'next/link'
 import { useContext } from 'react'
 import { formatDate } from 'utils/format/formatDate'
 import { formatWad } from 'utils/format/formatNumber'
-import { v2ProjectRoute } from 'utils/routes'
 import { V2CurrencyName } from 'utils/v2/currency'
 import { formatSplitPercent, SPLITS_TOTAL_PERCENT } from 'utils/v2/math'
+import V2ProjectHandle from './V2ProjectHandle'
 
 const LockedText = ({ lockedUntil }: { lockedUntil: number }) => {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+
   const lockedUntilFormatted = formatDate(lockedUntil * 1000, 'yyyy-MM-DD')
 
   return (
@@ -33,140 +31,142 @@ const LockedText = ({ lockedUntil }: { lockedUntil: number }) => {
   )
 }
 
-export default function SplitItem({
-  split,
-  showSplitValue,
-  currency,
-  totalValue,
+const JuiceboxProjectBeneficiary = ({
   projectOwnerAddress,
-  valueSuffix,
-  valueFormatProps,
-  reservedRate,
+  split,
 }: {
   split: Split
-  currency?: BigNumber
-  totalValue: BigNumber | undefined
   projectOwnerAddress: string | undefined
-  showSplitValue: boolean
-  valueSuffix?: string | JSX.Element
-  valueFormatProps?: { precision?: number }
-  reservedRate?: number
-}) {
+}) => {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
-  const isMobile = useMobile()
 
-  const { data: handle } = split.projectId
-    ? useProjectHandle({ projectId: parseInt(split.projectId) })
-    : { data: undefined }
+  if (!split.projectId) return null
 
   const isProjectOwner = projectOwnerAddress === split.beneficiary
+
+  return (
+    <div>
+      <V2ProjectHandle projectId={parseInt(split.projectId)} />
+
+      <div
+        style={{
+          fontSize: '.8rem',
+          color: colors.text.secondary,
+          marginLeft: 10,
+        }}
+      >
+        <TooltipLabel
+          label={<Trans>Tokens:</Trans>}
+          tip={
+            <Trans>
+              This address will receive any tokens minted when the recipient
+              project gets paid.
+            </Trans>
+          }
+        />{' '}
+        <FormattedAddress address={split.beneficiary} />{' '}
+        {isProjectOwner && (
+          <Tooltip title={<Trans>Project owner</Trans>}>
+            <CrownFilled />
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const ETHAddressBeneficiary = ({
+  projectOwnerAddress,
+  split,
+}: {
+  split: Split
+  projectOwnerAddress: string | undefined
+}) => {
+  const isProjectOwner = projectOwnerAddress === split.beneficiary
+
+  return (
+    <div
+      style={{
+        fontWeight: 500,
+        display: 'flex',
+        alignItems: 'baseline',
+      }}
+    >
+      {split.beneficiary ? (
+        <FormattedAddress address={split.beneficiary} />
+      ) : null}
+      {!split.beneficiary && isProjectOwner ? (
+        <Trans>Project owner (you)</Trans>
+      ) : null}
+      {isProjectOwner && (
+        <span style={{ marginLeft: 5 }}>
+          <Tooltip title={<Trans>Project owner</Trans>}>
+            <CrownFilled />
+          </Tooltip>
+        </span>
+      )}
+      :
+    </div>
+  )
+}
+
+const SplitValue = ({
+  split,
+  totalValue,
+  valueSuffix,
+  valueFormatProps,
+  currency,
+}: {
+  split: Split
+  totalValue: BigNumber | undefined
+  valueSuffix?: string | JSX.Element
+  valueFormatProps?: { precision?: number }
+  currency?: BigNumber
+}) => {
+  const splitValue = totalValue?.mul(split.percent).div(SPLITS_TOTAL_PERCENT)
+  const splitValueFormatted = formatWad(splitValue, { ...valueFormatProps })
+  const curr = V2CurrencyName(
+    currency?.toNumber() as V2CurrencyOption | undefined,
+  )
+  const tooltipTitle =
+    curr === 'ETH' ? <ETHToUSD ethAmount={splitValue ?? ''} /> : undefined
+
+  return (
+    <Tooltip title={tooltipTitle}>
+      <span>
+        (
+        <CurrencySymbol currency={curr} />
+        {splitValueFormatted}
+        {valueSuffix ? <span> {valueSuffix}</span> : null})
+      </span>
+    </Tooltip>
+  )
+}
+
+export default function SplitItem({
+  split,
+  showSplitValue,
+  totalValue,
+  projectOwnerAddress,
+  reservedRate,
+  valueSuffix,
+  valueFormatProps,
+  currency,
+}: {
+  split: Split
+  totalValue: BigNumber | undefined
+  projectOwnerAddress: string | undefined
+  showSplitValue?: boolean
+  reservedRate?: number
+  valueSuffix?: string | JSX.Element
+  valueFormatProps?: { precision?: number }
+  currency?: BigNumber
+}) {
   const isJuiceboxProject = split.projectId
     ? BigNumber.from(split.projectId).gt(0)
     : false
-  const itemFontSize = isMobile ? '0.9rem' : 'unset'
-
-  const JuiceboxProjectBeneficiary = () => {
-    const getProjectLabel = () => {
-      if (handle) {
-        return `@${handle}`
-      }
-      if (split.projectId) {
-        return t`Project ${parseInt(split.projectId)}`
-      }
-      return t`Unknown Project`
-    }
-
-    return (
-      <div>
-        <div>
-          <Link href={v2ProjectRoute({ projectId: split.projectId, handle })}>
-            <a
-              className="text-primary hover-text-action-primary hover-text-decoration-underline"
-              style={{ fontWeight: 500 }}
-              target="_blank"
-            >
-              {getProjectLabel()}
-            </a>
-          </Link>
-        </div>
-
-        <div
-          style={{
-            fontSize: '.8rem',
-            color: colors.text.secondary,
-            marginLeft: 10,
-          }}
-        >
-          <TooltipLabel
-            label={<Trans>Tokens:</Trans>}
-            tip={
-              <Trans>
-                This address will receive any tokens minted when the recipient
-                project gets paid.
-              </Trans>
-            }
-          />{' '}
-          <FormattedAddress address={split.beneficiary} />{' '}
-          {isProjectOwner && (
-            <Tooltip title={<Trans>Project owner</Trans>}>
-              <CrownFilled />
-            </Tooltip>
-          )}
-        </div>
-      </div>
-    )
-  }
-
-  const ETHAddressBeneficiary = () => {
-    return (
-      <div
-        style={{
-          fontWeight: 500,
-          fontSize: itemFontSize,
-          display: 'flex',
-          alignItems: 'baseline',
-        }}
-      >
-        {split.beneficiary ? (
-          <FormattedAddress address={split.beneficiary} />
-        ) : null}
-        {!split.beneficiary && isProjectOwner ? (
-          <Trans>Project owner (you)</Trans>
-        ) : null}
-        {isProjectOwner && (
-          <span style={{ marginLeft: 5 }}>
-            <Tooltip title={<Trans>Project owner</Trans>}>
-              <CrownFilled />
-            </Tooltip>
-          </span>
-        )}
-        :
-      </div>
-    )
-  }
-
-  const SplitValue = () => {
-    const splitValue = totalValue?.mul(split.percent).div(SPLITS_TOTAL_PERCENT)
-    const splitValueFormatted = formatWad(splitValue, { ...valueFormatProps })
-    const curr = V2CurrencyName(
-      currency?.toNumber() as V2CurrencyOption | undefined,
-    )
-    const tooltipTitle =
-      curr === 'ETH' ? <ETHToUSD ethAmount={splitValue ?? ''} /> : undefined
-
-    return (
-      <Tooltip title={tooltipTitle}>
-        <span style={{ fontSize: itemFontSize }}>
-          (
-          <CurrencySymbol currency={curr} />
-          {splitValueFormatted}
-          {valueSuffix ? <span> {valueSuffix}</span> : null})
-        </span>
-      </Tooltip>
-    )
-  }
 
   const formattedSplitPercent = formatSplitPercent(
     BigNumber.from(split.percent),
@@ -184,9 +184,15 @@ export default function SplitItem({
       <div style={{ lineHeight: 1.4 }}>
         <div style={{ display: 'flex', alignItems: 'baseline' }}>
           {isJuiceboxProject ? (
-            <JuiceboxProjectBeneficiary />
+            <JuiceboxProjectBeneficiary
+              projectOwnerAddress={projectOwnerAddress}
+              split={split}
+            />
           ) : (
-            <ETHAddressBeneficiary />
+            <ETHAddressBeneficiary
+              projectOwnerAddress={projectOwnerAddress}
+              split={split}
+            />
           )}
         </div>
 
@@ -199,7 +205,13 @@ export default function SplitItem({
         {totalValue?.gt(0) && showSplitValue ? (
           <span style={{ marginLeft: '0.2rem' }}>
             {' '}
-            <SplitValue />
+            <SplitValue
+              split={split}
+              totalValue={totalValue}
+              valueSuffix={valueSuffix}
+              valueFormatProps={valueFormatProps}
+              currency={currency}
+            />
           </span>
         ) : null}
         {reservedRate ? (

--- a/src/components/v2/shared/V2ProjectHandle.tsx
+++ b/src/components/v2/shared/V2ProjectHandle.tsx
@@ -21,7 +21,7 @@ export default function V2ProjectHandle({
   return (
     <Link href={v2ProjectRoute({ projectId, handle: handleToRender })}>
       <a
-        style={{ fontWeight: 500, marginRight: '0.5rem', ...style }}
+        style={{ fontWeight: 500, ...style }}
         className="text-primary hover-text-action-primary hover-text-decoration-underline"
       >
         {handleToRender ? (

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1826,9 +1826,6 @@ msgstr ""
 msgid "Project tokens will be minted to whoever pays this payer contract."
 msgstr ""
 
-msgid "Project {0}"
-msgstr ""
-
 msgid "Project {name} will be available soon! Try refreshing the page shortly."
 msgstr ""
 

--- a/src/pages/home/Payments.tsx
+++ b/src/pages/home/Payments.tsx
@@ -41,6 +41,7 @@ export default function Payments() {
             <V2ProjectHandle
               projectId={project.projectId}
               handle={project.handle}
+              style={{ marginRight: '0.5rem' }}
             />
             <ProjectVersionBadge versionText="V2" size="small" />
           </div>


### PR DESCRIPTION
## What does this PR do and why?

- Use V2ProjectHandle in SplitItem (+ fix re-rendering bugs)
- Use V2ProjectHandle in Distribute activity element.

## Screenshots or screen recordings

<img width="281" alt="Screen Shot 2022-09-12 at 4 20 08 PM" src="https://user-images.githubusercontent.com/12551741/189590570-2baf545e-8c8f-469c-ac13-bac3a95e6fbc.png">
<img width="267" alt="Screen Shot 2022-09-12 at 4 20 10 PM" src="https://user-images.githubusercontent.com/12551741/189590584-f18febfa-4eed-4402-bd46-cac6c56ed863.png">


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
