### PR TITLE
Adds the necessary models for Payouts page

### DIFF
--- a/src/components/Create/components/pages/FundingTarget/hooks/FundingTargetForm.ts
+++ b/src/components/Create/components/pages/FundingTarget/hooks/FundingTargetForm.ts
@@ -2,15 +2,14 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { Form } from 'antd'
 import { useWatch } from 'antd/lib/form/Form'
 import { CurrencySelectInputValue } from 'components/Create/components/CurrencySelectInput'
+import { FundingTargetType } from 'models/fundingTargetType'
 import { useDebugValue, useEffect, useMemo } from 'react'
 import { useEditingDistributionLimit } from 'redux/hooks/EditingDistributionLimit'
 import { V2V3_CURRENCY_ETH, V2V3_CURRENCY_USD } from 'utils/v2v3/currency'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 
-type TargetSelection = 'specific' | 'infinite' | 'none'
-
 export type FundingTargetFormProps = Partial<{
-  targetSelection: TargetSelection
+  targetSelection: FundingTargetType
   amount: CurrencySelectInputValue
 }>
 
@@ -25,7 +24,7 @@ export const useFundingTargetForm = () => {
       return undefined
     }
 
-    let targetSelection: TargetSelection
+    let targetSelection: FundingTargetType
 
     if (distributionLimit.amount.eq(MAX_DISTRIBUTION_LIMIT)) {
       targetSelection = 'infinite'

--- a/src/models/formItemInput.ts
+++ b/src/models/formItemInput.ts
@@ -1,0 +1,4 @@
+export interface FormItemInput<Value> {
+  value?: Value
+  onChange?: (value: Value) => void
+}

--- a/src/models/fundingTargetType.ts
+++ b/src/models/fundingTargetType.ts
@@ -1,0 +1,1 @@
+export type FundingTargetType = 'specific' | 'infinite' | 'none'

--- a/src/models/payoutsSelection.ts
+++ b/src/models/payoutsSelection.ts
@@ -1,0 +1,1 @@
+export type PayoutsSelection = 'percentages' | 'amounts'


### PR DESCRIPTION
## What does this PR do and why?

`FormItemInput` is pretty common actually due to Ant Design form, we should eventually replace all inputs with this.
`FundingTargetType` - used in the code to differentiate between funding target types.
`PayoutsSelection` - Used on the Payouts Page for the user selection

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
