### PR TITLE
redirect to projects page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,7 +17,7 @@ module.exports = {
   async redirects() {
     return [
       {
-        source: '/p',
+        source: '/projects',
         destination: '/projects',
         permanent: true,
       },


### PR DESCRIPTION
## What does this PR do and why?

going to `/p/projects` straight from the url bar gives the end user an error on local, and an infinite load on prod.


This change redirects the user to `/projects`
## Screenshots or screen recordings
current: 
<img width="1531" alt="CleanShot 2022-09-17 at 11 04 41@2x" src="https://user-images.githubusercontent.com/2502947/190863601-6987751f-2f2a-48f9-9821-0a1953ea76a0.png">


after: 
![CleanShot 2022-09-17 at 11 03 40](https://user-images.githubusercontent.com/2502947/190863608-7af899bb-0d3f-4638-95d2-c8113b5f714f.gif)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
