### PR TITLE
BugFix: Disallow entering hex values into formatted number input

### DIFF
--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -76,9 +76,12 @@ export default function FormattedNumberInput({
             : '') +
           _suffix
         }
-        parser={(val?: string) =>
-          parseFloat(
-            (val !== undefined ? val : '0')
+        parser={(val?: string) => {
+          if (!val) return '0'
+          // Stops user from entering hex values
+          if (/^0?0x[0-9a-fA-F]+$/.test(val)) return '0'
+          return parseFloat(
+            val
               .replace(new RegExp(thousandsSeparator, 'g'), '')
               .replace(_prefix, '')
               .replace(_suffix, '')
@@ -86,7 +89,7 @@ export default function FormattedNumberInput({
               .filter(char => allowedValueChars.includes(char))
               .join('') || '0',
           )
-        }
+        }}
         disabled={disabled}
         onBlur={_value => {
           onBlur?.(_value?.toString())


### PR DESCRIPTION
## What does this PR do and why?

This pull request fixes a bug in FormattedNumberInput where hexadecimal numbers were allowed as inputs. Hexadecimal numbers, such as wallet addresses, are no longer allowed and are set to 0 instead.

Before this change, users were able to enter wallet addresses into FormattedNumberInput, which caused issues with the application. This change ensures that only decimal numbers are allowed as inputs, which resolves the issue and improves the overall stability of the application.

I have tested this change and verified that it is working as intended. 

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
