### PR TITLE
Add formatCurrencyAmount util

### DIFF
--- a/src/utils/formatCurrencyAmount.ts
+++ b/src/utils/formatCurrencyAmount.ts
@@ -1,9 +1,8 @@
-import { isInteger } from 'lodash'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { V2V3_CURRENCY_ETH, V2V3_CURRENCY_USD } from './v2v3/currency'
 
 const formatAmount = (amount: number) => {
-  if (isInteger(amount)) {
+  if (Number.isInteger(amount)) {
     return amount.toString()
   }
   return amount.toFixed(2)

--- a/src/utils/formatCurrencyAmount.ts
+++ b/src/utils/formatCurrencyAmount.ts
@@ -1,0 +1,31 @@
+import { isInteger } from 'lodash'
+import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
+import { V2V3_CURRENCY_ETH, V2V3_CURRENCY_USD } from './v2v3/currency'
+
+const formatAmount = (amount: number) => {
+  if (isInteger(amount)) {
+    return amount.toString()
+  }
+  return amount.toFixed(2)
+}
+
+/**
+ * Format the input amount with the currency.
+ *
+ * For example, if using `V2V3_CURRENCY_USD` with an amount of 550.1 the format
+ * will be `"$550.1 USD"`.
+ * @returns
+ */
+export const formatCurrencyAmount = ({
+  amount,
+  currency = V2V3_CURRENCY_ETH,
+}: {
+  amount: number | undefined
+  currency: V2V3CurrencyOption | undefined
+}) => {
+  const currencyPrefix = currency === V2V3_CURRENCY_USD ? '$' : ''
+  const currencySuffix = currency === V2V3_CURRENCY_USD ? 'USD' : 'ETH'
+  return `${currencyPrefix}${
+    amount !== undefined ? formatAmount(amount) : '0'
+  } ${currencySuffix}`
+}


### PR DESCRIPTION
## What does this PR do and why?

Format the input amount with the currency.
 
For example, if using `V2V3_CURRENCY_USD` with an amount of 550.1 the format
will be `"$550.1 USD"`.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
