### PR TITLE
Cleanup quick project search

### DIFF
--- a/src/components/QuickProjectSearch.tsx
+++ b/src/components/QuickProjectSearch.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightOutlined, CloseCircleOutlined } from '@ant-design/icons'
-import { t } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import Input from 'antd/lib/input/Input'
 import Modal from 'antd/lib/modal/Modal'
 import { PV_V2 } from 'constants/pv'
@@ -192,7 +192,9 @@ export default function QuickProjectSearch() {
         )}
 
         {searchText && !isLoadingSearch && searchPages?.length === 0 && (
-          <div className="text-center text-grey-400">No results</div>
+          <div className="text-center text-grey-400">
+            <Trans>No results</Trans>
+          </div>
         )}
       </div>
     </Modal>

--- a/src/components/QuickProjectSearch.tsx
+++ b/src/components/QuickProjectSearch.tsx
@@ -28,14 +28,12 @@ export default function QuickProjectSearch() {
 
   // Debounce typing. Only set new `searchText` if `inputText` doesn't change for `DEBOUNCE_MILLIS`
   useEffect(() => {
-    let timer: NodeJS.Timeout | undefined = undefined
-
-    timer = setTimeout(() => {
+    const timer = setTimeout(() => {
       setSearchText(inputText)
     }, DEBOUNCE_MILLIS)
 
     return () => {
-      if (timer) clearTimeout(timer)
+      clearTimeout(timer)
     }
   }, [inputText])
 
@@ -89,14 +87,13 @@ export default function QuickProjectSearch() {
   }, [modalVisible, searchText, router, goToProject, reset])
 
   useEffect(() => {
-    let timer: NodeJS.Timeout | undefined = undefined
+    const timer = setTimeout(() => {
+      // timeout to wait for dom render after opening modal
 
-    if (modalVisible) {
-      timer = setTimeout(() => {
-        // timeout to wait for dom render after opening modal
+      if (modalVisible) {
         ;(document.getElementById(INPUT_ID) as HTMLInputElement | null)?.focus()
-      }, 0)
-    }
+      }
+    }, 0)
 
     return () => {
       if (timer) clearTimeout(timer)
@@ -156,42 +153,48 @@ export default function QuickProjectSearch() {
         />
       </div>
 
-      {isLoadingSearch && <Loading />}
+      <div hidden={!searchText} className="pb-5">
+        {isLoadingSearch && <Loading />}
 
-      {!!searchPages?.length && (
-        <div className="flex flex-col pb-5">
-          {searchPages.slice(0, MAX_RESULTS).map((p, i) => (
-            <div
-              key={p.id}
-              className={twMerge(
-                'flex cursor-pointer items-baseline gap-2 py-2 px-5',
-                highlightIndex === i ? 'bg-smoke-75 dark:bg-slate-600' : '',
-              )}
-              onClick={goToProject}
-              onMouseEnter={() => setHighlightIndex(i)}
-            >
-              {p.pv === PV_V2 ? (
-                <V2V3ProjectHandleLink
-                  projectId={p.projectId}
-                  handle={p.handle}
-                />
-              ) : (
-                <V1ProjectHandle projectId={p.projectId} handle={p.handle} />
-              )}
+        {!!searchPages?.length && (
+          <div className="flex flex-col">
+            {searchPages.slice(0, MAX_RESULTS).map((p, i) => (
+              <div
+                key={p.id}
+                className={twMerge(
+                  'flex cursor-pointer items-baseline gap-2 py-2 px-5',
+                  highlightIndex === i ? 'bg-smoke-75 dark:bg-slate-600' : '',
+                )}
+                onClick={goToProject}
+                onMouseEnter={() => setHighlightIndex(i)}
+              >
+                {p.pv === PV_V2 ? (
+                  <V2V3ProjectHandleLink
+                    projectId={p.projectId}
+                    handle={p.handle}
+                  />
+                ) : (
+                  <V1ProjectHandle projectId={p.projectId} handle={p.handle} />
+                )}
 
-              <div style={{ flex: 1 }}>
-                <ProjectVersionBadge
-                  transparent
-                  size="small"
-                  versionText={`V${p.pv}`}
-                />
+                <div style={{ flex: 1 }}>
+                  <ProjectVersionBadge
+                    transparent
+                    size="small"
+                    versionText={`V${p.pv}`}
+                  />
+                </div>
+
+                {highlightIndex === i && <ArrowRightOutlined />}
               </div>
+            ))}
+          </div>
+        )}
 
-              {highlightIndex === i && <ArrowRightOutlined />}
-            </div>
-          ))}
-        </div>
-      )}
+        {searchText && !isLoadingSearch && searchPages?.length === 0 && (
+          <div className="text-center text-grey-400">No results</div>
+        )}
+      </div>
     </Modal>
   )
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1910,6 +1910,9 @@ msgstr ""
 msgid "No reserved tokens configured."
 msgstr ""
 
+msgid "No results"
+msgstr ""
+
 msgid "No strategy"
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

Improvements to the quick project search menu:
- debounce search input. wait 250 millis after typing to run search
- cleanup timeouts
- better cmd + k shortcut performance using "keydown" event
- add a "no results" message to empty search results state

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
