### PR TITLE
Fix dark-themed treasury stats

### DIFF
--- a/src/components/Project/StatLine.tsx
+++ b/src/components/Project/StatLine.tsx
@@ -14,7 +14,7 @@ export default function StatLine({
 }) {
   return (
     <div className="flex flex-nowrap items-baseline justify-between">
-      <div className="text-sm font-medium uppercase text-grey-400 dark:text-grey-600">
+      <div className="text-sm font-medium uppercase text-grey-400 dark:text-slate-200">
         <TooltipLabel
           innerClassName="w-[400px]"
           label={statLabel}

--- a/src/components/v1/V1Project/TreasuryStatsSection.tsx
+++ b/src/components/v1/V1Project/TreasuryStatsSection.tsx
@@ -121,7 +121,7 @@ export function TreasuryStatsSection() {
               }
             />
           ) : (
-            <div className="text-right text-sm font-medium uppercase text-grey-400 dark:text-grey-600">
+            <div className="text-right text-sm font-medium uppercase text-grey-400 dark:text-slate-200">
               <TooltipLabel
                 tip={
                   <Trans>

--- a/src/components/v2v3/V2V3Project/TreasuryStats/DistributedRatio.tsx
+++ b/src/components/v2v3/V2V3Project/TreasuryStats/DistributedRatio.tsx
@@ -46,7 +46,7 @@ export default function DistributedRatio() {
             </>
           </div>
         ) : (
-          <div className="text-right text-sm font-medium uppercase text-grey-400 dark:text-grey-600">
+          <div className="text-right text-sm font-medium uppercase text-grey-400 dark:text-slate-200">
             <TooltipLabel
               tip={
                 <Trans>

--- a/src/components/v2v3/V2V3Project/TreasuryStats/ProjectBalance.tsx
+++ b/src/components/v2v3/V2V3Project/TreasuryStats/ProjectBalance.tsx
@@ -26,7 +26,7 @@ export default function ProjectBalance() {
       statValue={
         <div className="ml-2 text-lg font-medium text-juice-400 dark:text-juice-300">
           {distributionLimitCurrency?.eq(V2V3_CURRENCY_USD) && (
-            <span className="text-sm font-medium uppercase text-grey-400 dark:text-grey-600">
+            <span className="text-sm font-medium uppercase text-grey-400 dark:text-slate-200">
               <ETHAmount amount={ETHBalance} padEnd />{' '}
             </span>
           )}


### PR DESCRIPTION
## What does this PR do and why?

Closes #2594

Before:
<img width="551" alt="Screen Shot 2022-12-01 at 9 43 12 pm" src="https://user-images.githubusercontent.com/96150256/205048183-00d33cbe-13fa-468f-be41-759936741b79.png">

After:
<img width="566" alt="Screen Shot 2022-12-01 at 10 02 00 pm" src="https://user-images.githubusercontent.com/96150256/205048123-4f124e5c-f737-48f5-b97d-282451768324.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
