### PR TITLE
Improve deselect nft UX

### DIFF
--- a/src/components/NftRewards/RewardTier.tsx
+++ b/src/components/NftRewards/RewardTier.tsx
@@ -2,7 +2,8 @@ import { CheckOutlined, LoadingOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Skeleton, Tooltip } from 'antd'
 import { NftRewardTier } from 'models/nftRewardTier'
-import { MouseEvent, MouseEventHandler, useState } from 'react'
+import { MouseEventHandler, useState } from 'react'
+import { stopPropagation } from 'react-stop-propagation'
 import { classNames } from 'utils/classNames'
 import { ipfsToHttps } from 'utils/ipfs'
 import { NftPreview } from './NftPreview'
@@ -30,13 +31,6 @@ export function RewardTier({
     : rewardTier?.imageUrl
 
   function RewardIcon() {
-    const onRemoveTier = (
-      event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
-    ) => {
-      event.stopPropagation()
-      onRemove?.()
-    }
-
     return (
       <Tooltip
         title={
@@ -67,7 +61,7 @@ export function RewardTier({
             'absolute right-2 top-2 h-6 w-6 items-center justify-center rounded-full text-base',
             isSelected ? 'flex bg-haze-400 text-smoke-25' : 'hidden',
           )}
-          onClick={onRemoveTier}
+          onClick={onRemove ? stopPropagation(onRemove) : undefined}
         >
           <CheckOutlined />
         </div>
@@ -131,6 +125,9 @@ export function RewardTier({
               : 'bg-smoke-100 dark:bg-slate-600',
             !loading ? 'pt-2' : 'pt-1',
           )}
+          onClick={
+            isSelected && onRemove ? stopPropagation(onRemove) : undefined
+          }
         >
           <Skeleton
             loading={loading}


### PR DESCRIPTION
## What does this PR do and why?

Closes #2596

<img width="975" alt="Screen Shot 2022-12-01 at 10 26 58 pm" src="https://user-images.githubusercontent.com/96150256/205054231-2673b217-66eb-450a-a946-d7ec4e03cf9e.png">

https://user-images.githubusercontent.com/96150256/205052417-85d4e94d-0f1e-42fb-b4c5-aefcccfc2cec.mp4

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
