### PR TITLE
Safe page design update

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/ExecutedSafeTransactionsListing.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/ExecutedSafeTransactionsListing.tsx
@@ -1,6 +1,7 @@
 import { useExecutedSafeTransactions } from 'hooks/safe/ExecutedSafeTransaction'
 import { GnosisSafe, SafeTransactionType } from 'models/safe'
-import { SafeTransaction } from './SafeTransaction'
+import { getUniqueNonces } from 'utils/safe'
+import { SafeNonceRow } from './SafeNonceRow'
 
 export function ExecutedSafeTransactionsListing({
   safe,
@@ -14,22 +15,32 @@ export function ExecutedSafeTransactionsListing({
       safeAddress: safe.address,
     })
 
+  const uniqueNonces = getUniqueNonces(executedSafeTransactions)
+
   if (isLoading) {
     return <div style={{ marginTop: 20 }}>Loading...</div>
   }
 
   return (
     <>
-      {executedSafeTransactions?.map(
-        (transaction: SafeTransactionType, idx: number) => (
-          <SafeTransaction
-            key={`safe-${transaction.nonce}-${idx}`}
-            transaction={transaction}
-            selected={selectedTx === transaction.safeTxHash}
-            isPastTransaction
+      {uniqueNonces?.map((nonce: number, idx: number) => {
+        const transactionsOfNonce: SafeTransactionType[] =
+          executedSafeTransactions.filter(
+            (tx: SafeTransactionType) => tx.nonce === nonce && tx.dataDecoded,
+          )
+
+        if (!transactionsOfNonce.length) return
+
+        return (
+          <SafeNonceRow
+            key={`safe-${nonce}-${idx}`}
+            nonce={nonce}
+            transactions={transactionsOfNonce}
+            safeThreshold={safe.threshold}
+            selectedTx={selectedTx}
           />
-        ),
-      )}
+        )
+      })}
     </>
   )
 }

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/LinkToSafeButton.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/LinkToSafeButton.tsx
@@ -13,7 +13,14 @@ export function LinkToSafeButton({
   style?: CSSProperties
 }) {
   return (
-    <div style={{ ...style, display: 'flex' }}>
+    <div
+      style={{
+        ...style,
+        display: 'flex',
+        marginLeft: '1.5rem',
+        fontSize: '0.8rem',
+      }}
+    >
       <ExternalLink
         href={generateSafeTxUrl(transaction)}
         style={{ textDecoration: 'underline' }}

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/ProjectSafeDashboard.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/ProjectSafeDashboard.tsx
@@ -14,9 +14,10 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { CSSProperties, useContext } from 'react'
 import { v2v3ProjectRoute } from 'utils/routes'
+import { getUniqueNonces } from 'utils/safe'
 import { BackToProjectButton } from '../BackToProjectButton'
 import { ExecutedSafeTransactionsListing } from './ExecutedSafeTransactionsListing'
-import { SafeTransaction } from './SafeTransaction'
+import { SafeNonceRow } from './SafeNonceRow'
 
 export type SafeTxCategory = 'queued' | 'history'
 const SAFE_TX_QUEUED_KEY: SafeTxCategory = 'queued'
@@ -70,6 +71,9 @@ export function ProjectSafeDashboard() {
     )
   }
 
+  // Returns unique nonces from tx list. Used to group tx's by nonce
+  const uniqueNonces = getUniqueNonces(queuedSafeTransactions)
+
   const projectSafeRoute = `${v2v3ProjectRoute({ projectId, handle })}/safe`
 
   return (
@@ -113,21 +117,32 @@ export function ProjectSafeDashboard() {
             </Link>
           </Space>
 
-          <div style={{ marginTop: '1.5rem' }}>
+          <div
+            style={{
+              marginTop: '1.5rem',
+              borderTop: `1px solid ${colors.stroke.tertiary}`,
+            }}
+          >
             {selectedTab === SAFE_TX_QUEUED_KEY ? (
               <>
-                {queuedSafeTransactions?.map(
-                  (transaction: SafeTransactionType, idx: number) => (
-                    <SafeTransaction
-                      key={`safe-${transaction.nonce}-${idx}`}
-                      transaction={{
-                        ...transaction,
-                        threshold: gnosisSafe?.threshold,
-                      }}
-                      selected={preSelectedTx === transaction.safeTxHash}
+                {uniqueNonces?.map((nonce: number, idx: number) => {
+                  const transactionsOfNonce: SafeTransactionType[] =
+                    queuedSafeTransactions.filter(
+                      (tx: SafeTransactionType) => tx.nonce === nonce,
+                    )
+
+                  if (!transactionsOfNonce.length) return
+
+                  return (
+                    <SafeNonceRow
+                      key={`safe-${nonce}-${idx}`}
+                      nonce={nonce}
+                      transactions={transactionsOfNonce}
+                      safeThreshold={gnosisSafe?.threshold}
+                      selectedTx={preSelectedTx}
                     />
-                  ),
-                )}
+                  )
+                })}
               </>
             ) : selectedTab === SAFE_TX_HISTORY_KEY ? (
               <ExecutedSafeTransactionsListing

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/SafeNonceRow.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/SafeNonceRow.tsx
@@ -1,0 +1,72 @@
+import { ThemeContext } from 'contexts/themeContext'
+import { SafeTransactionType } from 'models/safe'
+import { CSSProperties, useContext } from 'react'
+import { SafeTransaction } from './SafeTransaction'
+
+export const safeNonceRowStyle: CSSProperties = {
+  justifyContent: 'space-between',
+  fontWeight: 400,
+  width: '100%',
+  padding: '1.5rem 1.5rem 0.5rem 0',
+  transition: 'background-color 100ms linear',
+  display: 'flex',
+  cursor: 'pointer',
+  borderTop: 'unset',
+  borderLeft: 'unset',
+  borderRight: 'unset',
+}
+
+export function SafeNonceRow({
+  nonce,
+  transactions,
+  selectedTx,
+  safeThreshold,
+}: {
+  nonce: number
+  transactions: SafeTransactionType[]
+  selectedTx: string | undefined
+  safeThreshold: number
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const containsSelectedTx = transactions.some(
+    (tx: SafeTransactionType) => tx.safeTxHash === selectedTx,
+  )
+
+  const rowStyle: CSSProperties = {
+    ...safeNonceRowStyle,
+    color: colors.text.primary,
+  }
+
+  if (containsSelectedTx) {
+    rowStyle.borderBottom = `1px solid ${colors.stroke.action.primary}`
+  }
+
+  return (
+    <div
+      className="clickable-border"
+      style={rowStyle}
+      id={`safe-nonce-${nonce}`}
+    >
+      <div
+        style={{
+          color: colors.text.secondary,
+          paddingRight: '2rem',
+        }}
+      >
+        {nonce}
+      </div>
+      <div style={{ width: '100%' }}>
+        {transactions.map((tx: SafeTransactionType, idx: number) => (
+          <SafeTransaction
+            key={idx}
+            transaction={{ ...tx, threshold: safeThreshold }}
+            selected={selectedTx === tx.safeTxHash}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/SafeTransaction.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/SafeTransaction.tsx
@@ -1,7 +1,7 @@
 import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { ThemeContext } from 'contexts/themeContext'
 import { SafeTransactionType } from 'models/safe'
-import { CSSProperties, useContext, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { ReconfigureFundingCyclesOfTransaction } from './juiceboxTransactions/reconfigureFundingCyclesOf'
 import { LinkToSafeButton } from './LinkToSafeButton'
 import { TransactionHeader } from './TransactionHeader'
@@ -10,18 +10,6 @@ export type SafeTransactionComponentProps = {
   transaction: SafeTransactionType
   selected: boolean
   isPastTransaction?: boolean
-}
-
-export const safeTransactionRowStyle: CSSProperties = {
-  justifyContent: 'space-between',
-  fontWeight: 400,
-  width: '100%',
-  padding: '0.5rem 1rem',
-  marginBottom: '1rem',
-  transition: 'background-color 100ms linear',
-  display: 'flex',
-  flexDirection: 'column',
-  cursor: 'pointer',
 }
 
 const GenericSafeTransaction = ({
@@ -35,23 +23,12 @@ const GenericSafeTransaction = ({
 
   const [expanded, setExpanded] = useState<boolean>(selected)
 
-  const rowStyle: CSSProperties = {
-    ...safeTransactionRowStyle,
-    color: colors.text.primary,
-    paddingRight: '1rem',
-  }
-
-  if (selected) {
-    rowStyle.border = `1px solid ${colors.stroke.action.primary}`
-  }
-
   return (
     <div
-      className="clickable-border"
-      style={rowStyle}
       onClick={() => {
         setExpanded(!expanded)
       }}
+      style={{ marginBottom: '1.5rem' }}
       id={`${transaction.safeTxHash}`}
     >
       <div style={{ display: 'flex', width: '100%' }}>
@@ -59,7 +36,7 @@ const GenericSafeTransaction = ({
           transaction={transaction}
           isPastTransaction={isPastTransaction}
         />
-        <div style={{ marginLeft: 10 }}>
+        <div style={{ marginLeft: 10, color: colors.text.tertiary }}>
           {expanded ? <UpOutlined /> : <DownOutlined />}
         </div>
       </div>
@@ -67,9 +44,7 @@ const GenericSafeTransaction = ({
       {expanded ? (
         <LinkToSafeButton
           transaction={transaction}
-          style={{
-            marginTop: '1rem',
-          }}
+          style={{ marginTop: '0.5rem' }}
         />
       ) : null}
     </div>

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/TransactionHeader.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/TransactionHeader.tsx
@@ -1,14 +1,9 @@
 import { ThemeContext } from 'contexts/themeContext'
 import { SafeTransactionType } from 'models/safe'
 import Link from 'next/link'
-import { CSSProperties, useContext } from 'react'
+import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/format/formatDate'
 import { TransactionSigStatus } from './TransactionSigStatus'
-
-const nonceStyle: CSSProperties = {
-  marginRight: '2rem',
-  width: '1rem',
-}
 
 export function TransactionHeader({
   transaction,
@@ -36,9 +31,6 @@ export function TransactionHeader({
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        <div style={{ ...nonceStyle, color: colors.text.secondary }}>
-          {transaction.nonce}
-        </div>
         <Link href={`#${transaction.safeTxHash}`}>
           <a className="text-primary hover-text-decoration-underline">
             {transactionTitle}
@@ -48,7 +40,7 @@ export function TransactionHeader({
       <div
         style={{
           width: '200px',
-          color: colors.text.secondary,
+          color: colors.text.tertiary,
           display: 'flex',
           justifyContent: isPastTransaction ? 'flex-end' : 'space-between',
         }}

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/ReconfigurationRichPreview.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/ReconfigurationRichPreview.tsx
@@ -78,7 +78,7 @@ export function ReconfigureRichPreview({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <div style={{ margin: '1rem 3rem 0' }}>
+      <div style={{ margin: '1rem 1.5rem 0' }}>
         {decodedData._memo.length ? (
           <i>{decodedData._memo}</i>
         ) : (
@@ -91,7 +91,7 @@ export function ReconfigureRichPreview({
       </div>
       <Space
         size={'middle'}
-        style={{ margin: '1rem 2rem' }}
+        style={{ margin: '1rem 1.5rem' }}
         direction={'vertical'}
         onClick={e => e.stopPropagation()}
       >
@@ -105,16 +105,14 @@ export function ReconfigureRichPreview({
         </MinimalCollapse>
         <MinimalCollapse header={t`Funding distribution`} light>
           {distributionLimit?.gt(0) ? (
-            payoutSplits ? (
-              <SplitList
-                splits={formatOutgoingSplits(payoutSplits)}
-                currency={distributionLimitCurrency}
-                totalValue={distributionLimit}
-                projectOwnerAddress={projectOwnerAddress}
-                showSplitValues={!distributionLimit?.eq(MAX_DISTRIBUTION_LIMIT)}
-                valueFormatProps={{ precision: 4 }}
-              />
-            ) : null
+            <SplitList
+              splits={formatOutgoingSplits(payoutSplits)}
+              currency={distributionLimitCurrency}
+              totalValue={distributionLimit}
+              projectOwnerAddress={projectOwnerAddress}
+              showSplitValues={!distributionLimit?.eq(MAX_DISTRIBUTION_LIMIT)}
+              valueFormatProps={{ precision: 4 }}
+            />
           ) : (
             <span style={{ color: colors.text.tertiary }}>
               <Trans>No distributions configured.</Trans>
@@ -123,14 +121,12 @@ export function ReconfigureRichPreview({
         </MinimalCollapse>
         <MinimalCollapse header={t`Reserved token allocation`} light>
           {reservedRate?.gt(0) ? (
-            reservedTokensSplits ? (
-              <SplitList
-                splits={formatOutgoingSplits(reservedTokensSplits)}
-                projectOwnerAddress={projectOwnerAddress}
-                totalValue={undefined}
-                reservedRate={parseFloat(formatReservedRate(reservedRate))}
-              />
-            ) : null
+            <SplitList
+              splits={formatOutgoingSplits(reservedTokensSplits)}
+              projectOwnerAddress={projectOwnerAddress}
+              totalValue={undefined}
+              reservedRate={parseFloat(formatReservedRate(reservedRate))}
+            />
           ) : (
             <span style={{ color: colors.text.tertiary }}>
               <Trans>No reserved tokens configured.</Trans>
@@ -138,12 +134,7 @@ export function ReconfigureRichPreview({
           )}
         </MinimalCollapse>
       </Space>
-      <LinkToSafeButton
-        transaction={transaction}
-        style={{
-          marginTop: '1rem',
-        }}
-      />
+      <LinkToSafeButton transaction={transaction} />
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/index.tsx
@@ -2,10 +2,7 @@ import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { t } from '@lingui/macro'
 import { ThemeContext } from 'contexts/themeContext'
 import { CSSProperties, useContext, useState } from 'react'
-import {
-  SafeTransactionComponentProps,
-  safeTransactionRowStyle,
-} from '../../SafeTransaction'
+import { SafeTransactionComponentProps } from '../../SafeTransaction'
 import { TransactionHeader } from '../../TransactionHeader'
 import { ReconfigureRichPreview } from './ReconfigurationRichPreview'
 
@@ -21,12 +18,8 @@ export function ReconfigureFundingCyclesOfTransaction({
   const [expanded, setExpanded] = useState<boolean>(selected)
 
   const rowStyle: CSSProperties = {
-    ...safeTransactionRowStyle,
     color: colors.text.primary,
-  }
-
-  if (selected) {
-    rowStyle.border = `1px solid ${colors.stroke.action.primary}`
+    marginBottom: '1.5rem',
   }
 
   return (
@@ -35,7 +28,6 @@ export function ReconfigureFundingCyclesOfTransaction({
       onClick={() => {
         setExpanded(!expanded)
       }}
-      className="clickable-border"
       id={`${transaction.safeTxHash}`}
     >
       <div style={{ display: 'flex', width: '100%' }}>
@@ -44,7 +36,7 @@ export function ReconfigureFundingCyclesOfTransaction({
           title={t`Reconfigure funding cycle`}
           isPastTransaction={isPastTransaction}
         />
-        <div style={{ marginLeft: 10 }}>
+        <div style={{ marginLeft: 10, color: colors.text.tertiary }}>
           {expanded ? <UpOutlined /> : <DownOutlined />}
         </div>
       </div>

--- a/src/utils/safe.ts
+++ b/src/utils/safe.ts
@@ -1,0 +1,10 @@
+import { SafeTransactionType } from 'models/safe'
+
+// e.g. [ {nonce: 69}, {nonce: 45}, {nonce: 69}] returns [69, 45]
+export function getUniqueNonces(transactions: SafeTransactionType[]) {
+  return [
+    ...new Set<number>(
+      transactions?.map((tx: SafeTransactionType) => tx.nonce),
+    ),
+  ]
+}

--- a/src/utils/splits.ts
+++ b/src/utils/splits.ts
@@ -83,8 +83,10 @@ export const getProjectOwnerRemainderSplit = (
  * (Outgoing Split objects have percent and lockedUntil as BigNumbers)
  */
 export const formatOutgoingSplits = (splits: OutgoingSplit[]): Split[] => {
-  return splits.map(
-    (split: OutgoingSplit) =>
-      ({ ...split, percent: split.percent.toNumber() } as Split),
+  return (
+    splits?.map(
+      (split: OutgoingSplit) =>
+        ({ ...split, percent: split.percent.toNumber() } as Split),
+    ) ?? []
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

- Combines tx of same Safe nonce
- Only shows executed tx of nonce on History tab
- Shows version badge on reconfig tx's
- Shows transactions with no `data` as `send` tx's 
- Removes signing status from history tx's

### This example shows multiple historical tx's per nonce to demonstrate the design. (Src code only shows the executed tx, and has the signing status hidden):

https://user-images.githubusercontent.com/96150256/195272327-52e638f9-e469-4287-83cc-ab5eb87e7fdb.mp4



## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
