### PR TITLE
Allow selection cards to be flexed, rather than using antd col/row

### DIFF
--- a/src/components/Create/components/Selection/SelectionCard.tsx
+++ b/src/components/Create/components/Selection/SelectionCard.tsx
@@ -1,4 +1,4 @@
-import { Col, Divider, Row } from 'antd'
+import { Divider } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { ReactNode, useCallback, useContext, useMemo } from 'react'
 import { CheckedCircle, RadialBackgroundIcon } from './components'
@@ -67,44 +67,48 @@ export const SelectionCard: React.FC<SelectionCardProps> = ({
 
   const defocused = !!defocusOnSelect && !!selection && !isSelected
 
+  const childGap = 42 + 32
+
   return (
     <Container isSelected={isSelected} isDefocused={defocused}>
       <div
         role="button"
         style={{
-          padding: '1.75rem 0',
+          padding: '1.5rem 0',
           userSelect: 'none',
           cursor: 'pointer',
         }}
         onClick={onClick}
       >
         <div style={{ padding: '0 1rem' }}>
-          <Row>
-            <Col span={3}>{icon && <RadialBackgroundIcon icon={icon} />}</Col>
-            <Col span={19}>{<h2>{title}</h2>}</Col>
-            <Col offset={1} span={1}>
-              <CheckedCircle checked={isSelected} />
-            </Col>
-          </Row>
-          {isSelected && description && (
-            <Row>
-              <Col offset={3} span={18}>
-                {description}
-              </Col>
-            </Row>
-          )}
+          <div
+            style={{
+              display: 'flex',
+              //TODO: This is probably not the best way to handle pushing content, could do with some help here
+              alignItems: isSelected ? 'baseline' : 'center',
+              gap: '1rem',
+            }}
+          >
+            <div>{icon && <RadialBackgroundIcon icon={icon} />}</div>
+            <div
+              style={{
+                flex: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.25rem',
+              }}
+            >
+              <h2 style={{ margin: 0 }}>{title}</h2>
+              {isSelected && description && <div>{description}</div>}
+            </div>
+            <CheckedCircle checked={isSelected} />
+          </div>
         </div>
       </div>
       {isSelected && children && (
         <div style={{ paddingBottom: '1.75rem' }}>
           <Divider style={{ marginTop: 0, marginBottom: '2rem' }} />
-          <div style={{ padding: '0 1rem' }}>
-            <Row>
-              <Col offset={3} span={18}>
-                {children}
-              </Col>
-            </Row>
-          </div>
+          <div style={{ padding: `0 ${childGap}px` }}>{children}</div>
         </div>
       )}
     </Container>

--- a/src/components/Create/components/Selection/components/RadialBackgroundIcon.tsx
+++ b/src/components/Create/components/Selection/components/RadialBackgroundIcon.tsx
@@ -10,6 +10,7 @@ export const RadialBackgroundIcon = ({ icon }: { icon: ReactNode }) => {
       style={{
         width: '2.625rem',
         height: '2.625rem',
+        minWidth: '2.625rem',
         fontSize: '1.3rem',
         backgroundColor: colors.background.l1,
         borderRadius: '50%',


### PR DESCRIPTION
## What does this PR do and why?

_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
