### PR TITLE
nav icons language selector and tx bolt centered

### DIFF
--- a/src/components/Navbar/NavLanguageSelector.tsx
+++ b/src/components/Navbar/NavLanguageSelector.tsx
@@ -60,7 +60,7 @@ export default function NavLanguageSelector({
         setDropdownOpen(!dropdownOpen)
       }}
     >
-      <GlobalOutlined className="mb-2" />
+      <GlobalOutlined className="mb-0.5" />
       <Select
         className="flex cursor-pointer items-center justify-evenly font-medium"
         popupClassName={!mobile ? 'mr-5' : ''}

--- a/src/components/Navbar/TransactionList/TransactionsList.tsx
+++ b/src/components/Navbar/TransactionList/TransactionsList.tsx
@@ -39,7 +39,7 @@ export function TransactionsList({
         role="button"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <span className="flex items-center justify-center">
+        <span className="mt-0.5 flex items-center justify-center">
           {hasPendingTxs ? (
             <Loading size="small" />
           ) : (


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2604

Fixing both language and lighting strike icons, the bug was because margin-bottom before tailwind was 20px which is 0.5 in rem unit

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/18723426/205637552-cb83539b-2151-4039-91c5-f55e8ffc4462.png)

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
