### PR TITLE
Increase NFT rewards tier limit

### DIFF
--- a/src/components/Create/components/RewardsList/RewardsList.tsx
+++ b/src/components/Create/components/RewardsList/RewardsList.tsx
@@ -3,6 +3,7 @@ import { Divider } from 'antd'
 import { useModal } from 'hooks/Modal'
 import { FormItemInput } from 'models/formItemInput'
 import { createContext, useCallback, useContext, useState } from 'react'
+import { MAX_NFT_REWARD_TIERS } from 'utils/nftRewards'
 import { CreateButton } from '../CreateButton'
 import { AddEditRewardModal } from './AddEditRewardModal'
 import { useRewards } from './hooks'
@@ -99,7 +100,7 @@ export const RewardsList: React.FC<RewardsListProps> &
             style={{
               height: '6rem',
             }}
-            disabled={rewards.length >= 3}
+            disabled={rewards.length >= MAX_NFT_REWARD_TIERS}
             onClick={modal.open}
           >
             Add NFT tier

--- a/src/components/NftRewards/NftRewardsSection.tsx
+++ b/src/components/NftRewards/NftRewardsSection.tsx
@@ -18,11 +18,7 @@ import { NftRewardTier } from 'models/nftRewardTier'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { fromWad } from 'utils/format/formatNumber'
-import {
-  getNftRewardTier,
-  hasNftRewards,
-  MAX_NFT_REWARD_TIERS,
-} from 'utils/nftRewards'
+import { getNftRewardTier, hasNftRewards } from 'utils/nftRewards'
 import { useModalFromUrlQuery } from '../modals/hooks/useModalFromUrlQuery'
 import { RewardTier } from './RewardTier'
 
@@ -31,7 +27,7 @@ function RewardTiersLoadingSkeleton() {
 
   return (
     <Row style={{ marginTop: '15px' }} gutter={isMobile ? 8 : 24}>
-      {[...Array(MAX_NFT_REWARD_TIERS)]?.map((_, index) => (
+      {[...Array(3)]?.map((_, index) => (
         <Col md={8} xs={8} key={`rewardTierLoading-${index}`}>
           <RewardTier loading />
         </Col>

--- a/src/providers/v2v3/NftRewardsProvider.tsx
+++ b/src/providers/v2v3/NftRewardsProvider.tsx
@@ -1,5 +1,3 @@
-import { readNetwork } from 'constants/networks'
-import { V2V3_PROJECT_IDS_NETWORK } from 'constants/v2v3/projectIds'
 import { NftRewardsContext } from 'contexts/nftRewardsContext'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
@@ -9,21 +7,6 @@ import { useNftRewardTiersOf } from 'hooks/v2v3/contractReader/NftRewardTiersOf'
 import { useContext } from 'react'
 import { EMPTY_NFT_COLLECTION_METADATA } from 'redux/slices/editingV2Project'
 import { CIDsOfNftRewardTiersResponse } from 'utils/nftRewards'
-
-/**
- * Get the limit of tiers to load for specific projects.
- *
- * By default we only load 3 tiers, but for some projects they have more (like Defifa has 32)
- *
- * @todo we shouldnt be doing this. We should page through the tiers until we get none back. Potentially via infinite scroll.
- * Tech debt to launch defifa quickly
- */
-const limitOverride = (projectId: number | undefined) => {
-  // Get all the Defifa tiers
-  return projectId === V2V3_PROJECT_IDS_NETWORK[readNetwork.name]?.DEFIFA
-    ? 32 // Defifa has 32 tiers
-    : undefined
-}
 
 export const NftRewardsProvider: React.FC = ({ children }) => {
   const { fundingCycleMetadata } = useContext(V2V3ProjectContext)
@@ -37,7 +20,6 @@ export const NftRewardsProvider: React.FC = ({ children }) => {
   const { data: nftRewardTiersResponse, loading: nftRewardsCIDsLoading } =
     useNftRewardTiersOf({
       dataSourceAddress: dataSourceAddress,
-      limit: limitOverride(projectId),
     })
 
   const { data: rewardTiers, isLoading: nftRewardTiersLoading } = useNftRewards(

--- a/src/utils/nftRewards.ts
+++ b/src/utils/nftRewards.ts
@@ -19,7 +19,7 @@ import { decodeEncodedIPFSUri, encodeIPFSUri } from 'utils/ipfs'
 
 import { ForgeDeploy } from './v2v3/loadV2V3Contract'
 
-export const MAX_NFT_REWARD_TIERS = 3
+export const MAX_NFT_REWARD_TIERS = 69
 const IJB721Delegate_INTERFACE_ID = '0xb3bcbb79'
 
 // Following three functions get the latest deployments of the NFT contracts from the NPM package


### PR DESCRIPTION
## What does this PR do and why?

Max # tiers is now 69. 

https://user-images.githubusercontent.com/96150256/202327391-64efb711-0bbb-4677-938b-e532118936fb.mp4

<img width="1220" alt="Screen Shot 2022-11-17 at 11 12 43 am" src="https://user-images.githubusercontent.com/96150256/202331470-cc9bc1f0-3a03-48f7-82ba-d150e753b0f6.png">

And then after an adjust tiers adding a 5th one: 

<img width="1237" alt="Screen Shot 2022-11-17 at 11 27 00 am" src="https://user-images.githubusercontent.com/96150256/202331393-3f0da8b2-4d1b-46dd-a4f1-bc7100c7d703.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
