### PR TITLE
update prop, open to visable

### DIFF
--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -54,7 +54,7 @@ export function TopLeftNavItems({
     <Dropdown
       overlay={resourcesMenu}
       overlayStyle={{ padding: 0 }}
-      open={resourcesOpen}
+      visible={resourcesOpen}
     >
       <div
         className="nav-menu-item hover-opacity"


### PR DESCRIPTION
## What does this PR do and why?

https://ant.design/components/dropdown/

Prop change is needed for new API: 


Why we need align pop component with [open prop?](https://ant.design/docs/react/faq#Why-we-need-align-pop-component-with-open-prop)

> For historical reasons, the display names of the pop components are not uniform, and both open and visible are used. This makes the memory cost that non-tsx users encounter when developing. It also leads to ambiguity about what name to choose when adding a feature. So we want to unify the attribute name, you can still use the original visible and it will still be backward compatible, but we will remove this attribute from the documentation as of v5.


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
