### PR TITLE
fix project asset owner balance v2 + v3 project

### DIFF
--- a/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2ProjectTokenBalance.tsx
+++ b/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2ProjectTokenBalance.tsx
@@ -1,8 +1,8 @@
+import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import useSymbolOfERC20 from 'hooks/SymbolOfERC20'
 import useProjectToken from 'hooks/v2v3/contractReader/ProjectToken'
 import useTotalBalanceOf from 'hooks/v2v3/contractReader/TotalBalanceOf'
-import { useWallet } from 'hooks/Wallet'
-import { CSSProperties } from 'react'
+import { CSSProperties, useContext } from 'react'
 import { formatWad } from 'utils/format/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -17,8 +17,8 @@ export const V2ProjectTokenBalance = ({
 }) => {
   const { data: tokenAddress } = useProjectToken({ projectId })
   const tokenSymbol = useSymbolOfERC20(tokenAddress)
-  const { userAddress } = useWallet()
-  const { data: balance } = useTotalBalanceOf(userAddress, projectId)
+  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
+  const { data: balance } = useTotalBalanceOf(projectOwnerAddress, projectId)
 
   return (
     <div style={{ ...style }}>


### PR DESCRIPTION
## What does this PR do and why?
pulls project address to query from, not userWallet fixes: #1680

This seems like the right fix, but I'm a little cautious because I don't see the jbx in the `owner` address: https://rinkeby.etherscan.io/address/0x2B1868FA2d8Ffe316531FC67EfB0166DD7cfd0b3

## Screenshots or screen recordings
<img width="863" alt="CleanShot 2022-09-23 at 10 53 56@2x" src="https://user-images.githubusercontent.com/2502947/191989898-cbbf4e0c-cd62-46e9-9614-6d1d2a467a5b.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
