### PR TITLE
[2/2] Only use V1UserProvider on v1 pages

### DIFF
--- a/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
+++ b/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
@@ -7,7 +7,6 @@ import { EtherPriceProvider } from 'providers/EtherPriceProvider'
 import LanguageProvider from 'providers/LanguageProvider'
 import ReactQueryProvider from 'providers/ReactQueryProvider'
 import { ThemeProvider } from 'providers/ThemeProvider'
-import { V1UserProvider } from 'providers/v1/UserProvider'
 import React from 'react'
 import { Provider } from 'react-redux'
 import store from 'redux/store'
@@ -28,12 +27,9 @@ export const AppWrapper: React.FC = ({ children }) => {
         <Provider store={store}>
           <LanguageProvider>
             <ThemeProvider>
-              {/* TODO: Remove v1 provider */}
-              <V1UserProvider>
-                <EtherPriceProvider>
-                  <_Wrapper>{children}</_Wrapper>
-                </EtherPriceProvider>
-              </V1UserProvider>
+              <EtherPriceProvider>
+                <_Wrapper>{children}</_Wrapper>
+              </EtherPriceProvider>
             </ThemeProvider>
           </LanguageProvider>
         </Provider>

--- a/src/pages/p/[handle].page.tsx
+++ b/src/pages/p/[handle].page.tsx
@@ -1,11 +1,10 @@
 import { AppWrapper, SEO } from 'components/common'
 import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { FeedbackFormButton } from 'components/FeedbackFormButton'
+import Loading from 'components/Loading'
 import NewDeployNotAvailable from 'components/NewDeployNotAvailable'
 import Project404 from 'components/Project404'
 import ScrollToTopButton from 'components/ScrollToTopButton'
-
-import Loading from 'components/Loading'
 import V1Project from 'components/v1/V1Project'
 import { layouts } from 'constants/styles/layouts'
 import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
@@ -33,6 +32,7 @@ import { ProjectMetadataV4 } from 'models/project-metadata'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { useRouter } from 'next/router'
+import { V1UserProvider } from 'providers/v1/UserProvider'
 import { V1CurrencyProvider } from 'providers/v1/V1CurrencyProvider'
 import { useMemo } from 'react'
 import { paginateDepleteProjectsQueryCall } from 'utils/apollo'
@@ -117,7 +117,13 @@ export default function V1HandlePage({
         </SEO>
       ) : null}
       <AppWrapper>
-        {metadata ? <V1Dashboard metadata={metadata} /> : <Loading />}
+        {metadata ? (
+          <V1UserProvider>
+            <V1Dashboard metadata={metadata} />
+          </V1UserProvider>
+        ) : (
+          <Loading />
+        )}
       </AppWrapper>
     </>
   )

--- a/src/pages/v1/create/index.page.tsx
+++ b/src/pages/v1/create/index.page.tsx
@@ -75,6 +75,7 @@ import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { drawerStyle } from 'constants/styles/drawerStyle'
 import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
 import Head from 'next/head'
+import { V1UserProvider } from 'providers/v1/UserProvider'
 
 const terminalVersion: V1TerminalVersion = '1.1'
 
@@ -85,7 +86,9 @@ export default function V1CreatePage() {
         <DesmosScript />
       </Head>
       <AppWrapper>
-        <V1Create />
+        <V1UserProvider>
+          <V1Create />
+        </V1UserProvider>
       </AppWrapper>
     </>
   )


### PR DESCRIPTION
## What does this PR do and why?

Follow-up to https://github.com/jbx-protocol/juice-interface/pull/1959.

Only use V1UserProvider on v1 pages.

Previously we needed V1UserProvider globally to fetch the ETH price. As of https://github.com/jbx-protocol/juice-interface/pull/1959, we don't need this no more.

## Screenshots or screen recordings

N/a.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [-] I have tested this PR in dark mode and light mode (if applicable).
