### PR TITLE
Add `useDataSourceForRedeem` to create and reconfigure

### DIFF
--- a/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
+++ b/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
@@ -4,7 +4,10 @@ import { useWatch } from 'antd/lib/form/Form'
 import { Callout } from 'components/Callout'
 import { Selection } from 'components/Create/components/Selection'
 import { JuiceSwitch } from 'components/JuiceSwitch'
-import { HOLD_FEES_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import {
+  HOLD_FEES_EXPLAINATION,
+  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION,
+} from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { readNetwork } from 'constants/networks'
 import { useContext } from 'react'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/EditingCreateFurthestPageReached'
@@ -77,6 +80,12 @@ export const ReconfigurationRulesPage = () => {
             </Form.Item>
             <Form.Item name="holdFees" extra={HOLD_FEES_EXPLAINATION}>
               <JuiceSwitch label={t`Hold fees`} />
+            </Form.Item>
+            <Form.Item
+              name="useDataSourceForRedeem"
+              extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+            >
+              <JuiceSwitch label={t`Use data source for redeem`} />
             </Form.Item>
           </CreateCollapse.Panel>
         </CreateCollapse>

--- a/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
+++ b/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
@@ -16,6 +16,7 @@ export type ReconfigurationRulesFormProps = Partial<{
   pausePayments: boolean
   allowTerminalConfiguration: boolean
   holdFees: boolean
+  useDataSourceForRedeem: boolean
 }>
 
 export const useReconfigurationRulesForm = () => {
@@ -125,6 +126,14 @@ export const useReconfigurationRulesForm = () => {
     fieldName: 'holdFees',
     ignoreUndefined: true,
     dispatchFunction: editingV2ProjectActions.setHoldFees,
+    formatter: v => !!v,
+  })
+
+  useFormDispatchWatch({
+    form,
+    fieldName: 'useDataSourceForRedeem',
+    ignoreUndefined: true,
+    dispatchFunction: editingV2ProjectActions.setUseDataSourceForRedeem,
     formatter: v => !!v,
   })
 

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/MobileRulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/MobileRulesReview.tsx
@@ -1,15 +1,22 @@
 import { t } from '@lingui/macro'
+import { Row } from 'antd'
 import FormattedAddress from 'components/FormattedAddress'
 import { DescriptionCol } from '../DescriptionCol'
 import { useRulesReview } from './hooks/RulesReview'
 
 export const MobileRulesReview = () => {
-  const { customAddress, pausePayments, strategy, terminalConfiguration } =
-    useRulesReview()
+  const {
+    customAddress,
+    pausePayments,
+    strategy,
+    terminalConfiguration,
+    holdFees,
+    useDataSourceForRedeem,
+  } = useRulesReview()
   return (
-    <>
+    <Row gutter={[20, 20]}>
       <DescriptionCol
-        span={6}
+        span={12}
         title={t`Reconfiguration`}
         desc={
           <div className="text-base font-medium">
@@ -24,17 +31,29 @@ export const MobileRulesReview = () => {
         }
       />
       <DescriptionCol
-        span={6}
+        span={12}
         title={t`Pause payments`}
         desc={<div className="text-base font-medium">{pausePayments}</div>}
       />
       <DescriptionCol
-        span={6}
+        span={12}
         title={t`Terminal configuration`}
         desc={
           <div className="text-base font-medium">{terminalConfiguration}</div>
         }
       />
-    </>
+      <DescriptionCol
+        span={12}
+        title={t`Hold fees`}
+        desc={<div className="text-base font-medium">{holdFees}</div>}
+      />
+      <DescriptionCol
+        span={12}
+        title={t`Use data source for redeem`}
+        desc={
+          <div className="text-base font-medium">{useDataSourceForRedeem}</div>
+        }
+      />
+    </Row>
   )
 }

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
@@ -8,16 +8,22 @@ import { MobileRulesReview } from './MobileRulesReview'
 
 export const RulesReview = () => {
   const isMobile = useMobile()
-  const { customAddress, pausePayments, strategy, terminalConfiguration } =
-    useRulesReview()
+  const {
+    customAddress,
+    pausePayments,
+    strategy,
+    terminalConfiguration,
+    holdFees,
+    useDataSourceForRedeem,
+  } = useRulesReview()
   return (
-    <div className="flex flex-col gap-10 pt-5 pb-12">
+    <div className="flex flex-col gap-10 pt-5 pb-8">
       {isMobile ? (
         <MobileRulesReview />
       ) : (
-        <Row>
+        <Row gutter={20}>
           <DescriptionCol
-            span={6}
+            span={5}
             title={t`Reconfiguration`}
             desc={
               <div className="text-base font-medium">
@@ -32,16 +38,30 @@ export const RulesReview = () => {
             }
           />
           <DescriptionCol
-            span={6}
+            span={5}
             title={t`Pause payments`}
             desc={<div className="text-base font-medium">{pausePayments}</div>}
           />
           <DescriptionCol
-            span={6}
+            span={5}
             title={t`Terminal configuration`}
             desc={
               <div className="text-base font-medium">
                 {terminalConfiguration}
+              </div>
+            }
+          />
+          <DescriptionCol
+            span={5}
+            title={t`Hold fees`}
+            desc={<div className="text-base font-medium">{holdFees}</div>}
+          />
+          <DescriptionCol
+            span={4}
+            title={t`Use data source for redeem`}
+            desc={
+              <div className="text-base font-medium">
+                {useDataSourceForRedeem}
               </div>
             }
           />

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
@@ -36,5 +36,28 @@ export const useRulesReview = () => {
     )?.name
   }, [availableBallotStrategies, reconfigurationRuleSelection])
 
-  return { customAddress, pausePayments, terminalConfiguration, strategy }
+  const holdFees = useMemo(() => {
+    if (fundingCycleMetadata.holdFees) {
+      return t`Yes`
+    } else {
+      return t`No`
+    }
+  }, [fundingCycleMetadata.holdFees])
+
+  const useDataSourceForRedeem = useMemo(() => {
+    if (fundingCycleMetadata.useDataSourceForRedeem) {
+      return t`Yes`
+    } else {
+      return t`No`
+    }
+  }, [fundingCycleMetadata.useDataSourceForRedeem])
+
+  return {
+    customAddress,
+    pausePayments,
+    terminalConfiguration,
+    strategy,
+    holdFees,
+    useDataSourceForRedeem,
+  }
 }

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
@@ -84,3 +84,9 @@ export const HOLD_FEES_EXPLAINATION = (
     </ExternalLink>
   </Trans>
 )
+
+export const USE_DATASOURCE_FOR_REDEEM_EXPLAINATION = (
+  <Trans>
+    When enabled, the data source will be used for redeem transactions.
+  </Trans>
+)

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/RulesForm.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/RulesForm.tsx
@@ -3,7 +3,10 @@ import { Trans } from '@lingui/macro'
 import { Button, Form, Space, Switch } from 'antd'
 import FormItemLabel from 'components/FormItemLabel'
 import ReconfigurationStrategySelector from 'components/ReconfigurationStrategy/ReconfigurationStrategySelector'
-import { HOLD_FEES_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import {
+  HOLD_FEES_EXPLAINATION,
+  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION,
+} from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import {
   ballotStrategiesFn,
   DEFAULT_BALLOT_STRATEGY,
@@ -39,6 +42,7 @@ export default function RulesForm({
       ),
       allowSetTerminals: fundingCycleMetadata.global.allowSetTerminals,
       holdFees: fundingCycleMetadata.holdFees,
+      useDataSourceForRedeem: fundingCycleMetadata.useDataSourceForRedeem,
     }),
     [fundingCycleData, fundingCycleMetadata],
   )
@@ -55,6 +59,9 @@ export default function RulesForm({
     initialValues.allowMinting,
   )
   const [holdFees, setHoldFees] = useState<boolean>(initialValues.holdFees)
+  const [useDataSourceForRedeem, setUseDataSourceForRedeem] = useState<boolean>(
+    initialValues.useDataSourceForRedeem,
+  )
 
   useEffect(() => {
     const hasFormUpdated =
@@ -79,6 +86,9 @@ export default function RulesForm({
     dispatch(editingV2ProjectActions.setAllowSetTerminals(allowSetTerminals))
     dispatch(editingV2ProjectActions.setBallot(ballotStrategy.address))
     dispatch(editingV2ProjectActions.setHoldFees(holdFees))
+    dispatch(
+      editingV2ProjectActions.setUseDataSourceForRedeem(useDataSourceForRedeem),
+    )
     onFinish?.()
   }, [
     dispatch,
@@ -88,6 +98,7 @@ export default function RulesForm({
     allowMinting,
     allowSetTerminals,
     holdFees,
+    useDataSourceForRedeem,
   ])
 
   const disableSaveButton =
@@ -159,6 +170,19 @@ export default function RulesForm({
               checked={holdFees}
             />
             <Trans>Hold fees</Trans>
+          </Form.Item>
+          <Form.Item
+            name="useDataSourceForRedeem"
+            extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+          >
+            <Switch
+              className="mr-2"
+              onChange={checked => {
+                setUseDataSourceForRedeem(checked)
+              }}
+              checked={useDataSourceForRedeem}
+            />
+            <Trans>Use data source for redeem</Trans>
           </Form.Item>
         </div>
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3254,6 +3254,9 @@ msgstr ""
 msgid "Use <0>Percentages</0> when you want to configure an <1>infinite distribution limit.</1> With an infinite distribution limit, your project reserves all funds for itself. Your project won't have overflow, so tokens can never be redeemed for ETH. <2>Learn more</2>."
 msgstr ""
 
+msgid "Use data source for redeem"
+msgstr ""
+
 msgid "Using a duration is recommended. Allowing funding cycles to be reconfigured at any time will appear risky to contributors."
 msgstr ""
 
@@ -3345,6 +3348,9 @@ msgid "When checked, payments to this address will mint this project's ERC-20 to
 msgstr ""
 
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
+msgstr ""
+
+msgid "When enabled, the data source will be used for redeem transactions."
 msgstr ""
 
 msgid "When enabled, the payments to the project are paused, and no new tokens will be issued."

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -371,6 +371,9 @@ const editingV2ProjectSlice = createSlice({
         )
       }
     },
+    setUseDataSourceForRedeem: (state, action: PayloadAction<boolean>) => {
+      state.fundingCycleMetadata.useDataSourceForRedeem = action.payload
+    },
     setTokenSettings: (
       state,
       action: PayloadAction<{


### PR DESCRIPTION
## What does this PR do and why?

**Reconfig:**
<img width="612" alt="Screen Shot 2022-12-09 at 11 06 12 am" src="https://user-images.githubusercontent.com/96150256/206599652-ae89991e-8269-42fd-aed7-4a795238a637.png">

**Create:**
<img width="667" alt="Screen Shot 2022-12-09 at 11 06 24 am" src="https://user-images.githubusercontent.com/96150256/206599679-406d6984-95dc-4342-b57f-9f8c421591b1.png">

**Create review and deploy:**
<img width="869" alt="Screen Shot 2022-12-09 at 11 04 11 am" src="https://user-images.githubusercontent.com/96150256/206599694-249da138-8d42-4f8a-ac68-c8b1964a0871.png">

<img width="386" alt="Screen Shot 2022-12-09 at 11 10 49 am" src="https://user-images.githubusercontent.com/96150256/206600228-17d524bb-e008-4826-973b-34e9a85cdc8f.png">



(didn't add `holdFees` or `useDataSourceForRedeem` to reconfig review and deploy because I'm about to redo that whole thing. 

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
