### PR TITLE
ToolTip prop visible to open

### DIFF
--- a/src/components/currency/ETHAmount.tsx
+++ b/src/components/currency/ETHAmount.tsx
@@ -52,7 +52,7 @@ export default function ETHAmount({
             {formatWad(amount, { precision: 8 })}
           </span>
         }
-        visible={hideTooltip ? !hideTooltip : undefined}
+        open={hideTooltip ? !hideTooltip : undefined}
       >
         <CurrencySymbol currency="ETH" />
         ~0
@@ -68,7 +68,7 @@ export default function ETHAmount({
   return (
     <Tooltip
       title={<ETHToUSD ethAmount={amount} />}
-      visible={hideTooltip ? !hideTooltip : undefined}
+      open={hideTooltip ? !hideTooltip : undefined}
     >
       <CurrencySymbol currency="ETH" />
       {formattedETHAmount}


### PR DESCRIPTION
## What does this PR do and why?
visible prop is deprecated components now need open prop per antd: https://github.com/ant-design/ant-design/releases/tag/4.23.0 

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
