### PR TITLE
Source project jb controller from blockchain

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/ReconfigurationRichPreview.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/ReconfigurationRichPreview.tsx
@@ -6,6 +6,7 @@ import FundingCycleDetails from 'components/v2v3/V2V3Project/V2V3FundingCycleSec
 import { ThemeContext } from 'contexts/themeContext'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { OutgoingProjectData } from 'models/outgoingProject'
 import { useContext } from 'react'
 import { formatOutgoingSplits } from 'utils/splits'
@@ -15,6 +16,9 @@ import { SafeTransactionComponentProps } from '../../SafeTransaction'
 export function ReconfigureRichPreview({
   transaction,
 }: SafeTransactionComponentProps) {
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
   const { contracts } = useContext(V2V3ContractsContext)
   const { projectOwnerAddress } = useContext(V2V3ProjectContext)
   const {
@@ -23,9 +27,7 @@ export function ReconfigureRichPreview({
 
   if (!contracts) return null
 
-  const dataResult: unknown = contracts[
-    'JBController'
-  ].interface.parseTransaction({
+  const dataResult: unknown = JBController?.interface?.parseTransaction({
     data: transaction.data ?? '',
   }).args
 

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleHistory/FundingCycleHistory.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleHistory/FundingCycleHistory.tsx
@@ -2,8 +2,8 @@ import { Trans } from '@lingui/macro'
 import { Space } from 'antd'
 import Loading from 'components/Loading'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   V2V3FundingCycle,
   V2V3FundingCycleMetadata,
@@ -13,9 +13,11 @@ import { PastFundingCycle } from './PastFundingCycle'
 import { fetchPastFundingCycles } from './utils'
 
 export function FundingCycleHistory() {
-  const { fundingCycle: currentFundingCycle } = useContext(V2V3ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
-  const { contracts } = useContext(V2V3ContractsContext)
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
+  const { fundingCycle: currentFundingCycle } = useContext(V2V3ProjectContext)
 
   const [pastFundingCycles, setPastFundingCycles] = useState<
     [V2V3FundingCycle, V2V3FundingCycleMetadata][]
@@ -23,19 +25,19 @@ export function FundingCycleHistory() {
 
   useEffect(() => {
     async function loadPastFundingCycles() {
-      if (!projectId || !currentFundingCycle || !contracts) return
+      if (!projectId || !currentFundingCycle || !JBController) return
 
       const pastFundingCycles = await fetchPastFundingCycles({
         projectId,
         currentFundingCycle,
-        contracts,
+        JBController,
       })
 
       setPastFundingCycles(pastFundingCycles)
     }
 
     loadPastFundingCycles()
-  }, [contracts, projectId, currentFundingCycle])
+  }, [JBController, projectId, currentFundingCycle])
 
   if (!projectId || !currentFundingCycle || !currentFundingCycle?.number)
     return null

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleHistory/utils.ts
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleHistory/utils.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { V2V3Contracts } from 'models/v2v3/contracts'
+import { Contract } from '@ethersproject/contracts'
 import {
   V2V3FundingCycle,
   V2V3FundingCycleMetadata,
@@ -98,17 +98,16 @@ const deriveFundingCyclesBetweenEachConfiguration = ({
 export const fetchPastFundingCycles = async ({
   projectId,
   currentFundingCycle,
-  contracts,
+  JBController,
 }: {
   projectId: number
   currentFundingCycle: V2V3FundingCycle
-  contracts: V2V3Contracts
+  JBController: Contract
 }): Promise<[V2V3FundingCycle, V2V3FundingCycleMetadata][]> => {
-  const firstFCOfCurrentConfiguration =
-    (await contracts?.JBController.getFundingCycleOf(
-      projectId,
-      currentFundingCycle.configuration,
-    )) as [V2V3FundingCycle, V2V3FundingCycleMetadata]
+  const firstFCOfCurrentConfiguration = (await JBController.getFundingCycleOf(
+    projectId,
+    currentFundingCycle.configuration,
+  )) as [V2V3FundingCycle, V2V3FundingCycleMetadata]
 
   let firstFCOfEachConfiguration: [
     V2V3FundingCycle,
@@ -119,7 +118,7 @@ export const fetchPastFundingCycles = async ({
   // Get first funding cycle of each configuration using basedOn
   while (!previousReconfiguration.eq(BigNumber.from(0))) {
     const previousReconfigurationFirstFundingCycle =
-      (await contracts?.JBController.getFundingCycleOf(
+      (await JBController.getFundingCycleOf(
         projectId,
         previousReconfiguration,
       )) as [V2V3FundingCycle, V2V3FundingCycleMetadata]

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
@@ -1,9 +1,32 @@
 import { Select } from 'antd'
+import { BaseOptionType } from 'antd/lib/select'
 import { CV_V2, CV_V3 } from 'constants/cv'
+import { readNetwork } from 'constants/networks'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2CVType, V3CVType } from 'models/cv'
+import { NetworkName } from 'models/network-name'
 import { useContext } from 'react'
 
+/**
+ * Note:
+ * - V2 isn't available on goerli.
+ * - V3 isn't available on rinkeby.
+ */
+const SELECT_OPTIONS: BaseOptionType[] = [
+  readNetwork.name !== NetworkName.goerli && {
+    value: CV_V2,
+    label: 'V2',
+  },
+  readNetwork.name &&
+    NetworkName.rinkeby && {
+      value: CV_V3,
+      label: 'V3',
+    },
+].filter(Boolean) as BaseOptionType[]
+
+/**
+ * A Select component that allows the user to switch between V2 and V3 contracts.
+ */
 export function ContractVersionSelect() {
   const { setVersion, cv } = useContext(V2V3ContractsContext)
 
@@ -13,9 +36,7 @@ export function ContractVersionSelect() {
       bordered={false}
       className="ant-select-color-secondary"
       onSelect={(value: V2CVType | V3CVType) => setVersion?.(value)}
-    >
-      <Select.Option value={CV_V2}>V2</Select.Option>
-      <Select.Option value={CV_V3}>V3</Select.Option>
-    </Select>
+      options={SELECT_OPTIONS}
+    />
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
@@ -17,11 +17,10 @@ const SELECT_OPTIONS: BaseOptionType[] = [
     value: CV_V2,
     label: 'V2',
   },
-  readNetwork.name &&
-    NetworkName.rinkeby && {
-      value: CV_V3,
-      label: 'V3',
-    },
+  readNetwork.name !== NetworkName.rinkeby && {
+    value: CV_V3,
+    label: 'V3',
+  },
 ].filter(Boolean) as BaseOptionType[]
 
 /**

--- a/src/components/v2v3/V2V3Project/banners/RelaunchFundingCycleBanner/RelaunchFundingCycleModal.tsx
+++ b/src/components/v2v3/V2V3Project/banners/RelaunchFundingCycleBanner/RelaunchFundingCycleModal.tsx
@@ -39,7 +39,6 @@ export function RelaunchFundingCycleModal(props: ModalProps) {
   const { data, loading: deprecatedFundingCycleLoading } =
     useProjectCurrentFundingCycle({
       projectId,
-      useDeprecatedContract: true,
     })
   const [deprecatedFundingCycle, deprecatedFundingCycleMetadata] = data ?? []
 
@@ -69,7 +68,6 @@ export function RelaunchFundingCycleModal(props: ModalProps) {
       projectId,
       configuration: deprecatedFundingCycle?.configuration?.toString(),
       terminal: primaryTerminal,
-      useDeprecatedContract: true,
     })
 
   const [deprecatedDistributionLimit, deprecatedDistributionLimitCurrency] =

--- a/src/contexts/v2v3/V2V3ProjectContext.ts
+++ b/src/contexts/v2v3/V2V3ProjectContext.ts
@@ -7,7 +7,7 @@ import {
 } from 'models/v2v3/fundingCycle'
 import { createContext } from 'react'
 
-type V2ProjectLoadingStates = {
+interface V2V3ProjectLoadingStates {
   ETHBalanceLoading: boolean
   balanceInDistributionLimitCurrencyLoading: boolean
   distributionLimitLoading: boolean
@@ -44,7 +44,7 @@ export type V2V3ProjectContextType = {
   primaryTerminalCurrentOverflow: BigNumber | undefined
   totalTokenSupply: BigNumber | undefined
 
-  loading: V2ProjectLoadingStates
+  loading: V2V3ProjectLoadingStates
 }
 
 export const V2V3ProjectContext = createContext<V2V3ProjectContextType>({

--- a/src/contexts/v2v3/V2V3ProjectContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ProjectContractsContext.ts
@@ -1,10 +1,12 @@
 import { Contract } from '@ethersproject/contracts'
 import { createContext } from 'react'
 
+export interface V2V3ProjectContracts {
+  JBController?: Contract
+}
+
 export const V2V3ProjectContractsContext: React.Context<{
-  contracts: {
-    JBController?: Contract
-  }
+  contracts: V2V3ProjectContracts
 }> = createContext({
   contracts: {},
 })

--- a/src/contexts/v2v3/V2V3ProjectContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ProjectContractsContext.ts
@@ -1,0 +1,10 @@
+import { Contract } from '@ethersproject/contracts'
+import { createContext } from 'react'
+
+export const V2V3ProjectContractsContext: React.Context<{
+  contracts: {
+    JBController?: Contract
+  }
+}> = createContext({
+  contracts: {},
+})

--- a/src/hooks/v2/transactor/V2IssueErc20TokenTx.ts
+++ b/src/hooks/v2/transactor/V2IssueErc20TokenTx.ts
@@ -5,6 +5,7 @@ import invariant from 'tiny-invariant'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   handleTransactionException,
   TransactorInstance,
@@ -17,14 +18,15 @@ export function useV2IssueErc20TokenTx(): TransactorInstance<{
   const { transactor } = useContext(TransactionContext)
   const { contracts } = useContext(V2V3ContractsContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
 
   return ({ name, symbol }, txOpts) => {
     try {
-      invariant(
-        transactor && projectId && contracts?.JBController && name && symbol,
-      )
+      invariant(transactor && projectId && JBController && name && symbol)
       return transactor(
-        contracts.JBController,
+        JBController,
         'issueTokenFor',
         [projectId, name, symbol],
         {

--- a/src/hooks/v2v3/V2V3ProjectContracts.ts
+++ b/src/hooks/v2v3/V2V3ProjectContracts.ts
@@ -1,0 +1,33 @@
+import { Contract } from '@ethersproject/contracts'
+import { readProvider } from 'constants/readProvider'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { useContext } from 'react'
+import useProjectController from './contractReader/ProjectController'
+
+/**
+ * Load project-specific JB contracts.
+ * @returns
+ */
+export function useV2V3ProjectContracts({ projectId }: { projectId: number }) {
+  const { contracts } = useContext(V2V3ContractsContext)
+
+  /**
+   * Load controller data
+   */
+  const { data: controllerAddress } = useProjectController({
+    projectId,
+  })
+
+  const JBController =
+    controllerAddress && contracts
+      ? new Contract(
+          controllerAddress,
+          contracts.JBController.interface,
+          readProvider,
+        )
+      : undefined
+
+  return {
+    JBController,
+  }
+}

--- a/src/hooks/v2v3/V2V3ProjectContracts.ts
+++ b/src/hooks/v2v3/V2V3ProjectContracts.ts
@@ -1,15 +1,23 @@
 import { Contract } from '@ethersproject/contracts'
+import { readNetwork } from 'constants/networks'
 import { readProvider } from 'constants/readProvider'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { useContext } from 'react'
+import { V2V3ProjectContracts } from 'contexts/v2v3/V2V3ProjectContractsContext'
+import { V2V3ContractName } from 'models/v2v3/contracts'
+import { useContext, useEffect, useState } from 'react'
+import { loadJuiceboxV2OrV3Contract } from 'utils/v2v3/contractLoaders/JuiceboxV2OrV3'
 import useProjectController from './contractReader/ProjectController'
 
 /**
  * Load project-specific JB contracts.
- * @returns
  */
-export function useV2V3ProjectContracts({ projectId }: { projectId: number }) {
-  const { contracts } = useContext(V2V3ContractsContext)
+export function useV2V3ProjectContracts({
+  projectId,
+}: {
+  projectId: number
+}): V2V3ProjectContracts {
+  const { cv } = useContext(V2V3ContractsContext)
+  const [contracts, setContracts] = useState<{ JBController?: Contract }>({})
 
   /**
    * Load controller data
@@ -18,16 +26,25 @@ export function useV2V3ProjectContracts({ projectId }: { projectId: number }) {
     projectId,
   })
 
-  const JBController =
-    controllerAddress && contracts
-      ? new Contract(
-          controllerAddress,
-          contracts.JBController.interface,
-          readProvider,
-        )
-      : undefined
+  useEffect(() => {
+    async function loadContracts() {
+      if (!cv) return
 
-  return {
-    JBController,
-  }
+      const JBControllerJson = await loadJuiceboxV2OrV3Contract(
+        cv,
+        V2V3ContractName.JBController,
+        readNetwork.name,
+      )
+      const JBController =
+        controllerAddress && JBControllerJson
+          ? new Contract(controllerAddress, JBControllerJson.abi, readProvider)
+          : undefined
+
+      setContracts({ JBController })
+    }
+
+    loadContracts()
+  }, [controllerAddress, cv])
+
+  return contracts
 }

--- a/src/hooks/v2v3/V2V3ProjectState.ts
+++ b/src/hooks/v2v3/V2V3ProjectState.ts
@@ -3,6 +3,7 @@ import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
 } from 'constants/splits'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2V3ProjectContextType } from 'contexts/v2v3/V2V3ProjectContext'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
 import useNameOfERC20 from 'hooks/NameOfERC20'
@@ -21,16 +22,13 @@ import useProjectTokenTotalSupply from 'hooks/v2v3/contractReader/ProjectTokenTo
 import useTerminalCurrentOverflow from 'hooks/v2v3/contractReader/TerminalCurrentOverflow'
 import useUsedDistributionLimit from 'hooks/v2v3/contractReader/UsedDistributionLimit'
 import first from 'lodash/first'
-import { CV } from 'models/cv'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
-import { useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import {
   NO_CURRENCY,
   V2V3CurrencyName,
   V2V3_CURRENCY_ETH,
 } from 'utils/v2v3/currency'
-
-const V2_PROJECT_CV: CV = '2'
 
 const useBalanceInDistributionLimitCurrency = ({
   ETHBalanceLoading,
@@ -68,6 +66,8 @@ const useBalanceInDistributionLimitCurrency = ({
 }
 
 export function useV2V3ProjectState({ projectId }: { projectId: number }) {
+  const { cv } = useContext(V2V3ContractsContext)
+
   /**
    * Load additional project metadata
    */
@@ -82,7 +82,7 @@ export function useV2V3ProjectState({ projectId }: { projectId: number }) {
   const { data: projects } = useProjectsQuery({
     projectId,
     keys: ['createdAt', 'totalPaid'],
-    cv: [V2_PROJECT_CV],
+    cv: cv ? [cv] : undefined,
   })
   const createdAt = first(projects)?.createdAt
   const totalVolume = first(projects)?.totalPaid

--- a/src/hooks/v2v3/contractReader/ProjectController.ts
+++ b/src/hooks/v2v3/contractReader/ProjectController.ts
@@ -1,0 +1,15 @@
+import { V2V3ContractName } from 'models/v2v3/contracts'
+
+import useV2ContractReader from './V2ContractReader'
+
+export default function useProjectController({
+  projectId,
+}: {
+  projectId?: number
+}) {
+  return useV2ContractReader<string>({
+    contract: V2V3ContractName.JBDirectory,
+    functionName: 'controllerOf',
+    args: projectId ? [projectId] : null,
+  })
+}

--- a/src/hooks/v2v3/contractReader/ProjectCurrentFundingCycle.ts
+++ b/src/hooks/v2v3/contractReader/ProjectCurrentFundingCycle.ts
@@ -1,22 +1,21 @@
-import { V2V3ContractName } from 'models/v2v3/contracts'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   V2V3FundingCycle,
   V2V3FundingCycleMetadata,
 } from 'models/v2v3/fundingCycle'
+import { useContext } from 'react'
 
 import useV2ContractReader from './V2ContractReader'
 
 export default function useProjectCurrentFundingCycle({
   projectId,
-  useDeprecatedContract,
 }: {
   projectId?: number
-  useDeprecatedContract?: boolean
 }) {
+  const { contracts } = useContext(V2V3ProjectContractsContext)
+
   return useV2ContractReader<[V2V3FundingCycle, V2V3FundingCycleMetadata]>({
-    contract: useDeprecatedContract
-      ? V2V3ContractName.DeprecatedJBController
-      : V2V3ContractName.JBController,
+    contract: contracts?.JBController,
     functionName: 'currentFundingCycleOf',
     args: projectId ? [projectId] : null,
   })

--- a/src/hooks/v2v3/contractReader/ProjectDistributionLimit.ts
+++ b/src/hooks/v2v3/contractReader/ProjectDistributionLimit.ts
@@ -1,26 +1,24 @@
 import { BigNumber } from '@ethersproject/bignumber'
-
-import { V2V3ContractName } from 'models/v2v3/contracts'
-
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
-
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
+import { useContext } from 'react'
 import useV2ContractReader from './V2ContractReader'
 
 export default function useProjectDistributionLimit({
   projectId,
   configuration,
   terminal,
-  useDeprecatedContract,
 }: {
   projectId: number | undefined
   configuration: string | undefined
   terminal: string | undefined
-  useDeprecatedContract?: boolean
 }) {
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
+
   return useV2ContractReader<BigNumber[]>({
-    contract: useDeprecatedContract
-      ? V2V3ContractName.DeprecatedJBController
-      : V2V3ContractName.JBController,
+    contract: JBController,
     functionName: 'distributionLimitOf',
     args:
       projectId && configuration && terminal

--- a/src/hooks/v2v3/contractReader/ProjectLatestConfiguredFundingCycle.ts
+++ b/src/hooks/v2v3/contractReader/ProjectLatestConfiguredFundingCycle.ts
@@ -1,9 +1,10 @@
-import { V2V3ContractName } from 'models/v2v3/contracts'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   BallotState,
   V2V3FundingCycle,
   V2V3FundingCycleMetadata,
 } from 'models/v2v3/fundingCycle'
+import { useContext } from 'react'
 import useV2ContractReader from './V2ContractReader'
 
 export function useProjectLatestConfiguredFundingCycle({
@@ -11,10 +12,14 @@ export function useProjectLatestConfiguredFundingCycle({
 }: {
   projectId?: number
 }) {
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
+
   return useV2ContractReader<
     [V2V3FundingCycle, V2V3FundingCycleMetadata, BallotState]
   >({
-    contract: V2V3ContractName.JBController,
+    contract: JBController,
     functionName: 'latestConfiguredFundingCycleOf',
     args: projectId ? [projectId] : null,
   })

--- a/src/hooks/v2v3/transactor/DistributeReservedTokensTx.ts
+++ b/src/hooks/v2v3/transactor/DistributeReservedTokensTx.ts
@@ -1,10 +1,10 @@
 import { t } from '@lingui/macro'
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -14,18 +14,20 @@ type DistributeReserveTokensTx = TransactorInstance<{
 
 export function useDistributeReservedTokens(): DistributeReserveTokensTx {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ContractsContext)
   const { tokenSymbol } = useContext(V2V3ProjectContext)
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
 
   return ({ memo = '' }, txOpts) => {
-    if (!transactor || !projectId || !contracts?.JBController) {
+    if (!transactor || !projectId || !JBController) {
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }
 
     return transactor(
-      contracts.JBController,
+      JBController,
       'distributeReservedTokensOf',
       [projectId, memo],
       {

--- a/src/hooks/v2v3/transactor/MintTokensTx.ts
+++ b/src/hooks/v2v3/transactor/MintTokensTx.ts
@@ -1,11 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   handleTransactionException,
   TransactorInstance,
@@ -20,8 +20,10 @@ export function useMintTokensTx(): TransactorInstance<{
   memo: string
 }> {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ContractsContext)
   const { tokenSymbol } = useContext(V2V3ProjectContext)
+  const {
+    contracts: { JBController },
+  } = useContext(V2V3ProjectContractsContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 
   // TODO new V2 feature:
@@ -30,9 +32,9 @@ export function useMintTokensTx(): TransactorInstance<{
 
   return ({ value, beneficiary, preferClaimed, memo }, txOpts) => {
     try {
-      invariant(transactor && projectId && contracts)
+      invariant(transactor && projectId && JBController)
       return transactor(
-        contracts?.JBController,
+        JBController,
         'mintTokensOf',
         [
           projectId,
@@ -53,8 +55,8 @@ export function useMintTokensTx(): TransactorInstance<{
     } catch {
       const missingParam = !transactor
         ? 'transactor'
-        : !contracts
-        ? 'contracts'
+        : !JBController
+        ? 'JBController'
         : !projectId
         ? 'projectId'
         : undefined

--- a/src/models/v2v3/contracts.ts
+++ b/src/models/v2v3/contracts.ts
@@ -20,7 +20,6 @@ export enum V2V3ContractName {
 
   JBV1TokenPaymentTerminal = 'JBV1TokenPaymentTerminal',
 
-  DeprecatedJBController = 'DeprecatedJBController',
   DeprecatedJBSplitsStore = 'DeprecatedJBSplitsStore',
   DeprecatedJBDirectory = 'DeprecatedJBDirectory',
 

--- a/src/pages/v2/p/[projectId]/components/V2V3Dashboard.tsx
+++ b/src/pages/v2/p/[projectId]/components/V2V3Dashboard.tsx
@@ -4,6 +4,7 @@ import { layouts } from 'constants/styles/layouts'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { TransactionProvider } from 'providers/TransactionProvider'
 import { NftRewardsProvider } from 'providers/v2v3/NftRewardsProvider'
+import { V2V3ProjectContractsProvider } from 'providers/v2v3/V2V3ProjectContractsProvider'
 import V2V3ProjectMetadataProvider from 'providers/v2v3/V2V3ProjectMetadataProvider'
 import V2V3ProjectProvider from 'providers/v2v3/V2V3ProjectProvider'
 import { VeNftProvider } from 'providers/v2v3/VeNftProvider'
@@ -18,15 +19,20 @@ export function V2V3Dashboard({
   return (
     <div style={layouts.maxWidth}>
       <TransactionProvider>
-        <V2V3ProjectMetadataProvider projectId={projectId} metadata={metadata}>
-          <V2V3ProjectProvider projectId={projectId}>
-            <NftRewardsProvider>
-              <VeNftProvider projectId={projectId}>
-                <V2V3Project />
-              </VeNftProvider>
-            </NftRewardsProvider>
-          </V2V3ProjectProvider>
-        </V2V3ProjectMetadataProvider>
+        <V2V3ProjectContractsProvider projectId={projectId}>
+          <V2V3ProjectMetadataProvider
+            projectId={projectId}
+            metadata={metadata}
+          >
+            <V2V3ProjectProvider projectId={projectId}>
+              <NftRewardsProvider>
+                <VeNftProvider projectId={projectId}>
+                  <V2V3Project />
+                </VeNftProvider>
+              </NftRewardsProvider>
+            </V2V3ProjectProvider>
+          </V2V3ProjectMetadataProvider>
+        </V2V3ProjectContractsProvider>
       </TransactionProvider>
 
       <div style={{ textAlign: 'center', marginTop: '3rem' }}>

--- a/src/pages/v2/p/[projectId]/components/V2V3Dashboard.tsx
+++ b/src/pages/v2/p/[projectId]/components/V2V3Dashboard.tsx
@@ -1,38 +1,19 @@
 import ScrollToTopButton from 'components/ScrollToTopButton'
 import { V2V3Project } from 'components/v2v3/V2V3Project'
 import { layouts } from 'constants/styles/layouts'
-import { ProjectMetadataV5 } from 'models/project-metadata'
 import { TransactionProvider } from 'providers/TransactionProvider'
 import { NftRewardsProvider } from 'providers/v2v3/NftRewardsProvider'
-import { V2V3ProjectContractsProvider } from 'providers/v2v3/V2V3ProjectContractsProvider'
-import V2V3ProjectMetadataProvider from 'providers/v2v3/V2V3ProjectMetadataProvider'
-import V2V3ProjectProvider from 'providers/v2v3/V2V3ProjectProvider'
 import { VeNftProvider } from 'providers/v2v3/VeNftProvider'
 
-export function V2V3Dashboard({
-  projectId,
-  metadata,
-}: {
-  projectId: number
-  metadata: ProjectMetadataV5
-}) {
+export function V2V3Dashboard({ projectId }: { projectId: number }) {
   return (
     <div style={layouts.maxWidth}>
       <TransactionProvider>
-        <V2V3ProjectContractsProvider projectId={projectId}>
-          <V2V3ProjectMetadataProvider
-            projectId={projectId}
-            metadata={metadata}
-          >
-            <V2V3ProjectProvider projectId={projectId}>
-              <NftRewardsProvider>
-                <VeNftProvider projectId={projectId}>
-                  <V2V3Project />
-                </VeNftProvider>
-              </NftRewardsProvider>
-            </V2V3ProjectProvider>
-          </V2V3ProjectMetadataProvider>
-        </V2V3ProjectContractsProvider>
+        <NftRewardsProvider>
+          <VeNftProvider projectId={projectId}>
+            <V2V3Project />
+          </VeNftProvider>
+        </NftRewardsProvider>
       </TransactionProvider>
 
       <div style={{ textAlign: 'center', marginTop: '3rem' }}>

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -10,7 +10,7 @@ import {
   GetStaticPropsResult,
   InferGetStaticPropsType,
 } from 'next'
-import { V2V3ContractsProvider } from 'providers/v2v3/V2V3ContractsProvider'
+import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
 
 import { V2V3Dashboard } from './components/V2V3Dashboard'
 import { getProjectProps, ProjectPageProps } from './utils/props'
@@ -68,9 +68,13 @@ export default function V2ProjectPage({
       ) : null}
       <AppWrapper>
         {metadata ? (
-          <V2V3ContractsProvider initialCv={cv}>
-            <V2V3Dashboard metadata={metadata} projectId={projectId} />
-          </V2V3ContractsProvider>
+          <V2V3ProjectPageProvider
+            projectId={projectId}
+            metadata={metadata}
+            cv={cv}
+          >
+            <V2V3Dashboard projectId={projectId} />
+          </V2V3ProjectPageProvider>
         ) : (
           <Loading />
         )}

--- a/src/pages/v2/p/[projectId]/safe/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/safe/index.page.tsx
@@ -4,10 +4,7 @@ import { V2CVType, V3CVType } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
 import { TransactionProvider } from 'providers/TransactionProvider'
-import { V2V3ContractsProvider } from 'providers/v2v3/V2V3ContractsProvider'
-
-import V2V3ProjectMetadataProvider from 'providers/v2v3/V2V3ProjectMetadataProvider'
-import V2V3ProjectProvider from 'providers/v2v3/V2V3ProjectProvider'
+import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
 import { getProjectProps, ProjectPageProps } from '../utils/props'
 
 export const getServerSideProps: GetServerSideProps<
@@ -30,18 +27,15 @@ export default function ProjectSafeDashboardPage({
 }) {
   return (
     <AppWrapper>
-      <V2V3ContractsProvider initialCv={cv}>
+      <V2V3ProjectPageProvider
+        projectId={projectId}
+        metadata={metadata}
+        cv={cv}
+      >
         <TransactionProvider>
-          <V2V3ProjectMetadataProvider
-            projectId={projectId}
-            metadata={metadata}
-          >
-            <V2V3ProjectProvider projectId={projectId}>
-              <ProjectSafeDashboard />
-            </V2V3ProjectProvider>
-          </V2V3ProjectMetadataProvider>
+          <ProjectSafeDashboard />
         </TransactionProvider>
-      </V2V3ContractsProvider>
+      </V2V3ProjectPageProvider>
     </AppWrapper>
   )
 }

--- a/src/pages/v2/p/[projectId]/settings/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/settings/index.page.tsx
@@ -4,9 +4,7 @@ import { V2CVType, V3CVType } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
 import { TransactionProvider } from 'providers/TransactionProvider'
-import { V2V3ContractsProvider } from 'providers/v2v3/V2V3ContractsProvider'
-import V2V3ProjectMetadataProvider from 'providers/v2v3/V2V3ProjectMetadataProvider'
-import V2V3ProjectProvider from 'providers/v2v3/V2V3ProjectProvider'
+import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
 import { getProjectProps, ProjectPageProps } from '../utils/props'
 
 export const getServerSideProps: GetServerSideProps<
@@ -29,18 +27,15 @@ export default function V2V3ProjectSettingsPage({
 }) {
   return (
     <AppWrapper>
-      <V2V3ContractsProvider initialCv={cv}>
+      <V2V3ProjectPageProvider
+        projectId={projectId}
+        metadata={metadata}
+        cv={cv}
+      >
         <TransactionProvider>
-          <V2V3ProjectMetadataProvider
-            projectId={projectId}
-            metadata={metadata}
-          >
-            <V2V3ProjectProvider projectId={projectId}>
-              <V2V3ProjectSettings />
-            </V2V3ProjectProvider>
-          </V2V3ProjectMetadataProvider>
+          <V2V3ProjectSettings />
         </TransactionProvider>
-      </V2V3ContractsProvider>
+      </V2V3ProjectPageProvider>
     </AppWrapper>
   )
 }

--- a/src/pages/v2/p/[projectId]/venft/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/venft/index.page.tsx
@@ -4,9 +4,7 @@ import { V2CVType, V3CVType } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
 import { TransactionProvider } from 'providers/TransactionProvider'
-import { V2V3ContractsProvider } from 'providers/v2v3/V2V3ContractsProvider'
-import V2V3ProjectMetadataProvider from 'providers/v2v3/V2V3ProjectMetadataProvider'
-import V2V3ProjectProvider from 'providers/v2v3/V2V3ProjectProvider'
+import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
 import { VeNftProvider } from 'providers/v2v3/VeNftProvider'
 import { getProjectProps, ProjectPageProps } from '../utils/props'
 
@@ -30,20 +28,17 @@ export default function V2V3ProjectSettingsPage({
 }) {
   return (
     <AppWrapper>
-      <V2V3ContractsProvider initialCv={cv}>
+      <V2V3ProjectPageProvider
+        projectId={projectId}
+        metadata={metadata}
+        cv={cv}
+      >
         <TransactionProvider>
-          <V2V3ProjectMetadataProvider
-            projectId={projectId}
-            metadata={metadata}
-          >
-            <V2V3ProjectProvider projectId={projectId}>
-              <VeNftProvider projectId={projectId}>
-                <VeNft />
-              </VeNftProvider>
-            </V2V3ProjectProvider>
-          </V2V3ProjectMetadataProvider>
+          <VeNftProvider projectId={projectId}>
+            <VeNft />
+          </VeNftProvider>
         </TransactionProvider>
-      </V2V3ContractsProvider>
+      </V2V3ProjectPageProvider>
     </AppWrapper>
   )
 }

--- a/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
@@ -1,0 +1,18 @@
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
+import { useV2V3ProjectContracts } from 'hooks/v2v3/V2V3ProjectContracts'
+
+export const V2V3ProjectContractsProvider: React.FC<{
+  projectId: number
+}> = ({ children, projectId }) => {
+  const contracts = useV2V3ProjectContracts({ projectId })
+
+  return (
+    <V2V3ProjectContractsContext.Provider
+      value={{
+        contracts,
+      }}
+    >
+      {children}
+    </V2V3ProjectContractsContext.Provider>
+  )
+}

--- a/src/providers/v2v3/V2V3ProjectPageProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectPageProvider.tsx
@@ -1,0 +1,27 @@
+import { V2CVType, V3CVType } from 'models/cv'
+import { ProjectMetadataV5 } from 'models/project-metadata'
+import { V2V3ContractsProvider } from './V2V3ContractsProvider'
+import { V2V3ProjectContractsProvider } from './V2V3ProjectContractsProvider'
+import V2V3ProjectMetadataProvider from './V2V3ProjectMetadataProvider'
+import V2V3ProjectProvider from './V2V3ProjectProvider'
+
+/**
+ * Provide all the necessary contexts to render a V2V3 Project.
+ */
+export const V2V3ProjectPageProvider: React.FC<{
+  projectId: number
+  metadata: ProjectMetadataV5
+  cv: V3CVType | V2CVType
+}> = ({ projectId, metadata, children, cv }) => {
+  return (
+    <V2V3ContractsProvider initialCv={cv}>
+      <V2V3ProjectContractsProvider projectId={projectId}>
+        <V2V3ProjectMetadataProvider projectId={projectId} metadata={metadata}>
+          <V2V3ProjectProvider projectId={projectId}>
+            {children}
+          </V2V3ProjectProvider>
+        </V2V3ProjectMetadataProvider>
+      </V2V3ProjectContractsProvider>
+    </V2V3ContractsProvider>
+  )
+}

--- a/src/providers/v2v3/VeNftProvider.tsx
+++ b/src/providers/v2v3/VeNftProvider.tsx
@@ -1,6 +1,6 @@
 import { VeNftContext } from 'contexts/veNftContext'
 import { useVeNftContractForProject } from 'hooks/veNft/VeNftContractForProject'
-import { first } from 'lodash'
+import first from 'lodash/first'
 import { PropsWithChildren } from 'react'
 
 export function VeNftProvider({

--- a/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
+++ b/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
@@ -7,10 +7,6 @@ import { V2V3ContractName } from 'models/v2v3/contracts'
 const V2_CONTRACT_ABI_OVERRIDES: {
   [k in V2V3ContractName]?: { filename: string; version: string }
 } = {
-  DeprecatedJBController: {
-    version: '4.0.0',
-    filename: 'JBController',
-  },
   DeprecatedJBSplitsStore: {
     version: '4.0.0',
     filename: 'JBSplitsStore',

--- a/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
+++ b/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
@@ -24,6 +24,7 @@ export const loadJuiceboxV2Contract = async (
   const contractOverride = V2_CONTRACT_ABI_OVERRIDES[contractName]
   const version = contractOverride?.version ?? 'latest'
   const filename = contractOverride?.filename ?? contractName
+
   return await import(
     `@jbx-protocol/contracts-v2-${version}/deployments/${network}/${filename}.json`
   )

--- a/src/utils/v2v3/contractLoaders/JuiceboxV2OrV3.ts
+++ b/src/utils/v2v3/contractLoaders/JuiceboxV2OrV3.ts
@@ -1,0 +1,18 @@
+import { CV_V2, CV_V3 } from 'constants/cv'
+import { CV } from 'models/cv'
+import { NetworkName } from 'models/network-name'
+import { V2V3ContractName } from 'models/v2v3/contracts'
+import { loadJuiceboxV2Contract } from './JuiceboxV2'
+import { loadJuiceboxV3Contract } from './JuiceboxV3'
+
+export async function loadJuiceboxV2OrV3Contract(
+  cv: CV,
+  contractName: V2V3ContractName,
+  network: NetworkName,
+) {
+  return cv === CV_V2
+    ? await loadJuiceboxV2Contract(contractName, network)
+    : cv === CV_V3
+    ? await loadJuiceboxV3Contract(contractName, network)
+    : undefined
+}

--- a/src/utils/v2v3/loadV2V3Contract.ts
+++ b/src/utils/v2v3/loadV2V3Contract.ts
@@ -1,5 +1,4 @@
 import { Contract, ContractInterface } from '@ethersproject/contracts'
-import { CV_V2, CV_V3 } from 'constants/cv'
 import { V2CVType, V3CVType } from 'models/cv'
 import { NetworkName } from 'models/network-name'
 import { SignerOrProvider } from 'models/signerOrProvider'
@@ -7,8 +6,7 @@ import { V2V3ContractName } from 'models/v2v3/contracts'
 import { loadJBProjectHandlesContract } from './contractLoaders/JBProjectHandles'
 import { loadJBTiered721DelegateProjectDeployerContract } from './contractLoaders/JBTiered721DelegateProjectDeployer'
 import { loadJBTiered721DelegateStoreContract } from './contractLoaders/JBTiered721DelegateStore'
-import { loadJuiceboxV2Contract } from './contractLoaders/JuiceboxV2'
-import { loadJuiceboxV3Contract } from './contractLoaders/JuiceboxV3'
+import { loadJuiceboxV2OrV3Contract } from './contractLoaders/JuiceboxV2OrV3'
 import { loadPublicResolverContract } from './contractLoaders/PublicResolver'
 import { loadJBV1TokenPaymentTerminalContract } from './contractLoaders/V1TokenPaymentTerminal'
 import { loadVeNftDeployer } from './contractLoaders/VeNftDeployer'
@@ -44,12 +42,11 @@ export const loadV2V3Contract = async (
   } else if (contractName === V2V3ContractName.JBVeTokenUriResolver) {
     contractJson = await loadVeTokenUriResolver()
   } else {
-    contractJson =
-      version === CV_V2
-        ? await loadJuiceboxV2Contract(contractName, network)
-        : version === CV_V3
-        ? await loadJuiceboxV3Contract(contractName, network)
-        : undefined
+    contractJson = await loadJuiceboxV2OrV3Contract(
+      version,
+      contractName,
+      network,
+    )
   }
 
   if (!contractJson) {


### PR DESCRIPTION
Projects don't all necessarily use the same JB controller contract.

This PR:
- add a new context: V2V3ProjectContractsContext.
- loads the project-specific JBController contract into the V2V3ProjectContractsContext.
- uses this project-specific JBController contract where ever needed.
- Sometimes we'll still use the hardcoded JBController address (from the npm package): this is fine in examples like project creation or launching funding cycles. But we need to use the project-specific one whenever in the context of a project.

Towards V3 migration.