### PR TITLE
Fix for navbar remains solid when modal is open

### DIFF
--- a/src/components/Navbar/navStyles.ts
+++ b/src/components/Navbar/navStyles.ts
@@ -5,6 +5,7 @@ export const topNavStyles: CSSProperties = {
   justifyContent: 'space-between',
   alignItems: 'center',
   background: 'var(--background-l0)',
+  zIndex: 1,
 }
 
 export const topRightNavStyles: CSSProperties = {


### PR DESCRIPTION
## What does this PR do and why?

Fixes - https://github.com/jbx-protocol/juice-interface/issues/2000

It was z-index issue, ive applied a fix in `navStyles.ts`

## Screenshots or screen recordings

**Before**
![image](https://user-images.githubusercontent.com/18723426/190897923-2b6fbff0-a261-4e42-badc-dbbfc7458f69.png)

**After**
![image](https://user-images.githubusercontent.com/18723426/190897939-6cde3589-bfe2-46d5-a1df-ee8486157c25.png)


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
