### PR TITLE
Add callback support to transaction history poller

### DIFF
--- a/src/components/Navbar/TransactionList/TransactionItem.tsx
+++ b/src/components/Navbar/TransactionList/TransactionItem.tsx
@@ -52,7 +52,7 @@ export function TransactionItem({
         </div>
 
         <ExternalLink
-          href={tx.tx.hash ? etherscanLink('tx', tx.tx.hash) : undefined}
+          href={tx.tx?.hash ? etherscanLink('tx', tx.tx.hash) : undefined}
           style={{ fontSize: '0.85rem' }}
           className="text-primary hover-text-decoration-underline"
         >

--- a/src/components/Navbar/TransactionList/TransactionsList.tsx
+++ b/src/components/Navbar/TransactionList/TransactionsList.tsx
@@ -71,24 +71,26 @@ export function TransactionsList({
               .sort((a, b) =>
                 timestampForTxLog(a) > timestampForTxLog(b) ? -1 : 1,
               )
-              .map(tx => (
-                <TransactionItem
-                  key={tx.tx.hash}
-                  tx={tx}
-                  onRemoveTransaction={
-                    removeTransaction
-                      ? () => {
-                          removeTransaction(tx.id)
+              .map(tx =>
+                tx ? (
+                  <TransactionItem
+                    key={tx.tx?.hash}
+                    tx={tx}
+                    onRemoveTransaction={
+                      removeTransaction
+                        ? () => {
+                            removeTransaction(tx.id)
 
-                          // Close menu if removing last tx
-                          if (transactions.length === 1 && isExpanded) {
-                            setIsExpanded(false)
+                            // Close menu if removing last tx
+                            if (transactions.length === 1 && isExpanded) {
+                              setIsExpanded(false)
+                            }
                           }
-                        }
-                      : undefined
-                  }
-                />
-              ))
+                        : undefined
+                    }
+                  />
+                ) : null,
+              )
           ) : (
             <div style={{ fontWeight: 600 }}>
               <Trans>No transaction history</Trans>

--- a/src/contexts/txHistoryContext.ts
+++ b/src/contexts/txHistoryContext.ts
@@ -1,13 +1,20 @@
 import { TransactionResponse } from '@ethersproject/providers'
-import { TransactionLog } from 'models/transaction'
+import { TransactionCallbacks, TransactionLog } from 'models/transaction'
 import { createContext } from 'react'
 
 // Prefer using tx.timestamp if tx has been mined. Otherwise use createdAt timestamp
-export const timestampForTxLog = (txLog: TransactionLog) =>
-  (txLog.tx as TransactionResponse).timestamp ?? txLog.createdAt
+export const timestampForTxLog = (txLog: TransactionLog) => {
+  return (txLog.tx as TransactionResponse)?.timestamp ?? txLog.createdAt
+}
+
+export type AddTransactionFunction = (
+  title: string,
+  tx: TransactionResponse,
+  callbacks?: Omit<TransactionCallbacks, 'onDone' | 'onError'>,
+) => void
 
 export const TxHistoryContext: React.Context<{
   transactions?: TransactionLog[]
-  addTransaction?: (title: string, tx: TransactionResponse) => void
+  addTransaction?: AddTransactionFunction
   removeTransaction?: (id: number) => void
 }> = createContext({})

--- a/src/hooks/v2/transactor/AddToBalanceTx.ts
+++ b/src/hooks/v2/transactor/AddToBalanceTx.ts
@@ -6,7 +6,10 @@ import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
-import { onCatch, TransactorInstance } from 'hooks/Transactor'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
 import invariant from 'tiny-invariant'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -50,7 +53,7 @@ export function useAddToBalanceTx(): TransactorInstance<{
         ? 'contracts.JBETHPaymentTerminal'
         : undefined
 
-      return onCatch({
+      return handleTransactionException({
         txOpts,
         missingParam,
         cv,

--- a/src/hooks/v2/transactor/ClaimTokensTx.ts
+++ b/src/hooks/v2/transactor/ClaimTokensTx.ts
@@ -4,7 +4,10 @@ import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
 import { V2ProjectContext } from 'contexts/v2/projectContext'
 import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
-import { onCatch, TransactorInstance } from 'hooks/Transactor'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
 import { useWallet } from 'hooks/Wallet'
 import { useContext } from 'react'
 import invariant from 'tiny-invariant'
@@ -48,7 +51,7 @@ export function useClaimTokensTx(): TransactorInstance<{
         ? 'contracts.JBTokenStore'
         : undefined
 
-      return onCatch({
+      return handleTransactionException({
         txOpts,
         missingParam,
         functionName: 'claimFor',

--- a/src/hooks/v2/transactor/IssueErc20TokenTx.ts
+++ b/src/hooks/v2/transactor/IssueErc20TokenTx.ts
@@ -5,7 +5,10 @@ import invariant from 'tiny-invariant'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
-import { onCatch, TransactorInstance } from 'hooks/Transactor'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
 
 export function useIssueErc20TokenTx(): TransactorInstance<{
   name: string
@@ -42,7 +45,7 @@ export function useIssueErc20TokenTx(): TransactorInstance<{
         ? 'symbol'
         : undefined
 
-      return onCatch({
+      return handleTransactionException({
         txOpts,
         missingParam,
         functionName: 'issueTokenFor',

--- a/src/hooks/v2/transactor/MintTokensTx.ts
+++ b/src/hooks/v2/transactor/MintTokensTx.ts
@@ -6,7 +6,10 @@ import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
-import { onCatch, TransactorInstance } from 'hooks/Transactor'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
 import invariant from 'tiny-invariant'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -56,7 +59,7 @@ export function useMintTokensTx(): TransactorInstance<{
         ? 'projectId'
         : undefined
 
-      return onCatch({
+      return handleTransactionException({
         txOpts,
         missingParam,
         functionName: 'mintTokensOf',

--- a/src/hooks/v2/transactor/RedeemTokensTx.ts
+++ b/src/hooks/v2/transactor/RedeemTokensTx.ts
@@ -9,7 +9,10 @@ import { V2ContractsContext } from 'contexts/v2/V2ContractsContext'
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
-import { onCatch, TransactorInstance } from 'hooks/Transactor'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
 import invariant from 'tiny-invariant'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -67,7 +70,7 @@ export function useRedeemTokensTx(): TransactorInstance<{
         ? 'contracts.JBETHPaymentTerminal'
         : undefined
 
-      return onCatch({
+      return handleTransactionException({
         txOpts,
         missingParam,
         functionName: 'redeemTokensOf',

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -1,3 +1,5 @@
+import { Signer } from '@ethersproject/abstract-signer'
+import { BigNumberish } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Transaction } from '@ethersproject/transactions'
 
@@ -7,19 +9,34 @@ export enum TxStatus {
   failed = 'FAILED',
 }
 
+export type TransactionCallback = (e?: Transaction, signer?: Signer) => void
+
+export interface TransactionCallbacks {
+  onDone?: VoidFunction
+  onConfirmed?: TransactionCallback
+  onCancelled?: TransactionCallback
+  onError?: ErrorCallback
+}
+
+export interface TransactionOptions extends TransactionCallbacks {
+  title?: string
+  value?: BigNumberish
+}
+
 export type TransactionLog = {
   id: number
   title: string
   createdAt: number
+  callbacks?: TransactionCallbacks
 } & (
   | {
       // Only pending txs have not been mined
       status: TxStatus.pending
-      tx: Transaction
+      tx: Transaction | null
     }
   | {
       // Once mined, tx will be a TransactionResponse
       status: TxStatus.success | TxStatus.failed
-      tx: TransactionResponse
+      tx: TransactionResponse | null
     }
 )

--- a/src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton.tsx
@@ -27,7 +27,7 @@ import { useRouter } from 'next/router'
 import { v2ProjectRoute } from 'utils/routes'
 
 import { readNetwork } from 'constants/networks'
-import { TransactorOptions } from 'hooks/Transactor'
+import { TransactionOptions } from 'models/transaction'
 import { findTransactionReceipt } from './utils'
 
 const NFT_CREATE_EVENT_IDX = 2
@@ -107,7 +107,7 @@ export function DeployProjectWithNftsButton({ form }: { form: FormInstance }) {
       return
     }
 
-    const txOpts: TransactorOptions = {
+    const txOpts: TransactionOptions = {
       onDone() {
         console.info('Transaction executed. Awaiting confirmation...')
         setTransactionPending(true)

--- a/src/providers/TxHistoryProvider.tsx
+++ b/src/providers/TxHistoryProvider.tsx
@@ -22,7 +22,7 @@ const pollTransaction = async (
 ): Promise<TransactionLog> => {
   // Only do refresh logic for pending txs
   // tx.hash shouldn't ever be undefined but it's optional typed :shrug:
-  if (!txLog.tx.hash || txLog.status !== TxStatus.pending) {
+  if (!txLog.tx?.hash || txLog.status !== TxStatus.pending) {
     return txLog
   }
 

--- a/src/providers/TxHistoryProvider.tsx
+++ b/src/providers/TxHistoryProvider.tsx
@@ -1,11 +1,13 @@
-import { TransactionResponse } from '@ethersproject/providers'
 import { useWallet } from 'hooks/Wallet'
 import { TransactionLog, TxStatus } from 'models/transaction'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { clearInterval, setInterval } from 'timers'
 
 import { readProvider } from '../constants/readProvider'
-import { TxHistoryContext } from '../contexts/txHistoryContext'
+import {
+  AddTransactionFunction,
+  TxHistoryContext,
+} from '../contexts/txHistoryContext'
 
 const nowSeconds = () => Math.round(new Date().valueOf() / 1000)
 
@@ -14,6 +16,42 @@ const LONG_POLL_INTERVAL_MILLISECONDS = 12 * 1000 // 12 sec
 
 // Arbitrary time to give folks a sense of tx history
 const TX_HISTORY_TIME_SECS = 60 * 60 // 1 hr
+
+const pollTransaction = async (
+  txLog: TransactionLog,
+): Promise<TransactionLog> => {
+  // Only do refresh logic for pending txs
+  // tx.hash shouldn't ever be undefined but it's optional typed :shrug:
+  if (!txLog.tx.hash || txLog.status !== TxStatus.pending) {
+    return txLog
+  }
+
+  const response = await readProvider.getTransaction(txLog.tx.hash)
+  // if no response, then the tx is cancelled.
+  if (!response) {
+    txLog.callbacks?.onCancelled?.(response)
+    return {
+      ...txLog,
+      tx: response,
+      status: TxStatus.failed,
+    }
+  }
+
+  // Tx has been mined
+  if (response.confirmations > 0 && txLog.status === TxStatus.pending) {
+    console.info('CALLING ONCONFIRMED', response)
+    txLog.callbacks?.onConfirmed?.(response)
+    return {
+      ...txLog,
+      tx: response,
+      status: TxStatus.success,
+    }
+  }
+
+  return {
+    ...txLog,
+  }
+}
 
 export default function TxHistoryProvider({
   children,
@@ -81,41 +119,15 @@ export default function TxHistoryProvider({
       console.info('TxHistoryProvider::poller::polling for tx updates...')
 
       const transactionLogs = await Promise.all(
-        transactions.map(async txLog => {
-          // Only do refresh logic for pending txs
-          // tx.hash shouldn't ever be undefined but it's optional typed :shrug:
-          if (!txLog.tx.hash || txLog.status !== TxStatus.pending) {
-            return txLog
-          }
-
-          // If no response yet, get response.
-          // We know tx is a TransactionResponse if `.wait` is defined.
-          const response = (txLog.tx as TransactionResponse).wait
-            ? (txLog.tx as TransactionResponse)
-            : await readProvider.getTransaction(txLog.tx.hash)
-
-          let status = TxStatus.pending
-          try {
-            // Tx has been mined
-            status = TxStatus.success
-          } catch (_) {
-            // ethers provider throws error when a transaction fails
-            status = TxStatus.failed
-          }
-
-          return {
-            ...txLog,
-            tx: response,
-            status,
-          }
+        transactions.map(txLog => {
+          return pollTransaction(txLog)
         }),
       )
 
       console.info(
-        'TxHistoryProvider::poller::settings transactions',
+        'TxHistoryProvider::poller::updating transactions state',
         transactionLogs,
       )
-
       _setTransactions(transactionLogs)
     }, pollInterval)
 
@@ -127,8 +139,8 @@ export default function TxHistoryProvider({
     }
   }, [transactions, _setTransactions])
 
-  const addTransaction = useCallback(
-    (title: string, tx: TransactionResponse) => {
+  const addTransaction: AddTransactionFunction = useCallback(
+    (title, tx, callbacks) => {
       _setTransactions([
         ...transactions,
         {
@@ -139,6 +151,7 @@ export default function TxHistoryProvider({
           tx,
           createdAt: nowSeconds(),
           status: TxStatus.pending,
+          callbacks,
         },
       ])
     },


### PR DESCRIPTION
The new transaciton poller didn't support the previous bnc-notify callbacks. This breaks any UI that relies on these callbacks (most of them).

This PR updates the transaction store to include callbacks for each tx. Callbacks are onSuccess and onCancelled.

Please test project creation and `pay` transactions. Note that, locally, page redirection is slow af.