### PR TITLE
Make IssueErc20TokenModal compatible with all contract versions

### DIFF
--- a/src/components/IssueErc20TokenButton.tsx
+++ b/src/components/IssueErc20TokenButton.tsx
@@ -25,9 +25,7 @@ export function IssueErc20TokenButton({
     setModalVisible(false)
 
     // remove newDeploy=true query parameter
-    router.replace(router.pathname, {
-      search: '',
-    })
+    router.replace(router.asPath, undefined, { shallow: true })
   }
 
   return (

--- a/src/components/IssueErc20TokenButton.tsx
+++ b/src/components/IssueErc20TokenButton.tsx
@@ -2,7 +2,6 @@ import { SettingOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
 
-import { TransactorInstance } from 'hooks/Transactor'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
@@ -14,10 +13,8 @@ export type IssueErc20TokenTxArgs = {
 }
 
 export function IssueErc20TokenButton({
-  useIssueErc20TokenTx,
   onCompleted,
 }: {
-  useIssueErc20TokenTx: () => TransactorInstance<IssueErc20TokenTxArgs>
   onCompleted?: VoidFunction
 }) {
   const [modalVisible, setModalVisible] = useState<boolean>(false)
@@ -56,7 +53,6 @@ export function IssueErc20TokenButton({
       </Tooltip>
       <IssueErc20TokenModal
         visible={modalVisible}
-        useIssueErc20TokenTx={useIssueErc20TokenTx}
         onClose={onClose}
         onConfirmed={onCompleted}
       />

--- a/src/components/v1/V1Project/Paid.tsx
+++ b/src/components/v1/V1Project/Paid.tsx
@@ -119,11 +119,11 @@ export default function Paid() {
               statLabel={<Trans>Distributed</Trans>}
               statLabelTip={
                 <Trans>
-                  The amount that has been distributed from the Juicebox balance
-                  in this funding cycle, out of the current funding target. No
-                  more than the funding target can be distributed in a single
-                  funding cycle—any remaining ETH in Juicebox is overflow, until
-                  the next cycle begins.
+                  The amount distributed from the Juicebox balance in this
+                  funding cycle, out of the current funding target. No more than
+                  the funding target can be distributed in a single funding
+                  cycle. Any remaining ETH in Juicebox is overflow until the
+                  next cycle begins.
                 </Trans>
               }
               statValue={

--- a/src/components/v1/V1Project/Rewards/index.tsx
+++ b/src/components/v1/V1Project/Rewards/index.tsx
@@ -18,7 +18,6 @@ import useTotalBalanceOf from 'hooks/v1/contractReader/TotalBalanceOf'
 import useTotalSupplyOfProjectToken from 'hooks/v1/contractReader/TotalSupplyOfProjectToken'
 import useUnclaimedBalanceOfUser from 'hooks/v1/contractReader/UnclaimedBalanceOfUser'
 import { useV1ConnectedWalletHasPermission } from 'hooks/v1/contractReader/V1ConnectedWalletHasPermission'
-import { useIssueErc20TokenTx } from 'hooks/v1/transactor/IssueErc20TokenTx'
 import { V1OperatorPermission } from 'models/v1/permissions'
 import { CSSProperties, useContext, useState } from 'react'
 import { formatPercent, formatWad } from 'utils/format/formatNumber'
@@ -203,7 +202,7 @@ export default function Rewards() {
         />
 
         {!ticketsIssued && hasIssueTicketsPermission && !isPreviewMode && (
-          <IssueErc20TokenButton useIssueErc20TokenTx={useIssueErc20TokenTx} />
+          <IssueErc20TokenButton />
         )}
       </Space>
 

--- a/src/components/v2v3/V2V3Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2v3/V2V3Project/TreasuryStats/DistributedRatio.tsx
@@ -31,10 +31,10 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
       statLabel={<Trans>Distributed</Trans>}
       statLabelTip={
         <Trans>
-          The amount that has been distributed from the Juicebox balance in this
-          funding cycle, out of the current distribution limit. No more than the
-          distribution limit can be distributed in a single funding cycle—any
-          remaining ETH in Juicebox is overflow, until the next cycle begins.
+          The amount distributed from the Juicebox balance in this funding
+          cycle, out of the current distribution limit. No more than the
+          distribution limit can be distributed in a single funding cycle. Any
+          remaining ETH in Juicebox is overflow until the next cycle begins.
         </Trans>
       }
       statValue={

--- a/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/index.tsx
@@ -152,9 +152,9 @@ export default function V2ManageTokensSection() {
                       includeTokenWord: true,
                     })}{' '}
                     are distributed to anyone who pays this project. If the
-                    project has set a funding target, tokens can be redeemed for
-                    a portion of the project's overflow whether or not they have
-                    been claimed yet.
+                    project has set a distribution limit, tokens can be redeemed
+                    for a portion of the project's overflow whether or not they
+                    have been claimed yet.
                   </Trans>
                 }
               />

--- a/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/index.tsx
@@ -23,7 +23,6 @@ import ManageTokensModal from 'components/ManageTokensModal'
 import ParticipantsModal from 'components/modals/ParticipantsModal'
 import { TextButton } from 'components/TextButton'
 import { ThemeContext } from 'contexts/themeContext'
-import { useIssueErc20TokenTx } from 'hooks/v2/transactor/IssueErc20TokenTx'
 import useTotalBalanceOf from 'hooks/v2v3/contractReader/TotalBalanceOf'
 import useUserUnclaimedTokenBalance from 'hooks/v2v3/contractReader/UserUnclaimedTokenBalance'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
@@ -161,10 +160,7 @@ export default function V2ManageTokensSection() {
               />
               {showIssueErc20TokenButton && (
                 <div style={{ marginBottom: 20 }}>
-                  <IssueErc20TokenButton
-                    useIssueErc20TokenTx={useIssueErc20TokenTx}
-                    onCompleted={reloadWindow}
-                  />
+                  <IssueErc20TokenButton onCompleted={reloadWindow} />
                 </div>
               )}
             </div>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions.tsx
@@ -1,6 +1,6 @@
 import { SettingOutlined, SmileOutlined, ToolOutlined } from '@ant-design/icons'
 import { t } from '@lingui/macro'
-import { Button, Tooltip } from 'antd'
+import { Button, Space, Tooltip } from 'antd'
 import ProjectVersionBadge from 'components/ProjectVersionBadge'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer/V2V3ProjectToolsDrawer'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
@@ -26,7 +26,7 @@ export default function V2V3ProjectHeaderActions() {
 
   return (
     <>
-      <div
+      <Space
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -71,7 +71,7 @@ export default function V2V3ProjectHeaderActions() {
             </Tooltip>
           )}
         </div>
-      </div>
+      </Space>
 
       <V2V3ProjectToolsDrawer
         visible={toolDrawerVisible}

--- a/src/components/v2v3/V2V3Project/modals/NewDeployModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/NewDeployModal.tsx
@@ -2,7 +2,6 @@ import { CheckCircleFilled } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Modal } from 'antd'
 import RichButton from 'components/RichButton'
-import { useIssueErc20TokenTx } from 'hooks/v2/transactor/IssueErc20TokenTx'
 import { useDeployProjectPayerTx } from 'hooks/v2v3/transactor/DeployProjectPayerTx'
 import { CSSProperties, useContext, useState } from 'react'
 
@@ -126,7 +125,6 @@ export default function NewDeployModal({
       </div>
       <IssueErc20TokenModal
         visible={issueTokenModalVisible}
-        useIssueErc20TokenTx={useIssueErc20TokenTx}
         onClose={() => setIssueTokenModalVisible(false)}
         onConfirmed={() => setHasIssuedToken(true)}
       />

--- a/src/hooks/v1/transactor/IssueErc20TokenTx.ts
+++ b/src/hooks/v1/transactor/IssueErc20TokenTx.ts
@@ -6,7 +6,7 @@ import { useContext } from 'react'
 
 import { TransactorInstance } from 'hooks/Transactor'
 
-export function useIssueErc20TokenTx(): TransactorInstance<{
+export function useV1IssueErc20TokenTx(): TransactorInstance<{
   name: string
   symbol: string
 }> {

--- a/src/hooks/v2/transactor/V2IssueErc20TokenTx.ts
+++ b/src/hooks/v2/transactor/V2IssueErc20TokenTx.ts
@@ -1,0 +1,56 @@
+import { t } from '@lingui/macro'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { useContext } from 'react'
+import invariant from 'tiny-invariant'
+
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
+
+export function useV2IssueErc20TokenTx(): TransactorInstance<{
+  name: string
+  symbol: string
+}> {
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2V3ContractsContext)
+  const { projectId, cv } = useContext(ProjectMetadataContext)
+
+  return ({ name, symbol }, txOpts) => {
+    try {
+      invariant(
+        transactor && projectId && contracts?.JBController && name && symbol,
+      )
+      return transactor(
+        contracts.JBController,
+        'issueTokenFor',
+        [projectId, name, symbol],
+        {
+          ...txOpts,
+          title: t`Issue $${symbol}`,
+        },
+      )
+    } catch {
+      const missingParam = !transactor
+        ? 'transactor'
+        : !projectId
+        ? 'projectId'
+        : !contracts?.JBTokenStore
+        ? 'contracts.JBTokenStore'
+        : !name
+        ? 'name'
+        : !symbol
+        ? 'symbol'
+        : undefined
+
+      return handleTransactionException({
+        txOpts,
+        missingParam,
+        functionName: 'issueTokenFor',
+        cv,
+      })
+    }
+  }
+}

--- a/src/hooks/v3/transactor/V3IssueErc20TokenTx.ts
+++ b/src/hooks/v3/transactor/V3IssueErc20TokenTx.ts
@@ -10,7 +10,7 @@ import {
   TransactorInstance,
 } from 'hooks/Transactor'
 
-export function useIssueErc20TokenTx(): TransactorInstance<{
+export function useV3IssueErc20TokenTx(): TransactorInstance<{
   name: string
   symbol: string
 }> {
@@ -21,11 +21,11 @@ export function useIssueErc20TokenTx(): TransactorInstance<{
   return ({ name, symbol }, txOpts) => {
     try {
       invariant(
-        transactor && projectId && contracts?.JBController && name && symbol,
+        transactor && projectId && contracts?.JBTokenStore && name && symbol,
       )
       return transactor(
-        contracts.JBController,
-        'issueTokenFor',
+        contracts.JBTokenStore,
+        'issueFor',
         [projectId, name, symbol],
         {
           ...txOpts,

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2486,6 +2486,12 @@ msgstr ""
 msgid "The address that should receive the tokens minted from paying this project."
 msgstr ""
 
+msgid "The amount distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle. Any remaining ETH in Juicebox is overflow until the next cycle begins."
+msgstr ""
+
+msgid "The amount distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle. Any remaining ETH in Juicebox is overflow until the next cycle begins."
+msgstr ""
+
 msgid "The amount of tokens minted to the receiver will be calculated based on if they had paid this amount to the project in the current funding cycle."
 msgstr ""
 
@@ -2493,12 +2499,6 @@ msgid "The amount of tokens this project has reserved. These tokens can be distr
 msgstr ""
 
 msgid "The amount of tokens to mint to the receiver."
-msgstr ""
-
-msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current distribution limit. No more than the distribution limit can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
-msgstr ""
-
-msgid "The amount that has been distributed from the Juicebox balance in this funding cycle, out of the current funding target. No more than the funding target can be distributed in a single funding cycle—any remaining ETH in Juicebox is overflow, until the next cycle begins."
 msgstr ""
 
 msgid "The balance of the project owner's wallet."
@@ -3275,7 +3275,7 @@ msgstr ""
 msgid "{0} ago"
 msgstr ""
 
-msgid "{0} are distributed to anyone who pays this project. If the project has set a funding target, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
+msgid "{0} are distributed to anyone who pays this project. If the project has set a distribution limit, tokens can be redeemed for a portion of the project's overflow whether or not they have been claimed yet."
 msgstr ""
 
 msgid "{0} balance"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1004,6 +1004,9 @@ msgstr ""
 msgid "ERC20 deployed"
 msgstr ""
 
+msgid "ERC20 transaction not ready. Try again."
+msgstr ""
+
 msgid "ETH"
 msgstr ""
 
@@ -1119,6 +1122,9 @@ msgid "Extend veNFT lock"
 msgstr ""
 
 msgid "FAQs"
+msgstr ""
+
+msgid "Failed to issue ERC20 token. Check transaction and try again."
 msgstr ""
 
 msgid "Failed to update project metadata"


### PR DESCRIPTION
## What does this PR do and why?

Updates `IssueErc20TokenModal` internals to use a different tx hook depending on the `cv` in context.
