### PR TITLE
Fix pay button width when it is loading or insufficient funds

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3PayButton.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3PayButton.tsx
@@ -57,7 +57,7 @@ export function V2V3PayButton({ disabled, wrapperClassName }: PayButtonProps) {
         className="block"
       >
         <Button
-          className="w-full"
+          style={{ width: '100%' }}
           type="primary"
           onClick={() => {
             setPayWarningModalVisible(true)


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2611

I encountered some challenges while researching this issue. 

Eventually, i found that using inline styling was the most effective solution. The key is to keep in mind that when the button is disabled, it gets wrapped in a span, so any classes applied to it will be appended to the span rather than the button itself.

I tried a few things, but so far i've only been able to make it work with inline styling. Let me know if you have any thoughts!

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/18723426/206525339-bc10cc17-fe87-43fe-adee-6de11b12bf34.png)

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
