### PR TITLE
move resource dropdownmobile to left nav items

### DIFF
--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -8,6 +8,7 @@ import Logo from './Logo'
 import { navMenuItemStyles } from './navStyles'
 
 import { resourcesMenuItems } from './constants'
+import ResourcesDropdownMobile from './Mobile/ResourcesDropdownMobile'
 
 const resourcesMenu = (
   <Menu
@@ -50,7 +51,7 @@ export function TopLeftNavItems({
     rel: 'noopener noreferrer',
   }
 
-  const desktopDropDown = !mobile ? (
+  const desktopDropDown = (
     <Dropdown
       overlay={resourcesMenu}
       overlayStyle={{ padding: 0 }}
@@ -72,7 +73,7 @@ export function TopLeftNavItems({
         )}
       </div>
     </Dropdown>
-  ) : null
+  )
 
   const menuItems = !mobile
     ? [
@@ -137,6 +138,10 @@ export function TopLeftNavItems({
               <a {...externalMenuLinkProps}>{t`Blog`}</a>
             </Link>
           ),
+        },
+        {
+          key: 'resources',
+          label: <ResourcesDropdownMobile />,
         },
       ]
 

--- a/src/components/Navbar/Mobile/MobileCollapse.tsx
+++ b/src/components/Navbar/Mobile/MobileCollapse.tsx
@@ -14,7 +14,6 @@ import { TopLeftNavItems } from '../MenuItems'
 import NavLanguageSelector from '../NavLanguageSelector'
 import { topNavStyles } from '../navStyles'
 import { TransactionsList } from '../TransactionList'
-import ResourcesDropdownMobile from './ResourcesDropdownMobile'
 import ThemePickerMobile from './ThemePickerMobile'
 
 const NAV_EXPANDED_KEY = 0
@@ -114,8 +113,6 @@ export default function MobileCollapse() {
         >
           <Menu mode="inline" defaultSelectedKeys={['resources']}>
             <TopLeftNavItems mobile onClickMenuItems={() => collapseNav()} />
-
-            <ResourcesDropdownMobile />
 
             <div style={{ marginLeft: 15 }}>
               <Menu.Item key="language-selector">

--- a/src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
+++ b/src/components/Navbar/Mobile/ResourcesDropdownMobile.tsx
@@ -7,13 +7,7 @@ const { SubMenu } = Menu
 
 export default function ResourcesDropdownMobile() {
   return (
-    <SubMenu
-      key="resources"
-      title={t`Resources`}
-      style={{
-        marginLeft: 30,
-      }}
-    >
+    <SubMenu key="resources" title={t`Resources`}>
       {resourcesMenuItems(true).map(r => (
         <Menu.Item key={r.key}>{r.label}</Menu.Item>
       ))}


### PR DESCRIPTION
## What does this PR do and why?

move `ResourcesDropdownMobile` to `MenuItems.tsx`. Remove unneed margin.
## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
