### PR TITLE
Automatically connect to Gnosis Safe wallets

### DIFF
--- a/src/hooks/Network/LoadSafeWallet.ts
+++ b/src/hooks/Network/LoadSafeWallet.ts
@@ -1,0 +1,11 @@
+import { useWallet } from 'hooks/Wallet'
+import { useCallback } from 'react'
+
+export function useLoadSafeWallet() {
+  const { connect } = useWallet()
+
+  const loadSafeWallet = useCallback(async () => {
+    await connect({ autoSelect: { label: 'Safe', disableModals: true } })
+  }, [connect])
+  return loadSafeWallet
+}

--- a/src/hooks/Network/index.ts
+++ b/src/hooks/Network/index.ts
@@ -1,2 +1,3 @@
 export * from './LoadWalletFromLocalStorage'
 export * from './StoreWalletsInLocalStorage'
+export * from './LoadSafeWallet'

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -13,6 +13,7 @@ import { NETWORKS } from 'constants/networks'
 import {
   useLoadWalletFromLocalStorage,
   useStoreWalletsInLocalStorage,
+  useLoadSafeWallet,
 } from 'hooks/Network'
 import type { AppProps } from 'next/app'
 import React, { useEffect } from 'react'
@@ -61,7 +62,13 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const updateAccountCenter = useAccountCenter()
   const loadWalletFromLocalStorage = useLoadWalletFromLocalStorage()
   const storeWalletsInLocalStorage = useStoreWalletsInLocalStorage()
+  const loadSafeWallet = useLoadSafeWallet()
   const connectedWallets = useWallets()
+
+  // If possible, load Safe wallets
+  useEffect(() => {
+    loadSafeWallet()
+  }, [loadSafeWallet])
 
   // Load any previously connected wallets
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do and why?

On load, attempt to connect to any Safe wallets. Automatically connecting to Safe wallets is a requirement for Juicebox to become a default app on Gnosis Safe. We had this functionality in the past and lost it somewhere along the way.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
