### PR TITLE
Add spacing to pay disclosure text

### DIFF
--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
@@ -199,7 +199,7 @@ export default function V1ConfirmPayOwnerModal({
         {projectMetadata.payDisclosure && (
           <div>
             <h4>
-              <Trans>Notice from {projectMetadata.name}</Trans>{' '}
+              <Trans>Notice from {projectMetadata.name}</Trans>
             </h4>
             <Paragraph description={projectMetadata.payDisclosure} />
           </div>

--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
@@ -199,7 +199,7 @@ export default function V1ConfirmPayOwnerModal({
         {projectMetadata.payDisclosure && (
           <div>
             <h4>
-              <Trans>Notice from {projectMetadata.name}</Trans>
+              <Trans>Notice from {projectMetadata.name}</Trans>{' '}
             </h4>
             <Paragraph description={projectMetadata.payDisclosure} />
           </div>

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
@@ -199,7 +199,7 @@ export function V2V3ConfirmPayModal({
         {projectMetadata.payDisclosure && (
           <Callout.Info className="border border-solid border-grey-200 dark:border-grey-400">
             <strong>
-              <Trans>Notice from {projectMetadata.name}</Trans>
+              <Trans>Notice from {projectMetadata.name}</Trans>{' '}
             </strong>
             <Paragraph
               className="text-sm"

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
@@ -198,8 +198,8 @@ export function V2V3ConfirmPayModal({
       <Space direction="vertical" size="large" className="w-full">
         {projectMetadata.payDisclosure && (
           <Callout.Info className="border border-solid border-grey-200 dark:border-grey-400">
-            <strong>
-              <Trans>Notice from {projectMetadata.name}</Trans>{' '}
+            <strong className="block">
+              <Trans>Notice from {projectMetadata.name}</Trans>
             </strong>
             <Paragraph
               className="text-sm"


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2637

I've just added spacing between `Note from [project]` text and text that user submitted, do we want to maybe break it into next line?

## Screenshots or screen recordings
![image](https://user-images.githubusercontent.com/18723426/206162062-00b07e3c-3878-429d-9312-751e4e333d51.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
