### PR TITLE
Kill serverSideProps

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/ContractVersionSelect.tsx
@@ -15,7 +15,7 @@ const CV_LABELS = {
  * A Select component to switch between V2 and V3 contracts.
  */
 export function ContractVersionSelect() {
-  const { setVersion, cv, cvs } = useContext(V2V3ContractsContext)
+  const { setCv, cv, cvs } = useContext(V2V3ContractsContext)
 
   const SELECT_OPTIONS: BaseOptionType[] =
     cvs?.map(cv => ({
@@ -32,7 +32,7 @@ export function ContractVersionSelect() {
       defaultValue={cv}
       bordered={false}
       className="ant-select-color-secondary"
-      onSelect={(value: CV2V3) => setVersion?.(value)}
+      onSelect={(value: CV2V3) => setCv?.(value)}
       options={SELECT_OPTIONS}
     />
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/V2V3ProjectSettings.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/V2V3ProjectSettings.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro'
 import { Layout, Menu, MenuProps, Space } from 'antd'
+import Loading from 'components/Loading'
 import { ProjectHeader } from 'components/Project/ProjectHeader'
 import { V2V3ProjectHeaderActions } from 'components/v2v3/V2V3Project/V2V3ProjectHeaderActions'
 import { ProjectSettingsContent } from 'components/v2v3/V2V3Project/V2V3ProjectSettings/ProjectSettingsContent'
@@ -141,7 +142,7 @@ const items: MenuItem[] = [
 export function V2V3ProjectSettings() {
   const { isPreviewMode, projectOwnerAddress, handle } =
     useContext(V2V3ProjectContext)
-  const { projectId } = useContext(ProjectMetadataContext)
+  const { projectId, projectMetadata } = useContext(ProjectMetadataContext)
   const { isDarkMode } = useContext(ThemeContext)
 
   const [collapsed, setCollapsed] = useState<boolean>(false)
@@ -162,6 +163,10 @@ export function V2V3ProjectSettings() {
     if (isMobile) {
       setCollapsed(true)
     }
+  }
+
+  if (!projectMetadata) {
+    return <Loading />
   }
 
   return (

--- a/src/contexts/v2v3/V2V3ContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ContractsContext.ts
@@ -6,6 +6,6 @@ export const V2V3ContractsContext: React.Context<{
   contracts?: V2V3Contracts
   cv?: CV2V3
   cvs?: CV2V3[]
-  setVersion?: (version: CV2V3) => void
+  setCv?: (version: CV2V3) => void
   setCvs?: (cvs: CV2V3[]) => void
 }> = createContext({})

--- a/src/contexts/v2v3/V2V3ContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ContractsContext.ts
@@ -4,7 +4,8 @@ import { createContext } from 'react'
 
 export const V2V3ContractsContext: React.Context<{
   contracts?: V2V3Contracts
-  setVersion?: (version: CV2V3) => void
   cv?: CV2V3
   cvs?: CV2V3[]
+  setVersion?: (version: CV2V3) => void
+  setCvs?: (cvs: CV2V3[]) => void
 }> = createContext({})

--- a/src/contexts/v2v3/V2V3ProjectContractsContext.ts
+++ b/src/contexts/v2v3/V2V3ProjectContractsContext.ts
@@ -8,6 +8,7 @@ export interface V2V3ProjectContracts {
 
 export const V2V3ProjectContractsContext: React.Context<{
   contracts: V2V3ProjectContracts
+  cvsLoading?: boolean
 }> = createContext({
   contracts: {},
 })

--- a/src/hooks/v2v3/V2V3ContractLoader.ts
+++ b/src/hooks/v2v3/V2V3ContractLoader.ts
@@ -9,12 +9,14 @@ import { readProvider } from 'constants/readProvider'
 import { CV2V3 } from 'models/cv'
 import { emitErrorNotification } from 'utils/notifications'
 
-export function useV2V3ContractLoader({ cv }: { cv: CV2V3 }) {
+export function useV2V3ContractLoader({ cv }: { cv?: CV2V3 }) {
   const { signer } = useWallet()
   const [contracts, setContracts] = useState<V2V3Contracts>()
 
   useEffect(() => {
     async function loadContracts() {
+      if (!cv) return
+
       console.info(`Loading v${cv} contracts...`)
       try {
         const network = readNetwork.name

--- a/src/hooks/v2v3/V2V3ProjectCvs.ts
+++ b/src/hooks/v2v3/V2V3ProjectCvs.ts
@@ -1,0 +1,43 @@
+import { CV_V2, CV_V3 } from 'constants/cv'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { CV2V3 } from 'models/cv'
+import { useContext, useEffect, useState } from 'react'
+import { featureFlagEnabled } from 'utils/featureFlags'
+import { hasFundingCycle } from 'utils/v2v3/cv'
+
+export const useLoadV2V3ProjectCvs = (projectId: number | undefined) => {
+  const { setCv, setCvs } = useContext(V2V3ContractsContext)
+
+  const [loadingCsv, setLoadingCsv] = useState<boolean>(true)
+
+  useEffect(() => {
+    async function load() {
+      if (!projectId) return
+
+      setLoadingCsv(true)
+
+      const [hasV2FundingCycle, hasV3FundingCycle] = await Promise.all([
+        hasFundingCycle(projectId, CV_V2),
+        featureFlagEnabled(FEATURE_FLAGS.V3)
+          ? hasFundingCycle(projectId, CV_V3)
+          : Promise.resolve(false),
+      ])
+
+      const cv = hasV3FundingCycle ? CV_V3 : CV_V2
+
+      const cvs: CV2V3[] = []
+      if (hasV2FundingCycle) cvs.push(CV_V2)
+      if (hasV3FundingCycle) cvs.push(CV_V3)
+
+      setCv?.(cv)
+      setCvs?.(cvs)
+
+      setLoadingCsv(false)
+    }
+
+    load()
+  }, [projectId, setCvs, setCv])
+
+  return { loading: loadingCsv }
+}

--- a/src/pages/v2/p/[projectId]/components/V2V3Dashboard.tsx
+++ b/src/pages/v2/p/[projectId]/components/V2V3Dashboard.tsx
@@ -1,14 +1,19 @@
+import Loading from 'components/Loading'
 import ScrollToTopButton from 'components/ScrollToTopButton'
 import { V2V3Project } from 'components/v2v3/V2V3Project'
 import { layouts } from 'constants/styles/layouts'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { TransactionProvider } from 'providers/TransactionProvider'
 import { NftRewardsProvider } from 'providers/v2v3/NftRewardsProvider'
 import { VeNftProvider } from 'providers/v2v3/VeNftProvider'
 import { useContext } from 'react'
 
 export function V2V3Dashboard() {
-  const { projectId } = useContext(ProjectMetadataContext)
+  const { projectId, projectMetadata } = useContext(ProjectMetadataContext)
+  const { cvsLoading } = useContext(V2V3ProjectContractsContext)
+
+  if (cvsLoading || !projectMetadata) return <Loading />
 
   return (
     <div style={layouts.maxWidth}>

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -1,6 +1,5 @@
 import { AppWrapper, SEO } from 'components/common'
 import { DesmosScript } from 'components/common/Head/scripts/DesmosScript'
-import Loading from 'components/Loading'
 import { CV_V2, CV_V3 } from 'constants/cv'
 import { V2V3_PROJECT_IDS } from 'constants/v2v3/projectIds'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
@@ -66,13 +65,9 @@ export default function V2ProjectPage({
         </SEO>
       ) : null}
       <AppWrapper>
-        {metadata ? (
-          <V2V3ProjectPageProvider projectId={projectId} metadata={metadata}>
-            <V2V3Dashboard />
-          </V2V3ProjectPageProvider>
-        ) : (
-          <Loading />
-        )}
+        <V2V3ProjectPageProvider projectId={projectId} metadata={metadata}>
+          <V2V3Dashboard />
+        </V2V3ProjectPageProvider>
       </AppWrapper>
     </>
   )

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -4,14 +4,12 @@ import Loading from 'components/Loading'
 import { CV_V2, CV_V3 } from 'constants/cv'
 import { V2V3_PROJECT_IDS } from 'constants/v2v3/projectIds'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
-import {
-  GetStaticPaths,
-  GetStaticProps,
-  GetStaticPropsResult,
-  InferGetStaticPropsType,
-} from 'next'
+import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
-import { getProjectProps, ProjectPageProps } from 'utils/server/pages/props'
+import {
+  getProjectStaticProps,
+  ProjectPageProps,
+} from 'utils/server/pages/props'
 import { V2V3Dashboard } from './components/V2V3Dashboard'
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -37,9 +35,7 @@ export const getStaticProps: GetStaticProps<
   if (!context.params) throw new Error('params not supplied')
 
   const projectId = parseInt(context.params.projectId as string)
-  const props = (await getProjectProps(
-    projectId,
-  )) as GetStaticPropsResult<ProjectPageProps>
+  const props = await getProjectStaticProps(projectId)
 
   return {
     ...props,
@@ -50,8 +46,6 @@ export const getStaticProps: GetStaticProps<
 export default function V2ProjectPage({
   metadata,
   projectId,
-  initialCv,
-  cvs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
@@ -73,12 +67,7 @@ export default function V2ProjectPage({
       ) : null}
       <AppWrapper>
         {metadata ? (
-          <V2V3ProjectPageProvider
-            projectId={projectId}
-            metadata={metadata}
-            initialCv={initialCv}
-            cvs={cvs}
-          >
+          <V2V3ProjectPageProvider projectId={projectId}>
             <V2V3Dashboard />
           </V2V3ProjectPageProvider>
         ) : (

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -67,7 +67,7 @@ export default function V2ProjectPage({
       ) : null}
       <AppWrapper>
         {metadata ? (
-          <V2V3ProjectPageProvider projectId={projectId}>
+          <V2V3ProjectPageProvider projectId={projectId} metadata={metadata}>
             <V2V3Dashboard />
           </V2V3ProjectPageProvider>
         ) : (

--- a/src/pages/v2/p/[projectId]/safe/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/safe/index.page.tsx
@@ -2,21 +2,11 @@ import { AppWrapper } from 'components/common'
 import { ProjectSafeDashboard } from 'components/ProjectSafeDashboard'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
-import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { useRouter } from 'next/router'
 import { TransactionProvider } from 'providers/TransactionProvider'
 import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
 import { useContext } from 'react'
 import { v2v3ProjectRoute } from 'utils/routes'
-import { getProjectProps, ProjectPageProps } from 'utils/server/pages/props'
-
-export const getServerSideProps: GetServerSideProps<
-  ProjectPageProps
-> = async context => {
-  if (!context.params) throw new Error('params not supplied')
-
-  const projectId = parseInt(context.params.projectId as string)
-  return getProjectProps(projectId)
-}
 
 function V2V3ProjectSafeDashboard() {
   const { handle, projectOwnerAddress } = useContext(V2V3ProjectContext)
@@ -30,18 +20,17 @@ function V2V3ProjectSafeDashboard() {
   )
 }
 
-export default function V2V3ProjectSafeDashboardPage({
-  projectId,
-  metadata,
-  initialCv,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function V2V3ProjectSafeDashboardPage() {
+  const router = useRouter()
+
+  const { projectId: rawProjectId } = router.query
+  if (!rawProjectId) return null
+
+  const projectId = parseInt(rawProjectId as string)
+
   return (
     <AppWrapper>
-      <V2V3ProjectPageProvider
-        projectId={projectId}
-        metadata={metadata}
-        initialCv={initialCv}
-      >
+      <V2V3ProjectPageProvider projectId={projectId}>
         <TransactionProvider>
           <V2V3ProjectSafeDashboard />
         </TransactionProvider>

--- a/src/pages/v2/p/[projectId]/settings/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/settings/index.page.tsx
@@ -1,31 +1,20 @@
 import { AppWrapper } from 'components/common'
 import { V2V3ProjectSettings } from 'components/v2v3/V2V3Project/V2V3ProjectSettings'
-import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { useRouter } from 'next/router'
 import { TransactionProvider } from 'providers/TransactionProvider'
 import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
-import { getProjectProps, ProjectPageProps } from 'utils/server/pages/props'
 
-export const getServerSideProps: GetServerSideProps<
-  ProjectPageProps
-> = async context => {
-  if (!context.params) throw new Error('params not supplied')
+export default function V2V3ProjectSettingsPage() {
+  const router = useRouter()
 
-  const projectId = parseInt(context.params.projectId as string)
-  return getProjectProps(projectId)
-}
+  const { projectId: rawProjectId } = router.query
+  if (!rawProjectId) return null
 
-export default function V2V3ProjectSettingsPage({
-  projectId,
-  metadata,
-  initialCv,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const projectId = parseInt(rawProjectId as string)
+
   return (
     <AppWrapper>
-      <V2V3ProjectPageProvider
-        projectId={projectId}
-        metadata={metadata}
-        initialCv={initialCv}
-      >
+      <V2V3ProjectPageProvider projectId={projectId}>
         <TransactionProvider>
           <V2V3ProjectSettings />
         </TransactionProvider>

--- a/src/pages/v2/p/[projectId]/venft/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/venft/index.page.tsx
@@ -1,32 +1,21 @@
 import { AppWrapper } from 'components/common'
 import { VeNft } from 'components/veNft/VeNft'
-import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { useRouter } from 'next/router'
 import { TransactionProvider } from 'providers/TransactionProvider'
 import { V2V3ProjectPageProvider } from 'providers/v2v3/V2V3ProjectPageProvider'
 import { VeNftProvider } from 'providers/v2v3/VeNftProvider'
-import { getProjectProps, ProjectPageProps } from 'utils/server/pages/props'
 
-export const getServerSideProps: GetServerSideProps<
-  ProjectPageProps
-> = async context => {
-  if (!context.params) throw new Error('params not supplied')
+export default function VeNftPage() {
+  const router = useRouter()
 
-  const projectId = parseInt(context.params.projectId as string)
-  return getProjectProps(projectId)
-}
+  const { projectId: rawProjectId } = router.query
+  if (!rawProjectId) return null
 
-export default function V2V3ProjectSettingsPage({
-  projectId,
-  metadata,
-  initialCv,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const projectId = parseInt(rawProjectId as string)
+
   return (
     <AppWrapper>
-      <V2V3ProjectPageProvider
-        projectId={projectId}
-        metadata={metadata}
-        initialCv={initialCv}
-      >
+      <V2V3ProjectPageProvider projectId={projectId}>
         <TransactionProvider>
           <VeNftProvider projectId={projectId}>
             <VeNft />

--- a/src/providers/v2v3/V2V3ContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ContractsProvider.tsx
@@ -3,12 +3,12 @@ import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { useV2V3ContractLoader } from 'hooks/v2v3/V2V3ContractLoader'
 import { CV2V3 } from 'models/cv'
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { hasFundingCycle } from 'utils/v2v3/cv'
 
 export const useSetCv = (projectId: number | undefined) => {
-  const { setVersion, setCvs } = useContext(V2V3ContractsContext)
+  const { setCv, setCvs } = useContext(V2V3ContractsContext)
 
   useEffect(() => {
     async function load() {
@@ -27,12 +27,12 @@ export const useSetCv = (projectId: number | undefined) => {
       if (hasV2FundingCycle) cvs.push(CV_V2)
       if (hasV3FundingCycle) cvs.push(CV_V3)
 
-      setVersion?.(cv)
+      setCv?.(cv)
       setCvs?.(cvs)
     }
 
     load()
-  }, [projectId, setVersion, setCvs])
+  }, [projectId, setCvs, setCv])
 }
 
 // TODO this needs to probably be reverted, and there
@@ -45,19 +45,24 @@ export const V2V3ContractsProvider: React.FC<{
 
   const contracts = useV2V3ContractLoader({ cv })
 
+  const setCvWithLog = useCallback(
+    (newCv: CV2V3) => {
+      console.info(
+        'V2V3ContractsProvider::Switching contracts version to',
+        newCv,
+      )
+      setCv(newCv)
+    },
+    [setCv],
+  )
+
   return (
     <V2V3ContractsContext.Provider
       value={{
         contracts,
         cv,
         cvs,
-        setVersion: (newCv: CV2V3) => {
-          console.info(
-            'V2V3ContractsProvider::Switching contracts version to',
-            newCv,
-          )
-          setCv(newCv)
-        },
+        setCv: setCvWithLog,
         setCvs,
       }}
     >

--- a/src/providers/v2v3/V2V3ContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ContractsProvider.tsx
@@ -1,19 +1,56 @@
+import { CV_V2, CV_V3 } from 'constants/cv'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { useV2V3ContractLoader } from 'hooks/v2v3/V2V3ContractLoader'
 import { CV2V3 } from 'models/cv'
-import { useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
+import { featureFlagEnabled } from 'utils/featureFlags'
+import { hasFundingCycle } from 'utils/v2v3/cv'
 
+export const useSetCv = (projectId: number | undefined) => {
+  const { setVersion, setCvs } = useContext(V2V3ContractsContext)
+
+  useEffect(() => {
+    async function load() {
+      if (!projectId) return
+
+      const [hasV2FundingCycle, hasV3FundingCycle] = await Promise.all([
+        hasFundingCycle(projectId, CV_V2),
+        featureFlagEnabled(FEATURE_FLAGS.V3)
+          ? hasFundingCycle(projectId, CV_V3)
+          : Promise.resolve(false),
+      ])
+
+      const cv = hasV3FundingCycle ? CV_V3 : CV_V2
+
+      const cvs: CV2V3[] = []
+      if (hasV2FundingCycle) cvs.push(CV_V2)
+      if (hasV3FundingCycle) cvs.push(CV_V3)
+
+      setVersion?.(cv)
+      setCvs?.(cvs)
+    }
+
+    load()
+  }, [projectId, setVersion, setCvs])
+}
+
+// TODO this needs to probably be reverted, and there
+// needs to be some other logic that determines which CV to use
 export const V2V3ContractsProvider: React.FC<{
-  initialCv: CV2V3
-  cvs?: CV2V3[]
-}> = ({ children, initialCv, cvs }) => {
-  const [cv, setCv] = useState<CV2V3>(initialCv)
+  initialCv?: CV2V3
+}> = ({ initialCv, children }) => {
+  const [cv, setCv] = useState<CV2V3 | undefined>(initialCv)
+  const [cvs, setCvs] = useState<CV2V3[]>()
 
   const contracts = useV2V3ContractLoader({ cv })
 
   return (
     <V2V3ContractsContext.Provider
       value={{
+        contracts,
+        cv,
+        cvs,
         setVersion: (newCv: CV2V3) => {
           console.info(
             'V2V3ContractsProvider::Switching contracts version to',
@@ -21,9 +58,7 @@ export const V2V3ContractsProvider: React.FC<{
           )
           setCv(newCv)
         },
-        cv,
-        contracts,
-        cvs,
+        setCvs,
       }}
     >
       {children}

--- a/src/providers/v2v3/V2V3ContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ContractsProvider.tsx
@@ -1,50 +1,8 @@
-import { CV_V2, CV_V3 } from 'constants/cv'
-import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { useV2V3ContractLoader } from 'hooks/v2v3/V2V3ContractLoader'
 import { CV2V3 } from 'models/cv'
-import { useCallback, useContext, useEffect, useState } from 'react'
-import { featureFlagEnabled } from 'utils/featureFlags'
-import { hasFundingCycle } from 'utils/v2v3/cv'
+import { useCallback, useState } from 'react'
 
-export const useLoadProjectCvs = (projectId: number | undefined) => {
-  const { setCv, setCvs } = useContext(V2V3ContractsContext)
-
-  const [loadingCsv, setLoadingCsv] = useState<boolean>(true)
-
-  useEffect(() => {
-    async function load() {
-      if (!projectId) return
-
-      setLoadingCsv(true)
-
-      const [hasV2FundingCycle, hasV3FundingCycle] = await Promise.all([
-        hasFundingCycle(projectId, CV_V2),
-        featureFlagEnabled(FEATURE_FLAGS.V3)
-          ? hasFundingCycle(projectId, CV_V3)
-          : Promise.resolve(false),
-      ])
-
-      const cv = hasV3FundingCycle ? CV_V3 : CV_V2
-
-      const cvs: CV2V3[] = []
-      if (hasV2FundingCycle) cvs.push(CV_V2)
-      if (hasV3FundingCycle) cvs.push(CV_V3)
-
-      setCv?.(cv)
-      setCvs?.(cvs)
-
-      setLoadingCsv(false)
-    }
-
-    load()
-  }, [projectId, setCvs, setCv])
-
-  return { loading: loadingCsv }
-}
-
-// TODO this needs to probably be reverted, and there
-// needs to be some other logic that determines which CV to use
 export const V2V3ContractsProvider: React.FC<{
   initialCv?: CV2V3
 }> = ({ initialCv, children }) => {

--- a/src/providers/v2v3/V2V3ContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ContractsProvider.tsx
@@ -7,12 +7,16 @@ import { useCallback, useContext, useEffect, useState } from 'react'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { hasFundingCycle } from 'utils/v2v3/cv'
 
-export const useSetCv = (projectId: number | undefined) => {
+export const useLoadProjectCvs = (projectId: number | undefined) => {
   const { setCv, setCvs } = useContext(V2V3ContractsContext)
+
+  const [loadingCsv, setLoadingCsv] = useState<boolean>(true)
 
   useEffect(() => {
     async function load() {
       if (!projectId) return
+
+      setLoadingCsv(true)
 
       const [hasV2FundingCycle, hasV3FundingCycle] = await Promise.all([
         hasFundingCycle(projectId, CV_V2),
@@ -29,10 +33,14 @@ export const useSetCv = (projectId: number | undefined) => {
 
       setCv?.(cv)
       setCvs?.(cvs)
+
+      setLoadingCsv(false)
     }
 
     load()
   }, [projectId, setCvs, setCv])
+
+  return { loading: loadingCsv }
 }
 
 // TODO this needs to probably be reverted, and there

--- a/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
@@ -1,10 +1,13 @@
 import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { useV2V3ProjectContracts } from 'hooks/v2v3/V2V3ProjectContracts'
+import { useSetCv } from './V2V3ContractsProvider'
 
 export const V2V3ProjectContractsProvider: React.FC<{
   projectId: number
 }> = ({ children, projectId }) => {
   const contracts = useV2V3ProjectContracts({ projectId })
+
+  useSetCv(projectId)
 
   return (
     <V2V3ProjectContractsContext.Provider

--- a/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
@@ -1,13 +1,12 @@
 import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { useV2V3ProjectContracts } from 'hooks/v2v3/V2V3ProjectContracts'
-import { useLoadProjectCvs } from './V2V3ContractsProvider'
+import { useLoadV2V3ProjectCvs } from 'hooks/v2v3/V2V3ProjectCvs'
 
 export const V2V3ProjectContractsProvider: React.FC<{
   projectId: number
 }> = ({ children, projectId }) => {
   const contracts = useV2V3ProjectContracts({ projectId })
-
-  const { loading: cvsLoading } = useLoadProjectCvs(projectId)
+  const { loading: cvsLoading } = useLoadV2V3ProjectCvs(projectId)
 
   return (
     <V2V3ProjectContractsContext.Provider

--- a/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectContractsProvider.tsx
@@ -1,18 +1,19 @@
 import { V2V3ProjectContractsContext } from 'contexts/v2v3/V2V3ProjectContractsContext'
 import { useV2V3ProjectContracts } from 'hooks/v2v3/V2V3ProjectContracts'
-import { useSetCv } from './V2V3ContractsProvider'
+import { useLoadProjectCvs } from './V2V3ContractsProvider'
 
 export const V2V3ProjectContractsProvider: React.FC<{
   projectId: number
 }> = ({ children, projectId }) => {
   const contracts = useV2V3ProjectContracts({ projectId })
 
-  useSetCv(projectId)
+  const { loading: cvsLoading } = useLoadProjectCvs(projectId)
 
   return (
     <V2V3ProjectContractsContext.Provider
       value={{
         contracts,
+        cvsLoading,
       }}
     >
       {children}

--- a/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
@@ -17,7 +17,6 @@ export default function V2V3ProjectMetadataProvider({
   const { cv } = useContext(V2V3ContractsContext)
 
   const hasMetadata = Boolean(metadata)
-
   const { data: metadataCid } = useProjectMetadataContent(
     hasMetadata ? projectId : undefined,
   )

--- a/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
@@ -3,27 +3,36 @@ import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import useProjectMetadataContent from 'hooks/v2v3/contractReader/ProjectMetadataContent'
+import { ProjectMetadataV5 } from 'models/project-metadata'
 import { PropsWithChildren, useContext } from 'react'
 
 export default function V2V3ProjectMetadataProvider({
   projectId,
+  metadata,
   children,
 }: PropsWithChildren<{
+  metadata: ProjectMetadataV5 | undefined
   projectId: number
 }>) {
   const { cv } = useContext(V2V3ContractsContext)
 
-  const { data: metadataCid } = useProjectMetadataContent(projectId)
-  const { data: metadata } = useProjectMetadata(metadataCid)
+  const hasMetadata = Boolean(metadata)
+
+  const { data: metadataCid } = useProjectMetadataContent(
+    hasMetadata ? projectId : undefined,
+  )
+  const { data: _metadata } = useProjectMetadata(metadataCid)
+
+  const projectMetadata = metadata || _metadata
 
   const isArchived = projectId
-    ? V2ArchivedProjectIds.includes(projectId) || metadata?.archived
+    ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived
     : false
 
   return (
     <ProjectMetadataContext.Provider
       value={{
-        projectMetadata: metadata,
+        projectMetadata,
         isArchived,
         projectId,
         cv,

--- a/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
@@ -1,25 +1,33 @@
 import { V2ArchivedProjectIds } from 'constants/v2v3/archivedProjects'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
-import { ProjectMetadataV5 } from 'models/project-metadata'
+import { useProjectMetadata } from 'hooks/ProjectMetadata'
+import useProjectMetadataContent from 'hooks/v2v3/contractReader/ProjectMetadataContent'
 import { PropsWithChildren, useContext } from 'react'
 
 export default function V2V3ProjectMetadataProvider({
   projectId,
-  metadata,
   children,
 }: PropsWithChildren<{
   projectId: number
-  metadata: ProjectMetadataV5
 }>) {
   const { cv } = useContext(V2V3ContractsContext)
+
+  const { data: metadataCid } = useProjectMetadataContent(projectId)
+  const { data: metadata } = useProjectMetadata(metadataCid)
+
   const isArchived = projectId
     ? V2ArchivedProjectIds.includes(projectId) || metadata?.archived
     : false
 
   return (
     <ProjectMetadataContext.Provider
-      value={{ projectMetadata: metadata, isArchived, projectId, cv }}
+      value={{
+        projectMetadata: metadata,
+        isArchived,
+        projectId,
+        cv,
+      }}
     >
       {children}
     </ProjectMetadataContext.Provider>

--- a/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
@@ -22,7 +22,7 @@ export default function V2V3ProjectMetadataProvider({
   )
   const { data: _metadata } = useProjectMetadata(metadataCid)
 
-  const projectMetadata = metadata || _metadata
+  const projectMetadata = metadata ?? _metadata
 
   const isArchived = projectId
     ? V2ArchivedProjectIds.includes(projectId) || projectMetadata?.archived

--- a/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectMetadataProvider.tsx
@@ -17,8 +17,10 @@ export default function V2V3ProjectMetadataProvider({
   const { cv } = useContext(V2V3ContractsContext)
 
   const hasMetadata = Boolean(metadata)
+
+  // only load metadata if it hasn't been previously loaded into the prop.
   const { data: metadataCid } = useProjectMetadataContent(
-    hasMetadata ? projectId : undefined,
+    !hasMetadata ? projectId : undefined,
   )
   const { data: _metadata } = useProjectMetadata(metadataCid)
 

--- a/src/providers/v2v3/V2V3ProjectPageProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectPageProvider.tsx
@@ -1,5 +1,5 @@
 import { ProjectPageProps } from 'utils/server/pages/props'
-import { V2V3ContractsProvider } from './V2V3ContractsProvider'
+import { useSetCv, V2V3ContractsProvider } from './V2V3ContractsProvider'
 import { V2V3ProjectContractsProvider } from './V2V3ProjectContractsProvider'
 import V2V3ProjectMetadataProvider from './V2V3ProjectMetadataProvider'
 import V2V3ProjectProvider from './V2V3ProjectProvider'
@@ -9,15 +9,14 @@ import V2V3ProjectProvider from './V2V3ProjectProvider'
  */
 export const V2V3ProjectPageProvider: React.FC<ProjectPageProps> = ({
   projectId,
-  metadata,
   children,
-  initialCv,
-  cvs,
 }) => {
+  useSetCv(projectId)
+
   return (
-    <V2V3ContractsProvider initialCv={initialCv} cvs={cvs}>
+    <V2V3ContractsProvider>
       <V2V3ProjectContractsProvider projectId={projectId}>
-        <V2V3ProjectMetadataProvider projectId={projectId} metadata={metadata}>
+        <V2V3ProjectMetadataProvider projectId={projectId}>
           <V2V3ProjectProvider projectId={projectId}>
             {children}
           </V2V3ProjectProvider>

--- a/src/providers/v2v3/V2V3ProjectPageProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectPageProvider.tsx
@@ -1,5 +1,5 @@
 import { ProjectPageProps } from 'utils/server/pages/props'
-import { useSetCv, V2V3ContractsProvider } from './V2V3ContractsProvider'
+import { V2V3ContractsProvider } from './V2V3ContractsProvider'
 import { V2V3ProjectContractsProvider } from './V2V3ProjectContractsProvider'
 import V2V3ProjectMetadataProvider from './V2V3ProjectMetadataProvider'
 import V2V3ProjectProvider from './V2V3ProjectProvider'
@@ -11,8 +11,6 @@ export const V2V3ProjectPageProvider: React.FC<ProjectPageProps> = ({
   projectId,
   children,
 }) => {
-  useSetCv(projectId)
-
   return (
     <V2V3ContractsProvider>
       <V2V3ProjectContractsProvider projectId={projectId}>

--- a/src/providers/v2v3/V2V3ProjectPageProvider.tsx
+++ b/src/providers/v2v3/V2V3ProjectPageProvider.tsx
@@ -9,12 +9,13 @@ import V2V3ProjectProvider from './V2V3ProjectProvider'
  */
 export const V2V3ProjectPageProvider: React.FC<ProjectPageProps> = ({
   projectId,
+  metadata,
   children,
 }) => {
   return (
     <V2V3ContractsProvider>
       <V2V3ProjectContractsProvider projectId={projectId}>
-        <V2V3ProjectMetadataProvider projectId={projectId}>
+        <V2V3ProjectMetadataProvider projectId={projectId} metadata={metadata}>
           <V2V3ProjectProvider projectId={projectId}>
             {children}
           </V2V3ProjectProvider>


### PR DESCRIPTION
## What does this PR do and why?

This PR removes all use of getServerSideProps in favor of client-side fetching where necessary.

It also moves all the CV loader logic to the client-side, rather than in static/serverside props. This should improve initial page load speeds quite well.

---

I realized we were incorrectly using ServerSideProps, which was causing longer perceived load times when navigating to some pages (like settings, safe) using next `Link` component.
