### PR TITLE
NFT reconfigureFundingCyclesOf tx

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/DeployConfigurationButton.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/DeployConfigurationButton.tsx
@@ -1,0 +1,25 @@
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+
+export function DeployConfigurationButton({
+  onClick,
+  disabled,
+  loading,
+}: {
+  onClick: VoidFunction
+  disabled?: boolean
+  loading: boolean
+}) {
+  return (
+    <Button
+      loading={loading}
+      onClick={onClick}
+      disabled={disabled}
+      type="primary"
+    >
+      <span>
+        <Trans>Deploy funding cycle configuration</Trans>
+      </span>
+    </Button>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigureFundingCycleForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigureFundingCycleForm.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Button, Form, Space } from 'antd'
+import { Form, Space } from 'antd'
 import Callout from 'components/Callout'
 import UnsavedChangesModal from 'components/modals/UnsavedChangesModal'
 import { MemoFormInput } from 'components/Project/PayProjectForm/MemoFormInput'
@@ -14,12 +14,14 @@ import { ThemeContext } from 'contexts/themeContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useContext, useState } from 'react'
 import { featureFlagEnabled } from 'utils/featureFlags'
+import { DeployConfigurationButton } from './DeployConfigurationButton'
 import { useEditingFundingCycleConfig } from './hooks/editingFundingCycleConfig'
 import { useFundingHasSavedChanges } from './hooks/fundingHasSavedChanges'
 import { useInitialEditingData } from './hooks/initialEditingData'
 import { useReconfigureFundingCycle } from './hooks/reconfigureFundingCycle'
 import ReconfigurePreview from './ReconfigurePreview'
 import V2V3ReconfigureUpcomingMessage from './ReconfigureUpcomingMessage'
+import { SetNftOperatorPermissionsButton } from './SetNftOperatorPermissionsButton'
 
 function ReconfigureButton({
   reconfigureHasChanges,
@@ -55,6 +57,8 @@ export function V2V3ReconfigureFundingCycleForm() {
   const [rulesDrawerVisible, setRulesDrawerVisible] = useState<boolean>(false)
   const [unsavedChangesModalVisibile, setUnsavedChangesModalVisible] =
     useState<boolean>(false)
+
+  const [nftOperatorConfirmed, setNftOperatorConfirmed] = useState<boolean>()
 
   const { initialEditingData } = useInitialEditingData({ visible: true })
   const editingFundingCycleConfig = useEditingFundingCycleConfig()
@@ -164,17 +168,33 @@ export function V2V3ReconfigureFundingCycleForm() {
             editingFundingCycleConfig.editingFundAccessConstraints
           }
         />
-
-        <Button
-          loading={reconfigureLoading}
-          onClick={reconfigureFundingCycle}
-          disabled={!fundingHasSavedChanges && !nftsWithFalseDataSourceForPay}
-          type="primary"
-        >
-          <span>
-            <Trans>Deploy funding cycle configuration</Trans>
-          </span>
-        </Button>
+        {nftDrawerHasSavedChanges ? (
+          <Space size="middle" direction="vertical">
+            <div style={{ display: 'flex' }}>
+              <h2 style={{ marginRight: 5 }}>1.</h2>
+              <SetNftOperatorPermissionsButton
+                onConfirmed={() => setNftOperatorConfirmed(true)}
+              />
+            </div>
+            <div style={{ display: 'flex' }}>
+              <h2 style={{ marginRight: 5 }}>2.</h2>
+              <DeployConfigurationButton
+                loading={reconfigureLoading}
+                onClick={reconfigureFundingCycle}
+                disabled={
+                  (!fundingHasSavedChanges || !nftOperatorConfirmed) &&
+                  !nftsWithFalseDataSourceForPay
+                }
+              />
+            </div>
+          </Space>
+        ) : (
+          <DeployConfigurationButton
+            loading={reconfigureLoading}
+            onClick={reconfigureFundingCycle}
+            disabled={!fundingHasSavedChanges && !nftsWithFalseDataSourceForPay}
+          />
+        )}
       </Space>
 
       <FundingDrawer

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigureFundingCycleForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigureFundingCycleForm.tsx
@@ -70,7 +70,11 @@ export function V2V3ReconfigureFundingCycleForm() {
   })
 
   const { reconfigureLoading, reconfigureFundingCycle } =
-    useReconfigureFundingCycle({ editingFundingCycleConfig, memo })
+    useReconfigureFundingCycle({
+      editingFundingCycleConfig,
+      memo,
+      launchedNewNfts: nftDrawerHasSavedChanges,
+    })
 
   const closeReconfigureDrawer = () => {
     setFundingDrawerVisible(false)

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigureFundingCycleForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigureFundingCycleForm.tsx
@@ -187,7 +187,7 @@ export function V2V3ReconfigureFundingCycleForm() {
           fundAccessConstraints={
             editingFundingCycleConfig.editingFundAccessConstraints
           }
-          nftRewards={editingProjectData.editingNftRewards.rewardTiers}
+          nftRewards={editingFundingCycleConfig.editingNftRewards?.rewardTiers}
         />
         {nftDrawerHasSavedChanges && !nftContractHasPermission ? (
           <Space size="middle" direction="vertical">

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview.tsx
@@ -10,6 +10,7 @@ import {
   V2V3FundingCycleMetadata,
 } from 'models/v2v3/fundingCycle'
 
+import { NftRewardTier } from 'models/nftRewardTier'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import {
   AllowMintingStatistic,
@@ -26,6 +27,7 @@ import {
   ReservedSplitsStatistic,
   ReservedTokensStatistic,
 } from 'pages/create/tabs/ReviewDeployTab/FundingAttributes'
+import NftSummarySection from 'pages/create/tabs/ReviewDeployTab/NftSummarySection'
 import { formattedNum } from 'utils/format/formatNumber'
 import { V2V3CurrencyName } from 'utils/v2v3/currency'
 import { getDefaultFundAccessConstraint } from 'utils/v2v3/fundingCycle'
@@ -44,12 +46,14 @@ export default function ReconfigurePreview({
   fundingCycleMetadata,
   fundingCycleData,
   fundAccessConstraints,
+  nftRewards,
 }: {
   payoutSplits: Split[]
   reserveSplits: Split[]
   fundingCycleMetadata: V2V3FundingCycleMetadata
   fundingCycleData: V2V3FundingCycleData
   fundAccessConstraints: V2V3FundAccessConstraint[]
+  nftRewards?: NftRewardTier[]
 }) {
   const { userAddress } = useWallet()
 
@@ -193,6 +197,7 @@ export default function ReconfigurePreview({
           projectOwnerAddress={userAddress}
         />
       )}
+      {nftRewards ? <NftSummarySection /> : null}
     </Space>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/SetNftOperatorPermissionsButton.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/SetNftOperatorPermissionsButton.tsx
@@ -1,0 +1,64 @@
+import { CheckCircleOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+import ExternalLink from 'components/ExternalLink'
+import { ThemeContext } from 'contexts/themeContext'
+import { useSetNftOperatorPermissionsTx } from 'hooks/v2v3/transactor/SetNftOperatorPermissionsTx'
+import { useContext, useState } from 'react'
+
+export function SetNftOperatorPermissionsButton({
+  onConfirmed,
+}: {
+  onConfirmed: VoidFunction
+}) {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
+
+  const [loading, setLoading] = useState<boolean>(false)
+  const [txExecuted, setTxExecuted] = useState<boolean>(false)
+
+  const setNftOperatorPermissionsTx = useSetNftOperatorPermissionsTx()
+
+  const setPermissions = async () => {
+    setLoading(true)
+    await setNftOperatorPermissionsTx(undefined, {
+      onConfirmed: () => {
+        setTxExecuted(true)
+        setLoading(false)
+        onConfirmed()
+      },
+    })
+  }
+
+  return (
+    <div>
+      <Button
+        loading={loading}
+        onClick={setPermissions}
+        type="primary"
+        disabled={txExecuted}
+      >
+        <span>
+          <Trans>Set NFT operator permissions</Trans>
+        </span>
+        {txExecuted ? <CheckCircleOutlined /> : null}
+      </Button>
+      <div
+        style={{
+          color: colors.text.secondary,
+          marginTop: 5,
+          fontSize: '0.7rem',
+        }}
+      >
+        Allow the{' '}
+        <ExternalLink
+          href={`https://github.com/jbx-protocol/juice-721-delegate/blob/main/contracts/JBTiered721DelegateDeployer.sol`}
+        >
+          Juicebox NFT deployer contract
+        </ExternalLink>{' '}
+        to executed reconfiguration transactions on this project's behalf.
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/SetNftOperatorPermissionsButton.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/SetNftOperatorPermissionsButton.tsx
@@ -51,13 +51,15 @@ export function SetNftOperatorPermissionsButton({
           fontSize: '0.7rem',
         }}
       >
-        Allow the{' '}
-        <ExternalLink
-          href={`https://github.com/jbx-protocol/juice-721-delegate/blob/main/contracts/JBTiered721DelegateDeployer.sol`}
-        >
-          Juicebox NFT deployer contract
-        </ExternalLink>{' '}
-        to executed reconfiguration transactions on this project's behalf.
+        <Trans>
+          Allow the{' '}
+          <ExternalLink
+            href={`https://github.com/jbx-protocol/juice-721-delegate/blob/main/contracts/JBTiered721DelegateDeployer.sol`}
+          >
+            Juicebox NFT deployer contract
+          </ExternalLink>{' '}
+          to reconfigure this project's funding cycle.
+        </Trans>
       </div>
     </div>
   )

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierCard.tsx
@@ -7,6 +7,7 @@ import { Trans } from '@lingui/macro'
 import { Button, Col, Image, Row, Tooltip } from 'antd'
 import Paragraph from 'components/Paragraph'
 import { ThemeContext } from 'contexts/themeContext'
+import { DEFAULT_NFT_MAX_SUPPLY } from 'hooks/NftRewards'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { useContext, useState } from 'react'
 
@@ -101,14 +102,15 @@ export default function NftRewardTierCard({
               </Trans>
             </div>
           )}
-          {rewardTier.maxSupply && (
+          {rewardTier.maxSupply &&
+          rewardTier.maxSupply !== DEFAULT_NFT_MAX_SUPPLY ? (
             <div style={{ fontSize: 13, marginTop: 15 }}>
               <Trans>
                 <strong>Max. supply:</strong>{' '}
                 <span>{rewardTier.maxSupply}</span>
               </Trans>
             </div>
-          )}
+          ) : null}
         </Col>
         <Col
           md={5}

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
@@ -385,23 +385,23 @@ export default function NftDrawer({
             <Trans>Save NFTs</Trans>
           </span>
         </Button>
+        <NftRewardTierModal
+          open={addTierModalVisible}
+          validateContributionFloor={validateContributionFloor}
+          onChange={handleAddRewardTier}
+          mode="Add"
+          onClose={() => setAddTierModalVisible(false)}
+          isCreate
+        />
+        <UnsavedChangesModal
+          open={unsavedChangesModalVisible}
+          onOk={() => {
+            closeModal()
+            emitDrawerClose()
+          }}
+          onCancel={closeModal}
+        />
       </FundingCycleDrawer>
-      <NftRewardTierModal
-        open={addTierModalVisible}
-        validateContributionFloor={validateContributionFloor}
-        onChange={handleAddRewardTier}
-        mode="Add"
-        onClose={() => setAddTierModalVisible(false)}
-        isCreate
-      />
-      <UnsavedChangesModal
-        open={unsavedChangesModalVisible}
-        onOk={() => {
-          closeModal()
-          emitDrawerClose()
-        }}
-        onCancel={closeModal}
-      />
     </>
   )
 }

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/index.tsx
@@ -8,6 +8,7 @@ import TooltipIcon from 'components/TooltipIcon'
 import NftRewardTierModal from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal'
 import { readProvider } from 'constants/readProvider'
 import { shadowCard } from 'constants/styles/shadowCard'
+import { NftRewardsContext } from 'contexts/nftRewardsContext'
 import { ThemeContext } from 'contexts/themeContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import { useAppDispatch } from 'hooks/AppDispatch'
@@ -56,6 +57,9 @@ export default function NftDrawer({
     theme,
     theme: { colors },
   } = useContext(ThemeContext)
+  const {
+    nftRewards: { rewardTiers: contextRewardTiers },
+  } = useContext(NftRewardsContext)
   const { fundingCycleMetadata } = useContext(V2V3ProjectContext)
   const [addTierModalVisible, setAddTierModalVisible] = useState<boolean>(false)
   const [submitLoading, setSubmitLoading] = useState<boolean>(false)
@@ -330,7 +334,7 @@ export default function NftDrawer({
             style={{ marginBottom: 30 }}
           />
           {
-            !rewardTiers?.length ? (
+            !contextRewardTiers?.length ? (
               <>
                 <MinimalCollapse
                   header={

--- a/src/hooks/v2v3/transactor/LaunchProjectWithNftsTx.ts
+++ b/src/hooks/v2v3/transactor/LaunchProjectWithNftsTx.ts
@@ -31,7 +31,7 @@ import { useV2ProjectTitle } from '../ProjectTitle'
 const DEFAULT_MUST_START_AT_OR_AFTER = '1' // start immediately
 const DEFAULT_MEMO = ''
 
-async function getJBDeployTiered721DelegateData({
+export async function getJBDeployTiered721DelegateData({
   collectionCID,
   collectionName,
   collectionSymbol,

--- a/src/hooks/v2v3/transactor/ReconfigureV2V3FundingCycleTx.ts
+++ b/src/hooks/v2v3/transactor/ReconfigureV2V3FundingCycleTx.ts
@@ -14,7 +14,7 @@ import {
 import { isValidMustStartAtOrAfter } from 'utils/v2v3/fundingCycle'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
-const DEFAULT_MUST_START_AT_OR_AFTER = '1'
+export const DEFAULT_MUST_START_AT_OR_AFTER = '1'
 const DEFAULT_MEMO = '1'
 
 export type ReconfigureTxArgs = {

--- a/src/hooks/v2v3/transactor/ReconfigureV2V3FundingCycleTx.ts
+++ b/src/hooks/v2v3/transactor/ReconfigureV2V3FundingCycleTx.ts
@@ -17,14 +17,16 @@ import { useV2ProjectTitle } from '../ProjectTitle'
 const DEFAULT_MUST_START_AT_OR_AFTER = '1'
 const DEFAULT_MEMO = '1'
 
-export function useReconfigureV2V3FundingCycleTx(): TransactorInstance<{
+export type ReconfigureTxArgs = {
   fundingCycleData: V2V3FundingCycleData
   fundingCycleMetadata: V2V3FundingCycleMetadata
   fundAccessConstraints: V2V3FundAccessConstraint[]
   groupedSplits?: GroupedSplits<SplitGroup>[]
   mustStartAtOrAfter?: string // epoch seconds. anything less than "now" will start immediately.
   memo?: string
-}> {
+}
+
+export function useReconfigureV2V3FundingCycleTx(): TransactorInstance<ReconfigureTxArgs> {
   const { transactor } = useContext(TransactionContext)
   const { contracts } = useContext(V2V3ContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)

--- a/src/hooks/v2v3/transactor/ReconfigureV2V3FundingCycleWithNftsTx.ts
+++ b/src/hooks/v2v3/transactor/ReconfigureV2V3FundingCycleWithNftsTx.ts
@@ -1,0 +1,113 @@
+import { getAddress } from '@ethersproject/address'
+import { t } from '@lingui/macro'
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
+import { TransactorInstance } from 'hooks/Transactor'
+import omit from 'lodash/omit'
+import { JBPayDataSourceFundingCycleMetadata } from 'models/v2v3/fundingCycle'
+import { useContext } from 'react'
+import { NftRewardsData } from 'redux/slices/editingV2Project'
+import {
+  buildJB721TierParams,
+  defaultNftCollectionName,
+  findJBTiered721DelegateStoreAddress,
+} from 'utils/nftRewards'
+import { isValidMustStartAtOrAfter } from 'utils/v2v3/fundingCycle'
+import { useV2ProjectTitle } from '../ProjectTitle'
+import { getJBDeployTiered721DelegateData } from './LaunchProjectWithNftsTx'
+import {
+  DEFAULT_MUST_START_AT_OR_AFTER,
+  ReconfigureTxArgs,
+} from './ReconfigureV2V3FundingCycleTx'
+
+export type ReconfigureWithNftsTxArgs = ReconfigureTxArgs & NftRewardsData
+
+export function useReconfigureV2V3FundingCycleWithNftsTx(): TransactorInstance<ReconfigureWithNftsTxArgs> {
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2V3ContractsContext)
+  const { projectId } = useContext(ProjectMetadataContext)
+  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
+
+  const projectTitle = useV2ProjectTitle()
+
+  return async (
+    {
+      fundingCycleData,
+      fundingCycleMetadata,
+      fundAccessConstraints,
+      groupedSplits = [],
+      mustStartAtOrAfter = DEFAULT_MUST_START_AT_OR_AFTER,
+      memo,
+      rewardTiers,
+      CIDs,
+      collectionMetadata,
+    },
+    txOpts,
+  ) => {
+    const JBTiered721DelegateStoreAddress =
+      await findJBTiered721DelegateStoreAddress()
+
+    if (
+      !transactor ||
+      !projectId ||
+      !CIDs ||
+      !rewardTiers ||
+      !JBTiered721DelegateStoreAddress ||
+      !projectOwnerAddress ||
+      !contracts ||
+      !isValidMustStartAtOrAfter(mustStartAtOrAfter, fundingCycleData.duration)
+    ) {
+      txOpts?.onDone?.()
+      return Promise.resolve(false)
+    }
+
+    // build `delegateData`
+    const tiers = buildJB721TierParams({ cids: CIDs, rewardTiers })
+    const collectionName =
+      collectionMetadata.name ?? defaultNftCollectionName(projectTitle)
+    const delegateData = await getJBDeployTiered721DelegateData({
+      collectionCID: collectionMetadata.CID ?? '',
+      collectionName,
+      collectionSymbol: collectionMetadata.symbol ?? '',
+      tiers,
+      ownerAddress: projectOwnerAddress,
+      JBDirectoryAddress: getAddress(contracts.JBDirectory.address),
+      JBFundingCycleStoreAddress: getAddress(
+        contracts.JBFundingCycleStore.address,
+      ),
+      JBPricesAddress: getAddress(contracts.JBPrices.address),
+      JBTiered721DelegateStoreAddress,
+    })
+
+    // NFT launch tx does not accept `useDataSourceForPay` and `dataSource` (see contracts:`JBPayDataSourceFundingCycleMetadata`)
+    const dataSourceFCMetadata: JBPayDataSourceFundingCycleMetadata = omit(
+      fundingCycleMetadata,
+      ['useDataSourceForPay', 'dataSource'],
+    )
+
+    const args = [
+      projectId,
+      delegateData, //_deployTiered721DelegateData
+      {
+        data: fundingCycleData,
+        metadata: dataSourceFCMetadata,
+        mustStartAtOrAfter,
+        groupedSplits,
+        fundAccessConstraints,
+        memo,
+      },
+    ]
+
+    return transactor(
+      contracts.JBTiered721DelegateProjectDeployer,
+      'reconfigureFundingCyclesOf',
+      args,
+      {
+        ...txOpts,
+        title: t`Reconfigure ${projectTitle} with new NFTs`,
+      },
+    )
+  }
+}

--- a/src/hooks/v2v3/transactor/SetNftOperatorPermissionsTx.tsx
+++ b/src/hooks/v2v3/transactor/SetNftOperatorPermissionsTx.tsx
@@ -1,0 +1,53 @@
+import { getAddress } from '@ethersproject/address'
+import { t } from '@lingui/macro'
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
+import { useWallet } from 'hooks/Wallet'
+import { V2OperatorPermission } from 'models/v2v3/permissions'
+import { useContext } from 'react'
+import invariant from 'tiny-invariant'
+
+export function useSetNftOperatorPermissionsTx(): TransactorInstance {
+  const { transactor } = useContext(TransactionContext)
+  const { contracts } = useContext(V2V3ContractsContext)
+  const { projectId, cv } = useContext(ProjectMetadataContext)
+
+  const { userAddress } = useWallet()
+
+  return (_, txOpts) => {
+    try {
+      invariant(
+        transactor && userAddress && projectId && contracts?.JBTokenStore,
+      )
+      return transactor(
+        contracts.JBOperatorStore,
+        'setOperator',
+        [
+          {
+            operator: getAddress(
+              contracts?.JBTiered721DelegateProjectDeployer.address,
+            ),
+            domain: projectId,
+            permissionIndexes: [V2OperatorPermission.RECONFIGURE],
+          },
+        ],
+        {
+          ...txOpts,
+          title: t`Set operator permissions for projectId=${projectId} to allow NFTs`,
+        },
+      )
+    } catch {
+      return handleTransactionException({
+        txOpts,
+        missingParam: '',
+        functionName: 'setOperator',
+        cv,
+      })
+    }
+  }
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -419,6 +419,9 @@ msgstr ""
 msgid "Allow terminal configuration"
 msgstr ""
 
+msgid "Allow the <0>Juicebox NFT deployer contract</0> to reconfigure this project's funding cycle."
+msgstr ""
+
 msgid "Allow token minting"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2573,6 +2573,9 @@ msgstr ""
 msgid "Set ENS text record for {ensName}"
 msgstr ""
 
+msgid "Set NFT operator permissions"
+msgstr ""
+
 msgid "Set URI for {projectTitle}"
 msgstr ""
 
@@ -2619,6 +2622,9 @@ msgid "Set handle @{handle}"
 msgstr ""
 
 msgid "Set operator for {projectTitle}"
+msgstr ""
+
+msgid "Set operator permissions for projectId={projectId} to allow NFTs"
 msgstr ""
 
 msgid "Set payouts of {projectTitle}"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2363,6 +2363,9 @@ msgstr ""
 msgid "Reconfigure {projectTitle}"
 msgstr ""
 
+msgid "Reconfigure {projectTitle} with new NFTs"
+msgstr ""
+
 msgid "Redeem"
 msgstr ""
 

--- a/src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
+++ b/src/pages/create/tabs/ReviewDeployTab/NftSummarySection.tsx
@@ -5,6 +5,7 @@ import Paragraph from 'components/Paragraph'
 import { NFT_IMAGE_SIDE_LENGTH } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload'
 import { ThemeContext } from 'contexts/themeContext'
 import { useAppSelector } from 'hooks/AppSelector'
+import { DEFAULT_NFT_MAX_SUPPLY } from 'hooks/NftRewards'
 import { useContext } from 'react'
 
 export default function NftSummarySection() {
@@ -64,14 +65,15 @@ export default function NftSummarySection() {
                 {rewardTier.contributionFloor} ETH
               </Trans>
             </p>
-            {rewardTier.maxSupply && (
+            {rewardTier.maxSupply &&
+            rewardTier.maxSupply !== DEFAULT_NFT_MAX_SUPPLY ? (
               <span>
                 <Trans>
                   <strong>Max. supply:</strong>{' '}
                   <span>{rewardTier.maxSupply}</span>
                 </Trans>
               </span>
-            )}
+            ) : null}
             {rewardTier.externalLink && (
               <span>
                 <Trans>


### PR DESCRIPTION
## What does this PR do and why?

- Allows projects without NFTs to deploy to have NFTs:
      1. Call `setOperator` tx
      2. Call `deployer.reconfigureFundingCyclesOf` tx

<img width="974" alt="Screen Shot 2022-11-04 at 12 42 17 pm" src="https://user-images.githubusercontent.com/96150256/199873744-fb147aa6-7153-4784-a66f-c63240c6c807.png">

<img width="844" alt="Screen Shot 2022-11-04 at 12 42 27 pm" src="https://user-images.githubusercontent.com/96150256/199873701-babe7d86-72ca-4dce-aba6-a44fb3ca342f.png">

(note: screenshots missing the NFT rewards in the review section)
      
- Adds NFT rewards to summary section of the reconfig review (this is very ugly, I know. I think we should just wait to redo the whole thing to a similar style as the new FC card in a follow-up)

- Also note: as we discussed @tomquirk the reconfigFC page has a bug that resets the redux state after some period of time. This is more likely to happen in this case because of the wait for the `setOperator` tx. We should definitely try to get it fixed in a follow-up before mainnet release. 

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
