### PR TITLE
Context-aware cv in subgraph queries

### DIFF
--- a/src/components/ArchiveProject/index.tsx
+++ b/src/components/ArchiveProject/index.tsx
@@ -2,11 +2,12 @@ import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import axios from 'axios'
-import { CV_V1, CV_V1_1, CV_V2 } from 'constants/cv'
+import { CV_V1, CV_V1_1, CV_V2, CV_V3 } from 'constants/cv'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useWallet } from 'hooks/Wallet'
+import { V2V3CVType } from 'models/cv'
 import { V1TerminalVersion } from 'models/v1/terminals'
 import { useContext, useState } from 'react'
 import { uploadProjectMetadata } from 'utils/ipfs'
@@ -46,9 +47,10 @@ export default function ArchiveProject({
         }
         break
       case CV_V2:
+      case CV_V3:
         if (projectId) {
           await revalidateProject({
-            cv: CV_V2,
+            cv: cv as V2V3CVType,
             projectId: String(projectId),
           })
         }

--- a/src/components/ArchiveProject/index.tsx
+++ b/src/components/ArchiveProject/index.tsx
@@ -7,7 +7,7 @@ import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useWallet } from 'hooks/Wallet'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { V1TerminalVersion } from 'models/v1/terminals'
 import { useContext, useState } from 'react'
 import { uploadProjectMetadata } from 'utils/ipfs'
