### PR TITLE
Fix sharing project to Twitter link

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
@@ -3,9 +3,10 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Space } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import { NEW_DEPLOY_QUERY_PARAM } from 'components/v2v3/V2V3Project/modals/NewDeployModal'
-import { MAINNET_CHAIN_ID, NETWORKS } from 'constants/networks'
+import { readNetwork } from 'constants/networks'
 import useMobile from 'hooks/Mobile'
 import { useWallet } from 'hooks/Wallet'
+import { NetworkName } from 'models/network-name'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo, useState } from 'react'
@@ -27,11 +28,11 @@ export const DeploySuccess = ({ projectId }: { projectId: number }) => {
    * Generate a twitter share link based on the project id.
    */
   const twitterShareUrl = useMemo(() => {
-    let juiceboxUrl = `https://juicebox.money/v2/p/${projectId}`
-    const chainId = parseInt(chain?.id ?? MAINNET_CHAIN_ID.toString())
-    if (chainId !== MAINNET_CHAIN_ID) {
-      juiceboxUrl = `https://${NETWORKS[chainId].name}.juicebox.money/v2/p/${projectId}`
-    }
+    const juiceboxUrl =
+      readNetwork.name === NetworkName.mainnet
+        ? `https://juicebox.money/v2/p/${projectId}`
+        : `https://${readNetwork.name}.juicebox.money/v2/p/${projectId}`
+
     const message = `Check out my project on ${
       chain?.name ? `${chain.name} ` : ''
     }Juicebox!\n${juiceboxUrl}`

--- a/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
@@ -3,6 +3,7 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Space } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import { NEW_DEPLOY_QUERY_PARAM } from 'components/v2v3/V2V3Project/modals/NewDeployModal'
+import { MAINNET_CHAIN_ID, NETWORKS } from 'constants/networks'
 import useMobile from 'hooks/Mobile'
 import { useWallet } from 'hooks/Wallet'
 import Image from 'next/image'
@@ -27,9 +28,9 @@ export const DeploySuccess = ({ projectId }: { projectId: number }) => {
    */
   const twitterShareUrl = useMemo(() => {
     let juiceboxUrl = `https://juicebox.money/v2/p/${projectId}`
-    const chainId = chain?.name.toLowerCase() ?? 'mainnet'
-    if (chainId !== 'mainnet') {
-      juiceboxUrl = `https://${chainId}.juicebox.money/v2/p/${projectId}`
+    const chainId = parseInt(chain?.id ?? MAINNET_CHAIN_ID.toString())
+    if (chainId !== MAINNET_CHAIN_ID) {
+      juiceboxUrl = `https://${NETWORKS[chainId].name}.juicebox.money/v2/p/${projectId}`
     }
     const message = `Check out my project on ${
       chain?.name ? `${chain.name} ` : ''

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -23,6 +23,8 @@ if (typeof window !== 'undefined') {
   hostname = window.location.hostname
 }
 
+export const MAINNET_CHAIN_ID = 1
+
 export const NETWORKS: Record<number, NetworkInfo> = {
   31337: {
     name: NetworkName.localhost,

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -23,8 +23,6 @@ if (typeof window !== 'undefined') {
   hostname = window.location.hostname
 }
 
-export const MAINNET_CHAIN_ID = 1
-
 export const NETWORKS: Record<number, NetworkInfo> = {
   31337: {
     name: NetworkName.localhost,


### PR DESCRIPTION
## What does this PR do and why?

Fixes this:
<img width="772" alt="Screen Shot 2022-12-20 at 4 40 43 pm" src="https://user-images.githubusercontent.com/96150256/208601165-dc0a7bb2-d2ab-4aa1-b96c-a4771526066f.png">

- seems to have been caused by Web3 onboard hook returning 'Ethereum Mainnet' for the network name, instead of just `mainnet`. 
- Fixes by looking up `chainId` instead of `name`

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
