### PR TITLE
reduce image sizes on home page

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
@@ -58,6 +58,7 @@ export const ProjectDetailsReview = () => {
               title={t`Project logo`}
               desc={
                 <ProjectLogo
+                  size="original"
                   className="h-36 w-36"
                   uri={
                     logoUri

--- a/src/components/ProjectLogo.tsx
+++ b/src/components/ProjectLogo.tsx
@@ -12,14 +12,21 @@ export default function ProjectLogo({
   uri,
   name,
   projectId,
+  size = 'default',
 }: {
   className?: string
   uri: string | undefined
   name: string | undefined
   projectId?: number | undefined
+  size?: 'default' | 'thumbnail' | 'large'
 }) {
   const [srcLoadError, setSrcLoadError] = useState(false)
   const validImg = uri && !srcLoadError
+  const imgSize = {
+    default: '256',
+    large: '540',
+    thumbnail: '65',
+  }
 
   const _uri = useMemo(() => {
     if (projectId && IMAGE_URI_OVERRIDES[projectId]) {
@@ -43,7 +50,7 @@ export default function ProjectLogo({
       {validImg ? (
         <img
           className="max-h-full max-w-full object-cover object-center"
-          src={_uri}
+          src={`${_uri}?img-width=${imgSize[size]}&img-height=${imgSize[size]}`}
           alt={name + ' logo'}
           onError={() => setSrcLoadError(true)}
           loading="lazy"

--- a/src/components/RichImgPreview.tsx
+++ b/src/components/RichImgPreview.tsx
@@ -7,13 +7,21 @@ import { twMerge } from 'tailwind-merge'
 export default function RichImgPreview({
   className,
   src,
+  size = 'default',
 }: {
   className?: string
   src: string | undefined
   maxWidth?: CSSProperties['maxWidth']
   maxHeight?: CSSProperties['maxHeight']
+  size: 'default' | 'thumbnail' | 'large'
 }) {
   const contentType = useContentType(src)
+
+  const imgSize = {
+    default: '256',
+    large: '800',
+    thumbnail: '65',
+  }
 
   if (
     contentType === 'image/jpeg' ||
@@ -25,7 +33,14 @@ export default function RichImgPreview({
     return (
       <Image
         className={twMerge('h-24 w-24', className)}
-        src={src}
+        placeholder={
+          <Image
+            preview={false}
+            src={`${src}?img-width=${imgSize['thumbnail']}&img-height=${imgSize['thumbnail']}`}
+            width={65}
+          />
+        }
+        src={`${src}?img-width=${imgSize[size]}&img-height=${imgSize[size]}`}
         alt={t`Payment memo image`}
         loading="lazy"
         crossOrigin="anonymous"

--- a/src/components/RichNote.tsx
+++ b/src/components/RichNote.tsx
@@ -8,6 +8,7 @@ type RichNoteProps = {
   className?: string
   note: string | undefined
   ignoreMediaLinks?: boolean
+  size?: string
 }
 
 export default function RichNote({
@@ -49,6 +50,7 @@ export default function RichNote({
                 className="mt-2 h-auto max-h-24 w-auto p-2"
                 key={i}
                 src={link}
+                size="large"
               />
             ))}
           </Space>

--- a/src/pages/home/TopProjectsSection.tsx
+++ b/src/pages/home/TopProjectsSection.tsx
@@ -42,6 +42,7 @@ const SmallProjectCardMobile = ({
             uri={metadata?.logoUri}
             name={metadata?.name}
             projectId={project.projectId}
+            size="thumbnail"
           />
         </div>
 
@@ -83,6 +84,7 @@ const SmallProjectCard = ({ project }: { project: ProjectCardProject }) => {
               uri={metadata?.logoUri}
               name={metadata?.name}
               projectId={project.projectId}
+              size="thumbnail"
             />
           </div>
 

--- a/src/pages/projects/TrendingProjectCard.tsx
+++ b/src/pages/projects/TrendingProjectCard.tsx
@@ -103,6 +103,7 @@ export default function TrendingProjectCard({
                 uri={metadata?.logoUri}
                 name={metadata?.name}
                 projectId={project.projectId}
+                size="thumbnail"
               />
             </div>
 


### PR DESCRIPTION
## What does this PR do and why?
Currently, images that are hosted on pinata (user generated or stickers) are being loaded on the landing page in their full size. Usually and the 1-3MB range.

Images are only shown at a max size of ~256px pixels, and don't need to be nearly this large.
todo add images of network requests
looking at the pinata docs, it seems like we only need to add a query parameter

https://docs.pinata.cloud/gateways/image-optimization



### After
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/2502947/206869239-b22da7fc-1087-4f4a-b885-8a5b0b1188b3.png">
(note, preview image is loaded first, then fullsize image)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
