### PR TITLE
Upgrade @web3-onboard/gnosis 2.1.1 -> 2.1.5 + dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@walletconnect/web3-provider": "1.8.0",
     "@web3-onboard/coinbase": "2.1.1",
     "@web3-onboard/core": "2.8.1",
-    "@web3-onboard/gnosis": "2.1.1",
+    "@web3-onboard/gnosis": "2.1.5",
     "@web3-onboard/injected-wallets": "2.2.0",
     "@web3-onboard/keystone": "2.2.1",
     "@web3-onboard/ledger": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5928,6 +5928,15 @@
     ethers "5.5.4"
     joi "^17.4.2"
 
+"@web3-onboard/common@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/common/-/common-2.2.3.tgz#fc0841186d84cf017f4cf0368dcd349e6ed8dc8b"
+  integrity sha512-ZI0XuCpxtuL9XGgeWglXR6rhgLP261EMEstjonxy8ptuOKLlTJcgvL7wSx2MjNDO3i/qmb/PGQpInvxYx5klSA==
+  dependencies:
+    bignumber.js "^9.1.0"
+    ethers "5.5.4"
+    joi "^17.6.1"
+
 "@web3-onboard/core@2.8.1", "@web3-onboard/core@^2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.8.1.tgz#559552f667850578e319a94ed98948d77da496f6"
@@ -5947,14 +5956,14 @@
     svelte "^3.49.0"
     svelte-i18n "^3.3.13"
 
-"@web3-onboard/gnosis@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/gnosis/-/gnosis-2.1.1.tgz#aa84a6913e369e6a62aea17afad32a838f2e23d0"
-  integrity sha512-QoMdpDYkaNOuYuf7UG3HyQZEBMnZFrkb1+jJ2DG+J5y2fBArdqynH5pU8k7eXeV54mfmBjXCHynaxZNisZyeCQ==
+"@web3-onboard/gnosis@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/gnosis/-/gnosis-2.1.5.tgz#c49b1734fca7042543029312581fc0e29bc4cb66"
+  integrity sha512-u5kL7kazROlotXEckjOn3Bm5FdHT1tgnOiYqjL7g/ypn+VzlpVpGQrpaW9SOa4DD8FGYCm8XkCsQZXlNUcvp/A==
   dependencies:
     "@gnosis.pm/safe-apps-provider" "^0.9.2"
     "@gnosis.pm/safe-apps-sdk" "^6.1.1"
-    "@web3-onboard/common" "^2.2.1"
+    "@web3-onboard/common" "^2.2.3"
 
 "@web3-onboard/hw-common@^2.0.1":
   version "2.0.1"
@@ -12745,6 +12754,17 @@ joi@17.6.0, joi@^17.4.2:
   version "17.6.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
   integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
+joi@^17.6.1:
+  version "17.7.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.7.0.tgz#591a33b1fe1aca2bc27f290bcad9b9c1c570a6b3"
+  integrity sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"


### PR DESCRIPTION
## What does this PR do and why?

Upgrade @web3-onboard/gnosis from 2.1.1 -> 2.1.5 and upgrade its dependencies accordingly. For a project to be listed as a default Gnosis Safe App, it must connect to Gnosis Safe automatically when loaded. The web3-onboard/gnosis package does this, but version 2.1.1 only has the old Gnosis Safe frontend URL whitelisted ([gnosis-safe.io](https://gnosis-safe.io/app)). Gnosis Safe recently released their new frontend at [app.safe.global](https://app.safe.global/).

In [this recent PR](https://github.com/blocknative/web3-onboard/pull/1347), the new Safe URL was added to the web3-onboard package. Updating this dependency will allow juicebox.money to automatically connect to Gnosis Safes through the new frontend, and be listed as a default app on that frontend (as per [this Discord conversation with a Safe contributor](https://discord.com/channels/907968493134155807/908129717507461130/1047442891603198002)).

I have tested that standard wallet connect still works with this PR, but was not able to test in the new Gnosis Safe app (due to dev mode) or on mobile.

## Screenshots or screen recordings

N/A

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- `N/A` I have tested this PR in dark mode and light mode (if applicable).
