### PR TITLE
Override wizard steps default antd blue on hover with primary color

### DIFF
--- a/src/styles/antd-overrides/steps.scss
+++ b/src/styles/antd-overrides/steps.scss
@@ -5,6 +5,22 @@
   line-height: 24px;
 }
 
+.ant-steps
+  .ant-steps-item:not(.ant-steps-item-active)
+  > .ant-steps-item-container[role='button']:hover
+  .ant-steps-item-title,
+.ant-steps
+  .ant-steps-item:not(.ant-steps-item-active)
+  > .ant-steps-item-container[role='button']:hover
+  .ant-steps-item-subtitle,
+.ant-steps
+  .ant-steps-item:not(.ant-steps-item-active)
+  > .ant-steps-item-container[role='button']:hover
+  .ant-steps-item-description {
+  color: var(--text-primary) ;
+}
+
+
 // Process steps
 .ant-steps-item-process
   > .ant-steps-item-container


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2615

## Screenshots or screen recordings

https://user-images.githubusercontent.com/18723426/206742101-fb1d5d28-3c3c-4f9a-a49b-533d57bcc08b.mov

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
