### PR TITLE
Add deployed split allocators and enable feature flag

### DIFF
--- a/src/constants/contracts/mainnet/Allocators.ts
+++ b/src/constants/contracts/mainnet/Allocators.ts
@@ -1,5 +1,7 @@
 import * as constants from '@ethersproject/constants'
 
-export const V2_V3_ALLOCATOR_ADDRESS = 'TODO_V2_V3_ALLOCATOR_ADDRESS'
-export const V1_V3_ALLOCATOR_ADDRESS = 'TODO_V1_V3_ALLOCATOR_ADDRESS'
+export const V2_V3_ALLOCATOR_ADDRESS =
+  '0x6aaF7afeF64c6852EE507876f9D25F92bd9A1aE7'
+export const V1_V3_ALLOCATOR_ADDRESS =
+  '0x1eb759829b1a3d55193472142f18df3091BcAc4B'
 export const NULL_ALLOCATOR_ADDRESS = constants.AddressZero

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -9,6 +9,9 @@ const FEATURE_FLAG_DEFAULTS: {
     goerli: true,
     mainnet: true,
   },
+  [FEATURE_FLAGS.SPLIT_ALLOCATORS]: {
+    mainnet: true,
+  },
 }
 
 const featureFlagKey = (baseKey: string) => {


### PR DESCRIPTION
## What does this PR do and why?

LFG

<img width="513" alt="Screen Shot 2022-12-15 at 11 42 48 am" src="https://user-images.githubusercontent.com/96150256/207754040-9efc09d5-15bd-471b-998d-aebf358a3d98.png">

Then after distribution:
<img width="1098" alt="Screen Shot 2022-12-15 at 11 43 19 am" src="https://user-images.githubusercontent.com/96150256/207754066-dab02589-f20a-4c0c-8d42-151e79d36a31.png">

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
