### PR TITLE
Split up V2UserContext

### DIFF
--- a/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
+++ b/src/components/v2/V2Project/V2FundingCycleSection/FundingCycleHistory.tsx
@@ -15,7 +15,7 @@ import { formatWad } from 'utils/format/formatNumber'
 import FundingCycleDetails from 'components/v2/V2Project/V2FundingCycleSection/FundingCycleDetails'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
 import useUsedDistributionLimit from 'hooks/v2/contractReader/UsedDistributionLimit'
 import { V2CurrencyOption } from 'models/v2/currencyOption'
@@ -210,7 +210,7 @@ export default function FundingCycleHistory() {
   const { fundingCycle: currentFundingCycle, primaryTerminal } =
     useContext(V2ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
 
   const [selectedIndex, setSelectedIndex] = useState<number>()
   const [pastFundingCycles, setPastFundingCycles] = useState<V2FundingCycle[]>(

--- a/src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/GrantTransferPermissionCallout.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import Callout from 'components/Callout'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useV1SetOperatorTx } from 'hooks/v1/transactor/V1SetOperatorTx'
 import { V1OperatorPermission } from 'models/v1/permissions'
 import { useContext, useState } from 'react'
@@ -12,7 +12,7 @@ export function GrantTransferPermissionCallout({
 }: {
   onFinish?: VoidFunction
 }) {
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   const [setPermissionLoading, setSetPermissionLoading] =
     useState<boolean>(false)
   const setV1OperatorTx = useV1SetOperatorTx()

--- a/src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
+++ b/src/components/v2/V2Project/V2ManageTokensSection/V1ProjectTokensSection/MigrateV1ProjectTokensModal/MigrateV1ProjectTokensModal.tsx
@@ -7,7 +7,7 @@ import { useContext, useState } from 'react'
 import { parseWad } from 'utils/format/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useV1HasPermissions } from 'hooks/v1/contractReader/V1HasPermissions'
 import { V1OperatorPermission } from 'models/v1/permissions'
 
@@ -26,7 +26,7 @@ export function MigrateProjectTokensModal({
   v1ProjectHandle: string
 } & ModalProps) {
   const { userAddress } = useWallet()
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
 
   const [loading, setLoading] = useState<boolean>(false)
   const [transactionPending, setTransactionPending] = useState<boolean>(false)

--- a/src/components/v2/V2Project/V2ProjectSettings/pages/GovernanceSettingsPage/SnapshotSettingsSection.tsx
+++ b/src/components/v2/V2Project/V2ProjectSettings/pages/GovernanceSettingsPage/SnapshotSettingsSection.tsx
@@ -3,7 +3,7 @@ import { Button, Tooltip } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useSetENSTextRecordForHandleTx } from 'hooks/v2/transactor/SetENSTextRecordForHandleTx'
 import { pokeSnapshot, uploadSnapshotSettingsToIPFS } from 'lib/snapshot'
 import Link from 'next/link'
@@ -14,7 +14,7 @@ import { helpPagePath } from 'utils/routes'
 export function SnapshotSettingsSection() {
   const { tokenSymbol, tokenAddress, handle, projectOwnerAddress } =
     useContext(V2ProjectContext)
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectMetadata, projectId } = useContext(ProjectMetadataContext)
 
   const JBTokenStoreAddress = contracts?.JBTokenStore.address

--- a/src/components/v2/V2Project/V2ProjectSettings/pages/V1V2TokenMigrationSettingsPage/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
+++ b/src/components/v2/V2Project/V2ProjectSettings/pages/V1V2TokenMigrationSettingsPage/V1TokenMigrationSetupSection/V1TokenMigrationSetupModal/AddTerminalSection.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import { MinimalCollapse } from 'components/MinimalCollapse'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useSetProjectTerminalsTx } from 'hooks/v2/transactor/SetProjectTerminalsTx'
 import { useCallback, useContext, useState } from 'react'
 import { emitErrorNotification } from 'utils/notifications'
@@ -16,7 +16,7 @@ export function AddTerminalSection({
   completed: boolean
   onCompleted: VoidFunction
 }) {
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   const [addTerminalLoading, setAddTerminalLoading] = useState<boolean>(false)
   const setProjectTerminalsTx = useSetProjectTerminalsTx()
   const { terminals } = useContext(V2ProjectContext)

--- a/src/components/v2/V2Project/V2ProjectSettings/pages/V2ProjectReconfigureFundingCycleSettingsPage/hooks/initialEditingData.ts
+++ b/src/components/v2/V2Project/V2ProjectSettings/pages/V2ProjectReconfigureFundingCycleSettingsPage/hooks/initialEditingData.ts
@@ -21,7 +21,7 @@ import { V2ProjectContext } from 'contexts/v2/projectContext'
 
 import useProjectQueuedFundingCycle from 'hooks/v2/contractReader/ProjectQueuedFundingCycle'
 
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 
 import { useAppDispatch } from 'hooks/AppDispatch'
 
@@ -53,7 +53,7 @@ export const useInitialEditingData = (visible: boolean) => {
     }
   }>()
 
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   const dispatch = useAppDispatch()
 
   const {

--- a/src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
+++ b/src/components/v2/V2Project/banners/RelaunchFundingCycleBanner.tsx
@@ -5,7 +5,7 @@ import { useContext, useEffect, useMemo, useState } from 'react'
 import { BigNumber } from '@ethersproject/bignumber'
 import Banner from 'components/Banner'
 import TransactionModal from 'components/TransactionModal'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import useProjectCurrentFundingCycle from 'hooks/v2/contractReader/ProjectCurrentFundingCycle'
 import useProjectDistributionLimit from 'hooks/v2/contractReader/ProjectDistributionLimit'
 import useProjectSplits from 'hooks/v2/contractReader/ProjectSplits'
@@ -34,7 +34,7 @@ import ReconfigurePreview from '../V2ProjectSettings/pages/V2ProjectReconfigureF
 
 export function RelaunchFundingCycleBanner() {
   const { projectId } = useContext(ProjectMetadataContext)
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   const [newDuration, setNewDuration] = useState<BigNumber>(BigNumber.from(0))
   const [newStart, setNewStart] = useState<string>('1')
 

--- a/src/contexts/transactionContext.ts
+++ b/src/contexts/transactionContext.ts
@@ -1,0 +1,6 @@
+import { Transactor } from 'hooks/Transactor'
+import { createContext } from 'react'
+
+export const TransactionContext: React.Context<{
+  transactor?: Transactor
+}> = createContext({})

--- a/src/contexts/v2/V2ContractsContext.ts
+++ b/src/contexts/v2/V2ContractsContext.ts
@@ -1,8 +1,6 @@
-import { Transactor } from 'hooks/Transactor'
 import { V2Contracts } from 'models/v2/contracts'
 import { createContext } from 'react'
 
-export const V2UserContext: React.Context<{
+export const V2ContractsContext: React.Context<{
   contracts?: V2Contracts
-  transactor?: Transactor
 }> = createContext({})

--- a/src/hooks/v2/contractReader/ETHPaymentTerminalFee.ts
+++ b/src/hooks/v2/contractReader/ETHPaymentTerminalFee.ts
@@ -1,10 +1,10 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext, useEffect, useState } from 'react'
 
 export function useETHPaymentTerminalFee() {
   const [fee, setFee] = useState<BigNumber>()
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
 
   useEffect(() => {
     async function fetchData() {

--- a/src/hooks/v2/contractReader/V2ContractReader.ts
+++ b/src/hooks/v2/contractReader/V2ContractReader.ts
@@ -1,4 +1,4 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { ContractReaderProps, useContractReader } from 'hooks/ContractReader'
 import { V2ContractName } from 'models/v2/contracts'
 import { useContext } from 'react'
@@ -8,6 +8,6 @@ export type ContractReadResult<V> = { data: V | undefined; loading: boolean }
 export default function useV2ContractReader<V>(
   props: Omit<ContractReaderProps<V2ContractName, V>, 'contracts'>,
 ): ContractReadResult<V> {
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   return useContractReader({ ...props, contracts })
 }

--- a/src/hooks/v2/hasV1TokenPaymentTerminal.ts
+++ b/src/hooks/v2/hasV1TokenPaymentTerminal.ts
@@ -1,10 +1,10 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { useHasPaymentTerminal } from './hasPaymentTerminal'
 
 export function useHasV1TokenPaymentTerminal(): boolean {
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
 
   return useHasPaymentTerminal(contracts?.JBV1TokenPaymentTerminal.address)
 }

--- a/src/hooks/v2/transactor/AddToBalanceTx.ts
+++ b/src/hooks/v2/transactor/AddToBalanceTx.ts
@@ -1,10 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { onCatch, TransactorInstance } from 'hooks/Transactor'
 import invariant from 'tiny-invariant'
 import { useV2ProjectTitle } from '../ProjectTitle'
@@ -14,8 +15,10 @@ const DEFAULT_METADATA = 0
 export function useAddToBalanceTx(): TransactorInstance<{
   value: BigNumber
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
-  const { projectId } = useContext(ProjectMetadataContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
+  const { projectId, cv } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   const DEFAULT_MEMO = ''
@@ -50,7 +53,7 @@ export function useAddToBalanceTx(): TransactorInstance<{
       return onCatch({
         txOpts,
         missingParam,
-        cv: '2',
+        cv,
         functionName: 'addToBalanceOf',
       })
     }

--- a/src/hooks/v2/transactor/ClaimTokensTx.ts
+++ b/src/hooks/v2/transactor/ClaimTokensTx.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { onCatch, TransactorInstance } from 'hooks/Transactor'
 import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
@@ -12,7 +13,8 @@ import { tokenSymbolText } from 'utils/tokenSymbolText'
 export function useClaimTokensTx(): TransactorInstance<{
   claimAmount: BigNumber
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { tokenSymbol } = useContext(V2ProjectContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 

--- a/src/hooks/v2/transactor/DeployProjectPayerTx.ts
+++ b/src/hooks/v2/transactor/DeployProjectPayerTx.ts
@@ -1,10 +1,11 @@
 import * as constants from '@ethersproject/constants'
 import { t } from '@lingui/macro'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -16,9 +17,11 @@ export type DeployProjectPayerTxArgs = {
 }
 
 export function useDeployProjectPayerTx(): TransactorInstance<DeployProjectPayerTxArgs> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { userAddress } = useWallet()
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   const DEFAULT_MEMO = ''

--- a/src/hooks/v2/transactor/DistributePayouts.ts
+++ b/src/hooks/v2/transactor/DistributePayouts.ts
@@ -1,4 +1,4 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { BigNumber } from '@ethersproject/bignumber'
@@ -8,6 +8,7 @@ import { V2CurrencyOption } from 'models/v2/currencyOption'
 import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -20,8 +21,10 @@ type DistributePayoutsTx = TransactorInstance<{
 const minReturnedTokens = 0 // TODO will need a field for this in WithdrawModal for v2
 
 export function useDistributePayoutsTx(): DistributePayoutsTx {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ amount, currency, memo = '' }, txOpts) => {

--- a/src/hooks/v2/transactor/DistributeReservedTokensTx.ts
+++ b/src/hooks/v2/transactor/DistributeReservedTokensTx.ts
@@ -1,9 +1,10 @@
 import { t } from '@lingui/macro'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -12,7 +13,8 @@ type DistributeReserveTokensTx = TransactorInstance<{
 }>
 
 export function useDistributeReservedTokens(): DistributeReserveTokensTx {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { tokenSymbol } = useContext(V2ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
 

--- a/src/hooks/v2/transactor/EditV2ProjectDetailsTx.ts
+++ b/src/hooks/v2/transactor/EditV2ProjectDetailsTx.ts
@@ -1,18 +1,21 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { JUICEBOX_MONEY_PROJECT_METADATA_DOMAIN } from 'constants/metadataDomain'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 export function useEditV2ProjectDetailsTx(): TransactorInstance<{
   cid: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ cid }, txOpts) => {

--- a/src/hooks/v2/transactor/EditV2ProjectHandleTx.ts
+++ b/src/hooks/v2/transactor/EditV2ProjectHandleTx.ts
@@ -1,16 +1,19 @@
 import { t } from '@lingui/macro'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 export function useEditV2ProjectHandleTx(): TransactorInstance<{
   ensName: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ ensName }, txOpts) => {

--- a/src/hooks/v2/transactor/IssueErc20TokenTx.ts
+++ b/src/hooks/v2/transactor/IssueErc20TokenTx.ts
@@ -1,16 +1,18 @@
 import { t } from '@lingui/macro'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 import invariant from 'tiny-invariant'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { onCatch, TransactorInstance } from 'hooks/Transactor'
 
 export function useIssueErc20TokenTx(): TransactorInstance<{
   name: string
   symbol: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 
   return ({ name, symbol }, txOpts) => {

--- a/src/hooks/v2/transactor/LaunchFundingCyclesTx.ts
+++ b/src/hooks/v2/transactor/LaunchFundingCyclesTx.ts
@@ -1,4 +1,4 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useWallet } from 'hooks/Wallet'
 import {
   V2FundAccessConstraint,
@@ -10,8 +10,9 @@ import { useContext } from 'react'
 import { GroupedSplits, SplitGroup } from 'models/splits'
 import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
-import { TransactorInstance } from 'hooks/Transactor'
 import { t } from '@lingui/macro'
+import { TransactionContext } from 'contexts/transactionContext'
+import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 const DEFAULT_MUST_START_AT_OR_AFTER = '1' // start immediately
@@ -25,7 +26,9 @@ export function useLaunchFundingCyclesTx(): TransactorInstance<{
   groupedSplits?: GroupedSplits<SplitGroup>[]
   mustStartAtOrAfter?: string // epoch seconds. anything less than "now" will start immediately.
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
+
   const { userAddress } = useWallet()
   const projectTitle = useV2ProjectTitle()
 

--- a/src/hooks/v2/transactor/LaunchProjectTx.ts
+++ b/src/hooks/v2/transactor/LaunchProjectTx.ts
@@ -1,4 +1,4 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useWallet } from 'hooks/Wallet'
 import {
   V2FundAccessConstraint,
@@ -10,8 +10,9 @@ import { useContext } from 'react'
 import { GroupedSplits, SplitGroup } from 'models/splits'
 import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
-import { JUICEBOX_MONEY_PROJECT_METADATA_DOMAIN } from 'constants/metadataDomain'
 import { t } from '@lingui/macro'
+import { JUICEBOX_MONEY_PROJECT_METADATA_DOMAIN } from 'constants/metadataDomain'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -26,8 +27,10 @@ export function useLaunchProjectTx(): TransactorInstance<{
   groupedSplits?: GroupedSplits<SplitGroup>[]
   mustStartAtOrAfter?: string // epoch seconds. anything less than "now" will start immediately.
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { userAddress } = useWallet()
+
   const projectTitle = useV2ProjectTitle()
 
   return (

--- a/src/hooks/v2/transactor/LaunchProjectWithNftsTx.ts
+++ b/src/hooks/v2/transactor/LaunchProjectWithNftsTx.ts
@@ -1,6 +1,6 @@
 import { getAddress } from '@ethersproject/address'
 import * as constants from '@ethersproject/constants'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useWallet } from 'hooks/Wallet'
 import {
   V2FundAccessConstraint,
@@ -18,9 +18,10 @@ import { encodeIPFSUri, ipfsCidUrl } from 'utils/ipfs'
 import { getLatestNftDelegateStoreContractAddress } from 'utils/nftRewards'
 import { isValidMustStartAtOrAfter } from 'utils/v2/fundingCycle'
 
-import { JUICEBOX_MONEY_PROJECT_METADATA_DOMAIN } from 'constants/metadataDomain'
 import { t } from '@lingui/macro'
+import { JUICEBOX_MONEY_PROJECT_METADATA_DOMAIN } from 'constants/metadataDomain'
 import { MaxUint48 } from 'constants/numbers'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -96,7 +97,8 @@ export function useLaunchProjectWithNftsTx(): TransactorInstance<{
   mustStartAtOrAfter?: string // epoch seconds. anything less than "now" will start immediately.
   nftRewards: TxNftArg
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { userAddress } = useWallet()
   const projectTitle = useV2ProjectTitle()
 

--- a/src/hooks/v2/transactor/MintTokensTx.ts
+++ b/src/hooks/v2/transactor/MintTokensTx.ts
@@ -1,10 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { onCatch, TransactorInstance } from 'hooks/Transactor'
 import invariant from 'tiny-invariant'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
@@ -15,7 +16,8 @@ export function useMintTokensTx(): TransactorInstance<{
   preferClaimed: boolean
   memo: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { tokenSymbol } = useContext(V2ProjectContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 

--- a/src/hooks/v2/transactor/PayETHPaymentTerminal.ts
+++ b/src/hooks/v2/transactor/PayETHPaymentTerminal.ts
@@ -1,4 +1,4 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { BigNumber } from '@ethersproject/bignumber'
@@ -6,6 +6,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -20,8 +21,10 @@ type PayV2ProjectTx = TransactorInstance<{
 }>
 
 export function usePayETHPaymentTerminalTx(): PayV2ProjectTx {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ memo, preferClaimedTokens, beneficiary, value }, txOpts) => {

--- a/src/hooks/v2/transactor/PayV1TokenPaymentTerminal.ts
+++ b/src/hooks/v2/transactor/PayV1TokenPaymentTerminal.ts
@@ -2,10 +2,11 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { useContext } from 'react'
 
 import * as constants from '@ethersproject/constants'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -20,8 +21,10 @@ type PayV2ProjectTx = TransactorInstance<{
 }>
 
 export function usePayV1TokenPaymentTerminal(): PayV2ProjectTx {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ memo, preferClaimedTokens, beneficiary, value }, txOpts) => {

--- a/src/hooks/v2/transactor/ReconfigureV2FundingCycleTx.ts
+++ b/src/hooks/v2/transactor/ReconfigureV2FundingCycleTx.ts
@@ -2,7 +2,8 @@ import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { TransactionContext } from 'contexts/transactionContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { GroupedSplits, SplitGroup } from 'models/splits'
 import {
@@ -23,8 +24,10 @@ export function useReconfigureV2FundingCycleTx(): TransactorInstance<{
   mustStartAtOrAfter?: string // epoch seconds. anything less than "now" will start immediately.
   memo: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return (

--- a/src/hooks/v2/transactor/RedeemTokensTx.ts
+++ b/src/hooks/v2/transactor/RedeemTokensTx.ts
@@ -4,10 +4,11 @@ import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
 
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { onCatch, TransactorInstance } from 'hooks/Transactor'
 import invariant from 'tiny-invariant'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
@@ -19,7 +20,8 @@ export function useRedeemTokensTx(): TransactorInstance<{
   minReturnedTokens: BigNumber
   memo: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { tokenSymbol } = useContext(V2ProjectContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 

--- a/src/hooks/v2/transactor/SetENSTextRecordForHandleTx.ts
+++ b/src/hooks/v2/transactor/SetENSTextRecordForHandleTx.ts
@@ -1,9 +1,10 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { namehash } from 'ethers/lib/utils'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 
 export function useSetENSTextRecordForHandleTx(): TransactorInstance<{
@@ -11,7 +12,8 @@ export function useSetENSTextRecordForHandleTx(): TransactorInstance<{
   key: string
   value: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
 
   return ({ ensName, key, value }, txOpts) => {

--- a/src/hooks/v2/transactor/SetProjectSplits.ts
+++ b/src/hooks/v2/transactor/SetProjectSplits.ts
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { TransactionContext } from 'contexts/transactionContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { GroupedSplits } from 'models/splits'
 import { useContext } from 'react'
@@ -14,7 +15,8 @@ export const useSetProjectSplits = <G>({
 }): TransactorInstance<{
   groupedSplits: GroupedSplits<G>
 }> => {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
   const projectTitle = useV2ProjectTitle()
 

--- a/src/hooks/v2/transactor/SetProjectTerminalsTx.ts
+++ b/src/hooks/v2/transactor/SetProjectTerminalsTx.ts
@@ -1,16 +1,19 @@
 import { t } from '@lingui/macro'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 export function useSetProjectTerminalsTx(): TransactorInstance<{
   terminals: string[]
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ terminals }, txOpts) => {

--- a/src/hooks/v2/transactor/SetV1ProjectIdTx.ts
+++ b/src/hooks/v2/transactor/SetV1ProjectIdTx.ts
@@ -1,17 +1,20 @@
 import { t } from '@lingui/macro'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 export function useSetV1ProjectIdTx(): TransactorInstance<{
   v1ProjectId: number
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
   const { signer } = useWallet()
 

--- a/src/hooks/v2/transactor/TransferProjectOwnershipTx.ts
+++ b/src/hooks/v2/transactor/TransferProjectOwnershipTx.ts
@@ -1,18 +1,21 @@
 import { t } from '@lingui/macro'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 export function useTransferProjectOwnershipTx(): TransactorInstance<{
   newOwnerAddress: string // new owner address
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectOwnerAddress } = useContext(V2ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
   const projectTitle = useV2ProjectTitle()
 
   return ({ newOwnerAddress }, txOpts) => {

--- a/src/hooks/v2/transactor/TransferUnclaimedTokensTx.ts
+++ b/src/hooks/v2/transactor/TransferUnclaimedTokensTx.ts
@@ -1,11 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -13,10 +14,12 @@ export function useTransferUnclaimedTokensTx(): TransactorInstance<{
   amount: BigNumber
   to: string
 }> {
-  const { transactor, contracts } = useContext(V2UserContext)
-  const { userAddress } = useWallet()
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { tokenSymbol } = useContext(V2ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
+
+  const { userAddress } = useWallet()
 
   return ({ amount, to }, txOpts) => {
     if (!transactor || !projectId || !contracts?.JBTokenStore) {

--- a/src/hooks/veNft/transactor/ERC20ApproveTx.ts
+++ b/src/hooks/veNft/transactor/ERC20ApproveTx.ts
@@ -1,7 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
+import { TransactionContext } from 'contexts/transactionContext'
 
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContractReader } from 'hooks/ContractReader'
 import { useErc20Contract } from 'hooks/Erc20Contract'
 import { TransactorInstance } from 'hooks/Transactor'
@@ -16,7 +17,8 @@ export type ERC20ApproveArgs = {
 export default function useERC20Approve(
   erc20address: string | undefined,
 ): TransactorInstance<ERC20ApproveArgs> {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const contract = useErc20Contract(erc20address)
 
   const { data: symbol } = useContractReader({

--- a/src/hooks/veNft/transactor/LaunchVeNftTx.ts
+++ b/src/hooks/veNft/transactor/LaunchVeNftTx.ts
@@ -1,8 +1,9 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useWallet } from 'hooks/Wallet'
 
@@ -14,7 +15,8 @@ export type ExtendLockTx = TransactorInstance<{
 }>
 
 export function useLaunchVeNftTx(): ExtendLockTx {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { userAddress } = useWallet()
   const { projectId } = useContext(ProjectMetadataContext)
 

--- a/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftExtendLockTx.ts
@@ -1,7 +1,7 @@
-import { V2UserContext } from 'contexts/v2/userContext'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useVeNftContract } from 'hooks/veNft/VeNftContract'
 
@@ -11,7 +11,7 @@ export type ExtendLockTx = TransactorInstance<{
 }>
 
 export function useExtendLockTx(): ExtendLockTx {
-  const { transactor } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
   const nftContract = useVeNftContract()
 
   return ({ tokenId, updatedDuration }, txOpts) => {

--- a/src/hooks/veNft/transactor/VeNftLockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftLockTx.ts
@@ -1,8 +1,8 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
-import { V2UserContext } from 'contexts/v2/userContext'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useVeNftContract } from 'hooks/veNft/VeNftContract'
 
@@ -16,7 +16,7 @@ export type LockTx = TransactorInstance<{
 }>
 
 export function useLockTx(): LockTx {
-  const { transactor } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
   const nftContract = useVeNftContract()
 
   return (

--- a/src/hooks/veNft/transactor/VeNftRedeemTx.ts
+++ b/src/hooks/veNft/transactor/VeNftRedeemTx.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { V2UserContext } from 'contexts/v2/userContext'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useVeNftContract } from 'hooks/veNft/VeNftContract'
 
@@ -15,7 +15,7 @@ export type RedeemVeNftTx = TransactorInstance<{
 }>
 
 export function useRedeemVeNftTx(): RedeemVeNftTx {
-  const { transactor } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
   const nftContract = useVeNftContract()
   const minReturnedTokens = BigNumber.from(0) // TODO will need a field for this in V2ConfirmPayOwnerModal
   const metadata: string[] = [] //randomBytes(1)

--- a/src/hooks/veNft/transactor/VeNftUnclaimedTokenPermissions.ts
+++ b/src/hooks/veNft/transactor/VeNftUnclaimedTokenPermissions.ts
@@ -1,16 +1,18 @@
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useContext } from 'react'
 
 import { TransactorInstance } from 'hooks/Transactor'
 
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { VeNftContext } from 'contexts/veNftContext'
 import { useV2ProjectTitle } from 'hooks/v2/ProjectTitle'
 import { V2OperatorPermission } from 'models/v2/permissions'
 
 export function useUnclaimedTokensPermissionTx(): TransactorInstance {
-  const { transactor, contracts } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
   const { contractAddress } = useContext(VeNftContext)
 

--- a/src/hooks/veNft/transactor/VeNftUnlockTx.ts
+++ b/src/hooks/veNft/transactor/VeNftUnlockTx.ts
@@ -1,7 +1,7 @@
-import { V2UserContext } from 'contexts/v2/userContext'
 import { useContext } from 'react'
 
 import { t } from '@lingui/macro'
+import { TransactionContext } from 'contexts/transactionContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useVeNftContract } from 'hooks/veNft/VeNftContract'
 
@@ -11,7 +11,7 @@ export type UnlockTx = TransactorInstance<{
 }>
 
 export function useUnlockTx(): UnlockTx {
-  const { transactor } = useContext(V2UserContext)
+  const { transactor } = useContext(TransactionContext)
   const nftContract = useVeNftContract()
 
   return ({ tokenId, beneficiary }, txOpts) => {

--- a/src/pages/create/forms/FundingForm/index.tsx
+++ b/src/pages/create/forms/FundingForm/index.tsx
@@ -11,7 +11,7 @@ import { DEFAULT_BALLOT_STRATEGY } from 'constants/v2/ballotStrategies'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 import { ThemeContext } from 'contexts/themeContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { useAppDispatch } from 'hooks/AppDispatch'
 import { useAppSelector } from 'hooks/AppSelector'
 import isEqual from 'lodash/isEqual'
@@ -73,7 +73,7 @@ export default function FundingForm({
     theme,
     theme: { colors },
   } = useContext(ThemeContext)
-  const { contracts } = useContext(V2UserContext)
+  const { contracts } = useContext(V2ContractsContext)
   const { payoutSplits } = useContext(V2ProjectContext)
 
   const dispatch = useAppDispatch()

--- a/src/pages/create/index.page.tsx
+++ b/src/pages/create/index.page.tsx
@@ -5,7 +5,8 @@ import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import { ThemeContext } from 'contexts/themeContext'
 import useMobile from 'hooks/Mobile'
 import Head from 'next/head'
-import { V2UserProvider } from 'providers/v2/UserProvider'
+import { TransactionProvider } from 'providers/TransactionProvider'
+import { V2ContractsProvider } from 'providers/v2/V2ContractsProvider'
 import { V2CurrencyProvider } from 'providers/v2/V2CurrencyProvider'
 import { useContext, useState } from 'react'
 import { scrollToTop } from 'utils/windowUtils'
@@ -62,46 +63,48 @@ function V2Create() {
   const isMobile = useMobile()
 
   return (
-    <V2UserProvider>
-      <V2CurrencyProvider>
-        <div
-          style={{
-            maxWidth: 1200,
-            margin: '0 auto',
-            padding: !isMobile ? '2rem 4rem' : '2rem 1rem',
-          }}
-        >
-          <h1
+    <V2ContractsProvider>
+      <TransactionProvider>
+        <V2CurrencyProvider>
+          <div
             style={{
-              color: colors.text.primary,
-              fontSize: 28,
+              maxWidth: 1200,
+              margin: '0 auto',
+              padding: !isMobile ? '2rem 4rem' : '2rem 1rem',
             }}
           >
-            <Trans>Launch your project</Trans>
-          </h1>
+            <h1
+              style={{
+                color: colors.text.primary,
+                fontSize: 28,
+              }}
+            >
+              <Trans>Launch your project</Trans>
+            </h1>
 
-          <Tabs
-            activeKey={activeTab}
-            onChange={setActiveTab}
-            tabBarGutter={50}
-            size="large"
-          >
-            {TABS.map((tab, idx) => (
-              <TabPane tab={<TabText>{tab.title}</TabText>} key={idx}>
-                <tab.component
-                  onFinish={() => {
-                    // bail if on last tab.
-                    if (idx === TABS.length - 1) return
+            <Tabs
+              activeKey={activeTab}
+              onChange={setActiveTab}
+              tabBarGutter={50}
+              size="large"
+            >
+              {TABS.map((tab, idx) => (
+                <TabPane tab={<TabText>{tab.title}</TabText>} key={idx}>
+                  <tab.component
+                    onFinish={() => {
+                      // bail if on last tab.
+                      if (idx === TABS.length - 1) return
 
-                    setActiveTab(`${idx + 1}`)
-                    scrollToTop()
-                  }}
-                />
-              </TabPane>
-            ))}
-          </Tabs>
-        </div>
-      </V2CurrencyProvider>
-    </V2UserProvider>
+                      setActiveTab(`${idx + 1}`)
+                      scrollToTop()
+                    }}
+                  />
+                </TabPane>
+              ))}
+            </Tabs>
+          </div>
+        </V2CurrencyProvider>
+      </TransactionProvider>
+    </V2ContractsProvider>
   )
 }

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -10,7 +10,8 @@ import {
   GetStaticPropsResult,
   InferGetStaticPropsType,
 } from 'next'
-import { V2UserProvider } from 'providers/v2/UserProvider'
+import { TransactionProvider } from 'providers/TransactionProvider'
+import { V2ContractsProvider } from 'providers/v2/V2ContractsProvider'
 import V2Dashboard from './components/V2Dashboard'
 import { getProjectProps, ProjectPageProps } from './utils/props'
 
@@ -65,13 +66,15 @@ export default function V2ProjectPage({
         </SEO>
       ) : null}
       <AppWrapper>
-        <V2UserProvider>
-          {metadata ? (
-            <V2Dashboard metadata={metadata} projectId={projectId} />
-          ) : (
-            <Loading />
-          )}
-        </V2UserProvider>
+        <V2ContractsProvider>
+          <TransactionProvider>
+            {metadata ? (
+              <V2Dashboard metadata={metadata} projectId={projectId} />
+            ) : (
+              <Loading />
+            )}
+          </TransactionProvider>
+        </V2ContractsProvider>
       </AppWrapper>
     </>
   )

--- a/src/pages/v2/p/[projectId]/settings/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/settings/index.page.tsx
@@ -2,7 +2,8 @@ import { AppWrapper } from 'components/common'
 import { V2ProjectSettings } from 'components/v2/V2Project/V2ProjectSettings'
 import { ProjectMetadataV4 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
-import { V2UserProvider } from 'providers/v2/UserProvider'
+import { TransactionProvider } from 'providers/TransactionProvider'
+import { V2ContractsProvider } from 'providers/v2/V2ContractsProvider'
 import V2ProjectMetadataProvider from 'providers/v2/V2ProjectMetadataProvider'
 import V2ProjectProvider from 'providers/v2/V2ProjectProvider'
 import { getProjectProps, ProjectPageProps } from '../utils/props'
@@ -25,13 +26,15 @@ export default function V2ProjectSettingsPage({
 }) {
   return (
     <AppWrapper>
-      <V2UserProvider>
-        <V2ProjectMetadataProvider projectId={projectId} metadata={metadata}>
-          <V2ProjectProvider projectId={projectId}>
-            <V2ProjectSettings />
-          </V2ProjectProvider>
-        </V2ProjectMetadataProvider>
-      </V2UserProvider>
+      <V2ContractsProvider>
+        <TransactionProvider>
+          <V2ProjectMetadataProvider projectId={projectId} metadata={metadata}>
+            <V2ProjectProvider projectId={projectId}>
+              <V2ProjectSettings />
+            </V2ProjectProvider>
+          </V2ProjectMetadataProvider>
+        </TransactionProvider>
+      </V2ContractsProvider>
     </AppWrapper>
   )
 }

--- a/src/pages/v2/p/[projectId]/venft/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/venft/index.page.tsx
@@ -2,7 +2,8 @@ import { AppWrapper } from 'components/common'
 import { VeNft } from 'components/veNft/VeNft'
 import { ProjectMetadataV4 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
-import { V2UserProvider } from 'providers/v2/UserProvider'
+import { TransactionProvider } from 'providers/TransactionProvider'
+import { V2ContractsProvider } from 'providers/v2/V2ContractsProvider'
 import V2ProjectMetadataProvider from 'providers/v2/V2ProjectMetadataProvider'
 import V2ProjectProvider from 'providers/v2/V2ProjectProvider'
 import { VeNftProvider } from 'providers/v2/VeNftProvider'
@@ -26,15 +27,17 @@ export default function V2ProjectSettingsPage({
 }) {
   return (
     <AppWrapper>
-      <V2UserProvider>
-        <V2ProjectMetadataProvider projectId={projectId} metadata={metadata}>
-          <V2ProjectProvider projectId={projectId}>
-            <VeNftProvider projectId={projectId}>
-              <VeNft />
-            </VeNftProvider>
-          </V2ProjectProvider>
-        </V2ProjectMetadataProvider>
-      </V2UserProvider>
+      <V2ContractsProvider>
+        <TransactionProvider>
+          <V2ProjectMetadataProvider projectId={projectId} metadata={metadata}>
+            <V2ProjectProvider projectId={projectId}>
+              <VeNftProvider projectId={projectId}>
+                <VeNft />
+              </VeNftProvider>
+            </V2ProjectProvider>
+          </V2ProjectMetadataProvider>
+        </TransactionProvider>
+      </V2ContractsProvider>
     </AppWrapper>
   )
 }

--- a/src/providers/TransactionProvider.tsx
+++ b/src/providers/TransactionProvider.tsx
@@ -1,26 +1,21 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { V2UserContext } from 'contexts/v2/userContext'
+import { TransactionContext } from 'contexts/transactionContext'
 import { useGasPriceQuery } from 'hooks/GasPrice'
 import { useTransactor } from 'hooks/Transactor'
-import { useV2ContractLoader } from 'hooks/v2/V2ContractLoader'
 
-export const V2UserProvider: React.FC = ({ children }) => {
-  const contracts = useV2ContractLoader()
-
+export const TransactionProvider: React.FC = ({ children }) => {
   const { data: gasPrice } = useGasPriceQuery('average')
-
   const transactor = useTransactor({
     gasPrice: gasPrice ? BigNumber.from(gasPrice) : undefined,
   })
 
   return (
-    <V2UserContext.Provider
+    <TransactionContext.Provider
       value={{
-        contracts,
         transactor,
       }}
     >
       {children}
-    </V2UserContext.Provider>
+    </TransactionContext.Provider>
   )
 }

--- a/src/providers/v2/V2ContractsProvider.tsx
+++ b/src/providers/v2/V2ContractsProvider.tsx
@@ -1,0 +1,16 @@
+import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
+import { useV2ContractLoader } from 'hooks/v2/V2ContractLoader'
+
+export const V2ContractsProvider: React.FC = ({ children }) => {
+  const contracts = useV2ContractLoader()
+
+  return (
+    <V2ContractsContext.Provider
+      value={{
+        contracts,
+      }}
+    >
+      {children}
+    </V2ContractsContext.Provider>
+  )
+}


### PR DESCRIPTION
This PR splits up V2Usercontext into 2 contexts:
- TransactionContext
- V2ContractsContext

TransactionContext can be reused across v1, 2 and 3.

Towards V3.