### PR TITLE
add dynamic imports to project

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:@next/next/recommended",
     "prettier"
   ],
   "parser": "@typescript-eslint/parser",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@lingui/macro": "^3.13.0",
     "@lingui/react": "^3.13.0",
     "@metamask/providers": "^10.0.0",
+    "@next/eslint-plugin-next": "^13.0.6",
     "@pinata/sdk": "^1.1.23",
     "@reduxjs/toolkit": "^1.6.2",
     "@sentry/react": "^6.18.2",

--- a/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
+++ b/src/components/common/CoreAppWrapper/CoreAppWrapper.tsx
@@ -1,7 +1,7 @@
 import { Layout } from 'antd'
 import { Content } from 'antd/lib/layout/layout'
-import SiteNavigation from 'components/Navbar/SiteNavigation'
 import useMobile from 'hooks/Mobile'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { ArcxProvider } from 'providers/ArcxProvider'
 import { EtherPriceProvider } from 'providers/EtherPriceProvider'
@@ -15,6 +15,12 @@ import store from 'redux/store'
 import { classNames } from 'utils/classNames'
 import { redirectTo } from 'utils/windowUtils'
 
+const SiteNavigation = dynamic(
+  () => import('components/Navbar/SiteNavigation'),
+  {
+    ssr: false,
+  },
+)
 /**
  * Contains all the core app providers used by each page.
  *

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -3,14 +3,42 @@ import { Col, Row } from 'antd'
 import { AppWrapper } from 'components/common'
 import Image from 'next/image'
 import { BigHeading } from './home/BigHeading'
-import Faq from './home/Faq'
-import Footer from './home/Footer'
-import { HeroSection } from './home/HeroSection'
-import { HowItWorksSection } from './home/HowItWorksSection'
-import { StatsSection } from './home/StatsSection'
 import { TopProjectsSection } from './home/TopProjectsSection'
-import TrendingSection from './home/TrendingSection'
 import blueBerry from '/public/assets/blueberry-ol.png'
+import dynamic from 'next/dynamic'
+
+const HeroSection = dynamic(
+  () => import('./home/HeroSection').then(module => module.HeroSection),
+  { ssr: true },
+)
+
+const StatsSection = dynamic(
+  () => import('./home/StatsSection').then(module => module.StatsSection),
+  { ssr: false },
+)
+
+const TrendingSection = dynamic(() => import('./home/TrendingSection'), {
+  loading: () => <div>Loading...</div>,
+  ssr: false,
+})
+const Footer = dynamic(() => import('./home/Footer'), {
+  loading: () => <div>Loading...</div>,
+  ssr: false,
+})
+
+const HowItWorksSection = dynamic(
+  () =>
+    import('./home/HowItWorksSection').then(module => module.HowItWorksSection),
+  {
+    loading: () => <div>Loading...</div>,
+    ssr: false,
+  },
+)
+
+const Faq = dynamic(() => import('./home/Faq'), {
+  loading: () => <div>Loading...</div>,
+  ssr: false,
+})
 
 function Landing() {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4552,6 +4552,13 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.2.2.tgz#cc1a0a445bd254499e30f632968c03192455f4cc"
   integrity sha512-BqDwE4gDl1F608TpnNxZqrCn6g48MBjvmWFEmeX5wEXDXh3IkAOw6ASKUgjT8H4OUePYFqghDFUss5ZhnbOUjw==
 
+"@next/eslint-plugin-next@^13.0.6":
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-13.0.6.tgz#4d73774ede50183c5ae5bab01ec4a7dd2d11fed5"
+  integrity sha512-JUANdYNCddhmQBjQQPxEJYL7GMCqYtbfrdmtX7c013srig7waNCG69Aoql7CgAgjdy8jn1ovHVdcF/NB46XN3Q==
+  dependencies:
+    glob "7.1.7"
+
 "@next/swc-android-arm-eabi@12.2.2":
   version "12.2.2"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.2.tgz#f6c4111e6371f73af6bf80c9accb3d96850a92cd"
@@ -11057,6 +11064,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.1.1, glob@^7.1.3:
   version "7.2.3"


### PR DESCRIPTION
## What does this PR do and why?

Removed the additions from: https://github.com/jbx-protocol/juice-interface/pull/2621 moving the wallet / account functionality from `_app.tsx`. I think that would require a bit more planning and a much larger refactor.

This PR splits up the initial bundle of the landing page, reducing the size of the bundle the user gets on load, resulting in a faster page load. 

more here in the docs: https://nextjs.org/docs/advanced-features/dynamic-import  
## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
