### PR TITLE
remove mobile menu items from desktop nav

### DIFF
--- a/src/components/Navbar/DeskTopNavigation.tsx
+++ b/src/components/Navbar/DeskTopNavigation.tsx
@@ -79,85 +79,44 @@ export default function DesktopNavigation({
     </Dropdown>
   )
 
-  const menuItems = desktop
-    ? [
-        {
-          key: 'index',
-          label: (
-            <Link href="/">
-              <a style={{ display: 'inline-block' }}>{<Logo />}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'projects',
-          label: (
-            <Link href="/projects">
-              <a {...menuItemProps}>{t`Projects`}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'docs',
-          label: (
-            <Link href="https://info.juicebox.money/">
-              <a {...externalMenuLinkProps}>{t`Docs`}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'blog',
-          label: (
-            <Link href="https://info.juicebox.money/blog">
-              <a {...externalMenuLinkProps}>{t`Blog`}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'resources',
-          label: desktopDropDown,
-        },
-      ]
-    : [
-        {
-          key: 'projects',
-          label: (
-            <Link href="/projects">
-              <a {...menuItemProps}>{t`Projects`}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'docs',
-          label: (
-            <Link href="https://info.juicebox.money/">
-              <a {...externalMenuLinkProps}>{t`Docs`}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'blog',
-          label: (
-            <Link href="https://info.juicebox.money/blog">
-              <a {...externalMenuLinkProps}>{t`Blog`}</a>
-            </Link>
-          ),
-        },
-        {
-          key: 'resources',
-          label: (
-            <Link href="">
-              <a
-                className="nav-menu-item hover-opacity"
-                style={{ ...navMenuItemStyles }}
-              >
-                {t`Resources`}
-              </a>
-            </Link>
-          ),
-          children: [...resourcesMenuItems(true)],
-        },
-      ]
+  const menuItems = [
+    {
+      key: 'index',
+      label: (
+        <Link href="/">
+          <a style={{ display: 'inline-block' }}>{<Logo />}</a>
+        </Link>
+      ),
+    },
+    {
+      key: 'projects',
+      label: (
+        <Link href="/projects">
+          <a {...menuItemProps}>{t`Projects`}</a>
+        </Link>
+      ),
+    },
+    {
+      key: 'docs',
+      label: (
+        <Link href="https://info.juicebox.money/">
+          <a {...externalMenuLinkProps}>{t`Docs`}</a>
+        </Link>
+      ),
+    },
+    {
+      key: 'blog',
+      label: (
+        <Link href="https://info.juicebox.money/blog">
+          <a {...externalMenuLinkProps}>{t`Blog`}</a>
+        </Link>
+      ),
+    },
+    {
+      key: 'resources',
+      label: desktopDropDown,
+    },
+  ]
 
   return (
     <Header className="top-nav" style={{ ...topNavStyles }}>


### PR DESCRIPTION
## What does this PR do and why?

We no longer need to check for mobile or desktop since Desktop and Mobile components will now have a singe check for viewport size in `Navbar`
## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
