### PR TITLE
Add etherscan link for pending txs in transaction modal

### DIFF
--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -30,7 +30,7 @@ const EtherscanLink: React.FC<{
   if (type === 'tx') {
     return (
       <ExternalLink onClick={onClick} {...linkProps}>
-        <LinkOutlined />
+        {children} <LinkOutlined />
       </ExternalLink>
     )
   }

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -25,6 +25,7 @@ const PendingTransactionModalBody = () => {
   const { transactions } = useContext(TxHistoryContext)
 
   const pendingTx = transactions?.find(tx => tx.status === TxStatus.pending)
+  const pendingTxHash = pendingTx?.tx?.hash
 
   return (
     <div
@@ -48,20 +49,16 @@ const PendingTransactionModalBody = () => {
         </h2>
         <p>
           <Trans>
-            Your transaction has been submitted and is awaiting confirmation{' '}
+            Your transaction has been submitted and is awaiting confirmation.
           </Trans>
         </p>
-        <p>
-          {pendingTx ? (
-            <EtherscanLink
-              value={pendingTx.tx?.hash}
-              style={{ fontSize: '0.85rem' }}
-              type="tx"
-            >
+        {pendingTxHash ? (
+          <p>
+            <EtherscanLink value={pendingTxHash} type="tx">
               <Trans>View in Etherscan</Trans>
             </EtherscanLink>
-          ) : null}
-        </p>
+          </p>
+        ) : null}
       </div>
     </div>
   )

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -49,10 +49,10 @@ const PendingTransactionModalBody = () => {
         <p>
           <Trans>
             Your transaction has been submitted and is awaiting confirmation{' '}
-            {pendingTx ? (
-              <EtherscanLink value={pendingTx.tx?.hash} type="tx" />
-            ) : null}
-          </Trans>
+          </Trans>{' '}
+          {pendingTx ? (
+            <EtherscanLink value={pendingTx.tx?.hash} type="tx" />
+          ) : null}
         </p>
       </div>
     </div>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -7,7 +7,8 @@ import { useWallet } from 'hooks/Wallet'
 import { TxStatus } from 'models/transaction'
 import Image from 'next/image'
 import { PropsWithChildren, useContext, useMemo } from 'react'
-import EtherscanLink from './EtherscanLink'
+import { etherscanLink } from 'utils/etherscan'
+import ExternalLink from './ExternalLink'
 import quint from '/public/assets/quint.gif'
 
 type TransactionModalProps = PropsWithChildren<
@@ -49,9 +50,21 @@ const PendingTransactionModalBody = () => {
         <p>
           <Trans>
             Your transaction has been submitted and is awaiting confirmation{' '}
-          </Trans>{' '}
+          </Trans>
+        </p>
+        <p>
           {pendingTx ? (
-            <EtherscanLink value={pendingTx.tx?.hash} type="tx" />
+            <ExternalLink
+              href={
+                pendingTx.tx?.hash
+                  ? etherscanLink('tx', pendingTx.tx.hash)
+                  : undefined
+              }
+              style={{ fontSize: '0.85rem' }}
+              className="text-primary hover-text-decoration-underline"
+            >
+              <Trans>View in Etherscan</Trans>
+            </ExternalLink>
           ) : null}
         </p>
       </div>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -2,9 +2,12 @@ import { t, Trans } from '@lingui/macro'
 import { Modal, ModalProps } from 'antd'
 import { readNetwork } from 'constants/networks'
 import { ThemeContext } from 'contexts/themeContext'
+import { TxHistoryContext } from 'contexts/txHistoryContext'
 import { useWallet } from 'hooks/Wallet'
+import { TxStatus } from 'models/transaction'
 import Image from 'next/image'
 import { PropsWithChildren, useContext, useMemo } from 'react'
+import EtherscanLink from './EtherscanLink'
 import quint from '/public/assets/quint.gif'
 
 type TransactionModalProps = PropsWithChildren<
@@ -19,6 +22,9 @@ const PendingTransactionModalBody = () => {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
+  const { transactions } = useContext(TxHistoryContext)
+
+  const pendingTx = transactions?.find(tx => tx.status === TxStatus.pending)
 
   return (
     <div
@@ -42,7 +48,10 @@ const PendingTransactionModalBody = () => {
         </h2>
         <p>
           <Trans>
-            Your transaction has been submitted and is awaiting confirmation.
+            Your transaction has been submitted and is awaiting confirmation{' '}
+            {pendingTx ? (
+              <EtherscanLink value={pendingTx.tx?.hash} type="tx" />
+            ) : null}
           </Trans>
         </p>
       </div>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -7,8 +7,7 @@ import { useWallet } from 'hooks/Wallet'
 import { TxStatus } from 'models/transaction'
 import Image from 'next/image'
 import { PropsWithChildren, useContext, useMemo } from 'react'
-import { etherscanLink } from 'utils/etherscan'
-import ExternalLink from './ExternalLink'
+import EtherscanLink from './EtherscanLink'
 import quint from '/public/assets/quint.gif'
 
 type TransactionModalProps = PropsWithChildren<
@@ -54,17 +53,13 @@ const PendingTransactionModalBody = () => {
         </p>
         <p>
           {pendingTx ? (
-            <ExternalLink
-              href={
-                pendingTx.tx?.hash
-                  ? etherscanLink('tx', pendingTx.tx.hash)
-                  : undefined
-              }
+            <EtherscanLink
+              value={pendingTx.tx?.hash}
               style={{ fontSize: '0.85rem' }}
-              className="text-primary hover-text-decoration-underline"
+              type="tx"
             >
               <Trans>View in Etherscan</Trans>
-            </ExternalLink>
+            </EtherscanLink>
           ) : null}
         </p>
       </div>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "Your project's current funding cycle has no duration. Changes you make below will take effect immediately."
 msgstr ""
 
-msgid "Your transaction has been submitted and is awaiting confirmation {0}"
+msgid "Your transaction has been submitted and is awaiting confirmation"
 msgstr ""
 
 msgid "Your unclaimed token balance: {0}"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3287,6 +3287,9 @@ msgstr ""
 msgid "Version of the terminal contract used by this project."
 msgstr ""
 
+msgid "View in Etherscan"
+msgstr ""
+
 msgid "View token ranges"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3554,7 +3554,7 @@ msgstr ""
 msgid "Your project's current funding cycle has no duration. Changes you make below will take effect immediately."
 msgstr ""
 
-msgid "Your transaction has been submitted and is awaiting confirmation"
+msgid "Your transaction has been submitted and is awaiting confirmation."
 msgstr ""
 
 msgid "Your unclaimed token balance: {0}"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "Your project's current funding cycle has no duration. Changes you make below will take effect immediately."
 msgstr ""
 
-msgid "Your transaction has been submitted and is awaiting confirmation."
+msgid "Your transaction has been submitted and is awaiting confirmation {0}"
 msgstr ""
 
 msgid "Your unclaimed token balance: {0}"


### PR DESCRIPTION
## What does this PR do and why?

Fixes - https://github.com/jbx-protocol/juice-interface/issues/2335

I'm using `TxHistoryContext` to retrieve transactions, and from there i'm just finding the first one that matches the pending status.

## Screenshots or screen recordings

I've created 3 iterations, i'm a fan of the first one but let me know which one we should decide or if we want some different UI iteration.

| First iteration| Second Iteration | Third Iteration
| ----------- | ----------- | ----------- | 
| ![first iteration](https://user-images.githubusercontent.com/18723426/198006425-40df583f-ddbb-42e0-b926-038729426ef9.PNG)     | ![second iteration](https://user-images.githubusercontent.com/18723426/198006470-9de5e628-f57b-446a-a292-10503913f033.PNG)| ![third iteration](https://user-images.githubusercontent.com/18723426/198006554-16b78578-4e52-4de3-8b3f-13b02e94ccda.PNG)     |


## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