@@ -50,7 +50,7 @@ export default function ArchiveProject({
       case CV_V3:
         if (projectId) {
           await revalidateProject({
-            cv: cv as V2V3CVType,
+            cv: cv as CV2V3,
             projectId: String(projectId),
           })
         }

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -7,7 +7,6 @@ import ProjectCreateEventElem from 'components/activityEventElems/ProjectCreateE
 import RedeemEventElem from 'components/activityEventElems/RedeemEventElem'
 import Loading from 'components/Loading'
 import SectionHeader from 'components/SectionHeader'
-import { CV_V2 } from 'constants/cv'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
@@ -40,23 +39,19 @@ type EventFilter =
   | 'deployETHERC20ProjectPayer'
 // TODO | 'useAllowanceEvent'
 
+const pageSize = 50
+
 export default function ProjectActivity() {
-  const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
-  const [eventFilter, setEventFilter] = useState<EventFilter>('all')
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+  const { projectId, cv } = useContext(ProjectMetadataContext)
 
-  const { projectId } = useContext(ProjectMetadataContext)
-
-  const pageSize = 50
+  const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
+  const [eventFilter, setEventFilter] = useState<EventFilter>('all')
 
   const where: WhereConfig<'projectEvent'>[] = useMemo(() => {
     const _where: WhereConfig<'projectEvent'>[] = [
-      {
-        key: 'cv',
-        value: CV_V2,
-      },
       {
         key: 'mintTokensEvent',
         value: null, // Exclude all mintTokensEvents. One of these events is created for every Pay event, and showing both event types may lead to confusion
@@ -71,6 +66,13 @@ export default function ProjectActivity() {
       _where.push({
         key: 'projectId',
         value: projectId,
+      })
+    }
+
+    if (cv) {
+      _where.push({
+        key: 'cv',
+        value: cv,
       })
     }
 
@@ -109,7 +111,7 @@ export default function ProjectActivity() {
     }
 
     return _where
-  }, [projectId, eventFilter])
+  }, [projectId, eventFilter, cv])
 
   const {
     data: projectEvents,

--- a/src/components/v2v3/V2V3Project/V2V3Project.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3Project.tsx
@@ -4,7 +4,6 @@ import { PayProjectForm } from 'components/Project/PayProjectForm'
 import { ProjectHeader } from 'components/Project/ProjectHeader'
 import { TextButton } from 'components/TextButton'
 import VolumeChart from 'components/VolumeChart'
-import { CV_V2 } from 'constants/cv'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { NftRewardsContext } from 'contexts/nftRewardsContext'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
@@ -58,7 +57,7 @@ export function V2V3Project() {
     projectOwnerAddress,
     handle,
   } = useContext(V2V3ProjectContext)
-  const { projectMetadata, projectId } = useContext(ProjectMetadataContext)
+  const { projectMetadata, projectId, cv } = useContext(ProjectMetadataContext)
   const {
     nftRewards: { rewardTiers: nftRewardTiers },
   } = useContext(NftRewardsContext)
@@ -179,12 +178,12 @@ export function V2V3Project() {
                 size={GUTTER_PX}
                 style={{ width: '100%' }}
               >
-                {!isPreviewMode ? (
+                {!isPreviewMode && cv ? (
                   <VolumeChart
                     style={{ height: 240 }}
                     createdAt={createdAt}
                     projectId={projectId}
-                    cv={CV_V2}
+                    cv={cv}
                   />
                 ) : null}
                 <V2ManageTokensSection />

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
@@ -3,7 +3,7 @@ import { BaseOptionType } from 'antd/lib/select'
 import { CV_V2, CV_V3 } from 'constants/cv'
 import { readNetwork } from 'constants/networks'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2V3CVType } from 'models/cv'
 import { NetworkName } from 'models/network-name'
 import { useContext } from 'react'
 
@@ -34,7 +34,7 @@ export function ContractVersionSelect() {
       defaultValue={cv}
       bordered={false}
       className="ant-select-color-secondary"
-      onSelect={(value: V2CVType | V3CVType) => setVersion?.(value)}
+      onSelect={(value: V2V3CVType) => setVersion?.(value)}
       options={SELECT_OPTIONS}
     />
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
@@ -3,7 +3,7 @@ import { BaseOptionType } from 'antd/lib/select'
 import { CV_V2, CV_V3 } from 'constants/cv'
 import { readNetwork } from 'constants/networks'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { NetworkName } from 'models/network-name'
 import { useContext } from 'react'
 
@@ -34,7 +34,7 @@ export function ContractVersionSelect() {
       defaultValue={cv}
       bordered={false}
       className="ant-select-color-secondary"
-      onSelect={(value: V2V3CVType) => setVersion?.(value)}
+      onSelect={(value: CV2V3) => setVersion?.(value)}
       options={SELECT_OPTIONS}
     />
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage.tsx
@@ -2,20 +2,20 @@ import { useForm } from 'antd/lib/form/Form'
 import ProjectDetailsForm, {
   ProjectDetailsFormFields,
 } from 'components/forms/ProjectDetailsForm'
-import { CV_V2 } from 'constants/cv'
 import { PROJECT_PAY_CHARACTER_LIMIT } from 'constants/numbers'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetailsTx'
+import { V2V3CVType } from 'models/cv'
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { uploadProjectMetadata } from 'utils/ipfs'
 import { revalidateProject } from 'utils/revalidateProject'
 
 export function ProjectDetailsSettingsPage() {
-  const [projectForm] = useForm<ProjectDetailsFormFields>()
+  const { projectId } = useContext(ProjectMetadataContext)
+  const { projectMetadata, cv } = useContext(ProjectMetadataContext)
 
   const [loadingSaveChanges, setLoadingSaveChanges] = useState<boolean>()
-  const { projectId } = useContext(ProjectMetadataContext)
-  const { projectMetadata } = useContext(ProjectMetadataContext)
+  const [projectForm] = useForm<ProjectDetailsFormFields>()
 
   const EditV2ProjectDetailsTx = useEditProjectDetailsTx()
 
@@ -47,7 +47,7 @@ export function ProjectDetailsSettingsPage() {
         onConfirmed: async () => {
           if (projectId) {
             await revalidateProject({
-              cv: CV_V2,
+              cv: cv as V2V3CVType,
               projectId: String(projectId),
             })
           }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage.tsx
@@ -5,7 +5,7 @@ import ProjectDetailsForm, {
 import { PROJECT_PAY_CHARACTER_LIMIT } from 'constants/numbers'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetailsTx'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { uploadProjectMetadata } from 'utils/ipfs'
 import { revalidateProject } from 'utils/revalidateProject'
@@ -47,7 +47,7 @@ export function ProjectDetailsSettingsPage() {
         onConfirmed: async () => {
           if (projectId) {
             await revalidateProject({
-              cv: cv as V2V3CVType,
+              cv: cv as CV2V3,
               projectId: String(projectId),
             })
           }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectReconfigureFundingCycleSettingsPage/hooks/reconfigureFundingCycle.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectReconfigureFundingCycleSettingsPage/hooks/reconfigureFundingCycle.ts
@@ -3,7 +3,7 @@ import { NftRewardsContext } from 'contexts/nftRewardsContext'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useReconfigureV2V3FundingCycleTx } from 'hooks/v2v3/transactor/ReconfigureV2V3FundingCycleTx'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { NFT_FUNDING_CYCLE_METADATA_OVERRIDES } from 'pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton'
 import { useCallback, useContext, useState } from 'react'
 import { fromWad } from 'utils/format/formatNumber'
@@ -111,7 +111,7 @@ export const useReconfigureFundingCycle = ({
         async onConfirmed() {
           if (projectId) {
             await revalidateProject({
-              cv: cv as V2V3CVType,
+              cv: cv as CV2V3,
               projectId: String(projectId),
             })
           }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectReconfigureFundingCycleSettingsPage/hooks/reconfigureFundingCycle.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectReconfigureFundingCycleSettingsPage/hooks/reconfigureFundingCycle.ts
@@ -1,9 +1,9 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { CV_V2 } from 'constants/cv'
 import { NftRewardsContext } from 'contexts/nftRewardsContext'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useReconfigureV2V3FundingCycleTx } from 'hooks/v2v3/transactor/ReconfigureV2V3FundingCycleTx'
+import { V2V3CVType } from 'models/cv'
 import { NFT_FUNDING_CYCLE_METADATA_OVERRIDES } from 'pages/create/tabs/ReviewDeployTab/DeployProjectWithNftsButton'
 import { useCallback, useContext, useState } from 'react'
 import { fromWad } from 'utils/format/formatNumber'
@@ -43,7 +43,7 @@ export const useReconfigureFundingCycle = ({
   memo: string
 }) => {
   const { fundingCycle } = useContext(V2V3ProjectContext)
-  const { projectId } = useContext(ProjectMetadataContext)
+  const { projectId, cv } = useContext(ProjectMetadataContext)
   const {
     nftRewards: { CIDs: nftRewardsCids },
   } = useContext(NftRewardsContext)
@@ -111,7 +111,7 @@ export const useReconfigureFundingCycle = ({
         async onConfirmed() {
           if (projectId) {
             await revalidateProject({
-              cv: CV_V2,
+              cv: cv as V2V3CVType,
               projectId: String(projectId),
             })
           }
@@ -134,6 +134,7 @@ export const useReconfigureFundingCycle = ({
     fundingCycle,
     memo,
     projectId,
+    cv,
   ])
 
   return { reconfigureLoading: reconfigureTxLoading, reconfigureFundingCycle }

--- a/src/components/v2v3/V2V3Project/banners/ProjectBanners.tsx
+++ b/src/components/v2v3/V2V3Project/banners/ProjectBanners.tsx
@@ -25,7 +25,7 @@ export function ProjectBanners() {
   const hasQueuedFundingCycle = queuedFundingCycle?.number.gt(0)
   const hasCurrentFundingCycle = fundingCycle?.number.gt(0)
 
-  // If a V2 project has no current or queued FC, we assume that
+  // If a V2 project (_not_ a V3 project) has no current or queued FC, we assume that
   // it's because it's using the old bugged contracts.
   // TODO probably should check the contract address instead.
   const showV2BugNoticeBanner =

--- a/src/components/v2v3/V2V3Project/modals/V2V3DownloadPaymentsModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/V2V3DownloadPaymentsModal.tsx
@@ -1,23 +1,21 @@
 import { t, Trans } from '@lingui/macro'
 import { Modal, ModalProps } from 'antd'
 import InputAccessoryButton from 'components/InputAccessoryButton'
-import { emitErrorNotification } from 'utils/notifications'
-
-import { useCallback, useContext, useEffect, useState } from 'react'
-import { fromWad } from 'utils/format/formatNumber'
-import { querySubgraphExhaustive } from 'utils/graph'
-
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
-import { CV_V2 } from 'constants/cv'
 import { readProvider } from 'constants/readProvider'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { downloadCsvFile } from 'utils/csv'
+import { fromWad } from 'utils/format/formatNumber'
+import { querySubgraphExhaustive } from 'utils/graph'
+import { emitErrorNotification } from 'utils/notifications'
 
 export default function V2V3DownloadPaymentsModal(props: ModalProps) {
+  const { projectId, cv } = useContext(ProjectMetadataContext)
+
   const [latestBlockNumber, setLatestBlockNumber] = useState<number>()
   const [blockNumber, setBlockNumber] = useState<number>()
   const [loading, setLoading] = useState<boolean>()
-  const { projectId } = useContext(ProjectMetadataContext)
 
   useEffect(() => {
     readProvider.getBlockNumber().then(val => {
@@ -27,7 +25,7 @@ export default function V2V3DownloadPaymentsModal(props: ModalProps) {
   }, [])
 
   const download = useCallback(async () => {
-    if (blockNumber === undefined || !projectId) return
+    if (blockNumber === undefined || !projectId || !cv) return
 
     setLoading(true)
 
@@ -51,7 +49,7 @@ export default function V2V3DownloadPaymentsModal(props: ModalProps) {
           },
           {
             key: 'cv',
-            value: CV_V2,
+            value: cv,
           },
         ],
       })
@@ -79,7 +77,7 @@ export default function V2V3DownloadPaymentsModal(props: ModalProps) {
       console.error('Error downloading payments', e)
       setLoading(false)
     }
-  }, [projectId, setLoading, blockNumber])
+  }, [projectId, setLoading, blockNumber, cv])
 
   return (
     <Modal

--- a/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2V3ProjectTokenBalancesModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2V3ProjectTokenBalancesModal.tsx
@@ -9,7 +9,7 @@ import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useV2ConnectedWalletHasPermission } from 'hooks/v2v3/contractReader/V2ConnectedWalletHasPermission'
 import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetailsTx'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { TokenRef } from 'models/token-ref'
 import { V2OperatorPermission } from 'models/v2v3/permissions'
@@ -81,7 +81,7 @@ export function V2V3ProjectTokenBalancesModal(props: ModalProps) {
         onDone: async () => {
           if (projectId) {
             await revalidateProject({
-              cv: cv as V2V3CVType,
+              cv: cv as CV2V3,
               projectId: String(projectId),
             })
           }

--- a/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2V3ProjectTokenBalancesModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2V3ProjectTokenBalancesModal.tsx
@@ -9,7 +9,7 @@ import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useV2ConnectedWalletHasPermission } from 'hooks/v2v3/contractReader/V2ConnectedWalletHasPermission'
 import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetailsTx'
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2V3CVType } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { TokenRef } from 'models/token-ref'
 import { V2OperatorPermission } from 'models/v2v3/permissions'
@@ -81,7 +81,7 @@ export function V2V3ProjectTokenBalancesModal(props: ModalProps) {
         onDone: async () => {
           if (projectId) {
             await revalidateProject({
-              cv: cv as V2CVType | V3CVType,
+              cv: cv as V2V3CVType,
               projectId: String(projectId),
             })
           }

--- a/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2V3ProjectTokenBalancesModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/V2V3ProjectTokenBalancesModal/V2V3ProjectTokenBalancesModal.tsx
@@ -4,30 +4,29 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Modal, ModalProps, Space } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import ERC20TokenBalance from 'components/ERC20TokenBalance'
-import { ProjectMetadataV5 } from 'models/project-metadata'
-import { TokenRef } from 'models/token-ref'
-import { useContext, useEffect, useState } from 'react'
-import { uploadProjectMetadata } from 'utils/ipfs'
-import { revalidateProject } from 'utils/revalidateProject'
-import { V2V3ProjectTokenBalance } from './V2V3ProjectTokenBalance'
-
-import { AssetInputType, TokenRefs } from './TokenRefs'
-
-import { CV_V2 } from 'constants/cv'
 import { V2V3_PROJECT_IDS } from 'constants/v2v3/projectIds'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useV2ConnectedWalletHasPermission } from 'hooks/v2v3/contractReader/V2ConnectedWalletHasPermission'
 import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetailsTx'
+import { V2CVType, V3CVType } from 'models/cv'
+import { ProjectMetadataV5 } from 'models/project-metadata'
+import { TokenRef } from 'models/token-ref'
 import { V2OperatorPermission } from 'models/v2v3/permissions'
+import { useContext, useEffect, useState } from 'react'
+import { uploadProjectMetadata } from 'utils/ipfs'
+import { revalidateProject } from 'utils/revalidateProject'
+import { AssetInputType, TokenRefs } from './TokenRefs'
+import { V2V3ProjectTokenBalance } from './V2V3ProjectTokenBalance'
 
 export interface EditTrackedAssetsForm {
   tokenRefs: { assetInput: { input: string; type: AssetInputType } }[]
 }
 
 export function V2V3ProjectTokenBalancesModal(props: ModalProps) {
-  const { projectId, projectMetadata } = useContext(ProjectMetadataContext)
+  const { projectId, projectMetadata, cv } = useContext(ProjectMetadataContext)
   const { projectOwnerAddress } = useContext(V2V3ProjectContext)
+
   const [editModalVisible, setEditModalVisible] = useState<boolean>()
   const [loading, setLoading] = useState<boolean>()
   const [form] = useForm<EditTrackedAssetsForm>()
@@ -52,7 +51,7 @@ export function V2V3ProjectTokenBalancesModal(props: ModalProps) {
   }, [form, projectMetadata, editModalVisible])
 
   async function updateTokenRefs() {
-    if (!projectName) return
+    if (!projectName || !cv) return
 
     await form.validateFields()
 
@@ -82,7 +81,7 @@ export function V2V3ProjectTokenBalancesModal(props: ModalProps) {
         onDone: async () => {
           if (projectId) {
             await revalidateProject({
-              cv: CV_V2,
+              cv: cv as V2CVType | V3CVType,
               projectId: String(projectId),
             })
           }

--- a/src/constants/cv.ts
+++ b/src/constants/cv.ts
@@ -1,7 +1,7 @@
-import { V2CVType, V3CVType } from 'models/cv'
+import { CV2, CV3 } from 'models/cv'
 import { V1TerminalVersion } from 'models/v1/terminals'
 
-export const CV_V3: V3CVType = '3'
-export const CV_V2: V2CVType = '2'
+export const CV_V3: CV3 = '3'
+export const CV_V2: CV2 = '2'
 export const CV_V1_1: V1TerminalVersion = '1.1'
 export const CV_V1: V1TerminalVersion = '1'

--- a/src/contexts/v2v3/V2V3ContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ContractsContext.ts
@@ -1,9 +1,9 @@
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2V3CVType } from 'models/cv'
 import { V2V3Contracts } from 'models/v2v3/contracts'
 import { createContext } from 'react'
 
 export const V2V3ContractsContext: React.Context<{
   contracts?: V2V3Contracts
-  setVersion?: (version: V2CVType | V3CVType) => void
-  cv?: V2CVType | V3CVType
+  setVersion?: (version: V2V3CVType) => void
+  cv?: V2V3CVType
 }> = createContext({})

--- a/src/contexts/v2v3/V2V3ContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ContractsContext.ts
@@ -1,9 +1,9 @@
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { V2V3Contracts } from 'models/v2v3/contracts'
 import { createContext } from 'react'
 
 export const V2V3ContractsContext: React.Context<{
   contracts?: V2V3Contracts
-  setVersion?: (version: V2V3CVType) => void
-  cv?: V2V3CVType
+  setVersion?: (version: CV2V3) => void
+  cv?: CV2V3
 }> = createContext({})

--- a/src/hooks/v2v3/V2V3ContractLoader.ts
+++ b/src/hooks/v2v3/V2V3ContractLoader.ts
@@ -6,10 +6,10 @@ import { loadV2V3Contract } from 'utils/v2v3/loadV2V3Contract'
 
 import { readNetwork } from 'constants/networks'
 import { readProvider } from 'constants/readProvider'
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2V3CVType } from 'models/cv'
 import { emitErrorNotification } from 'utils/notifications'
 
-export function useV2V3ContractLoader({ cv }: { cv: V2CVType | V3CVType }) {
+export function useV2V3ContractLoader({ cv }: { cv: V2V3CVType }) {
   const { signer } = useWallet()
   const [contracts, setContracts] = useState<V2V3Contracts>()
 

--- a/src/hooks/v2v3/V2V3ContractLoader.ts
+++ b/src/hooks/v2v3/V2V3ContractLoader.ts
@@ -6,10 +6,10 @@ import { loadV2V3Contract } from 'utils/v2v3/loadV2V3Contract'
 
 import { readNetwork } from 'constants/networks'
 import { readProvider } from 'constants/readProvider'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { emitErrorNotification } from 'utils/notifications'
 
-export function useV2V3ContractLoader({ cv }: { cv: V2V3CVType }) {
+export function useV2V3ContractLoader({ cv }: { cv: CV2V3 }) {
   const { signer } = useWallet()
   const [contracts, setContracts] = useState<V2V3Contracts>()
 

--- a/src/middleware.page.ts
+++ b/src/middleware.page.ts
@@ -1,4 +1,4 @@
-import { CV_V2 } from 'constants/cv'
+import { CV_V2, CV_V3 } from 'constants/cv'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -23,7 +23,7 @@ export async function middleware(request: NextRequest) {
   try {
     projects = await paginateDepleteProjectsQueryCall({
       variables: {
-        where: { cv: CV_V2, handle },
+        where: { cv_in: [CV_V2, CV_V3], handle },
       },
     })
   } catch (e) {

--- a/src/models/cv.ts
+++ b/src/models/cv.ts
@@ -1,6 +1,7 @@
 import { V1TerminalVersion } from 'models/v1/terminals'
 export type V2CVType = '2'
 export type V3CVType = '3'
+export type V2V3CVType = V2CVType | V3CVType
 
 // CV = contracts version
-export type CV = V1TerminalVersion | V2CVType | V3CVType
+export type CV = V1TerminalVersion | V2V3CVType

--- a/src/models/cv.ts
+++ b/src/models/cv.ts
@@ -1,7 +1,7 @@
 import { V1TerminalVersion } from 'models/v1/terminals'
-export type V2CVType = '2'
-export type V3CVType = '3'
-export type V2V3CVType = V2CVType | V3CVType
+export type CV2 = '2'
+export type CV3 = '3'
+export type CV2V3 = CV2 | CV3
 
 // CV = contracts version
-export type CV = V1TerminalVersion | V2V3CVType
+export type CV = V1TerminalVersion | CV2V3

--- a/src/pages/api/nextjs/revalidate-project.page.ts
+++ b/src/pages/api/nextjs/revalidate-project.page.ts
@@ -1,7 +1,7 @@
-import { CV_V1, CV_V1_1, CV_V2 } from 'constants/cv'
+import { CV_V1, CV_V1_1, CV_V2, CV_V3 } from 'constants/cv'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VALID_CVS = [CV_V1, CV_V1_1, CV_V2]
+const VALID_CVS = [CV_V1, CV_V1_1, CV_V2, CV_V3]
 
 export default async function handler(
   req: NextApiRequest,
@@ -18,6 +18,7 @@ export default async function handler(
       handle = project?.handle
       break
     case CV_V2:
+    case CV_V3:
       projectId = project?.projectId
       break
   }
@@ -57,6 +58,7 @@ function calculatePath({
     case CV_V1_1:
       return `/p/${handle}`
     case CV_V2:
+    case CV_V3:
       return `/v2/p/${projectId}`
     default:
       throw new Error(`Unsupported cv: ${cv}`)

--- a/src/pages/create/ProjectConfigurationFieldsContainer.tsx
+++ b/src/pages/create/ProjectConfigurationFieldsContainer.tsx
@@ -2,12 +2,11 @@ import { Trans } from '@lingui/macro'
 import { Col, Row } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { PropsWithChildren, useContext } from 'react'
-
-import ProjectPreview from './ProjectPreview'
+import { ProjectPreview } from './ProjectPreview'
 
 const FULL_WIDTH_PX = 24
 
-export default function ProjectConfigurationFieldsContainer({
+export function ProjectConfigurationFieldsContainer({
   showPreview,
   children,
 }: PropsWithChildren<{ showPreview?: boolean }>) {

--- a/src/pages/create/ProjectPreview.tsx
+++ b/src/pages/create/ProjectPreview.tsx
@@ -1,27 +1,25 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { V2V3Project } from 'components/v2v3/V2V3Project/V2V3Project'
+import { NftRewardsContext } from 'contexts/nftRewardsContext'
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import {
   V2V3ProjectContext,
   V2V3ProjectContextType,
 } from 'contexts/v2v3/V2V3ProjectContext'
-import { useWallet } from 'hooks/Wallet'
-
 import {
   useAppSelector,
   useEditingV2V3FundAccessConstraintsSelector,
   useEditingV2V3FundingCycleDataSelector,
   useEditingV2V3FundingCycleMetadataSelector,
 } from 'hooks/AppSelector'
-
+import { useWallet } from 'hooks/Wallet'
 import { V2V3FundingCycle } from 'models/v2v3/fundingCycle'
-
-import { V2V3Project } from 'components/v2v3/V2V3Project/V2V3Project'
-import { CV_V2 } from 'constants/cv'
-import { NftRewardsContext } from 'contexts/nftRewardsContext'
-import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { useContext } from 'react'
 import { V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
 import { getDefaultFundAccessConstraint } from 'utils/v2v3/fundingCycle'
 
-export default function ProjectPreview() {
+export function ProjectPreview() {
   const {
     projectMetadata,
     payoutGroupedSplits,
@@ -32,6 +30,7 @@ export default function ProjectPreview() {
   const fundingCycleData = useEditingV2V3FundingCycleDataSelector()
   const fundAccessConstraints = useEditingV2V3FundAccessConstraintsSelector()
   const { userAddress } = useWallet()
+  const { cv } = useContext(V2V3ContractsContext)
 
   const fundingCycle: V2V3FundingCycle = {
     ...fundingCycleData,
@@ -91,7 +90,7 @@ export default function ProjectPreview() {
 
   return (
     <ProjectMetadataContext.Provider
-      value={{ projectMetadata, isArchived: false, projectId: 0, cv: CV_V2 }}
+      value={{ projectMetadata, isArchived: false, projectId: 0, cv }}
     >
       <V2V3ProjectContext.Provider value={project}>
         <div>

--- a/src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
+++ b/src/pages/create/tabs/FundingCycleTab/FundingCycleTabContent.tsx
@@ -2,19 +2,16 @@ import { CheckCircleFilled } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Button, Space } from 'antd'
 import RichButton from 'components/RichButton'
-import { useContext, useState } from 'react'
-
-import NftDrawer from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer'
-import { ThemeContext } from 'contexts/themeContext'
-import { featureFlagEnabled } from 'utils/featureFlags'
-
 import FundingDrawer from 'components/v2v3/shared/FundingCycleConfigurationDrawers/FundingDrawer'
+import NftDrawer from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer'
 import RulesDrawer from 'components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer'
 import TokenDrawer from 'components/v2v3/shared/FundingCycleConfigurationDrawers/TokenDrawer'
-
 import { FEATURE_FLAGS } from 'constants/featureFlags'
+import { ThemeContext } from 'contexts/themeContext'
+import { useContext, useState } from 'react'
+import { featureFlagEnabled } from 'utils/featureFlags'
 import FundingCycleExplainer from '../../FundingCycleExplainer'
-import ProjectConfigurationFieldsContainer from '../../ProjectConfigurationFieldsContainer'
+import { ProjectConfigurationFieldsContainer } from '../../ProjectConfigurationFieldsContainer'
 
 export default function FundingCycleTabContent({
   onFinish,

--- a/src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
+++ b/src/pages/create/tabs/ProjectDetailsTab/ProjectDetailsTabContent.tsx
@@ -4,13 +4,11 @@ import { useForm } from 'antd/lib/form/Form'
 import ProjectDetailsForm, {
   ProjectDetailsFormFields,
 } from 'components/forms/ProjectDetailsForm'
-
 import { useAppDispatch } from 'hooks/AppDispatch'
 import { useAppSelector } from 'hooks/AppSelector'
 import { useCallback, useEffect } from 'react'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
-
-import ProjectConfigurationFieldsContainer from '../../ProjectConfigurationFieldsContainer'
+import { ProjectConfigurationFieldsContainer } from '../../ProjectConfigurationFieldsContainer'
 
 export default function ProjectDetailsDrawerContent({
   onFinish,

--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -24,7 +24,7 @@ import ExternalLink from 'components/ExternalLink'
 import { CV } from 'models/cv'
 import { helpPagePath } from 'utils/routes'
 
-import { CV_V1, CV_V1_1, CV_V2 } from 'constants/cv'
+import { CV_V1, CV_V1_1, CV_V2, CV_V3 } from 'constants/cv'
 import { layouts } from 'constants/styles/layouts'
 import ArchivedProjectsMessage from './ArchivedProjectsMessage'
 import HoldingsProjects from './HoldingsProjects'
@@ -93,8 +93,8 @@ function Projects() {
     const _cv: CV[] = []
     if (includeV1) _cv.push(CV_V1)
     if (includeV1_1) _cv.push(CV_V1_1)
-    if (includeV2) _cv.push(CV_V2)
-    return _cv.length ? _cv : [CV_V1, CV_V1_1, CV_V2]
+    if (includeV2) _cv.push(CV_V2, CV_V3)
+    return _cv.length ? _cv : [CV_V1, CV_V1_1, CV_V2, CV_V3]
   }, [includeV1, includeV1_1, includeV2])
 
   const {

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -1,7 +1,7 @@
 import { AppWrapper, SEO } from 'components/common'
 import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
 import Loading from 'components/Loading'
-import { CV_V2 } from 'constants/cv'
+import { CV_V2, CV_V3 } from 'constants/cv'
 import { V2V3_PROJECT_IDS } from 'constants/v2v3/projectIds'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
 import {
@@ -18,7 +18,7 @@ import { getProjectProps, ProjectPageProps } from './utils/props'
 export const getStaticPaths: GetStaticPaths = async () => {
   if (process.env.BUILD_CACHE_V2_PROJECTS === 'true') {
     const projects = await paginateDepleteProjectsQueryCall({
-      variables: { where: { cv: CV_V2 } },
+      variables: { where: { cv_in: [CV_V2, CV_V3] } },
     })
     const paths = projects.map(({ projectId }) => ({
       params: { projectId: String(projectId) },

--- a/src/pages/v2/p/[projectId]/safe/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/safe/index.page.tsx
@@ -1,6 +1,6 @@
 import { AppWrapper } from 'components/common'
 import { ProjectSafeDashboard } from 'components/v2v3/V2V3Project/ProjectSafeDashboard'
-import { V2CVType, V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
 import { TransactionProvider } from 'providers/TransactionProvider'
@@ -23,7 +23,7 @@ export default function ProjectSafeDashboardPage({
 }: {
   projectId: number
   metadata: ProjectMetadataV5
-  cv: V3CVType | V2CVType
+  cv: CV2V3
 }) {
   return (
     <AppWrapper>

--- a/src/pages/v2/p/[projectId]/settings/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/settings/index.page.tsx
@@ -1,6 +1,6 @@
 import { AppWrapper } from 'components/common'
 import { V2V3ProjectSettings } from 'components/v2v3/V2V3Project/V2V3ProjectSettings'
-import { V2CVType, V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
 import { TransactionProvider } from 'providers/TransactionProvider'
@@ -23,7 +23,7 @@ export default function V2V3ProjectSettingsPage({
 }: {
   projectId: number
   metadata: ProjectMetadataV5
-  cv: V3CVType | V2CVType
+  cv: CV2V3
 }) {
   return (
     <AppWrapper>

--- a/src/pages/v2/p/[projectId]/utils/props.ts
+++ b/src/pages/v2/p/[projectId]/utils/props.ts
@@ -3,7 +3,7 @@ import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { JUICEBOX_MONEY_PROJECT_METADATA_DOMAIN } from 'constants/metadataDomain'
 import { readNetwork } from 'constants/networks'
 import { readProvider } from 'constants/readProvider'
-import { V2CVType, V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { NetworkName } from 'models/network-name'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { V2V3ContractName } from 'models/v2v3/contracts'
@@ -15,7 +15,7 @@ import { loadV2V3Contract } from 'utils/v2v3/loadV2V3Contract'
 export interface ProjectPageProps {
   metadata: ProjectMetadataV5
   projectId: number
-  cv: V3CVType | V2CVType
+  cv: CV2V3
 }
 
 async function loadJBProjects() {

--- a/src/pages/v2/p/[projectId]/venft/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/venft/index.page.tsx
@@ -1,6 +1,6 @@
 import { AppWrapper } from 'components/common'
 import { VeNft } from 'components/veNft/VeNft'
-import { V2CVType, V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { GetServerSideProps } from 'next'
 import { TransactionProvider } from 'providers/TransactionProvider'
@@ -24,7 +24,7 @@ export default function V2V3ProjectSettingsPage({
 }: {
   projectId: number
   metadata: ProjectMetadataV5
-  cv: V3CVType | V2CVType
+  cv: CV2V3
 }) {
   return (
     <AppWrapper>

--- a/src/providers/v2v3/V2V3ContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ContractsProvider.tsx
@@ -1,19 +1,19 @@
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { useV2V3ContractLoader } from 'hooks/v2v3/V2V3ContractLoader'
-import { V2CVType, V2V3CVType, V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { useState } from 'react'
 
 export const V2V3ContractsProvider: React.FC<{
-  initialCv: V3CVType | V2CVType
+  initialCv: CV2V3
 }> = ({ children, initialCv }) => {
-  const [cv, setCv] = useState<V2V3CVType>(initialCv)
+  const [cv, setCv] = useState<CV2V3>(initialCv)
 
   const contracts = useV2V3ContractLoader({ cv })
 
   return (
     <V2V3ContractsContext.Provider
       value={{
-        setVersion: (newCv: V2V3CVType) => {
+        setVersion: (newCv: CV2V3) => {
           console.info(
             'V2V3ContractsProvider::Switching contracts version to',
             newCv,

--- a/src/providers/v2v3/V2V3ContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ContractsProvider.tsx
@@ -1,19 +1,19 @@
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { useV2V3ContractLoader } from 'hooks/v2v3/V2V3ContractLoader'
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2CVType, V2V3CVType, V3CVType } from 'models/cv'
 import { useState } from 'react'
 
 export const V2V3ContractsProvider: React.FC<{
   initialCv: V3CVType | V2CVType
 }> = ({ children, initialCv }) => {
-  const [cv, setCv] = useState<V2CVType | V3CVType>(initialCv)
+  const [cv, setCv] = useState<V2V3CVType>(initialCv)
 
   const contracts = useV2V3ContractLoader({ cv })
 
   return (
     <V2V3ContractsContext.Provider
       value={{
-        setVersion: (newCv: V2CVType | V3CVType) => {
+        setVersion: (newCv: V2V3CVType) => {
           console.info(
             'V2V3ContractsProvider::Switching contracts version to',
             newCv,

--- a/src/providers/v2v3/V2V3ProjectPageProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectPageProvider.tsx
@@ -1,4 +1,4 @@
-import { V2CVType, V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { ProjectMetadataV5 } from 'models/project-metadata'
 import { V2V3ContractsProvider } from './V2V3ContractsProvider'
 import { V2V3ProjectContractsProvider } from './V2V3ProjectContractsProvider'
@@ -11,7 +11,7 @@ import V2V3ProjectProvider from './V2V3ProjectProvider'
 export const V2V3ProjectPageProvider: React.FC<{
   projectId: number
   metadata: ProjectMetadataV5
-  cv: V3CVType | V2CVType
+  cv: CV2V3
 }> = ({ projectId, metadata, children, cv }) => {
   return (
     <V2V3ContractsProvider initialCv={cv}>

--- a/src/utils/revalidateProject.ts
+++ b/src/utils/revalidateProject.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { V2CVType } from 'models/cv'
+import { V2CVType, V3CVType } from 'models/cv'
 import { V1TerminalVersion } from 'models/v1/terminals'
 
 /**
@@ -15,7 +15,7 @@ import { V1TerminalVersion } from 'models/v1/terminals'
 export function revalidateProject(
   project:
     | { cv: V1TerminalVersion; handle: string }
-    | { cv: V2CVType; projectId: string },
+    | { cv: V2CVType | V3CVType; projectId: string },
 ) {
   return axios.post('/api/nextjs/revalidate-project', { project })
 }

--- a/src/utils/revalidateProject.ts
+++ b/src/utils/revalidateProject.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { V1TerminalVersion } from 'models/v1/terminals'
 
 /**
@@ -15,7 +15,7 @@ import { V1TerminalVersion } from 'models/v1/terminals'
 export function revalidateProject(
   project:
     | { cv: V1TerminalVersion; handle: string }
-    | { cv: V2V3CVType; projectId: string },
+    | { cv: CV2V3; projectId: string },
 ) {
   return axios.post('/api/nextjs/revalidate-project', { project })
 }

--- a/src/utils/revalidateProject.ts
+++ b/src/utils/revalidateProject.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2V3CVType } from 'models/cv'
 import { V1TerminalVersion } from 'models/v1/terminals'
 
 /**
@@ -15,7 +15,7 @@ import { V1TerminalVersion } from 'models/v1/terminals'
 export function revalidateProject(
   project:
     | { cv: V1TerminalVersion; handle: string }
-    | { cv: V2CVType | V3CVType; projectId: string },
+    | { cv: V2V3CVType; projectId: string },
 ) {
   return axios.post('/api/nextjs/revalidate-project', { project })
 }

--- a/src/utils/v2v3/loadV2V3Contract.ts
+++ b/src/utils/v2v3/loadV2V3Contract.ts
@@ -1,5 +1,5 @@
 import { Contract, ContractInterface } from '@ethersproject/contracts'
-import { V2V3CVType } from 'models/cv'
+import { CV2V3 } from 'models/cv'
 import { NetworkName } from 'models/network-name'
 import { SignerOrProvider } from 'models/signerOrProvider'
 import { V2V3ContractName } from 'models/v2v3/contracts'
@@ -20,7 +20,7 @@ export const loadV2V3Contract = async (
   contractName: V2V3ContractName,
   network: NetworkName,
   signerOrProvider: SignerOrProvider,
-  version: V2V3CVType,
+  version: CV2V3,
 ): Promise<Contract | undefined> => {
   let contractJson: { abi: ContractInterface; address: string } | undefined =
     undefined

--- a/src/utils/v2v3/loadV2V3Contract.ts
+++ b/src/utils/v2v3/loadV2V3Contract.ts
@@ -1,5 +1,5 @@
 import { Contract, ContractInterface } from '@ethersproject/contracts'
-import { V2CVType, V3CVType } from 'models/cv'
+import { V2V3CVType } from 'models/cv'
 import { NetworkName } from 'models/network-name'
 import { SignerOrProvider } from 'models/signerOrProvider'
 import { V2V3ContractName } from 'models/v2v3/contracts'
@@ -20,7 +20,7 @@ export const loadV2V3Contract = async (
   contractName: V2V3ContractName,
   network: NetworkName,
   signerOrProvider: SignerOrProvider,
-  version: V2CVType | V3CVType,
+  version: V2V3CVType,
 ): Promise<Contract | undefined> => {
   let contractJson: { abi: ContractInterface; address: string } | undefined =
     undefined


### PR DESCRIPTION
## What does this PR do and why?

Make sure all subgraph queries either:
- use the cv provided in the current context
- include both V2 and V3 in their cv_in queries

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
