### PR TITLE
Isolate v1 project context loader

### DIFF
--- a/src/components/v1/V1Project/index.tsx
+++ b/src/components/v1/V1Project/index.tsx
@@ -6,7 +6,6 @@ import { CV_V1 } from 'constants/cv'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { V1PayProjectFormProvider } from 'providers/v1/V1PayProjectFormProvider'
 import { CSSProperties, lazy, Suspense, useContext } from 'react'
-import { decodeFundingCycleMetadata } from 'utils/v1/fundingCycle'
 import FundingCycles from './FundingCycles'
 import Paid from './Paid'
 import ProjectActivity from './ProjectActivity'
@@ -26,7 +25,6 @@ export function V1Project({
 }) {
   const {
     createdAt,
-    currentFC,
     projectId,
     handle,
     metadata,
@@ -34,10 +32,6 @@ export function V1Project({
     isPreviewMode,
     owner,
   } = useContext(V1ProjectContext)
-
-  const fcMetadata = decodeFundingCycleMetadata(currentFC?.metadata)
-
-  if (projectId === undefined || !fcMetadata) return null
 
   return (
     <div style={style}>

--- a/src/constants/v1/projectTypes.ts
+++ b/src/constants/v1/projectTypes.ts
@@ -6,7 +6,7 @@ import { V1_PROJECT_IDS } from './projectIds'
 
 const { SHARK_DAO, SVSPOOL002, DEFI_DAO, CONSTITUTION_DAO } = V1_PROJECT_IDS
 
-const projectTypesByNetwork: Partial<
+const PROJECT_TYPES_BY_NETWORK: Partial<
   Record<NetworkName, Record<number, ProjectType>>
 > = {
   [NetworkName.mainnet]: {
@@ -20,4 +20,4 @@ const projectTypesByNetwork: Partial<
   },
 }
 
-export const projectTypes = projectTypesByNetwork[readNetwork.name] ?? {}
+export const PROJECT_TYPES = PROJECT_TYPES_BY_NETWORK[readNetwork.name] ?? {}

--- a/src/hooks/v1/V1ProjectState.ts
+++ b/src/hooks/v1/V1ProjectState.ts
@@ -1,0 +1,147 @@
+import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
+import { PROJECT_TYPES } from 'constants/v1/projectTypes'
+import { V1ProjectContextType } from 'contexts/v1/projectContext'
+import { useCurrencyConverter } from 'hooks/CurrencyConverter'
+import { useProjectsQuery } from 'hooks/Projects'
+import useSymbolOfERC20 from 'hooks/SymbolOfERC20'
+import { ProjectMetadataV5 } from 'models/project-metadata'
+import { V1CurrencyOption } from 'models/v1/currencyOption'
+import { useMemo } from 'react'
+import { V1CurrencyName } from 'utils/v1/currency'
+import { getTerminalName, getTerminalVersion } from 'utils/v1/terminals'
+import useBalanceOfProject from './contractReader/BalanceOfProject'
+import useCurrentFundingCycleOfProject from './contractReader/CurrentFundingCycleOfProject'
+import useCurrentPayoutModsOfProject from './contractReader/CurrentPayoutModsOfProject'
+import useCurrentTicketModsOfProject from './contractReader/CurrentTicketModsOfProject'
+import useOverflowOfProject from './contractReader/OverflowOfProject'
+import useOwnerOfProject from './contractReader/OwnerOfProject'
+import useProjectIdForHandle from './contractReader/ProjectIdForHandle'
+import useQueuedFundingCycleOfProject from './contractReader/QueuedFundingCycleOfProject'
+import useQueuedPayoutModsOfProject from './contractReader/QueuedPayoutModsOfProject'
+import useQueuedTicketModsOfProject from './contractReader/QueuedTicketModsOfProject'
+import useTerminalOfProject from './contractReader/TerminalOfProject'
+import useTokenAddressOfProject from './contractReader/TokenAddressOfProject'
+
+export function useV1ProjectState({
+  handle,
+  metadata,
+}: {
+  handle: string | undefined
+  metadata: ProjectMetadataV5 | undefined
+}): V1ProjectContextType {
+  const projectId = useProjectIdForHandle(handle)
+
+  const owner = useOwnerOfProject(projectId)
+  const terminalAddress = useTerminalOfProject(projectId)
+  const terminalName = getTerminalName({
+    address: terminalAddress,
+  })
+  const terminalVersion = getTerminalVersion(terminalAddress)
+  const currentFC = useCurrentFundingCycleOfProject(
+    projectId?.toNumber(),
+    terminalName,
+  )
+  const queuedFC = useQueuedFundingCycleOfProject(projectId)
+  const currentPayoutMods = useCurrentPayoutModsOfProject(
+    projectId,
+    currentFC?.configured,
+  )
+  const queuedPayoutMods = useQueuedPayoutModsOfProject(
+    projectId,
+    queuedFC?.configured,
+  )
+  const currentTicketMods = useCurrentTicketModsOfProject(
+    projectId,
+    currentFC?.configured,
+  )
+  const queuedTicketMods = useQueuedTicketModsOfProject(
+    projectId,
+    queuedFC?.configured,
+  )
+  const tokenAddress = useTokenAddressOfProject(projectId)
+  const tokenSymbol = useSymbolOfERC20(tokenAddress)
+  const balance = useBalanceOfProject(projectId?.toNumber(), terminalName)
+  const converter = useCurrencyConverter()
+  const balanceInCurrency = useMemo(
+    () =>
+      balance &&
+      converter.wadToCurrency(
+        balance,
+        V1CurrencyName(currentFC?.currency.toNumber() as V1CurrencyOption),
+        'ETH',
+      ),
+    [balance, converter, currentFC],
+  )
+  const overflow = useOverflowOfProject(projectId, terminalName)
+
+  const { data: projects } = useProjectsQuery({
+    projectId: projectId?.toNumber(),
+    keys: ['createdAt', 'totalPaid'],
+  })
+
+  const createdAt = projects?.[0]?.createdAt
+  const earned = projects?.[0]?.totalPaid
+
+  const project = useMemo<V1ProjectContextType>(() => {
+    const projectType = projectId
+      ? PROJECT_TYPES[projectId.toNumber()]
+      : 'standard'
+    const isPreviewMode = false
+    const isArchived = projectId
+      ? V1ArchivedProjectIds.includes(projectId.toNumber()) ||
+        metadata?.archived
+      : false
+
+    return {
+      createdAt,
+      projectId: projectId?.toNumber(),
+      projectType,
+      owner,
+      earned,
+      handle,
+      metadata,
+      currentFC,
+      queuedFC,
+      currentPayoutMods,
+      currentTicketMods,
+      queuedPayoutMods,
+      queuedTicketMods,
+      tokenAddress,
+      tokenSymbol,
+      balance,
+      balanceInCurrency,
+      overflow,
+      isPreviewMode,
+      isArchived,
+      cv: terminalVersion,
+      terminal: {
+        address: terminalAddress,
+        name: terminalName,
+        version: terminalVersion,
+      },
+    }
+  }, [
+    balance,
+    balanceInCurrency,
+    overflow,
+    createdAt,
+    currentFC,
+    currentPayoutMods,
+    currentTicketMods,
+    earned,
+    handle,
+    metadata,
+    owner,
+    projectId,
+    queuedFC,
+    queuedPayoutMods,
+    queuedTicketMods,
+    tokenAddress,
+    tokenSymbol,
+    terminalVersion,
+    terminalName,
+    terminalAddress,
+  ])
+
+  return project
+}

--- a/src/pages/p/[handle].page.tsx
+++ b/src/pages/p/[handle].page.tsx
@@ -8,38 +8,16 @@ import ScrollToTopButton from 'components/ScrollToTopButton'
 import { V1Project } from 'components/v1/V1Project'
 import { CV_V1, CV_V1_1 } from 'constants/cv'
 import { layouts } from 'constants/styles/layouts'
-import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
-import { projectTypes } from 'constants/v1/projectTypes'
-import {
-  V1ProjectContext,
-  V1ProjectContextType,
-} from 'contexts/v1/projectContext'
-import { useCurrencyConverter } from 'hooks/CurrencyConverter'
-import { useProjectsQuery } from 'hooks/Projects'
-import useSymbolOfERC20 from 'hooks/SymbolOfERC20'
-import useBalanceOfProject from 'hooks/v1/contractReader/BalanceOfProject'
-import useCurrentFundingCycleOfProject from 'hooks/v1/contractReader/CurrentFundingCycleOfProject'
-import useCurrentPayoutModsOfProject from 'hooks/v1/contractReader/CurrentPayoutModsOfProject'
-import useCurrentTicketModsOfProject from 'hooks/v1/contractReader/CurrentTicketModsOfProject'
-import useOverflowOfProject from 'hooks/v1/contractReader/OverflowOfProject'
-import useOwnerOfProject from 'hooks/v1/contractReader/OwnerOfProject'
-import useProjectIdForHandle from 'hooks/v1/contractReader/ProjectIdForHandle'
-import useQueuedFundingCycleOfProject from 'hooks/v1/contractReader/QueuedFundingCycleOfProject'
-import useQueuedPayoutModsOfProject from 'hooks/v1/contractReader/QueuedPayoutModsOfProject'
-import useQueuedTicketModsOfProject from 'hooks/v1/contractReader/QueuedTicketModsOfProject'
-import useTerminalOfProject from 'hooks/v1/contractReader/TerminalOfProject'
-import useTokenAddressOfProject from 'hooks/v1/contractReader/TokenAddressOfProject'
+import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
 import { ProjectMetadataV5 } from 'models/project-metadata'
-import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { useRouter } from 'next/router'
 import { V1UserProvider } from 'providers/v1/UserProvider'
 import { V1CurrencyProvider } from 'providers/v1/V1CurrencyProvider'
-import { useMemo } from 'react'
+import { V1ProjectProvider } from 'providers/v1/V1ProjectProvider'
+import { useContext } from 'react'
 import { findProjectMetadata } from 'utils/server'
-import { V1CurrencyName } from 'utils/v1/currency'
-import { getTerminalName, getTerminalVersion } from 'utils/v1/terminals'
 
 export const getStaticPaths: GetStaticPaths = async () => {
   if (process.env.BUILD_CACHE_V1_PROJECTS === 'true') {
@@ -123,7 +101,11 @@ export default function V1HandlePage({
       <AppWrapper>
         {metadata ? (
           <V1UserProvider>
-            <V1Dashboard metadata={metadata} />
+            <V1ProjectProvider handle={handle} metadata={metadata}>
+              <V1CurrencyProvider>
+                <V1Dashboard />
+              </V1CurrencyProvider>
+            </V1ProjectProvider>
           </V1UserProvider>
         ) : (
           <Loading />
@@ -133,148 +115,31 @@ export default function V1HandlePage({
   )
 }
 
-function V1Dashboard({ metadata }: { metadata: ProjectMetadataV5 }) {
+function V1Dashboard() {
+  const { projectId } = useContext(V1ProjectContext)
   const router = useRouter()
 
   // Checks URL to see if user was just directed from project deploy
   const handle = router.query.handle as string
   const isNewDeploy = Boolean(router.query.newDeploy)
 
-  const projectId = useProjectIdForHandle(handle)
-  const owner = useOwnerOfProject(projectId)
-  const terminalAddress = useTerminalOfProject(projectId)
-  const terminalName = getTerminalName({
-    address: terminalAddress,
-  })
-  const terminalVersion = getTerminalVersion(terminalAddress)
-  const currentFC = useCurrentFundingCycleOfProject(
-    projectId?.toNumber(),
-    terminalName,
-  )
-  const queuedFC = useQueuedFundingCycleOfProject(projectId)
-  const currentPayoutMods = useCurrentPayoutModsOfProject(
-    projectId,
-    currentFC?.configured,
-  )
-  const queuedPayoutMods = useQueuedPayoutModsOfProject(
-    projectId,
-    queuedFC?.configured,
-  )
-  const currentTicketMods = useCurrentTicketModsOfProject(
-    projectId,
-    currentFC?.configured,
-  )
-  const queuedTicketMods = useQueuedTicketModsOfProject(
-    projectId,
-    queuedFC?.configured,
-  )
-  const tokenAddress = useTokenAddressOfProject(projectId)
-  const tokenSymbol = useSymbolOfERC20(tokenAddress)
-  const balance = useBalanceOfProject(projectId?.toNumber(), terminalName)
-  const converter = useCurrencyConverter()
-  const balanceInCurrency = useMemo(
-    () =>
-      balance &&
-      converter.wadToCurrency(
-        balance,
-        V1CurrencyName(currentFC?.currency.toNumber() as V1CurrencyOption),
-        'ETH',
-      ),
-    [balance, converter, currentFC],
-  )
-  const overflow = useOverflowOfProject(projectId, terminalName)
-
-  const { data: projects } = useProjectsQuery({
-    projectId: projectId?.toNumber(),
-    keys: ['createdAt', 'totalPaid'],
-  })
-
-  const createdAt = projects?.[0]?.createdAt
-  const earned = projects?.[0]?.totalPaid
-
-  const project = useMemo<V1ProjectContextType>(() => {
-    const projectType = projectId
-      ? projectTypes[projectId.toNumber()]
-      : 'standard'
-    const isPreviewMode = false
-    const isArchived = projectId
-      ? V1ArchivedProjectIds.includes(projectId.toNumber()) ||
-        metadata?.archived
-      : false
-
-    return {
-      createdAt,
-      projectId: projectId?.toNumber(),
-      projectType,
-      owner,
-      earned,
-      handle,
-      metadata,
-      currentFC,
-      queuedFC,
-      currentPayoutMods,
-      currentTicketMods,
-      queuedPayoutMods,
-      queuedTicketMods,
-      tokenAddress,
-      tokenSymbol,
-      balance,
-      balanceInCurrency,
-      overflow,
-      isPreviewMode,
-      isArchived,
-      cv: terminalVersion,
-      terminal: {
-        address: terminalAddress,
-        name: terminalName,
-        version: terminalVersion,
-      },
-    }
-  }, [
-    balance,
-    balanceInCurrency,
-    overflow,
-    createdAt,
-    currentFC,
-    currentPayoutMods,
-    currentTicketMods,
-    earned,
-    handle,
-    metadata,
-    owner,
-    projectId,
-    queuedFC,
-    queuedPayoutMods,
-    queuedTicketMods,
-    tokenAddress,
-    tokenSymbol,
-    terminalVersion,
-    terminalName,
-    terminalAddress,
-  ])
-
+  if (!handle) return <Project404 projectId={handle} />
   if (!projectId) return <Loading />
-
-  if (projectId?.eq(0)) {
+  if (projectId === 0) {
     if (isNewDeploy) {
       return <NewDeployNotAvailable handleOrId={handle} />
     }
+
     return <Project404 projectId={handle} />
   }
 
-  if (!projectId || !handle || !metadata) return null
-
   return (
-    <V1ProjectContext.Provider value={project}>
-      <V1CurrencyProvider>
-        <div style={layouts.maxWidth}>
-          <V1Project />
-          <div style={{ textAlign: 'center', padding: 20 }}>
-            <ScrollToTopButton />
-          </div>
-          <FeedbackFormButton projectHandle={handle} />
-        </div>
-      </V1CurrencyProvider>
-    </V1ProjectContext.Provider>
+    <div style={layouts.maxWidth}>
+      <V1Project />
+      <div style={{ textAlign: 'center', padding: 20 }}>
+        <ScrollToTopButton />
+      </div>
+      <FeedbackFormButton projectHandle={handle} />
+    </div>
   )
 }

--- a/src/providers/v1/V1ProjectProvider.tsx
+++ b/src/providers/v1/V1ProjectProvider.tsx
@@ -1,0 +1,16 @@
+import { V1ProjectContext } from 'contexts/v1/projectContext'
+import { useV1ProjectState } from 'hooks/v1/V1ProjectState'
+import { ProjectMetadataV5 } from 'models/project-metadata'
+
+export const V1ProjectProvider: React.FC<{
+  handle: string
+  metadata: ProjectMetadataV5
+}> = ({ children, handle, metadata }) => {
+  const project = useV1ProjectState({ handle, metadata })
+
+  return (
+    <V1ProjectContext.Provider value={project}>
+      {children}
+    </V1ProjectContext.Provider>
+  )
+}


### PR DESCRIPTION
Copy pattern used in V2V3. Create a provider and hook for V1ProjectContext and use it for the V1 project page.