### PR TITLE
Error notification improvements + cleanup

### DIFF
--- a/src/styles/antd-overrides/notification.scss
+++ b/src/styles/antd-overrides/notification.scss
@@ -11,4 +11,9 @@
   .ant-notification-notice-close-icon {
     color: var(--icon-secondary);
   }
+
+  .ant-notification-notice-description {
+    max-height: 120px;
+    overflow-y: auto;
+  }
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -7,10 +7,7 @@ import { notification } from 'antd'
  */
 export const emitErrorNotification = (
   message: string,
-  {
-    description,
-    duration = null,
-  }: {
+  opts?: {
     description?: string
     duration?: number | null
   },
@@ -19,17 +16,14 @@ export const emitErrorNotification = (
   return notification.error({
     key,
     message,
-    description,
-    duration,
+    ...opts,
+    duration: opts?.duration ?? null,
   })
 }
 
 export const emitSuccessNotification = (
   message: string,
-  {
-    description,
-    duration = 5,
-  }: {
+  opts?: {
     description?: string
     duration?: number | null
   },
@@ -38,7 +32,7 @@ export const emitSuccessNotification = (
   return notification.success({
     key,
     message,
-    description,
-    duration,
+    ...opts,
+    duration: opts?.duration ?? 5,
   })
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -6,11 +6,11 @@ export const emitErrorNotification = (
   message: string,
   {
     description,
-    duration,
+    duration = DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS,
   }: {
     description?: string
     duration?: number
-  } = { duration: DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS },
+  },
 ) => {
   const key = new Date().valueOf().toString()
   return notification.error({
@@ -18,9 +18,6 @@ export const emitErrorNotification = (
     message,
     description,
     duration,
-    onClick() {
-      notification.close(key)
-    },
   })
 }
 
@@ -28,11 +25,11 @@ export const emitSuccessNotification = (
   message: string,
   {
     description,
-    duration,
+    duration = DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS,
   }: {
     description?: string
     duration?: number
-  } = { duration: DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS },
+  },
 ) => {
   const key = new Date().valueOf().toString()
   return notification.success({
@@ -40,8 +37,5 @@ export const emitSuccessNotification = (
     message,
     description,
     duration,
-    onClick() {
-      notification.close(key)
-    },
   })
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,15 +1,18 @@
 import { notification } from 'antd'
 
-const DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS = 3
-
+/**
+ * @param message Title of notification
+ * @param description Message to include in notification
+ * @param duration in seconds for how long the notification should persist. Pass `null` to persist indefinitely
+ */
 export const emitErrorNotification = (
   message: string,
   {
     description,
-    duration = DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS,
+    duration = null,
   }: {
     description?: string
-    duration?: number
+    duration?: number | null
   },
 ) => {
   const key = new Date().valueOf().toString()
@@ -25,10 +28,10 @@ export const emitSuccessNotification = (
   message: string,
   {
     description,
-    duration = DEFAULT_ERROR_NOTIFICATION_DURATION_SECONDS,
+    duration = 5,
   }: {
     description?: string
-    duration?: number
+    duration?: number | null
   },
 ) => {
   const key = new Date().valueOf().toString()


### PR DESCRIPTION
## What does this PR do and why?

- CSS update to make lengthy error notifications smaller, with scrollable text
- remove `onClick` function allowing user to click/highlight text in the notification if needed. clicking the `x` icon still closes the notification
- extend default `duration` from 3 to 5 seconds for normal notifications. default to `null` duration (persists indefinitely) for error notifications. Note: previously, default duration would be overwritten if passing `duration` _or_ `description`
 
## Screenshots or screen recordings

<img width="437" alt="image" src="https://user-images.githubusercontent.com/79433522/206923427-812f70e9-d593-4c16-b9f5-f7ea9331f4cf.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
