### PR TITLE
update consts for menu item to use new antd api for menu items

### DIFF
--- a/src/components/Navbar/constants.ts
+++ b/src/components/Navbar/constants.ts
@@ -1,0 +1,55 @@
+import { t } from '@lingui/macro'
+import { MenuProps } from 'antd'
+
+export const resourcesMenuItems = (): MenuProps['items'] => {
+  return [
+    {
+      key: 'governance',
+      label: t`Governance`,
+      onClick: () => {
+        window?.open('https://vote.juicebox.money/#/jbdao.eth', '_blank')
+      },
+      className: 'nav-dropdown-item',
+      style: {
+        color: 'var(--text-primary)',
+        fontWeight: 500,
+      },
+    },
+    {
+      key: 'newsletter',
+      label: t`Newsletter`,
+      onClick: () => {
+        window?.open('https://newsletter.juicebox.money', '_blank')
+      },
+      className: 'nav-dropdown-item',
+      style: {
+        color: 'var(--text-primary)',
+        fontWeight: 500,
+      },
+    },
+    {
+      key: 'podcast',
+      label: t`Podcast`,
+      onClick: () => {
+        window?.open('https://podcast.juicebox.money', '_blank')
+      },
+      className: 'nav-dropdown-item',
+      style: {
+        color: 'var(--text-primary)',
+        fontWeight: 500,
+      },
+    },
+    {
+      key: 'peel',
+      label: t`PeelDAO`,
+      onClick: () => {
+        window?.open('https://discord.gg/XvmfY4Hkcz', '_blank')
+      },
+      className: 'nav-dropdown-item',
+      style: {
+        color: 'var(--text-primary)',
+        fontWeight: 500,
+      },
+    },
+  ]
+}


### PR DESCRIPTION
## What does this PR do and why?

https://ant.design/components/menu/#API

To eventually replace antd v5 and upgrade to react 18 we need to update the menu and menu list.

https://github.com/ant-design/ant-design/issues/33862


Click on menu items in menu. They should behave the same as they are in production.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
