### PR TITLE
Hide holders and manage tokens buttons when count is 0

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/AccountBalanceDescription/AccountBalanceDescription.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/AccountBalanceDescription/AccountBalanceDescription.tsx
@@ -126,9 +126,11 @@ export function AccountBalanceDescription() {
         </div>
       </div>
 
-      <Button size="small" onClick={() => setManageTokensModalVisible(true)}>
-        <Trans>Manage {tokenText}</Trans>
-      </Button>
+      {totalBalance?.gt(0) ? (
+        <Button size="small" onClick={() => setManageTokensModalVisible(true)}>
+          <Trans>Manage {tokenText}</Trans>
+        </Button>
+      ) : null}
 
       <ManageTokensModal
         open={manageTokensModalVisible}

--- a/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/TotalSupplyDescription.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/TotalSupplyDescription.tsx
@@ -25,9 +25,11 @@ export function TotalSupplyDescription() {
         <div>
           {formatWad(totalTokenSupply, { precision: 0 })} {tokenText}
         </div>
-        <TextButton onClick={() => setParticipantsModalVisible(true)}>
-          <Trans>Holders</Trans>
-        </TextButton>
+        {totalTokenSupply?.gt(0) ? (
+          <TextButton onClick={() => setParticipantsModalVisible(true)}>
+            <Trans>Holders</Trans>
+          </TextButton>
+        ) : null}
       </div>
       <ParticipantsModal
         tokenSymbol={tokenSymbol}


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2665

Issue in notion - https://juicebox.notion.site/Hide-Holders-and-manage-tokens-button-when-token-count-is-0-1c47534d27d94ccdb8ece7adffc81a54

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/18723426/209100955-5d5f141c-c9f7-4617-8d87-0d668b10688a.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
