### PR TITLE
fix reconfigure tooltip placement

### DIFF
--- a/src/components/Project/FundingCycleDetailWarning.tsx
+++ b/src/components/Project/FundingCycleDetailWarning.tsx
@@ -18,13 +18,13 @@ export default function FundingCycleDetailWarning({
   if (!showWarning) return <span>{children}</span>
 
   return (
-    <Tooltip title={tooltipTitle}>
-      <div style={{ display: 'flex' }}>
-        <span style={{ fontWeight: 500 }}>{children} </span>
-        <span style={{ color: colors.text.warn, marginLeft: '0.5rem' }}>
+    <div style={{ display: 'flex' }}>
+      <span style={{ fontWeight: 500 }}>{children} </span>
+      <span style={{ color: colors.text.warn, marginLeft: '0.5rem' }}>
+        <Tooltip title={tooltipTitle} placement="top">
           <ExclamationCircleOutlined />
-        </span>
-      </div>
-    </Tooltip>
+        </Tooltip>
+      </span>
+    </div>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes #2325. Tooltip is properly placed

<img width="540" alt="image" src="https://user-images.githubusercontent.com/33093632/197429394-abd5cd69-c09d-44aa-9f83-78055e72901b.png">
