### PR TITLE
Update redeem NFT modal

### DIFF
--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -45,7 +45,7 @@ export function NftPreview({
           <h3 className="mb-0 uppercase text-slate-100">
             <Trans>{projectMetadata?.name}</Trans>
           </h3>
-          <CloseOutlined className="pl-4" onClick={onClose} />
+          <CloseOutlined className="pl-4 text-slate-100" onClick={onClose} />
         </div>
         <div className="flex justify-center" onClick={onClose}>
           <img

--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -18,6 +18,8 @@ export function NftTierCard({
   isSelected,
   onClick,
   onRemove,
+  previewDisabled,
+  hidePrice,
 }: {
   rewardTier?: NftRewardTier
   rewardTierUpperLimit?: number
@@ -25,6 +27,8 @@ export function NftTierCard({
   isSelected?: boolean
   onClick?: MouseEventHandler<HTMLDivElement>
   onRemove?: () => void
+  previewDisabled?: boolean
+  hidePrice?: boolean
 }) {
   const [previewVisible, setPreviewVisible] = useState<boolean>(false)
 
@@ -34,29 +38,33 @@ export function NftTierCard({
     ? ipfsToHttps(rewardTier.imageUrl)
     : rewardTier?.imageUrl
 
+  const _onRemove = onRemove ?? onClick
+
   function RewardIcon() {
     return (
       <Tooltip
         title={
-          <span className="text-xs">
-            {payMetadataOverrides(projectId ?? 0).dontOverspend ? (
-              <Trans>
-                Receive this NFT when you contribute{' '}
-                <strong>{rewardTier?.contributionFloor} ETH</strong>.
-              </Trans>
-            ) : rewardTierUpperLimit ? (
-              <Trans>
-                Receive this NFT when you contribute{' '}
-                <strong>{rewardTier?.contributionFloor}</strong> - {'<'}
-                <strong>{rewardTierUpperLimit} ETH</strong>.
-              </Trans>
-            ) : (
-              <Trans>
-                Receive this NFT when you contribute at least{' '}
-                <strong>{rewardTier?.contributionFloor} ETH</strong>.
-              </Trans>
-            )}
-          </span>
+          !hidePrice ? (
+            <span className="text-xs">
+              {payMetadataOverrides(projectId ?? 0).dontOverspend ? (
+                <Trans>
+                  Receive this NFT when you contribute{' '}
+                  <strong>{rewardTier?.contributionFloor} ETH</strong>.
+                </Trans>
+              ) : rewardTierUpperLimit ? (
+                <Trans>
+                  Receive this NFT when you contribute{' '}
+                  <strong>{rewardTier?.contributionFloor}</strong> - {'<'}
+                  <strong>{rewardTierUpperLimit} ETH</strong>.
+                </Trans>
+              ) : (
+                <Trans>
+                  Receive this NFT when you contribute at least{' '}
+                  <strong>{rewardTier?.contributionFloor} ETH</strong>.
+                </Trans>
+              )}
+            </span>
+          ) : undefined
         }
         overlayInnerStyle={{
           padding: '7px 10px',
@@ -70,7 +78,7 @@ export function NftTierCard({
             'absolute right-2 top-2 h-6 w-6 items-center justify-center rounded-full text-base',
             isSelected ? 'flex bg-haze-400 text-smoke-25' : 'hidden',
           )}
-          onClick={onRemove ? stopPropagation(onRemove) : undefined}
+          onClick={_onRemove ? stopPropagation(_onRemove) : undefined}
         >
           <CheckOutlined />
         </div>
@@ -88,7 +96,7 @@ export function NftTierCard({
             : '',
         )}
         onClick={
-          !isSelected
+          !isSelected || previewDisabled
             ? onClick
             : () => {
                 setPreviewVisible(true)
@@ -135,7 +143,7 @@ export function NftTierCard({
             !loading ? 'pt-2' : 'pt-1',
           )}
           onClick={
-            isSelected && onRemove ? stopPropagation(onRemove) : undefined
+            isSelected && _onRemove ? stopPropagation(_onRemove) : undefined
           }
         >
           <Skeleton
@@ -157,20 +165,22 @@ export function NftTierCard({
               {rewardTier?.name}
             </span>
           </Skeleton>
-          <Skeleton
-            className="mt-1"
-            loading={loading}
-            active
-            title={false}
-            paragraph={{ rows: 1, width: ['50%'] }}
-          >
-            <span className="text-xs text-grey-900 dark:text-slate-50">
-              {rewardTier?.contributionFloor} ETH
-            </span>
-          </Skeleton>
+          {!hidePrice ? (
+            <Skeleton
+              className="mt-1"
+              loading={loading}
+              active
+              title={false}
+              paragraph={{ rows: 1, width: ['50%'] }}
+            >
+              <span className="text-xs text-grey-900 dark:text-slate-50">
+                {rewardTier?.contributionFloor} ETH
+              </span>
+            </Skeleton>
+          ) : null}
         </div>
       </div>
-      {rewardTier ? (
+      {rewardTier && !previewDisabled ? (
         <NftPreview
           open={previewVisible}
           rewardTier={rewardTier}

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/ManageNftsSection.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/ManageNftsSection.tsx
@@ -77,6 +77,7 @@ export function ManageNftsSection() {
         <RedeemNftsModal
           open={redeemNftsModalVisible}
           onCancel={() => setRedeemNftsModalVisible(false)}
+          onConfirmed={() => setRedeemNftsModalVisible(false)}
         />
       )}
     </>

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
@@ -1,12 +1,14 @@
 import axios from 'axios'
-import { IPFSNftRewardTier } from 'models/nftRewardTier'
+import {
+  IPFSNftRewardTier,
+  NftRewardTier,
+  NFT_METADATA_CONTRIBUTION_FLOOR_ATTRIBUTES_INDEX,
+} from 'models/nftRewardTier'
 import { JB721DelegateToken } from 'models/subgraph-entities/v2/jb-721-delegate-tokens'
 import { MouseEventHandler } from 'react'
 import { useQuery, UseQueryResult } from 'react-query'
-import { twMerge } from 'tailwind-merge'
-import { classNames } from 'utils/classNames'
 import { cidFromIpfsUri, openIpfsUrl } from 'utils/ipfs'
-import { LoadingOutlined } from '@ant-design/icons'
+import { NftTierCard } from 'components/NftRewards/NftTierCard'
 
 function useJB721DelegateTokenMetadata(
   tokenUri: string | undefined,
@@ -40,55 +42,28 @@ export function RedeemNftCard({
   if (!tierData) return null
 
   const { name, image } = tierData
+  const contributionFloor =
+    tierData.attributes[NFT_METADATA_CONTRIBUTION_FLOOR_ATTRIBUTES_INDEX]
+      .value ?? 0
+
+  const rewardTier: NftRewardTier = {
+    name,
+    contributionFloor,
+    remainingSupply: undefined,
+    maxSupply: undefined,
+    imageUrl: image,
+    externalLink: undefined,
+    description: undefined,
+  }
 
   return (
-    <div
-      className={twMerge(
-        classNames(
-          'flex h-full w-1/4 cursor-pointer flex-col rounded-sm outline outline-0 outline-haze-400 transition-shadow duration-100 hover:outline-2',
-          isSelected
-            ? 'shadow-[2px_0px_10px_0px_var(--boxShadow-primary)] outline outline-2 outline-haze-400'
-            : '',
-        ),
-      )}
+    <NftTierCard
+      rewardTier={rewardTier}
       onClick={onClick}
-      role="button"
-    >
-      <div
-        className={classNames(
-          'relative flex w-full items-center justify-center',
-          !loading ? 'pt-[100%]' : 'pt-[unset]',
-          isSelected
-            ? 'bg-smoke-25 dark:bg-slate-800'
-            : 'bg-smoke-100 dark:bg-slate-600',
-        )}
-      >
-        {loading ? (
-          <div className="flex h-[151px] w-full items-center justify-center border border-solid border-smoke-200 dark:border-grey-600">
-            <LoadingOutlined />
-          </div>
-        ) : (
-          <img
-            className={classNames('absolute top-0 h-full w-full object-cover')}
-            alt={name}
-            src={image}
-            style={{
-              filter: isSelected ? 'unset' : 'brightness(50%)',
-            }}
-            crossOrigin="anonymous"
-          />
-        )}
-      </div>
-      {/* Details section below image */}
-      <div
-        className={classNames(
-          'flex h-full w-full flex-col justify-center px-3 pb-1.5',
-          isSelected
-            ? 'bg-smoke-25 dark:bg-slate-800'
-            : 'bg-smoke-100 dark:bg-slate-600',
-          !loading ? 'pt-2' : 'pt-1',
-        )}
-      ></div>
-    </div>
+      isSelected={isSelected}
+      loading={loading}
+      previewDisabled
+      hidePrice
+    />
   )
 }

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { Descriptions, Form, Space } from 'antd'
+import { Col, Descriptions, Form, Row, Space, Statistic } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import { Callout } from 'components/Callout'
 import { MemoFormInput } from 'components/Project/PayProjectForm/MemoFormInput'
@@ -15,6 +15,10 @@ import { formatRedemptionRate } from 'utils/v2v3/math'
 import { BigNumber } from '@ethersproject/bignumber'
 import { encodeJB721DelegateRedeemMetadata } from 'utils/nftRewards'
 import { RedeemNftCard } from './RedeemNftCard'
+import ETHAmount from 'components/currency/ETHAmount'
+import { useETHReceivedFromNftRedeem } from 'hooks/v2v3/contractReader/ETHReceivedFromNftRedeem'
+import TooltipLabel from 'components/TooltipLabel'
+import { REDEMPTION_RATE_EXPLANATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 
 export function RedeemNftsModal({
   open,
@@ -105,6 +109,10 @@ export function RedeemNftsModal({
     modalTitle = t`Burn NFTs`
   }
 
+  const redeemValue = useETHReceivedFromNftRedeem({
+    tokenIdsToRedeem,
+  })
+
   return (
     <TransactionModal
       transactionPending={transactionPending}
@@ -118,6 +126,7 @@ export function RedeemNftsModal({
         onCancel?.()
       }}
       okText={modalTitle}
+      okButtonProps={{ disabled: !tokenIdsToRedeem.length }}
       width={540}
       centered
     >
@@ -159,7 +168,12 @@ export function RedeemNftsModal({
           contentStyle={{ display: 'block', textAlign: 'right' }}
         >
           <Descriptions.Item
-            label={<Trans>Redemption rate</Trans>}
+            label={
+              <TooltipLabel
+                label={t`Redemption rate`}
+                tip={REDEMPTION_RATE_EXPLANATION}
+              />
+            }
             className="pb-1"
           >
             {formatRedemptionRate(fundingCycleMetadata.redemptionRate)}%
@@ -172,17 +186,24 @@ export function RedeemNftsModal({
         <div>
           <Form form={form} layout="vertical">
             <Form.Item label={t`Select NFTs to redeem`}>
-              <div className="mb-4 flex flex-wrap gap-4">
+              <Row gutter={[20, 20]}>
                 {nfts?.map(nft => (
-                  <RedeemNftCard
-                    key={nft.tokenId}
-                    nft={nft}
-                    onClick={() => onNftClick(nft)}
-                    isSelected={tokenIdsToRedeem.includes(nft.tokenId)}
-                  />
+                  <Col span={8} key={nft.tokenId}>
+                    <RedeemNftCard
+                      nft={nft}
+                      onClick={() => onNftClick(nft)}
+                      isSelected={tokenIdsToRedeem.includes(nft.tokenId)}
+                    />
+                  </Col>
                 ))}
-              </div>
+              </Row>
             </Form.Item>
+
+            <Statistic
+              title={<Trans>Redemption value</Trans>}
+              valueRender={() => <ETHAmount amount={redeemValue} />}
+              className={'pt-5 pb-5'}
+            />
 
             <Form.Item label={t`Memo`}>
               <MemoFormInput value={memo} onChange={setMemo} />

--- a/src/hooks/v2v3/contractReader/ETHReceivedFromNftRedeem.ts
+++ b/src/hooks/v2v3/contractReader/ETHReceivedFromNftRedeem.ts
@@ -1,0 +1,64 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
+import { V2BallotState } from 'models/ballot'
+import { useContext } from 'react'
+
+import { MAX_REDEMPTION_RATE } from 'utils/v2v3/math'
+import { useRedemptionWeightOfNfts } from './RedemptionWeightOfNfts'
+
+import { useTotalNftRedemptionWeight } from './TotalNftRedemptionWeight'
+
+/**
+ * Copies JB721Delegate.sol:redeemParams formula
+ *
+ * @param tokenIdsToRedeem
+ * @returns amount in ETH
+ */
+export function useETHReceivedFromNftRedeem({
+  tokenIdsToRedeem,
+}: {
+  tokenIdsToRedeem: string[] | undefined
+}): BigNumber | undefined {
+  const { fundingCycleMetadata, primaryTerminalCurrentOverflow, ballotState } =
+    useContext(V2V3ProjectContext)
+
+  // redemption weight of selected NFTs
+  const { data: selectedRedemptionWeight } = useRedemptionWeightOfNfts({
+    tokenIdsToRedeem,
+    dataSourceAddress: fundingCycleMetadata?.dataSource,
+  })
+
+  // total redemption weight
+  const { data: totalRedemptionWeight } = useTotalNftRedemptionWeight({
+    dataSourceAddress: fundingCycleMetadata?.dataSource,
+  })
+
+  if (
+    !fundingCycleMetadata ||
+    !selectedRedemptionWeight?.gt(0) ||
+    !totalRedemptionWeight?.gt(0)
+  )
+    return BigNumber.from(0)
+
+  const redemptionRate =
+    ballotState === V2BallotState.Active
+      ? fundingCycleMetadata.ballotRedemptionRate
+      : fundingCycleMetadata.redemptionRate
+
+  const base = primaryTerminalCurrentOverflow
+    ? primaryTerminalCurrentOverflow
+        .mul(selectedRedemptionWeight)
+        .div(totalRedemptionWeight)
+    : BigNumber.from(0)
+
+  if (redemptionRate.eq(BigNumber.from(MAX_REDEMPTION_RATE))) return base
+
+  // return { base * [RR + (weight * (maxRR - RR) / total )] / maxRR }
+  const numerator = redemptionRate.add(
+    selectedRedemptionWeight
+      .mul(BigNumber.from(MAX_REDEMPTION_RATE).sub(redemptionRate))
+      .div(totalRedemptionWeight),
+  )
+
+  return base.mul(numerator).div(MAX_REDEMPTION_RATE)
+}

--- a/src/hooks/v2v3/contractReader/RedemptionWeightOfNfts.ts
+++ b/src/hooks/v2v3/contractReader/RedemptionWeightOfNfts.ts
@@ -1,0 +1,24 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { useStoreOfJB721TieredDelegate } from 'hooks/contracts/JB721Delegate/useStoreofJB721TieredDelegate'
+import useV2ContractReader from './V2ContractReader'
+
+export function useRedemptionWeightOfNfts({
+  tokenIdsToRedeem,
+  dataSourceAddress,
+}: {
+  tokenIdsToRedeem: string[] | undefined
+  dataSourceAddress: string | undefined
+}) {
+  const JBTiered721DelegateStore = useStoreOfJB721TieredDelegate({
+    JB721TieredDelegateAddress: dataSourceAddress,
+  })
+
+  const _tokenIds = tokenIdsToRedeem?.map(idString => BigNumber.from(idString))
+  const args =
+    dataSourceAddress && _tokenIds ? [dataSourceAddress, _tokenIds] : null
+  return useV2ContractReader<BigNumber>({
+    contract: JBTiered721DelegateStore,
+    functionName: 'redemptionWeightOf',
+    args,
+  })
+}

--- a/src/hooks/v2v3/contractReader/TotalNftRedemptionWeight.ts
+++ b/src/hooks/v2v3/contractReader/TotalNftRedemptionWeight.ts
@@ -1,0 +1,20 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { useStoreOfJB721TieredDelegate } from 'hooks/contracts/JB721Delegate/useStoreofJB721TieredDelegate'
+import useV2ContractReader from './V2ContractReader'
+
+export function useTotalNftRedemptionWeight({
+  dataSourceAddress,
+}: {
+  dataSourceAddress: string | undefined
+}) {
+  const JBTiered721DelegateStore = useStoreOfJB721TieredDelegate({
+    JB721TieredDelegateAddress: dataSourceAddress,
+  })
+
+  const args = dataSourceAddress ? [dataSourceAddress] : null
+  return useV2ContractReader<BigNumber>({
+    contract: JBTiered721DelegateStore,
+    functionName: 'totalRedemptionWeight',
+    args,
+  })
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2468,6 +2468,9 @@ msgstr ""
 msgid "Redemption rate:"
 msgstr ""
 
+msgid "Redemption value"
+msgstr ""
+
 msgid "Redemptions"
 msgstr ""
 

--- a/src/models/nftRewardTier.ts
+++ b/src/models/nftRewardTier.ts
@@ -1,6 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { CurrencyOption } from './currencyOption'
 
+export const NFT_METADATA_CONTRIBUTION_FLOOR_ATTRIBUTES_INDEX = 0
+
 // How we store reward tiers for use around the app
 export type NftRewardTier = {
   contributionFloor: number // ETH amount


### PR DESCRIPTION
## What does this PR do and why?

- shows redeem value
- use same NFT cards as project page
- fixes pending and confirmed states of modals
- disable OK button when no NFTs selected

## **To test:**
1. Go to a Goerli NFT project locally (preview link doesn't load NFTs)
2. Buy some NFTs
3. Redeem them
4. Check redeem was successful:
- your NFT count reduced on reload
- your wallet ETH balance has increased

https://user-images.githubusercontent.com/96150256/207519198-483c46ea-e01c-4b20-bf8f-b52a1768249f.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
