### PR TITLE
add pinata pinning to user api key and add progress bars to uploads

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ const ContentSecurityPolicy = `
   style-src 'self' https://fonts.googleapis.com 'unsafe-inline';
   font-src 'self' https://fonts.gstatic.com data:;
   img-src 'self' https://*.juicebox.money https://juicebox.money https://*.infura-ipfs.io https://jbx.mypinata.cloud data:;
-  connect-src 'self' https://*.juicebox.money https://juicebox.money https://*.infura.io https://*.infura-ipfs.io https://jbx.mypinata.cloud https://api.studio.thegraph.com https://gateway.thegraph.com https://api.arcx.money https://api.tenderly.co https://*.hotjar.com https://*.hotjar.io wss://*.hotjar.com https://*.gnosis.io https://*.safe.global https://*.snapshot.org https://*.wallet.coinbase.com ${WALLET_CONNECT_URLS};
+  connect-src 'self' https://*.juicebox.money https://juicebox.money https://*.infura.io https://*.infura-ipfs.io https://api.pinata.cloud https://jbx.mypinata.cloud https://api.studio.thegraph.com https://gateway.thegraph.com https://api.arcx.money https://api.tenderly.co https://*.hotjar.com https://*.hotjar.io wss://*.hotjar.com https://*.gnosis.io https://*.safe.global https://*.snapshot.org https://*.wallet.coinbase.com ${WALLET_CONNECT_URLS};
   manifest-src 'self';
   prefetch-src 'self';
   frame-src 'self' https://vars.hotjar.com/ https://gnosis-safe.io https://app.safe.global;

--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -1,10 +1,6 @@
-import {
-  CloseCircleFilled,
-  LoadingOutlined,
-  UploadOutlined,
-} from '@ant-design/icons'
+import { CloseCircleFilled, UploadOutlined } from '@ant-design/icons'
 import { t } from '@lingui/macro'
-import { Form, Modal, Space } from 'antd'
+import { Form, Modal, Progress, Space } from 'antd'
 import InputAccessoryButton from 'components/InputAccessoryButton'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
@@ -12,8 +8,11 @@ import { JuiceInput } from 'components/inputs/JuiceTextInput'
 import { JuiceSwitch } from 'components/JuiceSwitch'
 import PrefixedInput from 'components/PrefixedInput'
 import { UploadNoStyle } from 'components/UploadNoStyle'
-import { pinFileToIpfs } from 'lib/api/ipfs'
-import { useCallback, useEffect, useState } from 'react'
+import { ThemeContext } from 'contexts/themeContext'
+import { usePinFileToIpfs } from 'hooks/PinFileToIpfs'
+import { useWallet } from 'hooks/Wallet'
+import { UploadRequestOption } from 'rc-upload/lib/interface'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { stopPropagation } from 'react-stop-propagation'
 import { restrictedIpfsUrl } from 'utils/ipfs'
 import { v4 } from 'uuid'
@@ -46,8 +45,14 @@ export const AddEditRewardModal = ({
   onOk: (reward: Reward) => void
   onCancel: VoidFunction
 }) => {
+  const {
+    theme: { colors },
+  } = useContext(ThemeContext)
   const [form] = Form.useForm<AddEditRewardModalFormProps>()
   const [limitedSupply, setLimitedSupply] = useState<boolean>(false)
+
+  const pinFileToIpfs = usePinFileToIpfs()
+  const wallet = useWallet()
 
   useEffect(() => {
     if (!open) return
@@ -88,11 +93,32 @@ export const AddEditRewardModal = ({
     form.resetFields()
   }, [form, onCancel])
 
-  const onCustomRequest = useCallback(async (file: File | string | Blob) => {
-    const res = await pinFileToIpfs(file)
-    const url = restrictedIpfsUrl(res.IpfsHash)
-    return url
-  }, [])
+  const onCustomRequest = useCallback(
+    async (options: UploadRequestOption) => {
+      const { file, onProgress } = options
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const res = await pinFileToIpfs({ file, onProgress: onProgress as any })
+        if (!res) throw new Error('Failed to pin file to IPFS')
+        const url = restrictedIpfsUrl(res.IpfsHash)
+        return url
+      } catch (err) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options.onError?.(null as any)
+        throw err
+      }
+    },
+    [pinFileToIpfs],
+  )
+
+  const onBeforeUpload = useCallback(async () => {
+    let walletConnected = wallet.isConnected
+    if (!wallet.isConnected) {
+      const connectStates = await wallet.connect()
+      walletConnected = connectStates.length > 0
+    }
+    return walletConnected
+  }, [wallet])
 
   const isEditing = !!editingData
   return (
@@ -122,15 +148,35 @@ export const AddEditRewardModal = ({
             supportedFileTypes={
               new Set(['image/jpeg', 'image/png', 'image/gif'])
             }
+            beforeUpload={onBeforeUpload}
             customRequest={onCustomRequest}
             listType="picture-card" // Tried to do away with styling, but need this -.-
           >
-            {({ uploadUrl, isUploading, undo }) => {
+            {({ uploadUrl, isUploading, undo, percent }) => {
               if (isUploading) {
-                return <LoadingOutlined />
+                return (
+                  <div>
+                    <Progress
+                      width={48}
+                      className="h-8 w-8"
+                      strokeColor={colors.background.action.primary}
+                      type="circle"
+                      percent={percent}
+                      format={percent => (
+                        <div className="text-black dark:text-grey-200">
+                          {percent ?? 0}%
+                        </div>
+                      )}
+                    />
+                  </div>
+                )
               }
               if (uploadUrl === undefined) {
-                return <UploadButton />
+                return (
+                  <>
+                    <UploadButton />
+                  </>
+                )
               }
               return (
                 <UploadedImage

--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -172,11 +172,7 @@ export const AddEditRewardModal = ({
                 )
               }
               if (uploadUrl === undefined) {
-                return (
-                  <>
-                    <UploadButton />
-                  </>
-                )
+                return <UploadButton />
               }
               return (
                 <UploadedImage

--- a/src/components/UploadNoStyle/UploadNoStyle.tsx
+++ b/src/components/UploadNoStyle/UploadNoStyle.tsx
@@ -4,6 +4,7 @@ import { RcFile } from 'antd/lib/upload'
 import { FormItemInput } from 'models/formItemInput'
 import { ReactNode, useCallback, useState } from 'react'
 import { emitErrorNotification } from 'utils/notifications'
+import { UploadRequestOption } from 'rc-upload/lib/interface'
 
 interface UploadNoStyleProps
   extends FormItemInput<string | undefined>,
@@ -13,8 +14,9 @@ interface UploadNoStyleProps
     > {
   sizeLimit?: number
   supportedFileTypes?: Set<'image/jpeg' | 'image/png' | 'image/gif'>
-  customRequest?: (req: File | Blob | string) => Promise<string> | string
+  customRequest?: (options: UploadRequestOption) => Promise<string> | string
   children?: (props: {
+    percent: number | undefined
     isUploading: boolean
     uploadUrl: string | undefined
     undo: VoidFunction
@@ -24,6 +26,7 @@ interface UploadNoStyleProps
 export const UploadNoStyle = (props: UploadNoStyleProps) => {
   const [_uploadUrl, _setUploadUrl] = useState<string>()
   const [isUploading, setIsUploading] = useState<boolean>(false)
+  const [percent, setPercent] = useState<number | undefined>(undefined)
 
   const uploadUrl = props.value ?? _uploadUrl
   const setUploadUrl = props.onChange ?? _setUploadUrl
@@ -31,7 +34,7 @@ export const UploadNoStyle = (props: UploadNoStyleProps) => {
   const undo = useCallback(() => setUploadUrl(undefined), [setUploadUrl])
 
   const handleBeforeUpload = useCallback(
-    (file: RcFile) => {
+    async (file: RcFile) => {
       const fileIsAllowed = props.supportedFileTypes?.size
         ? ([...props.supportedFileTypes] as string[]).includes(file.type)
         : true
@@ -52,9 +55,11 @@ export const UploadNoStyle = (props: UploadNoStyleProps) => {
         )
       }
 
-      return isInSizeLimit && fileIsAllowed
+      const childCheck = await props.beforeUpload?.(file, [])
+
+      return isInSizeLimit && fileIsAllowed && childCheck
     },
-    [props.sizeLimit, props.supportedFileTypes],
+    [props],
   )
 
   return (
@@ -67,8 +72,18 @@ export const UploadNoStyle = (props: UploadNoStyleProps) => {
         props.customRequest
           ? async req => {
               setIsUploading(true)
+              setPercent(0)
               try {
-                const val = await props.customRequest?.(req.file)
+                const val = await props.customRequest?.({
+                  ...req,
+                  onProgress: e => {
+                    req.onProgress?.(e)
+                    if (e) {
+                      // Bit of a hack
+                      setPercent(e as unknown as number)
+                    }
+                  },
+                })
                 setUploadUrl(val)
               } catch (e) {
                 console.error('Error occurred while uploading', e)
@@ -80,7 +95,9 @@ export const UploadNoStyle = (props: UploadNoStyleProps) => {
       }
       showUploadList={false}
     >
-      {props.children ? props.children({ uploadUrl, isUploading, undo }) : null}
+      {props.children
+        ? props.children({ uploadUrl, isUploading, undo, percent })
+        : null}
     </Upload>
   )
 }

--- a/src/components/UploadNoStyle/UploadNoStyle.tsx
+++ b/src/components/UploadNoStyle/UploadNoStyle.tsx
@@ -62,37 +62,39 @@ export const UploadNoStyle = (props: UploadNoStyleProps) => {
     [props],
   )
 
+  const onCustomRequest = useCallback(
+    async (req: UploadRequestOption) => {
+      if (!props.customRequest) return
+      setIsUploading(true)
+      setPercent(0)
+      try {
+        const val = await props.customRequest({
+          ...req,
+          onProgress: e => {
+            req.onProgress?.(e)
+            if (e) {
+              // Bit of a hack
+              setPercent(e as unknown as number)
+            }
+          },
+        })
+        setUploadUrl(val)
+      } catch (e) {
+        console.error('Error occurred while uploading', e)
+      } finally {
+        setIsUploading(false)
+      }
+    },
+    [props, setUploadUrl],
+  )
+
   return (
     <Upload
       {...props}
       className="w-full"
       onChange={undefined}
       beforeUpload={handleBeforeUpload}
-      customRequest={
-        props.customRequest
-          ? async req => {
-              setIsUploading(true)
-              setPercent(0)
-              try {
-                const val = await props.customRequest?.({
-                  ...req,
-                  onProgress: e => {
-                    req.onProgress?.(e)
-                    if (e) {
-                      // Bit of a hack
-                      setPercent(e as unknown as number)
-                    }
-                  },
-                })
-                setUploadUrl(val)
-              } catch (e) {
-                console.error('Error occurred while uploading', e)
-              } finally {
-                setIsUploading(false)
-              }
-            }
-          : undefined
-      }
+      customRequest={onCustomRequest}
       showUploadList={false}
     >
       {props.children

--- a/src/components/inputs/FormImageUploader.tsx
+++ b/src/components/inputs/FormImageUploader.tsx
@@ -2,9 +2,11 @@ import { CloseCircleFilled, FileImageOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { PinataMetadata } from '@pinata/sdk'
 import { Button, Col, message, Row, Space, Upload } from 'antd'
-import { pinFileToIpfs } from 'lib/api/ipfs'
+import { usePinFileToIpfs } from 'hooks/PinFileToIpfs'
+import { useWallet } from 'hooks/Wallet'
 import { useState } from 'react'
 import { cidFromIpfsUri, ipfsUrl, restrictedIpfsUrl } from 'utils/ipfs'
+import { emitErrorNotification } from 'utils/notifications'
 
 import ExternalLink from '../ExternalLink'
 
@@ -32,6 +34,9 @@ export const FormImageUploader = ({
   const [imageCid, setImageCid] = useState<string | undefined>(
     value ? cidFromIpfsUri(value) : undefined,
   )
+
+  const wallet = useWallet()
+  const pinFileToIpfs = usePinFileToIpfs()
 
   const setValue = (cid?: string) => {
     setImageCid(cid)
@@ -64,7 +69,7 @@ export const FormImageUploader = ({
           ) : (
             <Upload
               accept="image/png, image/jpeg, image/jpg, image/gif"
-              beforeUpload={file => {
+              beforeUpload={async file => {
                 if (maxSize !== undefined && file.size > maxSize * 1000) {
                   const unit = maxSize > 999 ? ByteUnit.MB : ByteUnit.KB
                   const formattedSize =
@@ -76,12 +81,32 @@ export const FormImageUploader = ({
                   )
                   return Upload.LIST_IGNORE
                 }
+                let walletConnected = wallet.isConnected
+                if (!wallet.isConnected) {
+                  const connectStates = await wallet.connect()
+                  walletConnected = connectStates.length > 0
+                }
+                if (!walletConnected) return Upload.LIST_IGNORE
               }}
               customRequest={async req => {
                 setLoadingUpload(true)
-                const res = await pinFileToIpfs(req.file, metadata)
-                setValue(res.IpfsHash)
-                setLoadingUpload(false)
+                try {
+                  const res = await pinFileToIpfs({
+                    ...req,
+                    metadata,
+                    onProgress: percent => {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      req.onProgress?.({ percent } as any)
+                    },
+                  })
+                  setValue(res.IpfsHash)
+                } catch (e) {
+                  emitErrorNotification(t`Error uploading file`)
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  req.onError?.(null as any)
+                } finally {
+                  setLoadingUpload(false)
+                }
               }}
             >
               <Button loading={loadingUpload} type="dashed">

--- a/src/components/inputs/FormImageUploader.tsx
+++ b/src/components/inputs/FormImageUploader.tsx
@@ -82,7 +82,7 @@ export const FormImageUploader = ({
                   return Upload.LIST_IGNORE
                 }
                 let walletConnected = wallet.isConnected
-                if (!wallet.isConnected) {
+                if (!walletConnected) {
                   const connectStates = await wallet.connect()
                   walletConnected = connectStates.length > 0
                 }

--- a/src/components/inputs/ImageUploader.tsx
+++ b/src/components/inputs/ImageUploader.tsx
@@ -2,7 +2,7 @@ import { CloseCircleFilled, FileImageOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { PinataMetadata } from '@pinata/sdk'
 import { Button, Col, message, Row, Space, Upload } from 'antd'
-import { pinFileToIpfs } from 'lib/api/ipfs'
+import { usePinFileToIpfs } from 'hooks/PinFileToIpfs'
 import { useLayoutEffect, useState } from 'react'
 import { restrictedIpfsUrl } from 'utils/ipfs'
 import { emitErrorNotification } from 'utils/notifications'
@@ -29,6 +29,8 @@ export default function ImageUploader({
 }) {
   const [url, setUrl] = useState<string | undefined>(initialUrl)
   const [loadingUpload, setLoadingUpload] = useState<boolean>()
+
+  const pinFileToIpfs = usePinFileToIpfs()
 
   const setValue = (cid?: string) => {
     const newUrl = cid ? restrictedIpfsUrl(cid) : undefined
@@ -75,10 +77,19 @@ export default function ImageUploader({
               customRequest={async req => {
                 setLoadingUpload(true)
                 try {
-                  const res = await pinFileToIpfs(req.file, metadata)
+                  const res = await pinFileToIpfs({
+                    ...req,
+                    metadata,
+                    onProgress: percent => {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      req.onProgress?.({ percent } as any)
+                    },
+                  })
                   setValue(res.IpfsHash)
                 } catch (err) {
                   emitErrorNotification(t`Error uploading file`)
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  req.onError?.(null as any)
                 }
                 setLoadingUpload(false)
               }}

--- a/src/hooks/PinFileToIpfs.ts
+++ b/src/hooks/PinFileToIpfs.ts
@@ -1,0 +1,97 @@
+import { PinataMetadata } from '@pinata/sdk'
+import axios from 'axios'
+import { isWalletRegistered, registerWallet } from 'lib/api/ipfs'
+import { useCallback } from 'react'
+import { useWallet } from './Wallet'
+import { v4 } from 'uuid'
+import { WalletSigningRequestMessageTemplate } from 'utils/server/ipfs/pinata'
+
+export const usePinFileToIpfs = () => {
+  const wallet = useWallet()
+
+  const loadCredsFromCache = useCallback(() => {
+    const apiKey = localStorage.getItem('ipfsApiKey')
+    const apiSecret = localStorage.getItem('ipfsApiSecret')
+    if (apiKey && apiSecret) {
+      return { apiKey, apiSecret }
+    }
+    return undefined
+  }, [])
+
+  const saveCredsToCache = useCallback((apiKey: string, apiSecret: string) => {
+    localStorage.setItem('ipfsApiKey', apiKey)
+    localStorage.setItem('ipfsApiSecret', apiSecret)
+  }, [])
+
+  const pinFileToIpfs = useCallback(
+    async ({
+      file,
+      metadata,
+      onProgress,
+    }: {
+      file: File | Blob | string
+      metadata?: PinataMetadata
+      onProgress: (percent: number) => void
+    }) => {
+      if (!wallet.isConnected) {
+        await wallet.connect()
+        return
+      }
+      if (!wallet.userAddress) {
+        throw new Error('Wallet is not connected')
+      }
+      const registered = await isWalletRegistered(wallet.userAddress)
+      let creds = loadCredsFromCache()
+      if (!registered || !creds) {
+        if (!wallet.signer) throw new Error('Wallet is not connected')
+        const nonce = v4()
+
+        const signature = await wallet.signer.signMessage(
+          WalletSigningRequestMessageTemplate({ nonce }),
+        )
+        const { apiKey, apiSecret } = await registerWallet(
+          wallet.userAddress,
+          signature,
+          nonce,
+        )
+        saveCredsToCache(apiKey, apiSecret)
+        creds = { apiKey, apiSecret }
+      }
+
+      const formData = new FormData()
+      formData.append('file', file)
+      if (metadata) {
+        formData.append('pinataMetadata', JSON.stringify(metadata))
+      }
+
+      const config = {
+        maxBodyLength: Infinity,
+        headers: {
+          pinata_api_key: creds.apiKey,
+          pinata_secret_api_key: creds.apiSecret,
+          'Content-Type': `multipart/form-data; boundary=${
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (formData as any)._boundary
+          }`,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onUploadProgress: (progressEvent: any) => {
+          const percentCompleted = Math.round(
+            (progressEvent.loaded * 100) / progressEvent.total,
+          )
+          onProgress(percentCompleted)
+        },
+      }
+      const res = await axios.post(
+        'https://api.pinata.cloud/pinning/pinFileToIPFS',
+        formData,
+        config,
+      )
+      return res.data
+    },
+
+    [loadCredsFromCache, saveCredsToCache, wallet],
+  )
+
+  return pinFileToIpfs
+}

--- a/src/lib/api/ipfs.ts
+++ b/src/lib/api/ipfs.ts
@@ -19,6 +19,39 @@ const extractJsonFromBase64Data = (base64: string) => {
   return JSON.parse(decoded.substring(jsonStart, jsonEnd + 1))
 }
 
+export const isWalletRegistered = async (
+  walletAddress: string,
+): Promise<boolean> => {
+  try {
+    const result = await axios.post('/api/ipfs/isWalletRegistered', {
+      walletAddress,
+    })
+    return result.data.registered
+  } catch (e) {
+    console.error('error occurred', e)
+    throw e
+  }
+}
+
+export const registerWallet = async (
+  walletAddress: string,
+  signature: string,
+  nonce: string,
+): Promise<{ apiKey: string; apiSecret: string }> => {
+  try {
+    const result = await axios.post('/api/ipfs/registerWallet', {
+      walletAddress,
+      signature,
+      nonce,
+    })
+    return result.data
+  } catch (e) {
+    console.error('error occurred', e)
+    throw e
+  }
+}
+
+// TODO: Move to wallet key
 // keyvalues will be upserted to existing metadata. A null value will remove an existing keyvalue
 export const editMetadataForCid = async (
   cid: string | undefined,
@@ -61,31 +94,6 @@ export const ipfsGetWithFallback = async (
   //     : await axios.get(openIpfsUrl(hash))
   //   return response
   // }
-}
-
-export const pinFileToIpfs = async (
-  file: File | Blob | string,
-  metadata?: PinataMetadata,
-) => {
-  const data = new FormData()
-  data.append('file', file)
-  if (metadata) {
-    data.append(
-      'pinataMetadata',
-      JSON.stringify({
-        keyvalues: metadata,
-      }),
-    )
-  }
-
-  const res = await axios.post('/api/ipfs/logo', data, {
-    maxContentLength: Infinity, //this is needed to prevent axios from erroring out with large files
-    headers: {
-      'Content-Type': `multipart/form-data;`,
-    },
-  })
-
-  return res.data as PinataPinResponse
 }
 
 export const uploadProjectMetadata = async (

--- a/src/pages/api/ipfs/isWalletRegistered.page.ts
+++ b/src/pages/api/ipfs/isWalletRegistered.page.ts
@@ -1,0 +1,62 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { requestPinataApiKeys } from 'utils/server/ipfs/pinata'
+
+const validateRequest = (req: NextApiRequest) => {
+  const reqIsPost = req.method === 'POST'
+  const reqBodyContainsWalletAddress = !!req.body.walletAddress
+  const walletAddressIsString = typeof req.body.walletAddress === 'string'
+  if (!reqIsPost || !reqBodyContainsWalletAddress || !walletAddressIsString) {
+    throw {
+      error: 'Bad Request',
+    }
+  }
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    try {
+      validateRequest(req)
+    } catch (e) {
+      return res.status(400).json(e)
+    }
+    const walletAddress = (req.body.walletAddress as string).toLowerCase()
+
+    const result = await requestPinataApiKeys()
+
+    const registeredWallet = result.find(key => key.name === walletAddress)
+    if (!registeredWallet || registeredWallet.revoked) {
+      return res.status(200).json({
+        registered: false,
+      })
+    }
+
+    if (
+      registeredWallet.max_uses !== null &&
+      registeredWallet.uses >= registeredWallet.max_uses
+    ) {
+      return res.status(200).json({
+        registered: false,
+      })
+    }
+
+    const createdAt = new Date(registeredWallet.createdAt)
+    const now = new Date()
+    const oneDay = 1000 * 60 * 60 * 24
+    if (now.getTime() - createdAt.getTime() > oneDay) {
+      return res.status(200).json({
+        registered: false,
+      })
+    }
+
+    return res.status(200).json({
+      registered: true,
+    })
+  } catch (e) {
+    console.error('error occurred', e)
+    return res.status(500).json({
+      error: 'Error occurred',
+    })
+  }
+}
+
+export default handler

--- a/src/pages/api/ipfs/registerWallet.page.ts
+++ b/src/pages/api/ipfs/registerWallet.page.ts
@@ -1,0 +1,82 @@
+import { recoverAddress } from '@ethersproject/transactions'
+import { hashMessage } from '@ethersproject/hash'
+import { NextApiRequest, NextApiResponse } from 'next'
+import {
+  registerApiKey,
+  requestPinataApiKeys,
+  revokeApiKey,
+  WalletSigningRequestMessageTemplate,
+} from 'utils/server/ipfs/pinata'
+
+const validateRequest = (req: NextApiRequest) => {
+  const reqIsGet = req.method === 'POST'
+  const reqBodyContainsWalletAddress = !!req.body.walletAddress
+  const walletAddressIsString = typeof req.body.walletAddress === 'string'
+  const reqBodyContainsSignature = !!req.body.signature
+  const signatureIsString = typeof req.body.signature === 'string'
+  const reqBodyContainsNonce = !!req.body.nonce
+  const nonceIsString = typeof req.body.nonce === 'string'
+  if (
+    !reqIsGet ||
+    !reqBodyContainsWalletAddress ||
+    !walletAddressIsString ||
+    !reqBodyContainsSignature ||
+    !signatureIsString ||
+    !reqBodyContainsNonce ||
+    !nonceIsString
+  ) {
+    throw {
+      error: 'Bad Request',
+    }
+  }
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    try {
+      validateRequest(req)
+    } catch (e) {
+      return res.status(400).json(e)
+    }
+    const walletAddress = (req.body.walletAddress as string).toLowerCase()
+    const signature = req.body.signature as string
+    const nonce = req.body.nonce as string
+
+    const signatureWalletAddress = recoverAddress(
+      hashMessage(WalletSigningRequestMessageTemplate({ nonce })),
+      signature,
+    ).toLowerCase()
+
+    if (signatureWalletAddress !== walletAddress) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+      })
+    }
+
+    const results = (await requestPinataApiKeys()).filter(
+      r => r.name === walletAddress,
+    )
+    const revoked = await Promise.allSettled(
+      results.map(async r => await revokeApiKey(r.key)),
+    )
+    revoked.forEach((r, i) => {
+      if (r.status !== 'fulfilled') {
+        console.error(`failed to revoke ${results[i].key}`)
+      }
+    })
+
+    const registeredApiKey = await registerApiKey(walletAddress)
+
+    return res.status(200).json({
+      apiKey: registeredApiKey.key,
+      apiSecret: registeredApiKey.secret,
+    })
+  } catch (e) {
+    console.error('error occurred', e)
+    return res.status(500).json({
+      error: 'Error occurred',
+    })
+  }
+}
+
+export default handler

--- a/src/utils/server/ipfs/pinata.ts
+++ b/src/utils/server/ipfs/pinata.ts
@@ -1,0 +1,87 @@
+import axios from 'axios'
+import { template } from 'lodash'
+
+export const WalletSigningRequestMessageTemplate = template(
+  'Sign this message to register your wallet to allow image uploads on Juicebox.\n\nYou may have to periodically sign for image upload.\n\nNo charges will be made against your wallet.\n\nRequest ID: ${nonce}',
+)
+
+interface PinataApiKey {
+  name: string
+  key: string
+  secret: string
+}
+const PINATA_PINNER_KEY = process.env.PINATA_PINNER_KEY
+const PINATA_PINNER_SECRET = process.env.PINATA_PINNER_SECRET
+
+const Headers = {
+  pinata_api_key: PINATA_PINNER_KEY,
+  pinata_secret_api_key: PINATA_PINNER_SECRET,
+}
+
+export const requestPinataApiKeys = async (): Promise<
+  Array<
+    PinataApiKey & {
+      max_uses: number | null
+      uses: number
+      createdAt: string
+      revoked: boolean
+    }
+  >
+> => {
+  const config = {
+    method: 'GET',
+    url: 'https://api.pinata.cloud/users/apiKeys',
+    headers: Headers,
+  }
+  return (await axios(config)).data.keys
+}
+
+export const revokeApiKey = async (apiKey: string): Promise<void> => {
+  const config = {
+    method: 'PUT',
+    url: 'https://api.pinata.cloud/users/revokeApiKey',
+    headers: Headers,
+    data: { apiKey },
+  }
+  return (await axios(config)).data
+}
+
+export const registerApiKey = async (
+  walletAddress: string,
+): Promise<PinataApiKey> => {
+  const data = {
+    keyName: walletAddress,
+    maxUses: 100,
+    permissions: {
+      endpoints: {
+        data: {
+          pinList: false,
+          userPinnedDataTotal: false,
+        },
+        pinning: {
+          hashMetadata: true,
+          hashPinPolicy: false,
+          pinByHash: true,
+          pinFileToIPFS: true,
+          pinJSONToIPFS: true,
+          pinJobs: false,
+          unpin: false,
+          userPinPolicy: false,
+        },
+      },
+    },
+  }
+  const config = {
+    method: 'POST',
+    url: 'https://api.pinata.cloud/users/generateApiKey',
+    headers: Headers,
+    data,
+  }
+
+  const result = (await axios(config)).data
+  return {
+    name: walletAddress,
+    key: result.pinata_api_key,
+    secret: result.pinata_api_secret,
+  }
+}


### PR DESCRIPTION
## What does this PR do and why?

This PR achieves a few things:
- Remove the need to pin via a vercel edge function (necessary to reduce our vercel bill).
- Adds progress to uploads.
- Wallets now send a sign request (as part of new api key generation) which is handled via the upload.

The pinning flow is as so:
![Untitled Diagram-Page-1 drawio](https://user-images.githubusercontent.com/104132113/208810227-ff268a5f-baa9-42bf-bb97-0d276f57ed82.png)


_Code quality on some of this is a bit meh, but a side effect of using antd as the base. In future, I think we should just write our own component for this - it'll be better long run._

We could probably look at tightening up the UX of this, but I think this is acceptable for now. Some future considerations (with creation of a new component) could be to show a modal explaining to the user they need to connect their wallet and what is happening, but I think for now lets roll with this

## Screenshots or screen recordings

### New Upload Flow

https://user-images.githubusercontent.com/104132113/208810034-cf9807d9-6c8d-4199-b9a5-23cb803a1e29.mov

![Screen Shot 2022-12-21 at 1 55 23 pm](https://user-images.githubusercontent.com/104132113/208810370-1f51dc9d-11e7-47ac-bb11-eb589a981ca8.png)

![Screen Shot 2022-12-21 at 1 55 54 pm](https://user-images.githubusercontent.com/104132113/208810381-49a54091-e5bd-482a-9f13-fcbdabfb95fb.png)

![Screen Shot 2022-12-21 at 1 59 50 pm](https://user-images.githubusercontent.com/104132113/208810489-d84fd9de-9d5e-4bae-8610-13841773d8c8.png)



## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
