### PR TITLE
remove mobile check for transaction list style + move mobile into desktop component

### DIFF
--- a/src/components/Navbar/DeskTopNavigation.tsx
+++ b/src/components/Navbar/DeskTopNavigation.tsx
@@ -1,12 +1,14 @@
 import { Menu } from 'antd'
 import { Header } from 'antd/lib/layout/layout'
+import useMobile from 'hooks/Mobile'
 import { CSSProperties, useEffect, useState } from 'react'
 
+import Account from './Account'
+import { desktopMenuItems, resourcesMenuItems } from './constants'
+import MobileCollapse from './Mobile/MobileCollapse'
 import NavLanguageSelector from './NavLanguageSelector'
 import { navMenuItemStyles, topNavStyles } from './navStyles'
 
-import { default as Account } from './Account'
-import { desktopMenuItems, resourcesMenuItems } from './constants'
 import ThemePicker from './ThemePicker'
 import { TransactionsList } from './TransactionList'
 
@@ -17,13 +19,10 @@ const resourcesMenu = (
   />
 )
 
-export default function DesktopNavigation({
-  desktop,
-}: {
-  desktop?: boolean
-  onClickMenuItems?: VoidFunction
-}) {
+export default function DesktopNavigation() {
   const [resourcesOpen, setResourcesOpen] = useState<boolean>(false)
+  const isMobile = useMobile()
+  const desktop = !isMobile
   const dropdownIconStyle: CSSProperties = {
     fontSize: 13,
     marginLeft: 7,
@@ -45,61 +44,63 @@ export default function DesktopNavigation({
     dropdownIconStyle,
   })
 
-  return (
-    <Header className="top-nav" style={{ ...topNavStyles }}>
-      <Menu
-        items={menuItems}
-        mode="inline"
-        style={{
-          display: 'flex',
-          flexDirection: desktop ? 'row' : 'column',
-          width: desktop ? 500 : 'auto',
-        }}
-        selectable={false}
-      />
-      <Menu
-        mode="horizontal"
-        items={[
-          {
-            key: 'navigation-selector',
-            label: (
-              <div style={navMenuItemStyles}>
-                <NavLanguageSelector />
-              </div>
-            ),
-          },
-          {
-            key: 'theme-picker',
-            label: (
-              <div style={navMenuItemStyles}>
-                <ThemePicker />
-              </div>
-            ),
-          },
-          {
-            key: 'transaction-list',
-            label: (
-              <div style={navMenuItemStyles}>
-                <TransactionsList
-                  listStyle={{
-                    position: 'absolute',
-                    top: 70,
-                    right: 30,
-                  }}
-                />
-              </div>
-            ),
-          },
-          {
-            key: 'account',
-            label: (
-              <div style={navMenuItemStyles}>
-                <Account />
-              </div>
-            ),
-          },
-        ]}
-      />
-    </Header>
-  )
+  if (desktop) {
+    return (
+      <Header className="top-nav" style={{ ...topNavStyles }}>
+        <Menu
+          items={menuItems}
+          mode="inline"
+          style={{
+            display: 'flex',
+            flexDirection: desktop ? 'row' : 'column',
+            width: desktop ? 500 : 'auto',
+          }}
+        />
+        <Menu
+          mode="horizontal"
+          items={[
+            {
+              key: 'navigation-selector',
+              label: (
+                <div style={navMenuItemStyles}>
+                  <NavLanguageSelector />
+                </div>
+              ),
+            },
+            {
+              key: 'theme-picker',
+              label: (
+                <div style={navMenuItemStyles}>
+                  <ThemePicker />
+                </div>
+              ),
+            },
+            {
+              key: 'transaction-list',
+              label: (
+                <div style={navMenuItemStyles}>
+                  <TransactionsList
+                    listStyle={{
+                      position: 'absolute',
+                      top: 70,
+                      right: 30,
+                    }}
+                  />
+                </div>
+              ),
+            },
+            {
+              key: 'account',
+              label: (
+                <div style={navMenuItemStyles}>
+                  <Account />
+                </div>
+              ),
+            },
+          ]}
+        />
+      </Header>
+    )
+  }
+  return <MobileCollapse />
 }

--- a/src/components/Navbar/Mobile/MobileCollapse.tsx
+++ b/src/components/Navbar/Mobile/MobileCollapse.tsx
@@ -3,7 +3,6 @@ import { Collapse, Menu } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
 import { Header } from 'antd/lib/layout/layout'
 import { ThemeContext } from 'contexts/themeContext'
-import useMobile from 'hooks/Mobile'
 import { useWallet } from 'hooks/Wallet'
 import Link from 'next/link'
 import { useContext, useEffect, useState } from 'react'
@@ -21,7 +20,6 @@ export default function MobileCollapse() {
 
   const [activeKey, setActiveKey] = useState<0 | undefined>()
 
-  const isMobile = useMobile()
   const { isConnected, disconnect } = useWallet()
 
   const isNavExpanded = activeKey === NAV_EXPANDED_KEY
@@ -78,22 +76,13 @@ export default function MobileCollapse() {
                 }}
               >
                 <TransactionsList
-                  listStyle={
-                    isMobile
-                      ? {
-                          position: 'absolute',
-                          top: 48,
-                          left: 0,
-                          right: 0,
-                          padding: 12,
-                        }
-                      : {
-                          position: 'absolute',
-                          top: 70, // Position below navbar
-                          right: 30,
-                          width: 300,
-                        }
-                  }
+                  listStyle={{
+                    position: 'absolute',
+                    top: 48,
+                    left: 0,
+                    right: 0,
+                    padding: 12,
+                  }}
                 />
                 <MenuOutlined
                   style={{

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,12 +1,5 @@
-import useMobile from 'hooks/Mobile'
 import DesktopNavigation from './DeskTopNavigation'
-import MobileCollapse from './Mobile/MobileCollapse'
 
 export default function Navbar() {
-  const isMobile = useMobile()
-  const desktop = !isMobile
-
-  if (isMobile) return <MobileCollapse />
-
-  return <DesktopNavigation desktop={desktop} />
+  return <DesktopNavigation />
 }


### PR DESCRIPTION
## What does this PR do and why?

Move mobile collapse into desktop navigation. Desktopnavigation will eventually turn into `Sitenavigation` to encapsulate nav logic. The goal here was to simplify the `NavBar component`, only use `useMobile` hook in one place, and remove additional desktop/mobile logic in the `MobileCollapse` component.
## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
