### PR TITLE
Center loading spinner on project page

### DIFF
--- a/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
+++ b/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
@@ -54,7 +54,7 @@ const _Wrapper: React.FC = ({ children }) => {
 
   return (
     <>
-      <Layout className="flex h-full flex-col bg-transparent">
+      <Layout className="flex h-screen flex-col bg-transparent">
         <SiteNavigation />
         <Content className={classNames(isMobile ? 'pt-16' : '')}>
           {children}


### PR DESCRIPTION
## What does this PR do and why?
Fixes - https://github.com/jbx-protocol/juice-interface/issues/2592

Changed `h-full` class with `h-screen` in layout, this way it uses the viewport length.

## Screenshots or screen recordings

https://user-images.githubusercontent.com/18723426/205331911-f02dbc41-6319-48e7-b1b4-7ab562028027.mov

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
