### PR TITLE
Load initial Create state from query param

### DIFF
--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -147,7 +147,7 @@ export function Create() {
                 <ReconfigurationRulesPage />
               </Wizard.Page>
               <Wizard.Page
-                className="max-w-[800px]"
+                className="max-w-full md:max-w-[800px]"
                 name="reviewDeploy"
                 title={t`Review & Deploy`}
                 description={

--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -21,6 +21,7 @@ import { CreateBadge } from './components/CreateBadge'
 import { DeploySuccess } from './components/pages/ReviewDeploy/components/DeploySuccess'
 import { RecallCard } from './components/RecallCard'
 import { Wizard } from './components/Wizard'
+import { useSetInitialStateFromQuery } from './hooks/SetInitialStateFromQuery'
 
 export function Create() {
   const router = useRouter()
@@ -29,6 +30,8 @@ export function Create() {
     const projectId = parseInt(deployedProjectId)
     return <DeploySuccess projectId={projectId} />
   }
+
+  useSetInitialStateFromQuery()
 
   return (
     // New projects will be launched using V3 contracts.

--- a/src/components/Create/components/RewardsList/RewardItem.tsx
+++ b/src/components/Create/components/RewardsList/RewardItem.tsx
@@ -1,6 +1,5 @@
 import { DeleteOutlined, EditOutlined, LinkOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
-import { Space } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import useMobile from 'hooks/Mobile'
 import { ReactNode } from 'react'
@@ -34,15 +33,17 @@ export const RewardItem = ({
     <div className="flex flex-col gap-4">
       {/* Title line */}
       <div className="flex items-center justify-between">
-        <div className="text-lg font-medium">{title}</div>
-        <Space size="middle">
+        <div className="w-4/5 overflow-hidden text-ellipsis text-lg font-medium">
+          {title}
+        </div>
+        <div className="flex gap-4">
           <RewardItemButton onClick={onEditClicked}>
             <EditOutlined />
           </RewardItemButton>
           <RewardItemButton onClick={onDeleteClicked}>
             <DeleteOutlined />
           </RewardItemButton>
-        </Space>
+        </div>
       </div>
 
       <div className="relative flex flex-col gap-6">
@@ -57,7 +58,7 @@ export const RewardItem = ({
             )}
           </div>
           {/* Description Col */}
-          <div className="flex flex-1 flex-col gap-8">
+          <div className="flex flex-1 flex-col gap-8 overflow-hidden">
             {/* Top */}
             <div
               className={classNames(
@@ -97,7 +98,9 @@ const Description = ({ description }: { description: ReactNode }) => {
       <div className="text-xs font-normal uppercase text-grey-600 dark:text-slate-200">
         <Trans>Description</Trans>
       </div>
-      <div className="text-sm font-normal">{description}</div>
+      <div className="overflow-hidden text-ellipsis text-sm font-normal">
+        {description}
+      </div>
     </div>
   )
 }

--- a/src/components/Create/components/Wizard/Page.tsx
+++ b/src/components/Create/components/Wizard/Page.tsx
@@ -50,7 +50,7 @@ export const Page: React.FC<PageProps> & {
       }}
     >
       <Space
-        className={twMerge('max-w-[600px]', className)}
+        className={twMerge('max-w-full md:max-w-[600px]', className)}
         direction="vertical"
         size="large"
       >

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/MobileProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/MobileProjectDetailsReview.tsx
@@ -19,12 +19,18 @@ export const MobileProjectDetailsReview = () => {
     <>
       <DescriptionCol
         title={t`Project name`}
-        desc={<div className="text-base font-medium">{name}</div>}
+        desc={
+          <div className="overflow-hidden text-ellipsis text-base font-medium">
+            {name}
+          </div>
+        }
       />
       <DescriptionCol
         title={t`Project description`}
         placeholder={t`No description`}
-        desc={description}
+        desc={
+          <div className="overflow-hidden text-ellipsis">{description}</div>
+        }
       />
       <DescriptionCol
         title={t`Project logo`}
@@ -39,26 +45,40 @@ export const MobileProjectDetailsReview = () => {
       <DescriptionCol
         title={t`Twitter`}
         desc={
-          twitter ? <div className="text-sm font-medium">{twitter}</div> : null
+          twitter ? (
+            <div className="overflow-hidden text-ellipsis text-sm font-medium">
+              {twitter}
+            </div>
+          ) : null
         }
       />
       <DescriptionCol
         title={t`Discord`}
         desc={
-          discord ? <div className="text-sm font-medium">{discord}</div> : null
+          discord ? (
+            <div className="overflow-hidden text-ellipsis text-sm font-medium">
+              {discord}
+            </div>
+          ) : null
         }
       />
       <DescriptionCol
         title={t`Website`}
         desc={
-          infoUri ? <div className="text-sm font-medium">{infoUri}</div> : null
+          infoUri ? (
+            <div className="overflow-hidden text-ellipsis text-sm font-medium">
+              {infoUri}
+            </div>
+          ) : null
         }
       />
       <DescriptionCol
         title={t`Pay button text`}
         desc={
           payButton ? (
-            <div className="text-base font-medium">{payButton}</div>
+            <div className="overflow-hidden text-ellipsis text-base font-medium">
+              {payButton}
+            </div>
           ) : null
         }
       />
@@ -66,7 +86,9 @@ export const MobileProjectDetailsReview = () => {
         title={t`Pay disclaimer`}
         desc={
           payDisclosure ? (
-            <div className="text-base font-medium">{payDisclosure}</div>
+            <div className="overflow-hidden text-ellipsis text-base font-medium">
+              {payDisclosure}
+            </div>
           ) : null
         }
       />

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
@@ -34,13 +34,21 @@ export const ProjectDetailsReview = () => {
             <DescriptionCol
               span={6}
               title={t`Project name`}
-              desc={<div className="text-base font-medium">{name}</div>}
+              desc={
+                <div className="overflow-hidden text-ellipsis text-base font-medium">
+                  {name}
+                </div>
+              }
             />
             <DescriptionCol
               span={18}
               title={t`Project description`}
               placeholder={t`No description`}
-              desc={description}
+              desc={
+                <div className="overflow-hidden text-ellipsis">
+                  {description}
+                </div>
+              }
             />
           </Row>
           {/* Bottom */}
@@ -68,7 +76,9 @@ export const ProjectDetailsReview = () => {
                     title={t`Twitter`}
                     desc={
                       twitter ? (
-                        <div className="text-sm font-medium">{twitter}</div>
+                        <div className="overflow-hidden text-ellipsis text-sm font-medium">
+                          {twitter}
+                        </div>
                       ) : null
                     }
                   />
@@ -77,7 +87,9 @@ export const ProjectDetailsReview = () => {
                     title={t`Discord`}
                     desc={
                       discord ? (
-                        <div className="text-sm font-medium">{discord}</div>
+                        <div className="overflow-hidden text-ellipsis text-sm font-medium">
+                          {discord}
+                        </div>
                       ) : null
                     }
                   />
@@ -86,7 +98,9 @@ export const ProjectDetailsReview = () => {
                     title={t`Website`}
                     desc={
                       infoUri ? (
-                        <div className="text-sm font-medium">{infoUri}</div>
+                        <div className="overflow-hidden text-ellipsis text-sm font-medium">
+                          {infoUri}
+                        </div>
                       ) : null
                     }
                   />
@@ -98,7 +112,7 @@ export const ProjectDetailsReview = () => {
                       title={t`Pay button text`}
                       desc={
                         payButton ? (
-                          <div className="text-base font-medium">
+                          <div className="overflow-hidden text-ellipsis text-base font-medium">
                             {payButton}
                           </div>
                         ) : null
@@ -111,7 +125,7 @@ export const ProjectDetailsReview = () => {
                       title={t`Pay disclaimer`}
                       desc={
                         payDisclosure ? (
-                          <div className="text-base font-medium">
+                          <div className="overflow-hidden text-ellipsis text-base font-medium">
                             {payDisclosure}
                           </div>
                         ) : null

--- a/src/components/Create/components/pages/hooks/FormDispatchWatch.ts
+++ b/src/components/Create/components/pages/hooks/FormDispatchWatch.ts
@@ -31,8 +31,10 @@ export const useFormDispatchWatch = <
 
   useEffect(() => {
     if (ignoreUndefined && fieldValue === undefined) return
+
     const v = formatter(fieldValue)
     if (isEqual(v, currentValue)) return
+
     dispatch(dispatchFunction(v))
   }, [
     currentValue,

--- a/src/components/Create/hooks/SetInitialStateFromQuery.ts
+++ b/src/components/Create/hooks/SetInitialStateFromQuery.ts
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import {
+  defaultProjectState,
+  editingV2ProjectActions,
+} from 'redux/slices/editingV2Project'
+
+/**
+ * Load redux state from a URL query parameter.
+ */
+export function useSetInitialStateFromQuery() {
+  const dispatch = useDispatch()
+  const router = useRouter()
+
+  useEffect(() => {
+    const { initialState } = router.query
+    if (!initialState) return
+
+    try {
+      const parsedInitialState = JSON.parse(initialState as string)
+
+      dispatch(
+        editingV2ProjectActions.setState({
+          ...defaultProjectState,
+          ...parsedInitialState,
+        }),
+      )
+    } catch (e) {
+      console.warn('Error parsing initialState:', e)
+    }
+  }, [router, dispatch])
+}

--- a/src/components/Create/hooks/SetInitialStateFromQuery.ts
+++ b/src/components/Create/hooks/SetInitialStateFromQuery.ts
@@ -2,8 +2,9 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import {
-  defaultProjectState,
+  defaultReduxState,
   editingV2ProjectActions,
+  ProjectState,
 } from 'redux/slices/editingV2Project'
 
 /**
@@ -18,11 +19,15 @@ export function useSetInitialStateFromQuery() {
     if (!initialState) return
 
     try {
-      const parsedInitialState = JSON.parse(initialState as string)
+      // TODO we can probably validate this object better in future.
+      // But worst case, if it's invalid, we'll just ignore it.
+      const parsedInitialState = JSON.parse(
+        initialState as string,
+      ) as ProjectState
 
       dispatch(
         editingV2ProjectActions.setState({
-          ...defaultProjectState,
+          ...defaultReduxState,
           ...parsedInitialState,
         }),
       )

--- a/src/components/NftRewards/NftPostPayModal.tsx
+++ b/src/components/NftRewards/NftPostPayModal.tsx
@@ -33,7 +33,9 @@ export function NftPostPayModal({
       cancelButtonProps={{
         hidden: true,
       }}
-      okText={config.ctaText}
+      okText={
+        <div className="overflow-hidden text-ellipsis">{config.ctaText}</div>
+      }
       destroyOnClose
     >
       {config.content}

--- a/src/redux/localStoragePreload.ts
+++ b/src/redux/localStoragePreload.ts
@@ -3,7 +3,7 @@ import {
   REDUX_STORE_V1_PROJECT_VERSION,
 } from './slices/editingProject'
 import {
-  defaultProjectState as defaultV2ProjectState,
+  defaultReduxState as defaultV2ProjectState,
   REDUX_STORE_V2_PROJECT_VERSION,
 } from './slices/editingV2Project'
 

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -82,18 +82,6 @@ export const REDUX_STORE_V2_PROJECT_VERSION = 10
 
 export const DEFAULT_MUST_START_AT_OR_AFTER = '1'
 
-const defaultProjectMetadataState: ProjectMetadataV5 = {
-  name: '',
-  infoUri: '',
-  logoUri: '',
-  description: '',
-  twitter: '',
-  discord: '',
-  tokens: [],
-  nftPaymentSuccessModal: undefined,
-  version: LATEST_METADATA_VERSION,
-}
-
 export const defaultFundingCycleData: SerializedV2V3FundingCycleData =
   serializeV2V3FundingCycleData({
     duration: BigNumber.from(0),
@@ -154,6 +142,19 @@ const defaultCreateState: CreateState = {
   payoutsSelection: undefined,
   projectTokensSelection: undefined,
 }
+
+const defaultProjectMetadataState: ProjectMetadataV5 = {
+  name: '',
+  infoUri: '',
+  logoUri: '',
+  description: '',
+  twitter: '',
+  discord: '',
+  tokens: [],
+  nftPaymentSuccessModal: undefined,
+  version: LATEST_METADATA_VERSION,
+}
+
 export const defaultProjectState: ProjectState = {
   projectMetadata: { ...defaultProjectMetadataState },
   fundingCycleData: { ...defaultFundingCycleData },

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -59,7 +59,7 @@ interface CreateState {
   projectTokensSelection: ProjectTokensSelection | undefined
 }
 
-interface ProjectState {
+export interface ProjectState {
   projectMetadata: ProjectMetadataV5
   fundingCycleData: SerializedV2V3FundingCycleData
   fundingCycleMetadata: SerializedV2V3FundingCycleMetadata

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -54,22 +54,26 @@ interface CreateState {
   reconfigurationRuleSelection: ReconfigurationStrategy | undefined
   createFurthestPageReached: CreatePage
   createSoftLockPageQueue: CreatePage[] | undefined
+  fundingTargetSelection: FundingTargetType | undefined
+  payoutsSelection: PayoutsSelection | undefined
+  projectTokensSelection: ProjectTokensSelection | undefined
 }
 
-type V2ProjectState = {
-  version: number
+interface ProjectState {
   projectMetadata: ProjectMetadataV5
   fundingCycleData: SerializedV2V3FundingCycleData
   fundingCycleMetadata: SerializedV2V3FundingCycleMetadata
   fundAccessConstraints: SerializedV2V3FundAccessConstraint[]
-  fundingTargetSelection: FundingTargetType | undefined
   payoutGroupedSplits: ETHPayoutGroupedSplits
-  payoutsSelection: PayoutsSelection | undefined
   reservedTokensGroupedSplits: ReservedTokensGroupedSplits
-  projectTokensSelection: ProjectTokensSelection | undefined
   nftRewards: NftRewardsData
   mustStartAtOrAfter: string
-} & CreateState
+}
+
+type ReduxState = {
+  version: number
+} & ProjectState &
+  CreateState
 
 // Increment this version by 1 when making breaking changes.
 // When users return to the site and their local version is less than
@@ -146,18 +150,17 @@ const defaultCreateState: CreateState = {
   fundingCyclesPageSelection: undefined,
   createFurthestPageReached: 'projectDetails',
   createSoftLockPageQueue: [],
+  fundingTargetSelection: undefined,
+  payoutsSelection: undefined,
+  projectTokensSelection: undefined,
 }
-export const defaultProjectState: V2ProjectState = {
-  version: REDUX_STORE_V2_PROJECT_VERSION,
+export const defaultProjectState: ProjectState = {
   projectMetadata: { ...defaultProjectMetadataState },
   fundingCycleData: { ...defaultFundingCycleData },
   fundingCycleMetadata: { ...defaultFundingCycleMetadata },
   fundAccessConstraints: [],
-  fundingTargetSelection: undefined,
   payoutGroupedSplits: EMPTY_PAYOUT_GROUPED_SPLITS,
-  payoutsSelection: undefined,
   reservedTokensGroupedSplits: EMPTY_RESERVED_TOKENS_GROUPED_SPLITS,
-  projectTokensSelection: undefined,
   nftRewards: {
     rewardTiers: [],
     CIDs: undefined,
@@ -165,17 +168,22 @@ export const defaultProjectState: V2ProjectState = {
     postPayModal: undefined,
   },
   mustStartAtOrAfter: DEFAULT_MUST_START_AT_OR_AFTER,
+}
+
+export const defaultReduxState: ReduxState = {
+  version: REDUX_STORE_V2_PROJECT_VERSION,
+  ...defaultProjectState,
   ...defaultCreateState,
 }
 
 const editingV2ProjectSlice = createSlice({
   name: 'editingV2Project',
-  initialState: defaultProjectState,
+  initialState: defaultReduxState,
   reducers: {
-    setState: (_, action: PayloadAction<V2ProjectState>) => {
+    setState: (_, action: PayloadAction<ReduxState>) => {
       return action.payload
     },
-    resetState: () => defaultProjectState,
+    resetState: () => defaultReduxState,
     setName: (state, action: PayloadAction<string>) => {
       state.projectMetadata.name = action.payload
     },

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -49,7 +49,14 @@ export type NftRewardsData = {
   postPayModal: NftPostPayModalConfig | undefined
 }
 
-interface V2ProjectState {
+interface CreateState {
+  fundingCyclesPageSelection: 'automated' | 'manual' | undefined
+  reconfigurationRuleSelection: ReconfigurationStrategy | undefined
+  createFurthestPageReached: CreatePage
+  createSoftLockPageQueue: CreatePage[] | undefined
+}
+
+type V2ProjectState = {
   version: number
   projectMetadata: ProjectMetadataV5
   fundingCycleData: SerializedV2V3FundingCycleData
@@ -61,12 +68,8 @@ interface V2ProjectState {
   reservedTokensGroupedSplits: ReservedTokensGroupedSplits
   projectTokensSelection: ProjectTokensSelection | undefined
   nftRewards: NftRewardsData
-  fundingCyclesPageSelection: 'automated' | 'manual' | undefined
-  reconfigurationRuleSelection: ReconfigurationStrategy | undefined
-  createFurthestPageReached: CreatePage
-  createSoftLockPageQueue: CreatePage[] | undefined
   mustStartAtOrAfter: string
-}
+} & CreateState
 
 // Increment this version by 1 when making breaking changes.
 // When users return to the site and their local version is less than
@@ -138,6 +141,12 @@ export const EMPTY_NFT_COLLECTION_METADATA = {
   description: undefined,
 }
 
+const defaultCreateState: CreateState = {
+  reconfigurationRuleSelection: undefined,
+  fundingCyclesPageSelection: undefined,
+  createFurthestPageReached: 'projectDetails',
+  createSoftLockPageQueue: [],
+}
 export const defaultProjectState: V2ProjectState = {
   version: REDUX_STORE_V2_PROJECT_VERSION,
   projectMetadata: { ...defaultProjectMetadataState },
@@ -155,17 +164,17 @@ export const defaultProjectState: V2ProjectState = {
     collectionMetadata: EMPTY_NFT_COLLECTION_METADATA,
     postPayModal: undefined,
   },
-  reconfigurationRuleSelection: undefined,
-  fundingCyclesPageSelection: undefined,
-  createFurthestPageReached: 'projectDetails',
-  createSoftLockPageQueue: [],
   mustStartAtOrAfter: DEFAULT_MUST_START_AT_OR_AFTER,
+  ...defaultCreateState,
 }
 
 const editingV2ProjectSlice = createSlice({
   name: 'editingV2Project',
   initialState: defaultProjectState,
   reducers: {
+    setState: (_, action: PayloadAction<V2ProjectState>) => {
+      return action.payload
+    },
     resetState: () => defaultProjectState,
     setName: (state, action: PayloadAction<string>) => {
       state.projectMetadata.name = action.payload

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -22,13 +22,14 @@ export function createStore() {
 const store = createStore()
 
 store.subscribe(() => {
-  localStorage &&
-    localStorage.setItem(
-      REDUX_STATE_LOCALSTORAGE_KEY,
-      JSON.stringify({
-        reduxState: store.getState(),
-      }),
-    )
+  if (typeof window === undefined || !window.localStorage) return
+
+  localStorage.setItem(
+    REDUX_STATE_LOCALSTORAGE_KEY,
+    JSON.stringify({
+      reduxState: store.getState(),
+    }),
+  )
 })
 
 export type RootState = ReturnType<typeof rootReducer>

--- a/src/styles/antd-overrides/modal.scss
+++ b/src/styles/antd-overrides/modal.scss
@@ -25,3 +25,9 @@
 .ant-modal-mask {
   z-index: 1;
 }
+
+.ant-modal-footer {
+  .ant-btn {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## What does this PR do and why?

This PR adds the ability to pre-populate project creation data from a query parameter `initialState`.

This kills a few birds:
- https://github.com/jbx-protocol/juice-interface/issues/2558. It turns out we need this for versioning. V1 projects need to launch a whole new project on V3, so this will help with that.
- Templating in future
- Sharable project config links

Here's a test link (note the project title). It's absurdly long but turns out that's probably fine (test URL below is 2093 characters long).

Besides: for when we're linking to these templates within JBM (with links and buttons and such), we can use Next magic to hide the query param in the browser URL bar anyway: https://nextjs.org/docs/api-reference/next/router#routerpush.

We could also serialize and compress this json further by tokenizing the object keys (like `projectMetadata` becomes `p`), but feels overkill for MVP.

<img width="713" alt="Screenshot 2022-11-25 at 1 56 17 PM" src="https://user-images.githubusercontent.com/12551741/203894373-dd7a95c0-692b-4c46-99cc-c0abf3e47a59.png">

http://localhost:3000/create?initialState=%7B%22projectMetadata%22%3A%7B%22name%22%3A%22test%20initial%20state%22%2C%22infoUri%22%3A%22%22%2C%22logoUri%22%3A%22%22%2C%22description%22%3A%22%22%2C%22twitter%22%3A%22%22%2C%22discord%22%3A%22%22%2C%22tokens%22%3A%5B%5D%2C%22version%22%3A5%7D%2C%22fundingCycleData%22%3A%7B%22duration%22%3A%220%22%2C%22weight%22%3A%221000000000000000000000000%22%2C%22discountRate%22%3A%220x00%22%2C%22ballot%22%3A%220x0000000000000000000000000000000000000000%22%7D%2C%22fundingCycleMetadata%22%3A%7B%22global%22%3A%7B%22allowSetTerminals%22%3Afalse%2C%22allowSetController%22%3Afalse%2C%22pauseTransfers%22%3Afalse%7D%2C%22reservedRate%22%3A%220x00%22%2C%22redemptionRate%22%3A%220x2710%22%2C%22ballotRedemptionRate%22%3A%220x2710%22%2C%22pausePay%22%3Afalse%2C%22pauseDistributions%22%3Afalse%2C%22pauseRedeem%22%3Afalse%2C%22allowMinting%22%3Afalse%2C%22pauseBurn%22%3Afalse%2C%22allowTerminalMigration%22%3Afalse%2C%22allowControllerMigration%22%3Afalse%2C%22holdFees%22%3Afalse%2C%22useTotalOverflowForRedemptions%22%3Afalse%2C%22useDataSourceForPay%22%3Afalse%2C%22useDataSourceForRedeem%22%3Afalse%2C%22dataSource%22%3A%220x0000000000000000000000000000000000000000%22%2C%22preferClaimedTokenOverride%22%3Afalse%2C%22metadata%22%3A%220%22%7D%2C%22fundAccessConstraints%22%3A%5B%7B%22terminal%22%3A%220x8E8d0C73ddee3819Aaa1A2943350012803Cb8AcE%22%2C%22token%22%3A%220x000000000000000000000000000000000000eeee%22%2C%22distributionLimit%22%3A%226901746346790563787434755862277025452451108972170386.555162524223799295%22%2C%22distributionLimitCurrency%22%3A%221%22%2C%22overflowAllowance%22%3A%220%22%2C%22overflowAllowanceCurrency%22%3A%220%22%7D%5D%2C%22payoutGroupedSplits%22%3A%7B%22group%22%3A1%2C%22splits%22%3A%5B%5D%7D%2C%22reservedTokensGroupedSplits%22%3A%7B%22group%22%3A2%2C%22splits%22%3A%5B%5D%7D%2C%22nftRewards%22%3A%7B%22rewardTiers%22%3A%5B%5D%2C%22collectionMetadata%22%3A%7B%22name%22%3A%22v2%20NFT%20rewards%22%2C%22description%22%3A%22NFTs%20rewarded%20to%20v2's%20Juicebox%20contributors.%22%7D%7D%2C%22mustStartAtOrAfter%22%3A%221%22%7D

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
