### PR TITLE
move resource menu items to menuItems

### DIFF
--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -140,7 +140,14 @@ export function TopLeftNavItems({
         },
         {
           key: 'resources',
-          label: 'thing',
+          label: (
+            <a
+              className="nav-menu-item hover-opacity"
+              style={navMenuItemStyles}
+            >
+              Resources
+            </a>
+          ),
           children: [...resourcesMenuItems(true)],
         },
       ]

--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -7,18 +7,7 @@ import { CSSProperties, useEffect, useState } from 'react'
 import Logo from './Logo'
 import { navMenuItemStyles } from './navStyles'
 
-import SubMenu from 'antd/lib/menu/SubMenu'
 import { resourcesMenuItems } from './constants'
-
-function ResourcesDropdownMobile() {
-  return (
-    <SubMenu key="resources" title={t`Resources`}>
-      {resourcesMenuItems(true).map(r => (
-        <Menu.Item key={r.key}>{r.label}</Menu.Item>
-      ))}
-    </SubMenu>
-  )
-}
 
 const resourcesMenu = (
   <Menu
@@ -151,7 +140,8 @@ export function TopLeftNavItems({
         },
         {
           key: 'resources',
-          label: <ResourcesDropdownMobile />,
+          label: 'thing',
+          children: [...resourcesMenuItems(true)],
         },
       ]
 


### PR DESCRIPTION
## What does this PR do and why?

`ResourcesDropdownMobile` removed, pass `resourceItems` into the new API.
## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
