### PR TITLE
10 24 distribution limit progress improvement

### DIFF
--- a/src/components/Project/SpendingStats.tsx
+++ b/src/components/Project/SpendingStats.tsx
@@ -42,7 +42,8 @@ export default function SpendingStats({
     color: colors.text.secondary,
   }
 
-  const formattedDistributionLimit = !targetAmount.eq(MAX_DISTRIBUTION_LIMIT)
+  const hasDistributionLimit = !targetAmount.eq(MAX_DISTRIBUTION_LIMIT)
+  const formattedDistributionLimit = hasDistributionLimit
     ? formatWad(targetAmount, { precision: 4 })
     : t`NO LIMIT`
 
@@ -85,7 +86,7 @@ export default function SpendingStats({
           <Trans>
             <CurrencySymbol currency={currency} />
             {formatWad(distributedAmount, { precision: 4 }) || '0'}
-            {hasFundingTarget ? (
+            {hasFundingTarget && hasDistributionLimit ? (
               <span>/{formattedDistributionLimit} </span>
             ) : null}{' '}
             distributed

--- a/src/components/v2v3/V2V3Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2v3/V2V3Project/TreasuryStats/DistributedRatio.tsx
@@ -50,14 +50,14 @@ export default function DistributedRatio({ style }: { style?: CSSProperties }) {
               currency={distributionLimitCurrency}
             />{' '}
             <>
-              /{' '}
-              {distributionLimit.eq(MAX_DISTRIBUTION_LIMIT) ? (
-                <Trans>NO LIMIT</Trans>
-              ) : (
-                <V2V3CurrencyAmount
-                  amount={distributionLimit}
-                  currency={distributionLimitCurrency}
-                />
+              {distributionLimit.eq(MAX_DISTRIBUTION_LIMIT) ? null : (
+                <>
+                  {'/ '}
+                  <V2V3CurrencyAmount
+                    amount={distributionLimit}
+                    currency={distributionLimitCurrency}
+                  />
+                </>
               )}
             </>
           </div>


### PR DESCRIPTION
## What does this PR do and why?

Closes #2353. Removes `/ NO LIMIT` from the Distributed Ratio and Payouts Card. Curious if we need some replacement indicator that the project has no distribution limit.

## Screenshots or screen recordings

NEW

<img width="533" alt="image" src="https://user-images.githubusercontent.com/33093632/197673439-63ba49ad-f9ce-4528-b565-2392b8752aa9.png">

OLD

<img width="553" alt="image" src="https://user-images.githubusercontent.com/33093632/197673538-75d33b3a-0748-4a07-b2ab-089e9ed78e1c.png">

___

NEW

<img width="504" alt="image" src="https://user-images.githubusercontent.com/33093632/197673462-b6d4ea39-784e-4363-a9f8-6b753b4e68d1.png">

OLD

<img width="509" alt="image" src="https://user-images.githubusercontent.com/33093632/197673603-f6547c42-7e51-4220-8b87-4edee6bae22c.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
