### PR TITLE
[1/2] Only load Prices contract in useEtherPrice

### DIFF
--- a/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
+++ b/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
@@ -7,7 +7,6 @@ import { EtherPriceProvider } from 'providers/EtherPriceProvider'
 import LanguageProvider from 'providers/LanguageProvider'
 import ReactQueryProvider from 'providers/ReactQueryProvider'
 import { ThemeProvider } from 'providers/ThemeProvider'
-import { V1UserProvider } from 'providers/v1/UserProvider'
 import React from 'react'
 import { Provider } from 'react-redux'
 import store from 'redux/store'
@@ -28,12 +27,9 @@ export const AppWrapper: React.FC = ({ children }) => {
         <Provider store={store}>
           <LanguageProvider>
             <ThemeProvider>
-              {/* TODO: Remove v1 provider */}
-              <V1UserProvider>
-                <EtherPriceProvider>
-                  <_Wrapper>{children}</_Wrapper>
-                </EtherPriceProvider>
-              </V1UserProvider>
+              <EtherPriceProvider>
+                <_Wrapper>{children}</_Wrapper>
+              </EtherPriceProvider>
             </ThemeProvider>
           </LanguageProvider>
         </Provider>

--- a/src/hooks/ContractReader/ContractReadValue.ts
+++ b/src/hooks/ContractReader/ContractReadValue.ts
@@ -15,16 +15,16 @@ import { callContractRead, getContract } from './util'
  */
 export function useContractReadValue<C extends string, V>({
   contract,
-  contracts,
   functionName,
   args,
+  contracts,
   formatter,
   valueDidChange,
 }: {
   contract: C | Contract | undefined
-  contracts: Record<C, Contract> | undefined
   functionName: string | undefined
   args: unknown[] | null | undefined
+  contracts?: Record<C, Contract> | undefined
   formatter?: (val?: any) => V | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
   valueDidChange?: (oldVal?: V, newVal?: V) => boolean
 }) {

--- a/src/hooks/ContractReader/util/callContractRead.ts
+++ b/src/hooks/ContractReader/util/callContractRead.ts
@@ -13,9 +13,9 @@ export async function callContractRead<T extends string>({
   args,
 }: {
   readContract: Contract | undefined
-  contracts: Record<T, Contract> | undefined
   functionName: string | undefined
   args: unknown[] | null | undefined
+  contracts?: Record<T, Contract> | undefined
 }) {
   if (!readContract || !functionName || args === null) return
 
@@ -29,7 +29,7 @@ export async function callContractRead<T extends string>({
       { args },
       { err },
       { contract: readContract.address },
-      contracts,
+      { contracts },
     )
 
     Sentry.captureException(err, {

--- a/src/hooks/ContractReader/util/getContract.ts
+++ b/src/hooks/ContractReader/util/getContract.ts
@@ -9,5 +9,7 @@ export function getContract<T extends string>(
 
   if (typeof contractConfig === 'string') {
     return contracts ? contracts[contractConfig] : undefined
-  } else return contractConfig
+  } else {
+    return contractConfig
+  }
 }

--- a/src/hooks/EtherPrice.ts
+++ b/src/hooks/EtherPrice.ts
@@ -1,15 +1,44 @@
-import { V1UserContext } from 'contexts/v1/userContext'
-import { V1ContractName } from 'models/v1/contracts'
-import { useContext, useEffect } from 'react'
+import { Contract } from '@ethersproject/contracts'
+import { readNetwork } from 'constants/networks'
+import { readProvider } from 'constants/readProvider'
+import { useEffect, useState } from 'react'
 import { fromWad } from 'utils/format/formatNumber'
 import { useContractReadValue } from './ContractReader'
+import { loadV1Contract } from './v1/V1ContractLoader'
+
+/**
+ * Chainlink feed doesn't tend to up date that quickly.
+ * Refresh every 5 minutes.
+ */
+const PRICE_REFRESH_INTERVAL = 60 * 1000 * 5 // 5 minutes
+
+const usePricesContract = () => {
+  const [contract, setContract] = useState<Contract | undefined>()
+
+  useEffect(() => {
+    if (contract) return
+
+    const load = async () => {
+      const contract = await loadV1Contract(
+        'Prices',
+        readNetwork.name,
+        readProvider,
+      )
+
+      setContract(contract)
+    }
+
+    load()
+  }, [contract])
+
+  return contract
+}
 
 export function useEtherPrice() {
-  const { contracts } = useContext(V1UserContext)
+  const contract = usePricesContract()
 
   const { refetchValue, value: price } = useContractReadValue({
-    contracts,
-    contract: V1ContractName.Prices,
+    contract,
     functionName: 'getETHPriceFor',
     args: ['1'], // $1 USD
     formatter: val => {
@@ -19,9 +48,9 @@ export function useEtherPrice() {
   })
 
   useEffect(() => {
-    const timer = setInterval(refetchValue, 5000)
+    const timer = setInterval(refetchValue, PRICE_REFRESH_INTERVAL)
     return () => clearInterval(timer)
-  })
+  }, [refetchValue])
 
   return price ?? 0
 }

--- a/src/hooks/v1/V1ContractLoader.ts
+++ b/src/hooks/v1/V1ContractLoader.ts
@@ -1,13 +1,22 @@
 import { Contract } from '@ethersproject/contracts'
+import { readNetwork } from 'constants/networks'
+import { readProvider } from 'constants/readProvider'
 import { useWallet } from 'hooks/Wallet'
-import { SignerOrProvider } from 'utils/types'
-
 import { NetworkName } from 'models/network-name'
 import { V1ContractName, V1Contracts } from 'models/v1/contracts'
 import { useEffect, useState } from 'react'
+import { SignerOrProvider } from 'utils/types'
 
-import { readNetwork } from 'constants/networks'
-import { readProvider } from 'constants/readProvider'
+export const loadV1Contract = async (
+  contractName: string,
+  network: NetworkName,
+  signerOrProvider: SignerOrProvider,
+): Promise<Contract> => {
+  const contract = await import(
+    `@jbx-protocol/contracts-v1/deployments/${network}/${contractName}.json`
+  )
+  return new Contract(contract.address, contract.abi, signerOrProvider)
+}
 
 export function useV1ContractLoader() {
   const [contracts, setContracts] = useState<V1Contracts>()
@@ -23,7 +32,7 @@ export function useV1ContractLoader() {
 
         const loadContractKeyPair = async (contractName: V1ContractName) => ({
           key: contractName,
-          val: await loadContract(contractName, network, signerOrProvider),
+          val: await loadV1Contract(contractName, network, signerOrProvider),
         })
 
         const newContracts = (
@@ -48,15 +57,4 @@ export function useV1ContractLoader() {
   }, [setContracts, signer])
 
   return contracts
-}
-
-const loadContract = async (
-  contractName: keyof typeof V1ContractName,
-  network: NetworkName,
-  signerOrProvider: SignerOrProvider,
-): Promise<Contract> => {
-  const contract = await import(
-    `@jbx-protocol/contracts-v1/deployments/${network}/${contractName}.json`
-  )
-  return new Contract(contract.address, contract.abi, signerOrProvider)
 }

--- a/src/models/v1/contracts.ts
+++ b/src/models/v1/contracts.ts
@@ -7,7 +7,6 @@ export enum V1ContractName {
   TerminalDirectory = 'TerminalDirectory',
   ModStore = 'ModStore',
   OperatorStore = 'OperatorStore',
-  Prices = 'Prices',
   Projects = 'Projects',
   TicketBooth = 'TicketBooth',
 }

--- a/src/models/v2/contracts.ts
+++ b/src/models/v2/contracts.ts
@@ -6,7 +6,6 @@ export enum V2ContractName {
   JBETHPaymentTerminal = 'JBETHPaymentTerminal',
   JBFundingCycleStore = 'JBFundingCycleStore',
   JBOperatorStore = 'JBOperatorStore',
-  JBPrices = 'JBPrices',
   JBProjects = 'JBProjects',
   JBSplitsStore = 'JBSplitsStore',
   JBTokenStore = 'JBTokenStore',

--- a/src/pages/p/[handle].page.tsx
+++ b/src/pages/p/[handle].page.tsx
@@ -1,11 +1,10 @@
 import { AppWrapper, SEO } from 'components/common'
 import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { FeedbackFormButton } from 'components/FeedbackFormButton'
+import Loading from 'components/Loading'
 import NewDeployNotAvailable from 'components/NewDeployNotAvailable'
 import Project404 from 'components/Project404'
 import ScrollToTopButton from 'components/ScrollToTopButton'
-
-import Loading from 'components/Loading'
 import V1Project from 'components/v1/V1Project'
 import { layouts } from 'constants/styles/layouts'
 import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
@@ -33,6 +32,7 @@ import { ProjectMetadataV4 } from 'models/project-metadata'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { useRouter } from 'next/router'
+import { V1UserProvider } from 'providers/v1/UserProvider'
 import { V1CurrencyProvider } from 'providers/v1/V1CurrencyProvider'
 import { useMemo } from 'react'
 import { paginateDepleteProjectsQueryCall } from 'utils/apollo'
@@ -117,7 +117,13 @@ export default function V1HandlePage({
         </SEO>
       ) : null}
       <AppWrapper>
-        {metadata ? <V1Dashboard metadata={metadata} /> : <Loading />}
+        {metadata ? (
+          <V1UserProvider>
+            <V1Dashboard metadata={metadata} />
+          </V1UserProvider>
+        ) : (
+          <Loading />
+        )}
       </AppWrapper>
     </>
   )

--- a/src/pages/v1/create/index.page.tsx
+++ b/src/pages/v1/create/index.page.tsx
@@ -75,6 +75,7 @@ import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { drawerStyle } from 'constants/styles/drawerStyle'
 import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
 import Head from 'next/head'
+import { V1UserProvider } from 'providers/v1/UserProvider'
 
 const terminalVersion: V1TerminalVersion = '1.1'
 
@@ -85,7 +86,9 @@ export default function V1CreatePage() {
         <DesmosScript />
       </Head>
       <AppWrapper>
-        <V1Create />
+        <V1UserProvider>
+          <V1Create />
+        </V1UserProvider>
       </AppWrapper>
     </>
   )


### PR DESCRIPTION
## What does this PR do and why?

This PR is in prep for removing V1UserProvider from the global app wrapper.

We only need the `Prices` contract for this single hook. So instead of loading it in the user context, we can load it only for this specific hook. This will allow us to remove V1UserProvider from the global app context and only use it when we need it (follow-up PR)

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [-] I have tested this PR in dark mode and light mode (if applicable).
