### PR TITLE
Add read held fees + process held fees to tools drawer (MERGE 2601 first)

### DIFF
--- a/src/components/Project/ProjectToolsDrawer/HeldFeesSection.tsx
+++ b/src/components/Project/ProjectToolsDrawer/HeldFeesSection.tsx
@@ -1,0 +1,66 @@
+import { Trans } from '@lingui/macro'
+import TransactorButton from 'components/TransactorButton'
+import { useHeldFeesOf } from 'hooks/v2v3/contractReader/HeldFeesOf'
+import { useV2ConnectedWalletHasPermission } from 'hooks/v2v3/contractReader/V2ConnectedWalletHasPermission'
+import { useProcessHeldFeesTx } from 'hooks/v2v3/transactor/ProcessHeldFeesTx'
+import { V2OperatorPermission } from 'models/v2v3/permissions'
+import { useState } from 'react'
+import { emitErrorNotification } from 'utils/notifications'
+
+export function HeldFeesSection() {
+  const [processingHeldFees, setProcessingHeldFees] = useState<boolean>()
+
+  const heldFees = useHeldFeesOf()
+  const processHeldFeesTx = useProcessHeldFeesTx()
+
+  const canProcessHeldFees = useV2ConnectedWalletHasPermission(
+    V2OperatorPermission.PROCESS_FEES,
+  )
+
+  async function processHeldFees() {
+    setProcessingHeldFees(true)
+
+    const result = await processHeldFeesTx(undefined, {
+      onConfirmed: () => {
+        setProcessingHeldFees(false)
+      },
+      onDone: () => {
+        setProcessingHeldFees(false)
+      },
+      onError: e => {
+        setProcessingHeldFees(false)
+        emitErrorNotification(e.message)
+      },
+    })
+
+    if (!result) {
+      setProcessingHeldFees(false)
+    }
+  }
+  if (!heldFees) return null
+
+  return (
+    <>
+      <p>
+        <Trans>
+          This project has <strong>{heldFees} ETH</strong> held fees. The
+          project owner or JuiceboxDAO can process these fees at an time.
+        </Trans>
+      </p>
+      <p>
+        <Trans>
+          The held fees will reset as new funds are added to the project's
+          balance with the <strong>Add to balance</strong> transaction above.
+        </Trans>
+      </p>
+      <TransactorButton
+        onClick={processHeldFees}
+        loading={processingHeldFees}
+        size="small"
+        type="primary"
+        text={<Trans>Process held fees</Trans>}
+        disabled={!canProcessHeldFees}
+      />
+    </>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectToolsDrawer/V2V3ProjectToolsDrawer.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectToolsDrawer/V2V3ProjectToolsDrawer.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Divider, Drawer, Space } from 'antd'
 import { AddToProjectBalanceForm } from 'components/Project/ProjectToolsDrawer/AddToProjectBalanceForm'
 import { ExportSection } from 'components/Project/ProjectToolsDrawer/ExportSection'
+import { HeldFeesSection } from 'components/Project/ProjectToolsDrawer/HeldFeesSection'
 import {
   ETH_PAYOUT_SPLIT_GROUP,
   RESERVED_TOKEN_SPLIT_GROUP,
@@ -52,6 +53,7 @@ export function V2V3ProjectToolsDrawer({
 
         <section>
           <AddToProjectBalanceForm useAddToBalanceTx={useAddToBalanceTx} />
+          <HeldFeesSection />
         </section>
 
         <Divider />

--- a/src/hooks/v2v3/contractReader/HeldFeesOf.ts
+++ b/src/hooks/v2v3/contractReader/HeldFeesOf.ts
@@ -1,0 +1,25 @@
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { useContext, useEffect, useState } from 'react'
+import { sumHeldFees } from 'utils/v2v3/math'
+
+export function useHeldFeesOf() {
+  const [heldFees, setHeldFees] = useState<number>()
+
+  const { projectId } = useContext(ProjectMetadataContext)
+  const { contracts } = useContext(V2V3ContractsContext)
+
+  useEffect(() => {
+    async function fetchData() {
+      const res = await contracts?.JBETHPaymentTerminal.functions.heldFeesOf(
+        projectId,
+      )
+      if (!res) return
+      const _heldFees = sumHeldFees(res[0])
+      setHeldFees(_heldFees)
+    }
+    fetchData()
+  }, [contracts, projectId])
+
+  return heldFees
+}

--- a/src/hooks/v2v3/transactor/ProcessHeldFeesTx.ts
+++ b/src/hooks/v2v3/transactor/ProcessHeldFeesTx.ts
@@ -1,0 +1,48 @@
+import { t } from '@lingui/macro'
+import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { TransactionContext } from 'contexts/transactionContext'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import {
+  handleTransactionException,
+  TransactorInstance,
+} from 'hooks/Transactor'
+import { useWallet } from 'hooks/Wallet'
+import { useContext } from 'react'
+import invariant from 'tiny-invariant'
+
+export function useProcessHeldFeesTx(): TransactorInstance {
+  const { transactor } = useContext(TransactionContext)
+  const { contracts, cv } = useContext(V2V3ContractsContext)
+  const { projectId } = useContext(ProjectMetadataContext)
+
+  const { userAddress } = useWallet()
+
+  return (_, txOpts) => {
+    try {
+      invariant(
+        transactor &&
+          userAddress &&
+          projectId &&
+          contracts?.JBETHPaymentTerminal,
+      )
+      return transactor(
+        contracts?.JBETHPaymentTerminal,
+        'processFees',
+        [projectId],
+        {
+          ...txOpts,
+          title: t`Process project #${projectId}'s held fees`,
+        },
+      )
+    } catch {
+      const missingParam = !projectId ? 'project' : undefined
+
+      return handleTransactionException({
+        txOpts,
+        missingParam,
+        functionName: 'processFees',
+        cv,
+      })
+    }
+  }
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2102,6 +2102,12 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
+msgid "Process held fees"
+msgstr ""
+
+msgid "Process project #{projectId}'s held fees"
+msgstr ""
+
 msgid "Project #{projectId}"
 msgstr ""
 
@@ -2780,6 +2786,9 @@ msgstr ""
 msgid "The future will be led by creators, and owned by communities."
 msgstr ""
 
+msgid "The held fees will reset as new funds are added to the project's balance with the <0>Add to balance</0> transaction above."
+msgstr ""
+
 msgid "The issuance rate of your second funding cycle will be {0} tokens per 1 ETH,{1} tokens per 1 ETH for your third funding cycle, and so on."
 msgstr ""
 
@@ -2913,6 +2922,9 @@ msgid "This is the maximum amount of funds that can leave the treasury each fund
 msgstr ""
 
 msgid "This list is using an experimental data index and may be inaccurate for some projects."
+msgstr ""
+
+msgid "This project has <0>{heldFees} ETH</0> held fees. The project owner or JuiceboxDAO can process these fees at an time."
 msgstr ""
 
 msgid "This project has no distributions."

--- a/src/models/v2v3/fee.ts
+++ b/src/models/v2v3/fee.ts
@@ -1,0 +1,14 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
+/** 
+  @member amount The total amount the fee was taken from, as a fixed point number with the same number of decimals as the terminal in which this struct was created.
+  @member fee The percent of the fee, out of MAX_FEE.
+  @member feeDiscount The discount of the fee.
+  @member beneficiary The address that will receive the tokens that are minted as a result of the fee payment.
+*/
+export type JBFee = {
+  amount: BigNumber
+  fee: number
+  feeDiscount: number
+  beneficiary: string
+}

--- a/src/utils/v2v3/math.ts
+++ b/src/utils/v2v3/math.ts
@@ -11,6 +11,7 @@ import {
   ONE_MILLION,
   TEN_THOUSAND,
 } from 'constants/numbers'
+import { JBFee } from 'models/v2v3/fee'
 
 export const MAX_RESERVED_RATE = TEN_THOUSAND
 export const MAX_REDEMPTION_RATE = TEN_THOUSAND
@@ -239,4 +240,15 @@ export const amountSubFee = (
   if (!feePerBillion || !amountWad) return
   const feeAmount = feeForAmount(amountWad, feePerBillion) ?? 0
   return amountWad.sub(feeAmount)
+}
+
+// `heldFeesOf` returns list of JBFee
+// We derive each fee amount by multiplying the distributed amount by the fee,
+// and return the sum of them all
+export function sumHeldFees(fees: JBFee[]) {
+  return fees.reduce((sum, heldFee) => {
+    const amountWad = feeForAmount(heldFee.amount, BigNumber.from(heldFee.fee))
+    const amountNum = parseFloat(fromWad(amountWad))
+    return sum + (amountNum ?? 0)
+  }, 0)
 }


### PR DESCRIPTION
## What does this PR do and why?

Test instructions: 
- go to Goerli `/v2/p/224` (project with`heldFees` enabled)
- pay it, distribute the funds
- Go to tools section, should see the `heldFee` amount as whatever you distributed from treasury MULT 0.025

- Only project owner or JBDAO can release the heldFees. Can test if you like by creating your own project with `holdFees` enabled, but here's a video demonstrating it working:

https://user-images.githubusercontent.com/96150256/205473777-71eb95eb-f02d-49c4-a51f-7ee50e697b30.mp4



## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
