### PR TITLE
Fix V1 history fc end date

### DIFF
--- a/src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
+++ b/src/components/v1/V1Project/FundingCycles/FundingHistory.tsx
@@ -108,7 +108,7 @@ export default function FundingHistory({
 
             <Space className="text-sm" align="baseline">
               {formatHistoricalDate(
-                cycle.start.add(cycle.duration).mul(1000).toNumber(),
+                cycle.start.add(cycle.duration.mul(86400)).mul(1000).toNumber(),
               )}
               <CaretRightOutlined />
             </Space>


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2614

Notion https://juicebox.notion.site/V1-history-should-use-end-date-9e96ee1769bd4ba1a045baef4c643c2f

The issue here was that in V1, the value of `cycle.duration` was returned in days units, however in V2, it is returned in seconds units.

## Screenshots or screen recordings

**Before**
![image](https://user-images.githubusercontent.com/18723426/209302149-67b4df62-bb1f-44f6-b76f-b3ae1dc42568.png)

**After**
![image](https://user-images.githubusercontent.com/18723426/209302199-1df502c9-b23e-496e-80a5-249251ef227c.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
