### PR TITLE
Temp fix v1/v1.1 participant subgraph queries

### DIFF
--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -5,21 +5,25 @@ import { emitErrorNotification } from 'utils/notifications'
 
 import { useCallback, useEffect, useState } from 'react'
 import { fromWad } from 'utils/format/formatNumber'
-import { querySubgraphExhaustive } from 'utils/graph'
+import { GraphQueryOpts, querySubgraphExhaustive } from 'utils/graph'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import { readProvider } from 'constants/readProvider'
+import { CV } from 'models/cv'
+import { Participant } from 'models/subgraph-entities/vX/participant'
 import { downloadCsvFile } from 'utils/csv'
 
 export default function DownloadParticipantsModal({
   projectId,
+  cv,
   tokenSymbol,
   projectName,
   visible,
   onCancel,
 }: {
   projectId: number | undefined
+  cv: CV | undefined
   tokenSymbol: string | undefined
   projectName: string | undefined
   visible: boolean | undefined
@@ -37,7 +41,21 @@ export default function DownloadParticipantsModal({
   }, [])
 
   const download = useCallback(async () => {
-    if (blockNumber === undefined || !projectId) return
+    if (blockNumber === undefined || !projectId || !cv) return
+
+    // Projects that migrate between 1 & 1.1 may change their CV without the CV of their participants being updated. This should be fixed by better subgraph infrastructure, but this fix will make sure the UI works for now.
+    const cvOpt: GraphQueryOpts<'participant', keyof Participant>['where'] =
+      cv === '1' || cv === '1.1'
+        ? {
+            key: 'cv',
+            operator: 'in',
+            value: ['1', '1.1'],
+          }
+        : {
+            key: 'cv',
+            value: cv,
+          }
+
     const rows = [
       [
         'Wallet address',
@@ -66,10 +84,13 @@ export default function DownloadParticipantsModal({
         block: {
           number: blockNumber,
         },
-        where: {
-          key: 'projectId',
-          value: projectId,
-        },
+        where: [
+          {
+            key: 'projectId',
+            value: projectId,
+          },
+          cvOpt,
+        ],
       })
 
       if (!participants) {
@@ -99,7 +120,7 @@ export default function DownloadParticipantsModal({
       console.error('Error downloading participants', e)
       setLoading(false)
     }
-  }, [blockNumber, projectId, tokenSymbol, projectName])
+  }, [blockNumber, projectId, tokenSymbol, projectName, cv])
 
   return (
     <Modal

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -16,7 +16,7 @@ import { CV } from 'models/cv'
 import { Participant } from 'models/subgraph-entities/vX/participant'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/format/formatNumber'
-import { OrderDirection, querySubgraph } from 'utils/graph'
+import { GraphQueryOpts, OrderDirection, querySubgraph } from 'utils/graph'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
 import DownloadParticipantsModal from './DownloadParticipantsModal'
@@ -57,10 +57,23 @@ export default function ParticipantsModal({
   useEffect(() => {
     setLoading(true)
 
-    if (!projectId || !visible) {
+    if (!projectId || !visible || !cv) {
       setParticipants([])
       return
     }
+
+    // Projects that migrate between 1 & 1.1 may change their CV without the CV of their participants being updated. This should be fixed by better subgraph infrastructure, but this fix will make sure the UI works for now.
+    const cvOpt: GraphQueryOpts<'participant', keyof Participant>['where'] =
+      cv === '1' || cv === '1.1'
+        ? {
+            key: 'cv',
+            operator: 'in',
+            value: ['1', '1.1'],
+          }
+        : {
+            key: 'cv',
+            value: cv,
+          }
 
     querySubgraph({
       entity: 'participant',
@@ -83,10 +96,7 @@ export default function ParticipantsModal({
                 key: 'projectId',
                 value: projectId,
               },
-              {
-                key: 'cv',
-                value: cv,
-              },
+              cvOpt,
               {
                 key: 'balance',
                 value: 0,
@@ -325,6 +335,7 @@ export default function ParticipantsModal({
         tokenSymbol={tokenSymbol}
         projectName={projectName}
         visible={downloadModalVisible}
+        cv={cv}
         onCancel={() => setDownloadModalVisible(false)}
       />
     </Modal>


### PR DESCRIPTION
## What does this PR do and why?

This is a basic but reliable fix for an issue with querying participants for v1/v1.1 projects. This should eventually be mitigated on the subgraph side, but we can use this workaround until then.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
