### PR TITLE
Override project payer deployer

### DIFF
--- a/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
+++ b/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
@@ -42,6 +42,14 @@ const V2_CONTRACT_ABI_OVERRIDES: {
   JBETHERC20ProjectPayerDeployer: {
     version: 'latest',
     filename: 'JBETHERC20ProjectPayerDeployer',
+    /**
+     * This deployment of the JBETHERC20ProjectPayerDeployer has slightly different
+     * internals to the one in the contracts-v2-latest package.
+     *
+     * It sets the beneficiary to tx.origin, instead of msg.sender.
+     *
+     * It was only deployed on mainnet, so we'll override it for mainnet only.
+     */
     addresses: {
       [NetworkName.mainnet]: '0x325Ba0eFC2c750e0317561e79cFa6911e29B24CC',
     },

--- a/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
+++ b/src/utils/v2v3/contractLoaders/JuiceboxV2.ts
@@ -23,7 +23,13 @@ const V2_GOERLI_CONTRACT_ADDRESSES: { [k in V2V3ContractName]?: string } = {
  *  Defines the ABI filename to use for a given V2V3ContractName.
  */
 const V2_CONTRACT_ABI_OVERRIDES: {
-  [k in V2V3ContractName]?: { filename: string; version: string }
+  [k in V2V3ContractName]?: {
+    filename: string
+    version: string
+    addresses?: {
+      [k in NetworkName]?: string
+    }
+  }
 } = {
   DeprecatedJBSplitsStore: {
     version: '4.0.0',
@@ -32,6 +38,13 @@ const V2_CONTRACT_ABI_OVERRIDES: {
   DeprecatedJBDirectory: {
     version: '4.0.0',
     filename: 'JBDirectory',
+  },
+  JBETHERC20ProjectPayerDeployer: {
+    version: 'latest',
+    filename: 'JBETHERC20ProjectPayerDeployer',
+    addresses: {
+      [NetworkName.mainnet]: '0x325Ba0eFC2c750e0317561e79cFa6911e29B24CC',
+    },
   },
 }
 
@@ -67,10 +80,17 @@ export const loadJuiceboxV2Contract = async (
   }
 
   const contractOverride = V2_CONTRACT_ABI_OVERRIDES[contractName]
+
   const version = contractOverride?.version ?? 'latest'
   const filename = contractOverride?.filename ?? contractName
-
-  return (await import(
+  const contractJson = (await import(
     `@jbx-protocol/contracts-v2-${version}/deployments/${network}/${filename}.json`
   )) as ContractJson
+
+  const address = contractOverride?.addresses?.[network] ?? contractJson.address
+
+  return {
+    ...contractJson,
+    address,
+  }
 }


### PR DESCRIPTION
## What does this PR do and why?

Jango deployed a new project payer contract that changes some internals (sets beneficiary to tx.origin instead of msg.sender). 

This address isn't in the npm package, so instead we'll hard-code it for mainnet.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
