### PR TITLE
Include terminal property on pv2 addToBalance events

### DIFF
--- a/src/components/activityEventElems/AddToBalanceEventElem.tsx
+++ b/src/components/activityEventElems/AddToBalanceEventElem.tsx
@@ -11,7 +11,13 @@ export default function AddToBalanceEventElem({
   event:
     | Pick<
         AddToBalanceEvent,
-        'amount' | 'timestamp' | 'caller' | 'note' | 'id' | 'txHash'
+        | 'amount'
+        | 'timestamp'
+        | 'caller'
+        | 'note'
+        | 'id'
+        | 'txHash'
+        | 'terminal'
       >
     | undefined
 }) {

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -145,7 +145,15 @@ export default function ProjectActivity() {
       },
       {
         entity: 'addToBalanceEvent',
-        keys: ['amount', 'timestamp', 'caller', 'note', 'id', 'txHash'],
+        keys: [
+          'amount',
+          'timestamp',
+          'caller',
+          'note',
+          'id',
+          'txHash',
+          'terminal',
+        ],
       },
       {
         entity: 'deployedERC20Event',


### PR DESCRIPTION
## What does this PR do and why?

Adds `terminal` key when querying addToBalance project events, so we can show terminal version in activity element.

## Screenshots or screen recordings

<img width="551" alt="image" src="https://user-images.githubusercontent.com/79433522/207696245-c4293ea6-e3e9-4abe-9b40-cf717a96e871.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
