### PR TITLE
Allow a redemption rate of 0

### DIFF
--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
@@ -210,7 +210,7 @@ export const CustomTokenSettings = () => {
             rules={[inputMustExistRule({ label: t`Redemption Rate` })]}
           >
             <NumberSlider
-              min={0.1}
+              min={0}
               defaultValue={0}
               suffix="%"
               step={0.5}


### PR DESCRIPTION
## What does this PR do and why?

Changes the `min` value of the redemption rate slider input to 0

Note: Not sure if there was a good reason for the previous min value of 0.1. Plz don't approve unless you're more sure than me

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
