### PR TITLE
Edge case pay memo image fix

### DIFF
--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -129,7 +129,7 @@ export const uploadProjectMetadata = async (
 
 // returns a native IPFS link (`ipfs://cid`) as a https link
 export function formatIpfsLink(ipfsLink: string) {
-  const ipfsLinkParts = ipfsLink.split('/')
+  const ipfsLinkParts = ipfsLink.split('//')
   const cid = ipfsLinkParts[ipfsLinkParts.length - 1]
   return `https://${DEFAULT_PINATA_GATEWAY}/ipfs/${cid}`
 }


### PR DESCRIPTION
## What does this PR do and why?

<img width="1132" alt="Screen Shot 2022-10-16 at 7 38 01 am" src="https://user-images.githubusercontent.com/96150256/196008520-de4210ee-ebf4-4bd3-8b41-023bf4527a67.png">

Problem was the additional `/` (`ipfs/QmT3SQdAQojLUo11ugU2rRPUWvhSQZeZupFSFJq9xGAX7G/1.png`) at the end of this link. 

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
