### PR TITLE
remove remaining legacy children menu items

### DIFF
--- a/src/components/Navbar/DeskTopNavigation.tsx
+++ b/src/components/Navbar/DeskTopNavigation.tsx
@@ -1,14 +1,14 @@
 import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Dropdown, Menu, Space } from 'antd'
+import { Dropdown, Menu } from 'antd'
+import { Header } from 'antd/lib/layout/layout'
 import Link from 'next/link'
 import { CSSProperties, useEffect, useState } from 'react'
 
 import Logo from './Logo'
 import NavLanguageSelector from './NavLanguageSelector'
-import { navMenuItemStyles, topNavStyles, topRightNavStyles } from './navStyles'
+import { navMenuItemStyles, topNavStyles } from './navStyles'
 
-import { Header } from 'antd/lib/layout/layout'
 import Account from './Account'
 import { resourcesMenuItems } from './constants'
 import ThemePicker from './ThemePicker'
@@ -171,18 +171,49 @@ export default function DesktopNavigation({
         }}
         selectable={false}
       />
-      <Space size="middle" style={{ ...topRightNavStyles }}>
-        <NavLanguageSelector />
-        <ThemePicker />
-        <TransactionsList
-          listStyle={{
-            position: 'absolute',
-            top: 70,
-            right: 30,
-          }}
-        />
-        <Account />
-      </Space>
+      <Menu
+        mode="horizontal"
+        items={[
+          {
+            key: 'navigation-selector',
+            label: (
+              <div style={navMenuItemStyles}>
+                <NavLanguageSelector />
+              </div>
+            ),
+          },
+          {
+            key: 'theme-picker',
+            label: (
+              <div style={navMenuItemStyles}>
+                <ThemePicker />
+              </div>
+            ),
+          },
+          {
+            key: 'transaction-list',
+            label: (
+              <div style={navMenuItemStyles}>
+                <TransactionsList
+                  listStyle={{
+                    position: 'absolute',
+                    top: 70,
+                    right: 30,
+                  }}
+                />
+              </div>
+            ),
+          },
+          {
+            key: 'account',
+            label: (
+              <div style={navMenuItemStyles}>
+                <Account />
+              </div>
+            ),
+          },
+        ]}
+      />
     </Header>
   )
 }

--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -19,7 +19,6 @@ export default function NavLanguageSelector({
     alignItems: 'center',
     justifyContent: 'space-evenly',
     cursor: 'pointer',
-    height: 30,
     fontWeight: 500,
   }
 

--- a/src/components/Navbar/TransactionList/TransactionsList.tsx
+++ b/src/components/Navbar/TransactionList/TransactionsList.tsx
@@ -41,7 +41,6 @@ export function TransactionsList({
             paddingLeft: 10,
             paddingRight: 5,
             borderRadius: 15,
-            height: 30,
             userSelect: 'none',
           }}
           onClick={() => setIsExpanded(!isExpanded)}

--- a/src/styles/antd-overrides/menu.scss
+++ b/src/styles/antd-overrides/menu.scss
@@ -59,6 +59,10 @@
   font-weight: 500;
 }
 
+.ant-menu-horizontal > .ant-menu-item {
+  padding: 0 10px !important;
+}
+
 .ant-menu-light .ant-menu-item:hover {
   color: var(--text-primary);
   background-color: var(--background-l2);


### PR DESCRIPTION
## What does this PR do and why?

_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

moves 
```
<NavLanguageSelector />
         <ThemePicker />
         <TransactionsList
           listStyle={{
             position: 'absolute',
             top: 70,
             right: 30,
           }}
         />
         <Account />
```

Into Menu's `items={}` prop so we can eventually upgrade antd and react 
## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
