### PR TITLE
Allow deselect of NFTs on blue check

### DIFF
--- a/src/components/NftRewards/NftRewardsSection.tsx
+++ b/src/components/NftRewards/NftRewardsSection.tsx
@@ -99,8 +99,10 @@ export function NftRewardsSection() {
   )
 
   const deselectTier = useCallback(() => {
+    setPayAmount?.('0')
     setPayMetadata?.(undefined)
     setSelectedIndex(undefined)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setPayMetadata])
 
   useEffect(() => {
@@ -172,6 +174,7 @@ export function NftRewardsSection() {
                   }
                   isSelected={idx === selectedIndex}
                   onClick={() => handleSelected(rewardTier, idx)}
+                  onRemove={deselectTier}
                 />
               </Col>
             ))}

--- a/src/components/NftRewards/RewardTier.tsx
+++ b/src/components/NftRewards/RewardTier.tsx
@@ -3,7 +3,13 @@ import { Trans } from '@lingui/macro'
 import { Skeleton, Tooltip } from 'antd'
 import { ThemeContext } from 'contexts/themeContext'
 import { NftRewardTier } from 'models/nftRewardTier'
-import { CSSProperties, MouseEventHandler, useContext, useState } from 'react'
+import {
+  CSSProperties,
+  MouseEvent,
+  MouseEventHandler,
+  useContext,
+  useState,
+} from 'react'
 import { ipfsToHttps } from 'utils/ipfs'
 import { NftPreview } from './NftPreview'
 
@@ -56,6 +62,7 @@ export function RewardTier({
   rewardTierUpperLimit,
   isSelected,
   onClick,
+  onRemove,
 }: {
   loading?: boolean
   tierRank?: number
@@ -63,6 +70,7 @@ export function RewardTier({
   rewardTierUpperLimit?: number | undefined
   isSelected?: boolean
   onClick?: MouseEventHandler<HTMLDivElement>
+  onRemove?: () => void
 }) {
   const {
     theme: { colors, radii },
@@ -91,9 +99,16 @@ export function RewardTier({
       borderRadius: '100%',
       height: '25px',
       width: '25px',
-      display: 'flex',
+      display: !isSelected ? 'none' : 'flex',
       justifyContent: 'center',
       alignItems: 'center',
+    }
+
+    const onRemoveTier = (
+      event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
+    ) => {
+      event.stopPropagation()
+      onRemove?.()
     }
 
     return (
@@ -121,7 +136,7 @@ export function RewardTier({
         }}
         placement={'bottom'}
       >
-        <div style={iconStyle}>
+        <div style={iconStyle} onClick={onRemoveTier}>
           <CheckOutlined />
         </div>
       </Tooltip>
@@ -140,7 +155,13 @@ export function RewardTier({
           borderRadius: radii.sm,
           transition: 'box-shadow 100ms linear',
         }}
-        onClick={!isSelected ? onClick : () => setPreviewVisible(true)}
+        onClick={
+          !isSelected
+            ? onClick
+            : () => {
+                setPreviewVisible(true)
+              }
+        }
         role="button"
       >
         {/* Image container */}


### PR DESCRIPTION
## What does this PR do and why?

Fixes - https://github.com/jbx-protocol/juice-interface/issues/2503

The only important thing here is using `stopPropagation` when a child is clicked so it prevents the parent from firing, for deselecting logic i'm using a function that is already there `deselectTier`
## Screenshots or screen recordings


https://user-images.githubusercontent.com/18723426/201931245-95f06764-88f2-4408-b5bd-280fdaed18d3.mov



## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
