### PR TITLE
Distribution fee modal rework

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/modals/DistributePayoutsModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/modals/DistributePayoutsModal.tsx
@@ -131,12 +131,11 @@ export default function DistributePayoutsModal({
       width={640}
     >
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        <p>
+        <Callout>
           <Trans>
-            Distribute your project's funds. Distribution to addresses other
-            than other Juicebox projects will incur a 2.5% platform fee.
+            Distributions to Ethereum addresses incur a 2.5% JBX membership fee.
           </Trans>
-        </p>
+        </Callout>
 
         <Form layout="vertical">
           <Form.Item

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/modals/DistributePayoutsModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/modals/DistributePayoutsModal.tsx
@@ -1,7 +1,7 @@
 import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
-import { Divider, Form, Space } from 'antd'
+import { Form, Space } from 'antd'
 import Callout from 'components/Callout'
 import CurrencySymbol from 'components/CurrencySymbol'
 import InputAccessoryButton from 'components/InputAccessoryButton'
@@ -17,7 +17,6 @@ import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useContext, useEffect, useState } from 'react'
 import { formatWad, fromWad, parseWad } from 'utils/format/formatNumber'
 import { V2V3CurrencyName, V2V3_CURRENCY_USD } from 'utils/v2v3/currency'
-import { amountSubFee, feeForAmount, formatFee } from 'utils/v2v3/math'
 
 export default function DistributePayoutsModal({
   open,
@@ -111,25 +110,7 @@ export default function DistributePayoutsModal({
     ? unusedFunds
     : balanceInDistributionLimitCurrency
 
-  const feePercentage = formatFee(ETHPaymentTerminalFee)
   const grossAvailableAmount = formatWad(distributable, { precision: 4 })
-  const feeAmount = formatWad(
-    feeForAmount(distributable, ETHPaymentTerminalFee) ?? 0,
-    {
-      precision: 4,
-    },
-  )
-  const netAvailableAmount =
-    amountSubFee(distributable, ETHPaymentTerminalFee) ?? BigNumber.from(0)
-
-  const netAvailableAmountFormatted = formatWad(netAvailableAmount, {
-    precision: 4,
-  })
-  const netDistributionAmount = formatWad(
-    distributionAmount
-      ? amountSubFee(parseWad(distributionAmount), ETHPaymentTerminalFee)
-      : BigNumber.from(0),
-  )
 
   return (
     <TransactionModal
@@ -150,45 +131,12 @@ export default function DistributePayoutsModal({
       width={640}
     >
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
-        <div>
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <Trans>
-              Total funds:{' '}
-              <div>
-                <CurrencySymbol currency={distributionCurrencyName} />
-                {grossAvailableAmount}
-              </div>
-            </Trans>
-          </div>
-
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <div>
-              <Trans>JBX Fee ({feePercentage}%):</Trans>
-            </div>
-            <div>
-              - <CurrencySymbol currency={distributionCurrencyName} />
-              {feeAmount}
-            </div>
-          </div>
-
-          <Divider style={{ margin: '4px 0' }} />
-
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              fontWeight: 500,
-            }}
-          >
-            <div>
-              <Trans>Available after fee:</Trans>
-            </div>
-            <div>
-              <CurrencySymbol currency={distributionCurrencyName} />
-              {netAvailableAmountFormatted}
-            </div>
-          </div>
-        </div>
+        <p>
+          <Trans>
+            Distribute your project's funds. Distribution to addresses other
+            than other Juicebox projects will incur a 2.5% platform fee.
+          </Trans>
+        </p>
 
         <Form layout="vertical">
           <Form.Item
@@ -199,9 +147,9 @@ export default function DistributePayoutsModal({
                 <Trans>
                   <span style={{ fontWeight: 500 }}>
                     <CurrencySymbol currency={distributionCurrencyName} />
-                    {netDistributionAmount}
+                    {grossAvailableAmount}
                   </span>{' '}
-                  after {feePercentage}% JBX fee
+                  available to distribute
                 </Trans>
               </div>
             }
@@ -210,6 +158,7 @@ export default function DistributePayoutsModal({
               placeholder="0"
               value={distributionAmount}
               onChange={value => setDistributionAmount(value)}
+              min={0}
               accessory={
                 <div
                   style={{
@@ -253,11 +202,12 @@ export default function DistributePayoutsModal({
           ) : null}
 
           <SplitList
-            totalValue={netAvailableAmount}
+            totalValue={parseWad(distributionAmount)}
             currency={distributionLimitCurrency}
             splits={payoutSplits ?? []}
             projectOwnerAddress={projectOwnerAddress}
             showSplitValues
+            showFees
           />
         </div>
         <p style={{ fontSize: '0.8rem' }}>

--- a/src/components/v2v3/shared/SplitItem.tsx
+++ b/src/components/v2v3/shared/SplitItem.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from 'antd'
 import ETHToUSD from 'components/currency/ETHToUSD'
 import CurrencySymbol from 'components/CurrencySymbol'
 import FormattedAddress from 'components/FormattedAddress'
+import { Parenthesis } from 'components/Parenthesis'
 import TooltipIcon from 'components/TooltipIcon'
 import TooltipLabel from 'components/TooltipLabel'
 import { ThemeContext } from 'contexts/themeContext'
@@ -15,6 +16,7 @@ import { useContext } from 'react'
 import { formatDate } from 'utils/format/formatDate'
 import { formatWad } from 'utils/format/formatNumber'
 import { V2V3CurrencyName } from 'utils/v2v3/currency'
+import { isJuiceboxProjectSplit } from 'utils/v2v3/distributions'
 import {
   feeForAmount,
   formatSplitPercent,
@@ -30,7 +32,7 @@ const LockedText = ({ lockedUntil }: { lockedUntil: number }) => {
   const lockedUntilFormatted = formatDate(lockedUntil * 1000, 'yyyy-MM-DD')
 
   return (
-    <div style={{ fontSize: '.8rem', color: colors.text.secondary }}>
+    <div style={{ fontSize: '.875rem', color: colors.text.secondary }}>
       <LockOutlined /> <Trans>locked until {lockedUntilFormatted}</Trans>
     </div>
   )
@@ -123,12 +125,10 @@ const SplitValue = ({
   valueSuffix,
   valueFormatProps,
   currency,
-  isJuiceboxProject,
   showFees = false,
 }: {
   split: Split
   totalValue: BigNumber | undefined
-  isJuiceboxProject: boolean
   valueSuffix?: string | JSX.Element
   valueFormatProps?: { precision?: number }
   currency?: BigNumber
@@ -140,6 +140,7 @@ const SplitValue = ({
 
   const ETHPaymentTerminalFee = useETHPaymentTerminalFee()
   const splitValue = totalValue?.mul(split.percent).div(SPLITS_TOTAL_PERCENT)
+  const isJuiceboxProject = isJuiceboxProjectSplit(split)
   const feeAmount = !isJuiceboxProject
     ? feeForAmount(splitValue, ETHPaymentTerminalFee)
     : BigNumber.from(0)
@@ -177,12 +178,10 @@ const SplitValue = ({
         }}
       >
         {showFees && !isJuiceboxProject && (
-          <>
-            {`(`}
+          <Parenthesis>
             <CurrencySymbol currency={curr} />
-            {feeAmountFormatted}
-            {` ${t`fee`})`}
-          </>
+            {t` ${feeAmountFormatted} fee`}
+          </Parenthesis>
         )}
       </div>
     </Tooltip>
@@ -210,9 +209,7 @@ export default function SplitItem({
   currency?: BigNumber
   showFees?: boolean
 }) {
-  const isJuiceboxProject = split.projectId
-    ? BigNumber.from(split.projectId).gt(0)
-    : false
+  const isJuiceboxProject = isJuiceboxProjectSplit(split)
 
   const formattedSplitPercent = formatSplitPercent(
     BigNumber.from(split.percent),
@@ -258,7 +255,6 @@ export default function SplitItem({
               valueFormatProps={valueFormatProps}
               currency={currency}
               showFees={showFees}
-              isJuiceboxProject={isJuiceboxProject}
             />
           </span>
         ) : null}

--- a/src/components/v2v3/shared/SplitItem.tsx
+++ b/src/components/v2v3/shared/SplitItem.tsx
@@ -1,6 +1,6 @@
 import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
-import { t, Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
 import ETHToUSD from 'components/currency/ETHToUSD'
 import CurrencySymbol from 'components/CurrencySymbol'
@@ -179,8 +179,10 @@ const SplitValue = ({
       >
         {showFees && !isJuiceboxProject && (
           <Parenthesis>
-            <CurrencySymbol currency={curr} />
-            {t` ${feeAmountFormatted} fee`}
+            <Trans>
+              <CurrencySymbol currency={curr} />
+              {feeAmountFormatted} fee
+            </Trans>
           </Parenthesis>
         )}
       </div>

--- a/src/components/v2v3/shared/SplitList.tsx
+++ b/src/components/v2v3/shared/SplitList.tsx
@@ -8,6 +8,7 @@ import SplitItem from './SplitItem'
 export default function SplitList({
   splits,
   showSplitValues = false,
+  showFees = false,
   currency,
   totalValue,
   projectOwnerAddress,
@@ -20,6 +21,7 @@ export default function SplitList({
   totalValue: BigNumber | undefined
   projectOwnerAddress: string | undefined
   showSplitValues?: boolean
+  showFees?: boolean
   valueSuffix?: string | JSX.Element
   valueFormatProps?: { precision?: number }
   reservedRate?: number
@@ -47,6 +49,7 @@ export default function SplitList({
               valueSuffix={valueSuffix}
               valueFormatProps={valueFormatProps}
               reservedRate={reservedRate}
+              showFees={showFees}
             />
           </div>
         ))}
@@ -60,6 +63,7 @@ export default function SplitList({
           valueSuffix={valueSuffix}
           valueFormatProps={valueFormatProps}
           reservedRate={reservedRate}
+          showFees={showFees}
         />
       ) : null}
     </div>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -104,6 +104,9 @@ msgstr ""
 msgid "<0/>{0}{1} distributed"
 msgstr ""
 
+msgid "<0/>{feeAmountFormatted} fee"
+msgstr ""
+
 msgid "<0><1/>{0}</0> Distribution Limit"
 msgstr ""
 
@@ -3711,9 +3714,6 @@ msgid "{count} total"
 msgstr ""
 
 msgid "{exchangeName} has no market for {tokenSymbol}."
-msgstr ""
-
-msgid "{feeAmountFormatted} fee"
 msgstr ""
 
 msgid "{formattedTimeLeft} left"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1046,9 +1046,6 @@ msgstr ""
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr ""
 
-msgid "Distribute your project's funds. Distribution to addresses other than other Juicebox projects will incur a 2.5% platform fee."
-msgstr ""
-
 msgid "Distribute {tokenTextPlural}"
 msgstr ""
 
@@ -1089,6 +1086,9 @@ msgid "Distribution limit is 0: All funds will be considered overflow and can be
 msgstr ""
 
 msgid "Distribution limit is infinite. <0>The project will control how all funds are distributed, and none can be redeemed by token holders.</0>"
+msgstr ""
+
+msgid "Distributions to Ethereum addresses incur a 2.5% JBX membership fee."
 msgstr ""
 
 msgid "Do I have to make my project open source to use Juicebox as its business model?"
@@ -3557,9 +3557,6 @@ msgstr ""
 msgid "days"
 msgstr ""
 
-msgid "fee"
-msgstr ""
-
 msgid "handle"
 msgstr ""
 
@@ -3714,6 +3711,9 @@ msgid "{count} total"
 msgstr ""
 
 msgid "{exchangeName} has no market for {tokenSymbol}."
+msgstr ""
+
+msgid "{feeAmountFormatted} fee"
 msgstr ""
 
 msgid "{formattedTimeLeft} left"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -107,7 +107,7 @@ msgstr ""
 msgid "<0><1/>{0}</0> Distribution Limit"
 msgstr ""
 
-msgid "<0><1/>{netDistributionAmount}</0> after {feePercentage}% JBX fee"
+msgid "<0><1/>{grossAvailableAmount}</0> available to distribute"
 msgstr ""
 
 msgid "<0><1>This project has no overflow</1>, so you will not receive any ETH for burning tokens.</0>"
@@ -1046,6 +1046,9 @@ msgstr ""
 msgid "Distribute reserved {tokenTextPlural}"
 msgstr ""
 
+msgid "Distribute your project's funds. Distribution to addresses other than other Juicebox projects will incur a 2.5% platform fee."
+msgstr ""
+
 msgid "Distribute {tokenTextPlural}"
 msgstr ""
 
@@ -1551,9 +1554,6 @@ msgid "It'd be a lot cooler if you did"
 msgstr ""
 
 msgid "JBX Fee ({0}%):"
-msgstr ""
-
-msgid "JBX Fee ({feePercentage}%):"
 msgstr ""
 
 msgid "Join <0>hundreds of projects</0> sippin' the Juice."
@@ -3089,9 +3089,6 @@ msgstr ""
 msgid "Total funds:"
 msgstr ""
 
-msgid "Total funds: <0><1/>{grossAvailableAmount}</0>"
-msgstr ""
-
 msgid "Total locked period"
 msgstr ""
 
@@ -3558,6 +3555,9 @@ msgid "day"
 msgstr ""
 
 msgid "days"
+msgstr ""
+
+msgid "fee"
 msgstr ""
 
 msgid "handle"

--- a/src/utils/v2v3/distributions.ts
+++ b/src/utils/v2v3/distributions.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { Split } from 'models/splits'
 
 import { preciseFormatSplitPercent, splitPercentFrom } from './math'
@@ -110,4 +111,8 @@ export function getNewDistributionLimit({
     parseFloat(currentDistributionLimit) - previousSplitAmount + newSplitAmount
 
   return parseFloat(newDistributionLimit.toFixed(4)) // round to 4dp
+}
+
+export function isJuiceboxProjectSplit(split: Split) {
+  return split.projectId ? BigNumber.from(split.projectId).gt(0) : false
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes #2277. Reworks the distribution modal to accurately reflect the fact that payments to JB projects do not incur the 2.5% platform fee. 

## Screenshots or screen recordings

<img width="631" alt="image" src="https://user-images.githubusercontent.com/33093632/197669368-7f843ebe-ff11-4b19-b9b1-7866c62120df.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
