### PR TITLE
Move project ID in UI, better UI

### DIFF
--- a/src/components/Project/ProjectHeader/EditProjectHandleButton.tsx
+++ b/src/components/Project/ProjectHeader/EditProjectHandleButton.tsx
@@ -1,0 +1,39 @@
+import { EditOutlined } from '@ant-design/icons'
+import { t, Trans } from '@lingui/macro'
+import { Button, Tooltip } from 'antd'
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { V2ProjectContext } from 'contexts/v2/projectContext'
+import Link from 'next/link'
+import { useContext } from 'react'
+import { settingsPagePath } from 'utils/routes'
+
+export function EditProjectHandleButton() {
+  const { projectId } = useContext(ProjectMetadataContext)
+  const { handle } = useContext(V2ProjectContext)
+
+  return (
+    <Tooltip
+      placement="bottom"
+      title={t`A project's handle is used in its URL, and allows it to be included in search results on the projects page.`}
+    >
+      <div>
+        <Link
+          href={settingsPagePath('projecthandle', {
+            projectId,
+            handle,
+          })}
+        >
+          <Button
+            type="link"
+            icon={<EditOutlined />}
+            style={{ paddingLeft: 0 }}
+          >
+            <span>
+              <Trans>Add handle</Trans>
+            </span>
+          </Button>
+        </Link>
+      </div>
+    </Tooltip>
+  )
+}

--- a/src/components/Project/ProjectHeader/index.tsx
+++ b/src/components/Project/ProjectHeader/index.tsx
@@ -1,6 +1,6 @@
-import { EditOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Button, Tooltip } from 'antd'
+import { Tooltip } from 'antd'
+import { Badge } from 'components/Badge'
 import FormattedAddress from 'components/FormattedAddress'
 import Paragraph from 'components/Paragraph'
 import { GnosisSafeBadge } from 'components/Project/ProjectHeader/GnosisSafeBadge'
@@ -9,9 +9,8 @@ import { ThemeContext } from 'contexts/themeContext'
 import { useAddressIsGnosisSafe } from 'hooks/AddressIsGnosisSafe'
 import useMobile from 'hooks/Mobile'
 import { ProjectMetadataV4 } from 'models/project-metadata'
-import Link from 'next/link'
 import { useContext } from 'react'
-import { settingsPagePath } from 'utils/routes'
+import { EditProjectHandleButton } from './EditProjectHandleButton'
 import SocialLinks from './SocialLinks'
 
 const headerHeight = 120
@@ -76,24 +75,42 @@ export default function ProjectHeader({
             alignItems: 'flex-start',
           }}
         >
-          <h1
+          <div
             style={{
-              fontSize: '2.4rem',
-              lineHeight: '2.8rem',
-              margin: 0,
-              color: metadata?.name
-                ? colors.text.primary
-                : colors.text.placeholder,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
               maxWidth: isMobile ? '100%' : '75%',
+              display: 'flex',
+              alignItems: 'center',
             }}
-            title={projectTitle}
           >
-            {projectTitle}
-          </h1>
+            <h1
+              style={{
+                fontSize: '2.4rem',
+                lineHeight: '2.8rem',
+                margin: 0,
+                color: metadata?.name
+                  ? colors.text.primary
+                  : colors.text.placeholder,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+              title={projectTitle}
+            >
+              {projectTitle}
+            </h1>
+            {isArchived && (
+              <Badge
+                variant="warning"
+                style={{
+                  textTransform: 'uppercase',
+                  marginLeft: '1rem',
+                }}
+              >
+                <Trans>Archived</Trans>
+              </Badge>
+            )}
+          </div>
 
-          {actions ? actions : null}
+          {actions ?? null}
         </div>
 
         <div
@@ -107,51 +124,25 @@ export default function ProjectHeader({
             columnGap: 20,
           }}
         >
-          {isArchived && (
-            <span
-              style={{
-                fontSize: '0.8rem',
-                color: colors.text.disabled,
-                textTransform: 'uppercase',
-              }}
-            >
-              (archived)
-            </span>
-          )}
-          {handle ? (
-            <span
-              style={{
-                color: colors.text.secondary,
-                fontWeight: 600,
-              }}
-            >
-              @{handle}
-            </span>
-          ) : canEditProjectHandle && projectId ? (
-            <Tooltip
-              placement="bottom"
-              title={t`A project's handle is used in its URL, and allows it to be included in search results on the projects page.`}
-            >
-              <div>
-                <Link
-                  href={settingsPagePath('projecthandle', {
-                    projectId,
-                    handle,
-                  })}
-                >
-                  <Button
-                    type="link"
-                    icon={<EditOutlined />}
-                    style={{ paddingLeft: 0 }}
-                  >
-                    <span>
-                      <Trans>Add handle</Trans>
-                    </span>
-                  </Button>
-                </Link>
-              </div>
-            </Tooltip>
+          <span
+            style={{
+              color: colors.text.secondary,
+              fontWeight: 600,
+            }}
+          >
+            {handle ? (
+              <Tooltip title={t`Project ID: ${projectId}`}>
+                <span>@{handle}</span>
+              </Tooltip>
+            ) : (
+              <Trans>Project #{projectId}</Trans>
+            )}
+          </span>
+
+          {!handle && canEditProjectHandle && projectId ? (
+            <EditProjectHandleButton />
           ) : null}
+
           <SocialLinks
             discord={metadata?.discord}
             twitter={metadata?.twitter}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1886,6 +1886,9 @@ msgstr ""
 msgid "Project ID must be a number."
 msgstr ""
 
+msgid "Project ID: {projectId}"
+msgstr ""
+
 msgid "Project Links"
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

- Moves project ID to handle tooltip (in prep for v3)
- Make the archived state a bit nicer
- Moved **Edit Handle** code to own component

| no handle | has handle |
| --- | --- |
| <img width="742" alt="Screen Shot 2022-09-21 at 9 58 07 AM" src="https://user-images.githubusercontent.com/12551741/191388635-3904b6cb-03f7-4411-a2f8-5778812a4071.png"> | <img width="785" alt="Screen Shot 2022-09-21 at 9 58 20 AM" src="https://user-images.githubusercontent.com/12551741/191388665-6674fc0d-bcfb-49c8-a500-5afa7c8b75e1.png"> |

Archived states (ignore version selector 😉 )

| archived | archived long title | archived mobile |
| --- | --- | --- |
| <img width="1103" alt="Screen Shot 2022-09-21 at 9 50 56 AM" src="https://user-images.githubusercontent.com/12551741/191388712-2a75cb5e-5eff-4b66-adc8-fd32ab4430c5.png"> | <img width="1105" alt="Screen Shot 2022-09-21 at 9 51 03 AM" src="https://user-images.githubusercontent.com/12551741/191388726-8af99b2d-ca57-4541-ba67-1d899de44b59.png"> | <img width="491" alt="Screen Shot 2022-09-21 at 9 51 16 AM" src="https://user-images.githubusercontent.com/12551741/191388744-240139c1-5b6e-45de-b480-d29f7d5d9582.png"> | 


 