### PR TITLE
move top level nav items into TopLeft items component

### DIFF
--- a/src/components/Navbar/MenuItems.tsx
+++ b/src/components/Navbar/MenuItems.tsx
@@ -1,13 +1,18 @@
 import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Dropdown, Menu } from 'antd'
+import { Dropdown, Menu, Space } from 'antd'
 import Link from 'next/link'
 import { CSSProperties, useEffect, useState } from 'react'
 
 import Logo from './Logo'
-import { navMenuItemStyles } from './navStyles'
+import { navMenuItemStyles, topNavStyles, topRightNavStyles } from './navStyles'
 
+import { Header } from 'antd/lib/layout/layout'
+import Account from './Account'
 import { resourcesMenuItems } from './constants'
+import NavLanguageSelector from './NavLanguageSelector'
+import ThemePicker from './ThemePicker'
+import { TransactionsList } from './TransactionList'
 
 const resourcesMenu = (
   <Menu
@@ -155,15 +160,29 @@ export function TopLeftNavItems({
       ]
 
   return (
-    <Menu
-      items={menuItems}
-      mode="inline"
-      style={{
-        display: 'flex',
-        flexDirection: desktop ? 'row' : 'column',
-        width: desktop ? 500 : 'auto',
-      }}
-      selectable={false}
-    />
+    <Header className="top-nav" style={{ ...topNavStyles }}>
+      <Menu
+        items={menuItems}
+        mode="inline"
+        style={{
+          display: 'flex',
+          flexDirection: desktop ? 'row' : 'column',
+          width: desktop ? 500 : 'auto',
+        }}
+        selectable={false}
+      />
+      <Space size="middle" style={{ ...topRightNavStyles }}>
+        <NavLanguageSelector />
+        <ThemePicker />
+        <TransactionsList
+          listStyle={{
+            position: 'absolute',
+            top: 70,
+            right: 30,
+          }}
+        />
+        <Account />
+      </Space>
+    </Header>
   )
 }

--- a/src/components/Navbar/Mobile/MobileCollapse.tsx
+++ b/src/components/Navbar/Mobile/MobileCollapse.tsx
@@ -1,5 +1,5 @@
 import { MenuOutlined } from '@ant-design/icons'
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { Button, Collapse, Menu } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
 import { Header } from 'antd/lib/layout/layout'
@@ -9,10 +9,10 @@ import { useWallet } from 'hooks/Wallet'
 import Link from 'next/link'
 import { useContext, useEffect, useState } from 'react'
 import Account from '../Account'
+import { resourcesMenuItems } from '../constants'
 import Logo from '../Logo'
-import { TopLeftNavItems } from '../MenuItems'
 import NavLanguageSelector from '../NavLanguageSelector'
-import { topNavStyles } from '../navStyles'
+import { navMenuItemStyles, topNavStyles } from '../navStyles'
 import { TransactionsList } from '../TransactionList'
 import ThemePickerMobile from './ThemePickerMobile'
 
@@ -33,6 +33,18 @@ export default function MobileCollapse() {
   const collapseNav = () => setActiveKey(undefined)
   const expandNav = () => setActiveKey(NAV_EXPANDED_KEY)
   const toggleNav = () => (isNavExpanded ? collapseNav() : expandNav())
+
+  const menuItemProps = {
+    onClick: () => collapseNav,
+    style: navMenuItemStyles,
+    className: 'nav-menu-item hover-opacity',
+  }
+
+  const externalMenuLinkProps = {
+    ...menuItemProps,
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  }
 
   // Close collapse when clicking anywhere in the window except the collapse items
   useEffect(() => {
@@ -111,36 +123,64 @@ export default function MobileCollapse() {
             </div>
           }
         >
-          <Menu mode="inline" defaultSelectedKeys={['resources']}>
-            <TopLeftNavItems
-              desktop={false}
-              onClickMenuItems={() => collapseNav()}
-            />
-
-            <div style={{ marginLeft: 15 }}>
-              <Menu.Item key="language-selector">
-                <NavLanguageSelector mobile />
-              </Menu.Item>
-              <Menu.Item key="theme-picker">
-                <ThemePickerMobile />
-              </Menu.Item>
-            </div>
-          </Menu>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              marginTop: '1rem',
-            }}
-          >
-            <Account />
-            {isConnected ? (
-              <Button onClick={disconnect} style={{ marginTop: 10 }} block>
-                <Trans>Disconnect</Trans>
-              </Button>
-            ) : null}
-          </div>
+          <Menu
+            mode="inline"
+            items={[
+              {
+                key: 'projects',
+                label: (
+                  <Link href="/projects">
+                    <a {...menuItemProps}>{t`Projects`}</a>
+                  </Link>
+                ),
+              },
+              {
+                key: 'docs',
+                label: (
+                  <Link href="https://info.juicebox.money/">
+                    <a {...externalMenuLinkProps}>{t`Docs`}</a>
+                  </Link>
+                ),
+              },
+              {
+                key: 'blog',
+                label: (
+                  <Link href="https://info.juicebox.money/blog">
+                    <a {...externalMenuLinkProps}>{t`Blog`}</a>
+                  </Link>
+                ),
+              },
+              {
+                key: 'resources',
+                label: (
+                  <Link href="">
+                    <a
+                      className="nav-menu-item hover-opacity"
+                      style={{ ...navMenuItemStyles }}
+                    >
+                      {t`Resources`}
+                    </a>
+                  </Link>
+                ),
+                children: [...resourcesMenuItems(true)],
+              },
+              { key: 'language-picker', label: <NavLanguageSelector /> },
+              { key: 'theme-picker', label: <ThemePickerMobile /> },
+              {
+                key: 'account',
+                label: <Account />,
+              },
+              {
+                key: 'disconnect',
+                label: isConnected ? (
+                  <Button onClick={disconnect} style={{ marginTop: 10 }} block>
+                    <Trans>Disconnect</Trans>
+                  </Button>
+                ) : null,
+              },
+            ]}
+            defaultSelectedKeys={['resources']}
+          />
         </CollapsePanel>
       </Collapse>
     </Header>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,13 +1,6 @@
-import { Space } from 'antd'
-import { Header } from 'antd/lib/layout/layout'
-import { TransactionsList } from 'components/Navbar/TransactionList'
 import useMobile from 'hooks/Mobile'
-import Account from './Account'
 import { TopLeftNavItems } from './MenuItems'
 import MobileCollapse from './Mobile/MobileCollapse'
-import NavLanguageSelector from './NavLanguageSelector'
-import { topNavStyles, topRightNavStyles } from './navStyles'
-import ThemePicker from './ThemePicker'
 
 export default function Navbar() {
   const isMobile = useMobile()
@@ -15,22 +8,5 @@ export default function Navbar() {
 
   if (isMobile) return <MobileCollapse />
 
-  return (
-    <Header className="top-nav" style={{ ...topNavStyles }}>
-      <TopLeftNavItems desktop={desktop} />
-
-      <Space size="middle" style={{ ...topRightNavStyles }}>
-        <NavLanguageSelector />
-        <ThemePicker />
-        <TransactionsList
-          listStyle={{
-            position: 'absolute', // Position below navbar
-            top: 70,
-            right: 30,
-          }}
-        />
-        <Account />
-      </Space>
-    </Header>
-  )
+  return <TopLeftNavItems desktop={desktop} />
 }


### PR DESCRIPTION
## What does this PR do and why?

This PR moves `transactions`, `account`, `lang` from `NavBar` to mobile collapse and topleftItems. The Navigation will further be refactored to use the new `items=` API from menu. This is the first step of adding these NavItems and will separate concerns a bit from mobile and desktop headers.
## Screenshots or screen recordings
### Mobile
<img width="862" alt="CleanShot 2022-10-17 at 20 58 29@2x" src="https://user-images.githubusercontent.com/2502947/196318119-66956b64-693d-4c2d-8731-588bc8ac0f80.png">

### Desktop
<img width="408" alt="CleanShot 2022-10-17 at 20 58 18@2x" src="https://user-images.githubusercontent.com/2502947/196318153-7494fbe4-9c47-4687-8c5f-b11ecc373d9e.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
