### PR TITLE
V1 and V2 split allocators behind feature flag

### DIFF
--- a/src/components/formItems/index.tsx
+++ b/src/components/formItems/index.tsx
@@ -1,4 +1,5 @@
 import ProjectHandleFormItem from 'components/v1/shared/formItems/ProjectHandle/ProjectHandleFormItem'
+import { ProjectPayoutFormItem } from 'components/v1/shared/formItems/ProjectPayoutFormItem'
 import TokenRefs from 'components/v1/shared/formItems/TokenRefs'
 import ProjectTicketMods from 'components/v1/shared/ProjectTicketMods'
 
@@ -27,6 +28,7 @@ export const FormItems = {
   ProjectDiscountRate,
   ProjectDuration,
   ProjectHandleFormItem,
+  ProjectPayoutFormItem,
   ProjectLink,
   ProjectLogoUri,
   ProjectName,

--- a/src/components/v1/shared/Mod.tsx
+++ b/src/components/v1/shared/Mod.tsx
@@ -1,9 +1,15 @@
 import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
-import { Tooltip } from 'antd'
+import { Space, Tooltip } from 'antd'
 import FormattedAddress from 'components/FormattedAddress'
 import TooltipLabel from 'components/TooltipLabel'
+import { AllocatorBadge } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/AllocatorBadge'
+import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
+import {
+  NULL_ALLOCATOR_ADDRESS,
+  V1_V3_ALLOCATOR_ADDRESS,
+} from 'constants/contracts/mainnet/Allocators'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { PayoutMod, TicketMod } from 'models/mods'
 import { useContext } from 'react'
@@ -22,18 +28,27 @@ export default function Mod({
 
   if (!mod) return null
 
+  const _mod = mod as PayoutMod
+  const projectId = _mod.projectId as BigNumber
+  const allocator = _mod.allocator
+
+  const isV1Project = projectId && allocator === NULL_ALLOCATOR_ADDRESS
+  const isV3Project = projectId && allocator === V1_V3_ALLOCATOR_ADDRESS
+
   return (
     <div className="mb-1 flex items-baseline justify-between">
       <div className="leading-6">
         <div className="flex items-baseline">
-          {(mod as PayoutMod).projectId &&
-          BigNumber.from((mod as PayoutMod).projectId).gt(0) ? (
+          {projectId?.gt(0) ? (
             <div>
               <div className="font-medium">
-                {(mod as PayoutMod).projectId ? (
-                  <V1ProjectHandle
-                    projectId={(mod as PayoutMod).projectId as BigNumber}
-                  />
+                {isV1Project ? (
+                  <V1ProjectHandle projectId={projectId} />
+                ) : isV3Project ? (
+                  <Space size="middle">
+                    <V2V3ProjectHandleLink projectId={projectId.toNumber()} />
+                    <AllocatorBadge allocator={allocator} />
+                  </Space>
                 ) : (
                   '--'
                 )}

--- a/src/components/v1/shared/ProjectPayMods/ProjectModInput.tsx
+++ b/src/components/v1/shared/ProjectPayMods/ProjectModInput.tsx
@@ -12,10 +12,13 @@ import {
 } from 'utils/format/formatNumber'
 import { amountSubFee } from 'utils/v1/math'
 import { BigNumber } from '@ethersproject/bignumber'
+import * as constants from '@ethersproject/constants'
 import { CurrencyName } from 'constants/currency'
 import { classNames } from 'utils/classNames'
 import V1ProjectHandle from '../V1ProjectHandle'
 import { EditingPayoutMod } from './types'
+import { V1_V3_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
+import { AllocatorBadge } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/AllocatorBadge'
 
 const FormattedRow = ({
   label,
@@ -89,6 +92,11 @@ export function ProjectModInput({
 }) {
   const feePerbicent = percentToPerbicent(feePercentage)
 
+  const isV1Project =
+    mod.projectId?.gt(0) && mod.allocator === constants.AddressZero
+  const isV3Project =
+    mod.projectId?.gt(0) && mod.allocator === V1_V3_ALLOCATOR_ADDRESS
+
   return (
     <div
       className={classNames(
@@ -107,9 +115,16 @@ export function ProjectModInput({
         )}
         onClick={() => onSelect?.(index)}
       >
-        {mod.projectId?.gt(0) ? (
+        {mod.projectId && isV1Project ? (
           <FormattedRow label={'Project'}>
             <V1ProjectHandle projectId={mod.projectId} />
+          </FormattedRow>
+        ) : isV3Project ? (
+          <FormattedRow label={'Project ID'}>
+            <Space size="middle">
+              <span>{mod.projectId?.toNumber()}</span>
+              <AllocatorBadge allocator={mod.allocator} />
+            </Space>
           </FormattedRow>
         ) : (
           <FormattedRow label={'Address'}>

--- a/src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
+++ b/src/components/v1/shared/ProjectPayMods/ProjectPayoutModsModal.tsx
@@ -38,6 +38,7 @@ type ProjectPayoutModsForm = {
   projectId: string
   handle: string
   beneficiary: string
+  allocator: string
   percent: number
   amount: number
   lockedUntil: moment.Moment
@@ -67,6 +68,7 @@ export const ProjectPayoutModsModal = ({
   const [modalMode, setModalMode] = useState<ModalMode>('Add') //either 'Add', or 'Edit'
   const [editingModType, setEditingModType] = useState<ModType>('address')
   const [editingModHandle, setEditingModHandle] = useState<string | BigNumber>()
+  const [editingModAllocator, setEditingModAllocator] = useState<string>()
   const [, setEditingPercent] = useState<number>()
   const [form] = useForm<ProjectPayoutModsForm>()
 
@@ -77,6 +79,7 @@ export const ProjectPayoutModsModal = ({
         BigNumber.from(mod.projectId ?? '0').gt(0) ? 'project' : 'address',
       )
       setEditingModHandle(mod.handle ?? mod.projectId)
+      setEditingModAllocator(mod.allocator)
       const percent = parseFloat(permyriadToPercent(mod.percent))
       setEditingPercent(percent)
       form.setFieldsValue({
@@ -97,6 +100,7 @@ export const ProjectPayoutModsModal = ({
       setModalMode('Add')
       setEditingModType('address')
       setEditingModHandle(undefined)
+      setEditingModAllocator(undefined)
       setEditingPercent(undefined)
     }
 
@@ -150,6 +154,7 @@ export const ProjectPayoutModsModal = ({
 
     const handle = form.getFieldValue('handle')
     const beneficiary = form.getFieldValue('beneficiary')
+    const allocator = form.getFieldValue('allocator')
     const percent = percentToPermyriad(form.getFieldValue('percent')).toNumber()
     const _projectId = form.getFieldValue('projectId')
     const projectId = _projectId ? BigNumber.from(_projectId) : undefined
@@ -162,7 +167,14 @@ export const ProjectPayoutModsModal = ({
       : undefined
 
     // Store handle in mod object only to repopulate handle input while editing
-    const newMod = { beneficiary, percent, handle, lockedUntil, projectId }
+    const newMod = {
+      beneficiary,
+      percent,
+      allocator,
+      handle,
+      lockedUntil,
+      projectId,
+    }
 
     let modsToReturn = [...mods, newMod]
     if (editingModIndex !== undefined && editingModIndex < mods.length) {
@@ -229,16 +241,10 @@ export const ProjectPayoutModsModal = ({
             <EthAddressInput />
           </Form.Item>
         ) : (
-          <FormItems.ProjectHandleFormItem
-            name="handle"
-            requireState="exists"
-            initialValue={editingModHandle}
-            returnValue="id"
-            onValueChange={id => form.setFieldsValue({ projectId: id })}
-            formItemProps={{
-              label: t`Project handle`,
-            }}
-            required
+          <FormItems.ProjectPayoutFormItem
+            initialHandle={editingModHandle}
+            initialAllocator={editingModAllocator}
+            onChange={id => form.setFieldsValue({ projectId: id })}
           />
         )}
         {editingModType === 'project' ? (

--- a/src/components/v1/shared/formItems/ProjectPayoutFormItem.tsx
+++ b/src/components/v1/shared/formItems/ProjectPayoutFormItem.tsx
@@ -1,0 +1,72 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { t, Trans } from '@lingui/macro'
+import { Form, InputNumber, Radio } from 'antd'
+import { FormItems } from 'components/formItems'
+import {
+  NULL_ALLOCATOR_ADDRESS,
+  V1_V3_ALLOCATOR_ADDRESS,
+} from 'constants/contracts/mainnet/Allocators'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
+import { useState } from 'react'
+import { featureFlagEnabled } from 'utils/featureFlags'
+
+export function ProjectPayoutFormItem({
+  initialHandle,
+  initialAllocator,
+  onChange,
+}: {
+  initialHandle: string | BigNumber | undefined
+  initialAllocator: string | undefined
+  onChange: (id: string) => void
+}) {
+  // need state here (as well as form value in parent component)
+  // to handle the changing of the V1/V3 project input field
+  const [allocator, setAllocator] = useState<string | undefined>(
+    initialAllocator,
+  )
+
+  const allocatorsEnabled = featureFlagEnabled(FEATURE_FLAGS.SPLIT_ALLOCATORS)
+
+  const V1ProjectHandleFormItem = (
+    <FormItems.ProjectHandleFormItem
+      name="handle"
+      requireState="exists"
+      initialValue={initialHandle}
+      returnValue="id"
+      onValueChange={onChange}
+      formItemProps={{
+        label: t`V1 Project handle`,
+      }}
+      required
+    />
+  )
+
+  if (!allocatorsEnabled) {
+    return V1ProjectHandleFormItem
+  }
+  return (
+    <>
+      <Form.Item label={t`Project treasury version`} name={'allocator'}>
+        <Radio.Group
+          value={allocator}
+          onChange={e => setAllocator(e.target.value)}
+        >
+          <Radio value={NULL_ALLOCATOR_ADDRESS}>
+            <Trans>V1</Trans>
+          </Radio>
+          <Radio value={V1_V3_ALLOCATOR_ADDRESS}>
+            <Trans>V3</Trans>
+          </Radio>
+        </Radio.Group>
+      </Form.Item>
+
+      {allocator === NULL_ALLOCATOR_ADDRESS ? (
+        V1ProjectHandleFormItem
+      ) : (
+        <Form.Item name={'projectId'} label={t`V3 Project ID`} required>
+          <InputNumber className="w-full" />
+        </Form.Item>
+      )}
+    </>
+  )
+}

--- a/src/components/v2v3/shared/DistributionSplitCard.tsx
+++ b/src/components/v2v3/shared/DistributionSplitCard.tsx
@@ -8,11 +8,13 @@ import FormattedAddress from 'components/FormattedAddress'
 import TooltipIcon from 'components/TooltipIcon'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import { CurrencyName } from 'constants/currency'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
 import { PropsWithChildren, useContext, useState } from 'react'
 import { classNames } from 'utils/classNames'
+import { featureFlagEnabled } from 'utils/featureFlags'
 import { formatDate } from 'utils/format/formatDate'
 import { parseWad } from 'utils/format/formatNumber'
 import { amountFromPercent } from 'utils/v2v3/distributions'
@@ -22,6 +24,7 @@ import {
   preciseFormatSplitPercent,
   SPLITS_TOTAL_PERCENT,
 } from 'utils/v2v3/math'
+import { AllocatorBadge } from './FundingCycleConfigurationDrawers/AllocatorBadge'
 import { DistributionSplitModal } from './FundingCycleConfigurationDrawers/DistributionSplitModal/DistributionSplitModal'
 
 const Parens = ({
@@ -88,6 +91,8 @@ export function DistributionSplitCard({
     currencyName === 'USD' ? 4 : 2,
   )
 
+  const allocatorsEnabled = featureFlagEnabled(FEATURE_FLAGS.SPLIT_ALLOCATORS)
+
   return (
     <div
       className={classNames(
@@ -118,9 +123,12 @@ export function DistributionSplitCard({
               </label>{' '}
             </Col>
             <Col span={dataColSpan}>
-              <div className="flex items-center justify-between">
+              <Space size="middle">
                 <V2V3ProjectHandleLink projectId={parseInt(split.projectId)} />
-              </div>
+                {allocatorsEnabled ? (
+                  <AllocatorBadge allocator={split.allocator} />
+                ) : null}
+              </Space>
             </Col>
           </Row>
         ) : (

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/AllocatorBadge.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/AllocatorBadge.tsx
@@ -1,0 +1,39 @@
+import { Trans } from '@lingui/macro'
+import { Tooltip } from 'antd'
+import ExternalLink from 'components/ExternalLink'
+import { ProjectVersionBadge } from 'components/ProjectVersionBadge'
+import {
+  V1_V3_ALLOCATOR_ADDRESS,
+  V2_V3_ALLOCATOR_ADDRESS,
+} from 'constants/contracts/mainnet/Allocators'
+
+export function AllocatorBadge({
+  allocator,
+}: {
+  allocator: string | undefined
+}) {
+  const allocatorAddresses = [V2_V3_ALLOCATOR_ADDRESS, V1_V3_ALLOCATOR_ADDRESS]
+  const versionName =
+    allocator && allocatorAddresses.includes(allocator) ? 'V3' : undefined
+
+  if (!versionName) return null
+  return (
+    <Tooltip
+      title={
+        <Trans>
+          Payout allocated to this project's {versionName} payment terminal.{' '}
+          <ExternalLink
+            href={'https://github.com/jbx-protocol/juice-v3-migration'}
+          >
+            Learn more
+          </ExternalLink>
+          .
+        </Trans>
+      }
+    >
+      <div>
+        <ProjectVersionBadge versionText={versionName} />
+      </div>
+    </Tooltip>
+  )
+}

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/DistributionSplitModal/AllocatorFormItem.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/DistributionSplitModal/AllocatorFormItem.tsx
@@ -1,0 +1,35 @@
+import { t, Trans } from '@lingui/macro'
+import { Form, Radio } from 'antd'
+import {
+  V2_V3_ALLOCATOR_ADDRESS,
+  NULL_ALLOCATOR_ADDRESS,
+} from 'constants/contracts/mainnet/Allocators'
+import { CV_V2 } from 'constants/cv'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
+import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { useContext } from 'react'
+import { featureFlagEnabled } from 'utils/featureFlags'
+
+export function AllocatorFormItem() {
+  const { cv } = useContext(V2V3ContractsContext)
+
+  const allocatorsEnabled = featureFlagEnabled(FEATURE_FLAGS.SPLIT_ALLOCATORS)
+
+  if (!allocatorsEnabled || cv !== CV_V2) return null
+  return (
+    <Form.Item
+      label={t`Project treasury version`}
+      name="allocator"
+      initialValue={NULL_ALLOCATOR_ADDRESS}
+    >
+      <Radio.Group>
+        <Radio value={NULL_ALLOCATOR_ADDRESS}>
+          <Trans>V2</Trans>
+        </Radio>
+        <Radio value={V2_V3_ALLOCATOR_ADDRESS}>
+          <Trans>V3</Trans>
+        </Radio>
+      </Radio.Group>
+    </Form.Item>
+  )
+}

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/DistributionSplitModal/V2V3ProjectPayoutFormItem.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/DistributionSplitModal/V2V3ProjectPayoutFormItem.tsx
@@ -1,0 +1,40 @@
+import { t } from '@lingui/macro'
+import { Form, InputNumber } from 'antd'
+import { stringIsDigit } from 'utils/math'
+import { AllocatorFormItem } from './AllocatorFormItem'
+
+export function V2V3ProjectPayoutFormItem({
+  value,
+  onChange,
+}: {
+  value: string | undefined
+  onChange: (projectId: string | undefined) => void
+}) {
+  const validateProjectId = () => {
+    if (!stringIsDigit(value ?? '')) {
+      return Promise.reject(t`Project ID must be a number.`)
+    }
+    // TODO: check if projectId exists
+    return Promise.resolve()
+  }
+
+  return (
+    <>
+      <AllocatorFormItem />
+      <Form.Item
+        name={'projectId'}
+        rules={[{ validator: validateProjectId }]}
+        label={t`Juicebox Project ID`}
+        required
+      >
+        <InputNumber
+          value={parseInt(value ?? '')}
+          className="w-full"
+          onChange={(projectId: number | null) => {
+            onChange(projectId?.toString())
+          }}
+        />
+      </Form.Item>
+    </>
+  )
+}

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/DistributionSplitModal/types.ts
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/DistributionSplitModal/types.ts
@@ -8,4 +8,5 @@ export type AddOrEditSplitFormFields = {
   percent: number
   amount: string | undefined
   lockedUntil: Moment.Moment | undefined | null
+  allocator: string | undefined
 }

--- a/src/components/v2v3/shared/SplitItem.tsx
+++ b/src/components/v2v3/shared/SplitItem.tsx
@@ -1,16 +1,18 @@
 import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Trans } from '@lingui/macro'
-import { Tooltip } from 'antd'
+import { Space, Tooltip } from 'antd'
 import ETHToUSD from 'components/currency/ETHToUSD'
 import CurrencySymbol from 'components/CurrencySymbol'
 import FormattedAddress from 'components/FormattedAddress'
 import { Parenthesis } from 'components/Parenthesis'
 import TooltipIcon from 'components/TooltipIcon'
 import TooltipLabel from 'components/TooltipLabel'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { useETHPaymentTerminalFee } from 'hooks/v2v3/contractReader/ETHPaymentTerminalFee'
 import { Split } from 'models/splits'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
+import { featureFlagEnabled } from 'utils/featureFlags'
 import { formatDate } from 'utils/format/formatDate'
 import { formatWad } from 'utils/format/formatNumber'
 import { V2V3CurrencyName } from 'utils/v2v3/currency'
@@ -20,6 +22,7 @@ import {
   formatSplitPercent,
   SPLITS_TOTAL_PERCENT,
 } from 'utils/v2v3/math'
+import { AllocatorBadge } from './FundingCycleConfigurationDrawers/AllocatorBadge'
 import V2V3ProjectHandleLink from './V2V3ProjectHandleLink'
 
 const LockedText = ({ lockedUntil }: { lockedUntil: number }) => {
@@ -42,10 +45,15 @@ const JuiceboxProjectBeneficiary = ({
   if (!split.projectId) return null
 
   const isProjectOwner = projectOwnerAddress === split.beneficiary
-
+  const allocatorsEnabled = featureFlagEnabled(FEATURE_FLAGS.SPLIT_ALLOCATORS)
   return (
     <div>
-      <V2V3ProjectHandleLink projectId={parseInt(split.projectId)} />
+      <Space size="middle">
+        <V2V3ProjectHandleLink projectId={parseInt(split.projectId)} />
+        {allocatorsEnabled ? (
+          <AllocatorBadge allocator={split.allocator} />
+        ) : null}
+      </Space>
 
       <div className="ml-2 text-sm text-grey-500 dark:text-grey-300">
         <TooltipLabel

--- a/src/constants/contracts/mainnet/Allocators.ts
+++ b/src/constants/contracts/mainnet/Allocators.ts
@@ -1,0 +1,5 @@
+import * as constants from '@ethersproject/constants'
+
+export const V2_V3_ALLOCATOR_ADDRESS = 'TODO_V2_V3_ALLOCATOR_ADDRESS'
+export const V1_V3_ALLOCATOR_ADDRESS = 'TODO_V1_V3_ALLOCATOR_ADDRESS'
+export const NULL_ALLOCATOR_ADDRESS = constants.AddressZero

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -4,4 +4,5 @@ export const FEATURE_FLAGS = {
   VENFT_CREATOR: 'veNftCreator',
   PROJECT_CONTRACT_UPGRADES: 'projectContractUpgrades',
   SIMULATE_TXS: 'simulateTxs',
+  SPLIT_ALLOCATORS: 'splitAllocators',
 }

--- a/src/hooks/v1/transactor/SetPayoutModsTx.ts
+++ b/src/hooks/v1/transactor/SetPayoutModsTx.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import * as constants from '@ethersproject/constants'
 import { t } from '@lingui/macro'
+import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V1ProjectContext } from 'contexts/v1/projectContext'
 import { V1UserContext } from 'contexts/v1/userContext'
@@ -45,7 +46,7 @@ export function useSetPayoutModsTx(): TransactorInstance<{
           lockedUntil: BigNumber.from(m.lockedUntil ?? 0).toHexString(),
           beneficiary: m.beneficiary || constants.AddressZero,
           projectId: m.projectId || BigNumber.from(0).toHexString(),
-          allocator: constants.AddressZero,
+          allocator: m.allocator ?? NULL_ALLOCATOR_ADDRESS,
         })),
       ],
       {

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2084,6 +2084,9 @@ msgstr ""
 msgid "Payout addresses"
 msgstr ""
 
+msgid "Payout allocated to this project's {versionName} payment terminal. <0>Learn more</0>."
+msgstr ""
+
 msgid "Payout is locked"
 msgstr ""
 
@@ -2235,6 +2238,9 @@ msgid "Project tokens <0>aren't ERC-20 tokens</0> by default. Once you deploy yo
 msgstr ""
 
 msgid "Project tokens are not ERC-20 tokens by default. Once you deploy your project, you can issue an ERC-20 for your holders to claim. This is optional."
+msgstr ""
+
+msgid "Project treasury version"
 msgstr ""
 
 msgid "Project upgrades"
@@ -3263,6 +3269,9 @@ msgstr ""
 msgid "V1"
 msgstr ""
 
+msgid "V1 Project handle"
+msgstr ""
+
 msgid "V1 token holders can swap their tokens for your V2 tokens on your V2 project's <0>Tokens</0> section."
 msgstr ""
 
@@ -3276,6 +3285,12 @@ msgid "V1.1"
 msgstr ""
 
 msgid "V2"
+msgstr ""
+
+msgid "V3"
+msgstr ""
+
+msgid "V3 Project ID"
 msgstr ""
 
 msgid "Value has already been submitted"

--- a/src/utils/splits.ts
+++ b/src/utils/splits.ts
@@ -48,7 +48,7 @@ export const sanitizeSplit = (split: Split): Split => {
     lockedUntil: split.lockedUntil ?? 0,
     projectId: split.projectId ?? BigNumber.from(0).toHexString(),
     beneficiary: split.beneficiary ?? constants.AddressZero,
-    allocator: constants.AddressZero,
+    allocator: split.allocator ?? constants.AddressZero,
     preferClaimed: false,
     percent: split.percent,
   }


### PR DESCRIPTION
## What does this PR do and why?

Closes #2561 
Closes #2630

- Hidden behind `splitAllocators` feature flag (enable with `localStorage.setItem('splitAllocators_mainnet', true)`)

## Screenshots or screen recordings

Video demonstrates an `allocator` value passed into the **V2** split tx:

https://user-images.githubusercontent.com/96150256/206342189-06f8c8ba-e9cc-4161-9296-342a1573edcd.mp4

<img width="862" alt="Screen Shot 2022-12-08 at 1 02 58 pm" src="https://user-images.githubusercontent.com/96150256/206359056-561a86c1-758e-41d0-a925-0c9d7c044319.png">

<img width="874" alt="Screen Shot 2022-12-08 at 2 44 55 pm" src="https://user-images.githubusercontent.com/96150256/206359086-64cc4445-7765-4108-be78-2a4b8bbfacb7.png">


**V1:**

https://user-images.githubusercontent.com/96150256/206902273-68504a29-d305-40a0-87be-9d541022e3df.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
