### PR TITLE
Read project owner address from context for hasPerm hook

### DIFF
--- a/src/hooks/v2v3/contractReader/V2ConnectedWalletHasPermission.ts
+++ b/src/hooks/v2v3/contractReader/V2ConnectedWalletHasPermission.ts
@@ -9,9 +9,8 @@ export function useV2ConnectedWalletHasPermission(
   permission: V2OperatorPermission | V2OperatorPermission[],
 ) {
   const { userAddress } = useWallet()
-  const { isPreviewMode } = useContext(V2V3ProjectContext)
+  const { isPreviewMode, projectOwnerAddress } = useContext(V2V3ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
-  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
 
   const hasOperatorPermission = useV2HasPermissions({
     operator: userAddress,

--- a/src/hooks/v2v3/contractReader/V2ConnectedWalletHasPermission.ts
+++ b/src/hooks/v2v3/contractReader/V2ConnectedWalletHasPermission.ts
@@ -3,8 +3,6 @@ import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useWallet } from 'hooks/Wallet'
 import { V2OperatorPermission } from 'models/v2v3/permissions'
 import { useContext } from 'react'
-
-import useProjectOwner from './ProjectOwner'
 import { useV2HasPermissions } from './V2HasPermissions'
 
 export function useV2ConnectedWalletHasPermission(
@@ -13,12 +11,11 @@ export function useV2ConnectedWalletHasPermission(
   const { userAddress } = useWallet()
   const { isPreviewMode } = useContext(V2V3ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
-
-  const { data: owner } = useProjectOwner(projectId)
+  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
 
   const hasOperatorPermission = useV2HasPermissions({
     operator: userAddress,
-    account: owner,
+    account: projectOwnerAddress,
     domain: projectId,
     permissions: Array.isArray(permission) ? permission : [permission],
   })
@@ -26,7 +23,9 @@ export function useV2ConnectedWalletHasPermission(
   if (isPreviewMode) return false
 
   const isOwner =
-    userAddress && owner && userAddress.toLowerCase() === owner.toLowerCase()
+    userAddress &&
+    projectOwnerAddress &&
+    userAddress.toLowerCase() === projectOwnerAddress.toLowerCase()
 
   return (
     isOwner ||

--- a/src/utils/format/formatCurrency.ts
+++ b/src/utils/format/formatCurrency.ts
@@ -10,10 +10,6 @@ export class CurrencyUtils {
 
   constructor(usdPerEth: number | undefined) {
     if (!usdPerEth) {
-      console.info(
-        'Failed to construct CurrencyUtils, received a usdPerEth value of',
-        usdPerEth,
-      )
       return
     }
 


### PR DESCRIPTION
Before, we were doing a network request each time we called hasPermission. Inneficient! This PR updates it so we use the pre-fetched porjectOwnerAddress from the context.