### PR TITLE
[1/2] Source JBETHPaymentTerminal from chain

### DIFF
--- a/src/components/forms/ProjectDetailsForm.tsx
+++ b/src/components/forms/ProjectDetailsForm.tsx
@@ -82,6 +82,7 @@ export default function ProjectDetailsForm({
             initialUrl={form.getFieldValue('logoUri')}
             onSuccess={logoUri => {
               form.setFieldsValue({ logoUri })
+              onValuesChange?.()
             }}
             formItemProps={{ style: { marginBottom: 0 } }}
           />

--- a/src/contexts/v2v3/V2V3ProjectContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ProjectContractsContext.ts
@@ -3,6 +3,7 @@ import { createContext } from 'react'
 
 export interface V2V3ProjectContracts {
   JBController?: Contract
+  JBETHPaymentTerminal?: Contract
 }
 
 export const V2V3ProjectContractsContext: React.Context<{

--- a/src/hooks/LoadContractFromAddress.ts
+++ b/src/hooks/LoadContractFromAddress.ts
@@ -2,7 +2,6 @@ import * as constants from '@ethersproject/constants'
 import { Contract, ContractInterface } from '@ethersproject/contracts'
 import { isAddress } from 'ethers/lib/utils'
 import { useEffect, useState } from 'react'
-
 import { useWallet } from './Wallet'
 
 export const useLoadContractFromAddress = <ABI extends ContractInterface>({
@@ -10,7 +9,7 @@ export const useLoadContractFromAddress = <ABI extends ContractInterface>({
   abi,
 }: {
   address: string | undefined
-  abi: ABI
+  abi: ABI | undefined
 }) => {
   const [contract, setContract] = useState<Contract>()
 
@@ -26,7 +25,7 @@ export const useLoadContractFromAddress = <ABI extends ContractInterface>({
   }
 
   useEffect(() => {
-    if (!isInputAddressValid(address)) {
+    if (!abi || !isInputAddressValid(address)) {
       return setContract(undefined)
     }
 

--- a/src/hooks/v2v3/LoadV2V3Contract.ts
+++ b/src/hooks/v2v3/LoadV2V3Contract.ts
@@ -5,6 +5,11 @@ import { V2V3ContractName } from 'models/v2v3/contracts'
 import { useEffect, useState } from 'react'
 import { loadJuiceboxV2OrV3Contract } from 'utils/v2v3/contractLoaders/JuiceboxV2OrV3'
 
+/**
+ * Load a JB V2 or V3 contract, depending on the given [cv].
+ *
+ * (optional) If [address] is provided, load the contract at that address.
+ */
 export const useLoadV2V3Contract = ({
   cv,
   contractName,

--- a/src/hooks/v2v3/LoadV2V3Contract.ts
+++ b/src/hooks/v2v3/LoadV2V3Contract.ts
@@ -1,0 +1,45 @@
+import { readNetwork } from 'constants/networks'
+import { useLoadContractFromAddress } from 'hooks/LoadContractFromAddress'
+import { CV2V3 } from 'models/cv'
+import { V2V3ContractName } from 'models/v2v3/contracts'
+import { useEffect, useState } from 'react'
+import { loadJuiceboxV2OrV3Contract } from 'utils/v2v3/contractLoaders/JuiceboxV2OrV3'
+
+export const useLoadV2V3Contract = ({
+  cv,
+  contractName,
+  address,
+}: {
+  contractName: V2V3ContractName
+  cv: CV2V3 | undefined
+  address?: string // optional address, to override the default address
+}) => {
+  const [contractJson, setContractJson] = useState<{
+    address: string
+    abi: string
+  }>()
+
+  useEffect(() => {
+    async function loadAbi() {
+      if (!cv) return
+
+      const contractJson = await loadJuiceboxV2OrV3Contract(
+        cv,
+        contractName,
+        readNetwork.name,
+      )
+
+      setContractJson({
+        address: address ?? contractJson.address,
+        abi: contractJson.abi,
+      })
+    }
+
+    loadAbi()
+  }, [cv, contractName, address])
+
+  return useLoadContractFromAddress({
+    address: contractJson?.address,
+    abi: contractJson?.abi,
+  })
+}

--- a/src/hooks/v2v3/V2V3ProjectState.ts
+++ b/src/hooks/v2v3/V2V3ProjectState.ts
@@ -5,6 +5,7 @@ import {
 } from 'constants/splits'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { V2V3ProjectContextType } from 'contexts/v2v3/V2V3ProjectContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { useCurrencyConverter } from 'hooks/CurrencyConverter'
 import useNameOfERC20 from 'hooks/NameOfERC20'
 import { useProjectsQuery } from 'hooks/Projects'
@@ -29,7 +30,6 @@ import {
   V2V3CurrencyName,
   V2V3_CURRENCY_ETH,
 } from 'utils/v2v3/currency'
-import { useProjectPrimaryEthTerminal } from './contractReader/ProjectPrimaryEthTerminal'
 
 const useBalanceInDistributionLimitCurrency = ({
   ETHBalanceLoading,
@@ -68,6 +68,9 @@ const useBalanceInDistributionLimitCurrency = ({
 
 export function useV2V3ProjectState({ projectId }: { projectId: number }) {
   const { cv } = useContext(V2V3ContractsContext)
+  const {
+    contracts: { JBETHPaymentTerminal },
+  } = useContext(V2V3ProjectContractsContext)
 
   /**
    * Load additional project metadata
@@ -118,9 +121,7 @@ export function useV2V3ProjectState({ projectId }: { projectId: number }) {
   const { data: terminals } = useProjectTerminals({
     projectId,
   })
-  const { data: primaryETHTerminal } = useProjectPrimaryEthTerminal({
-    projectId,
-  })
+  const primaryETHTerminal = JBETHPaymentTerminal?.address
   const { data: ETHBalance, loading: ETHBalanceLoading } =
     usePaymentTerminalBalance({
       terminal: primaryETHTerminal,

--- a/src/hooks/v2v3/transactor/AddToBalanceTx.ts
+++ b/src/hooks/v2v3/transactor/AddToBalanceTx.ts
@@ -1,15 +1,14 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { useContext } from 'react'
-
 import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   handleTransactionException,
   TransactorInstance,
 } from 'hooks/Transactor'
+import { useContext } from 'react'
 import invariant from 'tiny-invariant'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
@@ -19,7 +18,7 @@ export function useAddToBalanceTx(): TransactorInstance<{
   value: BigNumber
 }> {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ContractsContext)
+  const { contracts } = useContext(V2V3ProjectContractsContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 
   const projectTitle = useV2ProjectTitle()

--- a/src/hooks/v2v3/transactor/DeployProjectPayerTx.ts
+++ b/src/hooks/v2v3/transactor/DeployProjectPayerTx.ts
@@ -36,7 +36,7 @@ export function useDeployProjectPayerTx(): TransactorInstance<DeployProjectPayer
     },
     txOpts,
   ) => {
-    if (!transactor || !projectId || !contracts?.JBETHPaymentTerminal) {
+    if (!transactor || !projectId || !contracts) {
       txOpts?.onDone?.()
       return Promise.resolve(false)
     }

--- a/src/hooks/v2v3/transactor/DistributePayouts.ts
+++ b/src/hooks/v2v3/transactor/DistributePayouts.ts
@@ -1,15 +1,12 @@
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { useContext } from 'react'
-
 import { BigNumber } from '@ethersproject/bignumber'
-
-import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
-
 import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { TransactorInstance } from 'hooks/Transactor'
+import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
+import { useContext } from 'react'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 type DistributePayoutsTx = TransactorInstance<{
@@ -22,7 +19,7 @@ const minReturnedTokens = 0 // TODO will need a field for this in WithdrawModal 
 
 export function useDistributePayoutsTx(): DistributePayoutsTx {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ContractsContext)
+  const { contracts } = useContext(V2V3ProjectContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
 
   const projectTitle = useV2ProjectTitle()

--- a/src/hooks/v2v3/transactor/PayETHPaymentTerminal.ts
+++ b/src/hooks/v2v3/transactor/PayETHPaymentTerminal.ts
@@ -1,13 +1,11 @@
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { useContext } from 'react'
-
 import { BigNumber } from '@ethersproject/bignumber'
-
 import { t } from '@lingui/macro'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { TransactorInstance } from 'hooks/Transactor'
+import { useContext } from 'react'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 const DEFAULT_DELEGATE_METADATA = 0
@@ -22,7 +20,7 @@ type PayV2ProjectTx = TransactorInstance<{
 
 export function usePayETHPaymentTerminalTx(): PayV2ProjectTx {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ContractsContext)
+  const { contracts } = useContext(V2V3ProjectContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
 
   const projectTitle = useV2ProjectTitle()

--- a/src/hooks/v2v3/transactor/RedeemTokensTx.ts
+++ b/src/hooks/v2v3/transactor/RedeemTokensTx.ts
@@ -1,18 +1,16 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import * as constants from '@ethersproject/constants'
-import { useWallet } from 'hooks/Wallet'
-import { useContext } from 'react'
-
-import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
-
 import { t } from '@lingui/macro'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import {
   handleTransactionException,
   TransactorInstance,
 } from 'hooks/Transactor'
+import { useWallet } from 'hooks/Wallet'
+import { useContext } from 'react'
 import invariant from 'tiny-invariant'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
@@ -24,7 +22,7 @@ export function useRedeemTokensTx(): TransactorInstance<{
   memo: string
 }> {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ContractsContext)
+  const { contracts } = useContext(V2V3ProjectContractsContext)
   const { tokenSymbol } = useContext(V2V3ProjectContext)
   const { projectId, cv } = useContext(ProjectMetadataContext)
 

--- a/src/models/v2/fundingCycle.ts
+++ b/src/models/v2/fundingCycle.ts
@@ -1,11 +1,5 @@
-import {
-  BaseV2V3FundingCycleMetadata,
-  BaseV2V3FundingCycleMetadataGlobal,
-} from 'models/v2v3/fundingCycle'
-
-export type V2FundingCycleMetadataGlobal = BaseV2V3FundingCycleMetadataGlobal
+import { BaseV2V3FundingCycleMetadata } from 'models/v2v3/fundingCycle'
 
 export type V2FundingCycleMetadata = BaseV2V3FundingCycleMetadata & {
-  global: BaseV2V3FundingCycleMetadataGlobal
   allowChangeToken: boolean
 }

--- a/src/models/v2v3/fundingCycle.ts
+++ b/src/models/v2v3/fundingCycle.ts
@@ -2,8 +2,14 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 import { V3FundingCycleMetadata } from 'models/v3/fundingCycle'
 
+export type BaseV2V3FundingCycleMetadataGlobal = {
+  allowSetController: boolean
+  allowSetTerminals: boolean
+}
+
 export type BaseV2V3FundingCycleMetadata = {
   version?: number
+  global: BaseV2V3FundingCycleMetadataGlobal
   reservedRate: BigNumber
   redemptionRate: BigNumber
   ballotRedemptionRate: BigNumber
@@ -19,11 +25,6 @@ export type BaseV2V3FundingCycleMetadata = {
   useDataSourceForPay: boolean
   useDataSourceForRedeem: boolean
   dataSource: string // hex, contract address
-}
-
-export type BaseV2V3FundingCycleMetadataGlobal = {
-  allowSetController: boolean
-  allowSetTerminals: boolean
 }
 
 export type V2V3FundAccessConstraint = {

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -31,12 +31,14 @@ import {
   redemptionRateFrom,
 } from 'utils/v2v3/math'
 
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
 } from 'constants/splits'
 import { PayoutsSelection } from 'models/payoutsSelection'
 import { ProjectTokensSelection } from 'models/projectTokenSelection'
+import { featureFlagEnabled } from 'utils/featureFlags'
 
 interface V2ProjectState {
   version: number
@@ -59,7 +61,7 @@ interface V2ProjectState {
 // Increment this version by 1 when making breaking changes.
 // When users return to the site and their local version is less than
 // this number, their state will be reset.
-export const REDUX_STORE_V2_PROJECT_VERSION = 7
+export const REDUX_STORE_V2_PROJECT_VERSION = 8
 
 const defaultProjectMetadataState: ProjectMetadataV5 = {
   name: '',
@@ -82,28 +84,55 @@ export const defaultFundingCycleData: SerializedV2V3FundingCycleData =
   })
 
 export const defaultFundingCycleMetadata: SerializedV2V3FundingCycleMetadata =
-  serializeV2V3FundingCycleMetadata({
-    global: {
-      allowSetTerminals: false,
-      allowSetController: false,
-    },
-    reservedRate: BigNumber.from(0), // A number from 0-10,000
-    redemptionRate: redemptionRateFrom('100'), // A number from 0-10,000
-    ballotRedemptionRate: redemptionRateFrom('100'), // A number from 0-10,000
-    pausePay: false,
-    pauseDistributions: false,
-    pauseRedeem: false,
-    allowMinting: false,
-    pauseBurn: false,
-    allowChangeToken: false,
-    allowTerminalMigration: false,
-    allowControllerMigration: false,
-    holdFees: false,
-    useTotalOverflowForRedemptions: false,
-    useDataSourceForPay: false,
-    useDataSourceForRedeem: false,
-    dataSource: constants.AddressZero,
-  })
+  serializeV2V3FundingCycleMetadata(
+    featureFlagEnabled(FEATURE_FLAGS.V3)
+      ? {
+          global: {
+            allowSetTerminals: false,
+            allowSetController: false,
+            pauseTransfers: false,
+          },
+          reservedRate: BigNumber.from(0), // A number from 0-10,000
+          redemptionRate: redemptionRateFrom('100'), // A number from 0-10,000
+          ballotRedemptionRate: redemptionRateFrom('100'), // A number from 0-10,000
+          pausePay: false,
+          pauseDistributions: false,
+          pauseRedeem: false,
+          allowMinting: false,
+          pauseBurn: false,
+          preferClaimedTokenOverride: false,
+          allowTerminalMigration: false,
+          allowControllerMigration: false,
+          holdFees: false,
+          useTotalOverflowForRedemptions: false,
+          useDataSourceForPay: false,
+          useDataSourceForRedeem: false,
+          dataSource: constants.AddressZero,
+          metadata: BigNumber.from(0),
+        }
+      : {
+          global: {
+            allowSetTerminals: false,
+            allowSetController: false,
+          },
+          reservedRate: BigNumber.from(0), // A number from 0-10,000
+          redemptionRate: redemptionRateFrom('100'), // A number from 0-10,000
+          ballotRedemptionRate: redemptionRateFrom('100'), // A number from 0-10,000
+          pausePay: false,
+          pauseDistributions: false,
+          pauseRedeem: false,
+          allowMinting: false,
+          pauseBurn: false,
+          allowChangeToken: false,
+          allowTerminalMigration: false,
+          allowControllerMigration: false,
+          holdFees: false,
+          useTotalOverflowForRedemptions: false,
+          useDataSourceForPay: false,
+          useDataSourceForRedeem: false,
+          dataSource: constants.AddressZero,
+        },
+  ) ?? {}
 
 const EMPTY_PAYOUT_GROUPED_SPLITS = {
   group: ETH_PAYOUT_SPLIT_GROUP,

--- a/src/utils/v2v3/serializers.ts
+++ b/src/utils/v2v3/serializers.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { V2FundingCycleMetadata } from 'models/v2/fundingCycle'
 import {
+  BaseV2V3FundingCycleMetadata,
   V2V3FundAccessConstraint,
   V2V3FundingCycleData,
   V2V3FundingCycleMetadata,
@@ -50,6 +51,7 @@ type V3FundingCycleMetadataBooleans = Record<
     | 'dataSource'
     | 'version'
     | 'global'
+    | 'metadata'
   >,
   boolean
 >
@@ -103,60 +105,92 @@ export const serializeV2V3FundingCycleMetadata = (
     dataSource: fundingCycleMetadata.dataSource, // hex, contract address
   }
 
+  const v2FundingCycleMetadata: V2FundingCycleMetadata =
+    fundingCycleMetadata as V2FundingCycleMetadata
   // Return V2 FC Metadata type if fundingCycleMetadata matches the type
-  if (
-    typeof (fundingCycleMetadata as V2FundingCycleMetadata).allowChangeToken !==
-    'undefined'
-  ) {
+  if (typeof v2FundingCycleMetadata.allowChangeToken !== 'undefined') {
     return {
       ...baseSerializedMetadata,
-      allowChangeToken: (fundingCycleMetadata as V2FundingCycleMetadata)
-        .allowChangeToken,
+      allowChangeToken: v2FundingCycleMetadata.allowChangeToken,
     } as SerializedV2FundingCycleMetadata
   }
+
+  const v3FundingCycleMetadata: V3FundingCycleMetadata =
+    fundingCycleMetadata as V3FundingCycleMetadata
 
   return {
     ...baseSerializedMetadata,
     global: {
       ...baseSerializedMetadata.global,
-      pauseTransfers: (fundingCycleMetadata as V3FundingCycleMetadata).global
-        .pauseTransfers,
+      pauseTransfers: v3FundingCycleMetadata.global.pauseTransfers,
     },
-    preferClaimedTokenOverride: (fundingCycleMetadata as V3FundingCycleMetadata)
-      .preferClaimedTokenOverride,
-    metadata: (fundingCycleMetadata as V3FundingCycleMetadata).metadata,
-  } as SerializedV3FundingCycleMetadata
+    preferClaimedTokenOverride:
+      v3FundingCycleMetadata.preferClaimedTokenOverride ?? false,
+    metadata: v3FundingCycleMetadata?.metadata?.toString() ?? '',
+  }
 }
 
 export const deserializeV2V3FundingCycleMetadata = (
   serializedFundingCycleMetadata: SerializedV2V3FundingCycleMetadata,
-): Omit<V2FundingCycleMetadata, 'version'> => ({
-  global: {
-    allowSetTerminals: serializedFundingCycleMetadata.global.allowSetTerminals,
-    allowSetController:
-      serializedFundingCycleMetadata.global.allowSetController,
-  },
-  reservedRate: BigNumber.from(serializedFundingCycleMetadata.reservedRate),
-  redemptionRate: BigNumber.from(serializedFundingCycleMetadata.redemptionRate),
-  ballotRedemptionRate: BigNumber.from(
-    serializedFundingCycleMetadata.ballotRedemptionRate,
-  ),
-  pausePay: serializedFundingCycleMetadata.pausePay,
-  pauseDistributions: serializedFundingCycleMetadata.pauseDistributions,
-  pauseRedeem: serializedFundingCycleMetadata.pauseRedeem,
-  allowMinting: serializedFundingCycleMetadata.allowMinting,
-  pauseBurn: serializedFundingCycleMetadata.pauseBurn,
-  allowChangeToken: serializedFundingCycleMetadata.allowChangeToken,
-  allowTerminalMigration: serializedFundingCycleMetadata.allowTerminalMigration,
-  allowControllerMigration:
-    serializedFundingCycleMetadata.allowControllerMigration,
-  holdFees: serializedFundingCycleMetadata.holdFees,
-  useTotalOverflowForRedemptions:
-    serializedFundingCycleMetadata.useTotalOverflowForRedemptions,
-  useDataSourceForPay: serializedFundingCycleMetadata.useDataSourceForPay,
-  useDataSourceForRedeem: serializedFundingCycleMetadata.useDataSourceForRedeem,
-  dataSource: serializedFundingCycleMetadata.dataSource, // hex, contract address
-})
+): Omit<V2V3FundingCycleMetadata, 'version'> => {
+  const baseMetadata: BaseV2V3FundingCycleMetadata = {
+    global: {
+      allowSetTerminals:
+        serializedFundingCycleMetadata.global.allowSetTerminals,
+      allowSetController:
+        serializedFundingCycleMetadata.global.allowSetController,
+    },
+    reservedRate: BigNumber.from(serializedFundingCycleMetadata.reservedRate),
+    redemptionRate: BigNumber.from(
+      serializedFundingCycleMetadata.redemptionRate,
+    ),
+    ballotRedemptionRate: BigNumber.from(
+      serializedFundingCycleMetadata.ballotRedemptionRate,
+    ),
+    pausePay: serializedFundingCycleMetadata.pausePay,
+    pauseDistributions: serializedFundingCycleMetadata.pauseDistributions,
+    pauseRedeem: serializedFundingCycleMetadata.pauseRedeem,
+    allowMinting: serializedFundingCycleMetadata.allowMinting,
+    pauseBurn: serializedFundingCycleMetadata.pauseBurn,
+    allowTerminalMigration:
+      serializedFundingCycleMetadata.allowTerminalMigration,
+    allowControllerMigration:
+      serializedFundingCycleMetadata.allowControllerMigration,
+    holdFees: serializedFundingCycleMetadata.holdFees,
+    useTotalOverflowForRedemptions:
+      serializedFundingCycleMetadata.useTotalOverflowForRedemptions,
+    useDataSourceForPay: serializedFundingCycleMetadata.useDataSourceForPay,
+    useDataSourceForRedeem:
+      serializedFundingCycleMetadata.useDataSourceForRedeem,
+    dataSource: serializedFundingCycleMetadata.dataSource, // hex, contract address
+  }
+
+  // Return V2 FC Metadata type if fundingCycleMetadata matches the type
+  if (
+    typeof (serializedFundingCycleMetadata as SerializedV2FundingCycleMetadata)
+      .allowChangeToken !== 'undefined'
+  ) {
+    return {
+      ...baseMetadata,
+      allowChangeToken: (
+        serializedFundingCycleMetadata as SerializedV2FundingCycleMetadata
+      ).allowChangeToken,
+    } as V2FundingCycleMetadata
+  }
+
+  const v3SerializedFundingCycleMetadata: SerializedV3FundingCycleMetadata =
+    serializedFundingCycleMetadata as SerializedV3FundingCycleMetadata
+  return {
+    ...baseMetadata,
+    global: {
+      ...baseMetadata.global,
+      pauseTransfers: v3SerializedFundingCycleMetadata.global.pauseTransfers,
+    },
+    preferClaimedTokenOverride:
+      v3SerializedFundingCycleMetadata.preferClaimedTokenOverride,
+    metadata: BigNumber.from(v3SerializedFundingCycleMetadata.metadata),
+  } as V3FundingCycleMetadata
+}
 
 export const serializeV2V3FundingCycleData = (
   fundingCycleData: V2V3FundingCycleData,


### PR DESCRIPTION
## What does this PR do and why?

This PR:
- uses the project-specific JBETHPaymentTerminal address, rather than the 'hard-coded' address from the npm package.
- refactors the safe TX JBController contract loader to be nicer

**IMPORTANT**: this PR touches the pay functionality. Please test pay functionality.

## Screenshots or screen recordings

No user facing changes.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
