### PR TITLE
Fix gnosis link from v1 project + minor NFT bug

### DIFF
--- a/src/components/Project/ProjectHeader/GnosisSafeBadge.tsx
+++ b/src/components/Project/ProjectHeader/GnosisSafeBadge.tsx
@@ -1,43 +1,33 @@
 import Icon from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
-import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { ThemeContext } from 'contexts/themeContext'
-import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import Link from 'next/link'
 import { useContext } from 'react'
-import { v2v3ProjectRoute } from 'utils/routes'
 
-function SafeIcon() {
-  const { isDarkMode } = useContext(ThemeContext)
-  const { handle } = useContext(V2V3ProjectContext)
-  const { projectId } = useContext(ProjectMetadataContext)
-  const src = isDarkMode
-    ? '/assets/icons/gnosis_od.svg'
-    : '/assets/icons/gnosis_ol.svg'
+export function GnosisSafeBadge({ href }: { href: string }) {
+  function SafeIcon() {
+    const { isDarkMode } = useContext(ThemeContext)
+    const src = isDarkMode
+      ? '/assets/icons/gnosis_od.svg'
+      : '/assets/icons/gnosis_ol.svg'
 
-  return (
-    <Link href={`${v2v3ProjectRoute({ projectId, handle })}/safe`}>
-      <a>
-        <img src={src} alt="Safe" width={15} height={15} />
-      </a>
-    </Link>
-  )
-}
+    return (
+      <Link href={href}>
+        <a>
+          <img src={src} alt="Safe" width={15} height={15} />
+        </a>
+      </Link>
+    )
+  }
 
-export function GnosisSafeBadge() {
-  const { handle } = useContext(V2V3ProjectContext)
-  const { projectId } = useContext(ProjectMetadataContext)
   return (
     <Tooltip
       placement="bottom"
       title={
         <Trans>
           This project is owned by a Safe.{' '}
-          <Link href={`${v2v3ProjectRoute({ projectId, handle })}/safe`}>
-            See transactions
-          </Link>
-          .
+          <Link href={href}>See transactions</Link>.
         </Trans>
       }
     >

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -169,7 +169,9 @@ export function ProjectHeader({
                 Owned by <FormattedAddress address={projectOwnerAddress} />
               </Trans>
             </span>
-            {!gnosisSafeLoading && gnosisSafe && <GnosisSafeBadge />}
+            {!gnosisSafeLoading && gnosisSafe && (
+              <GnosisSafeBadge href={`${window.location.href}/safe`} />
+            )}
           </div>
         )}
       </div>

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
@@ -108,6 +108,8 @@ export function V2V3ConfirmPayModal({
     setLoading(false)
     setTransactionPending(false)
 
+    form.resetFields()
+
     if (nftRewardTier && projectMetadata?.nftPaymentSuccessModal) {
       router.replace(
         `${v2v3ProjectRoute({ handle, projectId })}?nftPurchaseConfirmed=true`,

--- a/src/components/v2v3/V2V3Project/V2V3Project.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3Project.tsx
@@ -107,34 +107,29 @@ export function V2V3Project() {
     }
   }, [query])
 
-  // Change URL without refreshing page
-  const removeQueryParams = () => {
-    // `Next` `query.nftPurchaseConfirmed` not updating unless a new
-    // `nftPurchaseConfirmed` value is given
-    const newQuery: Record<string, string> = {}
-    Object.keys(query).forEach((key: string) => {
-      if (key !== 'projectId') {
-        newQuery[key] = 'null'
-      }
-    })
-
+  const closeNewDeployModal = () => {
+    // Wipes query param
     routerReplace(
       {
         pathname: v2v3ProjectRoute({ projectId }),
-        query: newQuery,
       },
       undefined,
       { shallow: true },
     )
-  }
-
-  const closeNewDeployModal = () => {
-    removeQueryParams()
     setNewDeployModalVisible(false)
   }
 
   const closeNftPostPayModal = () => {
-    removeQueryParams()
+    // `Next` `query.nftPurchaseConfirmed` not updating unless a new
+    // `nftPurchaseConfirmed` value is given
+    routerReplace(
+      {
+        pathname: v2v3ProjectRoute({ projectId }),
+        query: { nftPurchaseConfirmed: 'null' },
+      },
+      undefined,
+      { shallow: true },
+    )
     setNftPostPayModalVisible(false)
   }
 


### PR DESCRIPTION
## What does this PR do and why?

In addition to PR title: 
- **A:** Fixes wrong NFT getting attached to pay memo if you pay for 2 different NFT's consecutively (previously was still attaching the first NFT for the second payment because the form wasn't being reset)
- **B:** Only uses the `queryParam` `null` thing for `nftPurchaseConfirmed` where it is currently necessary. Stops it happening when closing the `newDeploy` modal

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
