### PR TITLE
Change NFT post-pay redirect

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2ConfirmPayModal/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2ConfirmPayModal/index.tsx
@@ -36,8 +36,9 @@ import { weightedAmount } from 'utils/v2v3/math'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { NftRewardsContext } from 'contexts/nftRewardsContext'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { useRouter } from 'next/router'
 import { v2v3ProjectRoute } from 'utils/routes'
-import { redirectTo, reloadWindow } from 'utils/windowUtils'
+import { reloadWindow } from 'utils/windowUtils'
 import { V2PayForm, V2PayFormType } from '../V2PayForm'
 import { NftRewardCell } from './NftRewardCell'
 
@@ -67,6 +68,7 @@ export function V2ConfirmPayModal({
   const converter = useCurrencyConverter()
   const payProjectTx = usePayETHPaymentTerminalTx()
   const isMobile = useMobile()
+  const router = useRouter()
   const {
     userAddress,
     chainUnsupported,
@@ -109,8 +111,12 @@ export function V2ConfirmPayModal({
   }
 
   const handlePaySuccess = () => {
+    if (onCancel) onCancel()
+    setLoading(false)
+    setTransactionPending(false)
+
     if (nftRewardTier && projectMetadata?.nftPaymentSuccessModal) {
-      redirectTo(
+      router.push(
         `${v2v3ProjectRoute({ handle, projectId })}?nftPurchaseConfirmed=true`,
       )
     } else {
@@ -155,9 +161,6 @@ export function V2ConfirmPayModal({
         },
         {
           onConfirmed() {
-            setLoading(false)
-            setTransactionPending(false)
-
             handlePaySuccess()
           },
           onError() {

--- a/src/components/v2v3/V2V3Project/V2V3Project.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3Project.tsx
@@ -156,15 +156,18 @@ export function V2V3Project({
 
   if (projectId === undefined) return null
 
+  // Change URL without refreshing page
+  const removeQueryParams = () => {
+    router.push(v2v3ProjectRoute({ projectId }), undefined, { shallow: true })
+  }
+
   const closeNewDeployModal = () => {
-    // Change URL without refreshing page
-    router.replace(v2v3ProjectRoute({ projectId }))
+    removeQueryParams()
     setNewDeployModalVisible(false)
   }
 
   const closeNftPostPayModal = () => {
-    // Change URL without refreshing page
-    router.replace(v2v3ProjectRoute({ projectId }))
+    removeQueryParams()
     setNftPostPayModalVisible(false)
   }
 

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
@@ -74,12 +74,13 @@ export default function NftDrawer({
     const [rewardTiersCIDs, nftCollectionMetadataCID] = await Promise.all([
       uploadNftRewardsToIPFS(rewardTiers),
       uploadNftCollectionMetadataToIPFS({
-        collectionName:
-          marketplaceFormValues.collectionName ??
-          defaultNftCollectionName(projectName),
-        collectionDescription:
-          marketplaceFormValues.collectionDescription ??
-          defaultNftCollectionDescription(projectName),
+        collectionName: marketplaceFormValues.collectionName?.length
+          ? marketplaceFormValues.collectionName
+          : defaultNftCollectionName(projectName),
+        collectionDescription: marketplaceFormValues.collectionDescription
+          ?.length
+          ? marketplaceFormValues.collectionDescription
+          : defaultNftCollectionDescription(projectName),
         collectionLogoUri: logoUri,
         collectionInfoUri: infoUri,
       }),


### PR DESCRIPTION
## What does this PR do and why?

- **A:** Uses `router.push` for NFT post-pay redirect rather than `redirectTo`
- **B:** Fixes NFT collection metadata sometimes submitting as empty strings
- **C:** Remove query strings from URL when `newDeploy` and `nftPostPay` modals are closed 


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
