### PR TITLE
fix lang font color dark

### DIFF
--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -73,7 +73,7 @@
 }
 
 .ant-form {
-  color: var(--text-primary)
+  color: var(--text-primary);
 }
 
 .ant-form-item {
@@ -100,7 +100,7 @@ input.ant-input[type='number'] {
   -moz-appearance: textfield;
 }
 
-.ant-input-prefix, 
+.ant-input-prefix,
 .ant-input-show-count-suffix {
   color: var(--text-secondary);
 }
@@ -165,7 +165,6 @@ textarea.ant-input::placeholder {
 .ant-select {
   .ant-select-selector {
     background-color: transparent;
-    color: var(--text-primary);
     border-color: var(--stroke-secondary);
   }
 
@@ -246,7 +245,6 @@ textarea.ant-input::placeholder {
   border: none !important;
   box-shadow: none !important;
 }
-
 
 .ant-upload {
   color: var(--text-primary);


### PR DESCRIPTION
## What does this PR do and why?
The selected lang in dark mode is difficult to see. Removed the color in overrides in the selector component to stick with black text

Give it a try on both light and dark mode.

## Screenshots or screen recordings
before:
<img width="622" alt="CleanShot 2022-09-23 at 08 32 29@2x" src="https://user-images.githubusercontent.com/2502947/191961438-89010bd6-de90-4b1f-b57c-4abccf19d59f.png">


after:
<img width="494" alt="CleanShot 2022-09-23 at 08 32 50@2x" src="https://user-images.githubusercontent.com/2502947/191961461-bed1f824-0299-4fd7-9507-b47fa62bea5d.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
