### PR TITLE
Add remaining supply to NFT cards

### DIFF
--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -1,5 +1,5 @@
 import { CheckOutlined, LoadingOutlined } from '@ant-design/icons'
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { Skeleton, Tooltip } from 'antd'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { NftRewardTier } from 'models/nftRewardTier'
@@ -10,6 +10,8 @@ import { ipfsToHttps } from 'utils/ipfs'
 import { payMetadataOverrides } from 'utils/nftRewards'
 import { NftPreview } from './NftPreview'
 
+const MAX_REMAINING_SUPPLY = 10000
+
 // The clickable cards on the project page
 export function NftTierCard({
   loading,
@@ -19,7 +21,7 @@ export function NftTierCard({
   onClick,
   onRemove,
   previewDisabled,
-  hidePrice,
+  hideAttributes,
 }: {
   rewardTier?: NftRewardTier
   rewardTierUpperLimit?: number
@@ -28,7 +30,7 @@ export function NftTierCard({
   onClick?: MouseEventHandler<HTMLDivElement>
   onRemove?: () => void
   previewDisabled?: boolean
-  hidePrice?: boolean
+  hideAttributes?: boolean
 }) {
   const [previewVisible, setPreviewVisible] = useState<boolean>(false)
 
@@ -44,7 +46,7 @@ export function NftTierCard({
     return (
       <Tooltip
         title={
-          !hidePrice ? (
+          !hideAttributes ? (
             <span className="text-xs">
               {payMetadataOverrides(projectId ?? 0).dontOverspend ? (
                 <Trans>
@@ -85,6 +87,12 @@ export function NftTierCard({
       </Tooltip>
     )
   }
+
+  const remainingSupply =
+    rewardTier?.remainingSupply &&
+    rewardTier.remainingSupply < MAX_REMAINING_SUPPLY
+      ? rewardTier?.remainingSupply
+      : t`Unlimited`
 
   return (
     <>
@@ -165,18 +173,34 @@ export function NftTierCard({
               {rewardTier?.name}
             </span>
           </Skeleton>
-          {!hidePrice ? (
-            <Skeleton
-              className="mt-1"
-              loading={loading}
-              active
-              title={false}
-              paragraph={{ rows: 1, width: ['50%'] }}
-            >
-              <span className="text-xs text-grey-900 dark:text-slate-50">
-                {rewardTier?.contributionFloor} ETH
-              </span>
-            </Skeleton>
+          {!hideAttributes ? (
+            <>
+              <Skeleton
+                className="mt-1"
+                loading={loading}
+                active
+                title={false}
+                paragraph={{ rows: 1, width: ['50%'] }}
+              >
+                <span className="text-xs text-grey-900 dark:text-slate-50">
+                  {rewardTier?.contributionFloor} ETH
+                </span>
+              </Skeleton>
+              <Skeleton
+                className="pt-5"
+                loading={loading}
+                active
+                title={false}
+                paragraph={{ rows: 1, width: ['50%'] }}
+              >
+                <span
+                  className="mt-2 text-grey-500"
+                  style={{ fontSize: '0.6rem' }}
+                >
+                  <Trans>REMAINING: {remainingSupply}</Trans>
+                </span>
+              </Skeleton>
+            </>
           ) : null}
         </div>
       </div>

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
@@ -63,7 +63,7 @@ export function RedeemNftCard({
       isSelected={isSelected}
       loading={loading}
       previewDisabled
-      hidePrice
+      hideAttributes
     />
   )
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2318,6 +2318,9 @@ msgstr ""
 msgid "REMAINING SUPPLY: {0}/{1}"
 msgstr ""
 
+msgid "REMAINING: {remainingSupply}"
+msgstr ""
+
 msgid "Raised on Juicebox"
 msgstr ""
 
@@ -3273,6 +3276,9 @@ msgid "Unknown Project"
 msgstr ""
 
 msgid "Unless payments are paused in your funding cycle settings, your project can still receive payments directly through the Juicebox protocol contracts."
+msgstr ""
+
+msgid "Unlimited"
 msgstr ""
 
 msgid "Unlock"


### PR DESCRIPTION
## What does this PR do and why?

Implements: https://www.figma.com/file/XEBCjxletE7rDdbj3Mk8lV/JBX---NFT-Rewards-UI---July-2022?node-id=581%3A6680&t=SvCNohyneIzvQr3p-0

<img width="528" alt="Screen Shot 2022-12-15 at 12 38 43 pm" src="https://user-images.githubusercontent.com/96150256/207760088-78cec8f9-d0c3-4292-b973-2eee000313bf.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
