### PR TITLE
Select a single NFT tier multiple times

### DIFF
--- a/src/components/NftRewards/NftRewardsSection.tsx
+++ b/src/components/NftRewards/NftRewardsSection.tsx
@@ -72,12 +72,11 @@ export function NftRewardsSection() {
   const payAmountETH =
     payInCurrency === ETH ? payAmount : fromWad(converter.usdToWei(payAmount))
 
-  const onTierDeselect = (tierId: number | undefined) => {
+  const handleTierDeselect = (tierId: number | undefined) => {
     if (tierId === undefined || !rewardTiers || !payMetadata) return
-
-    const newSelectedTierIds = [...payMetadata.tierIdsToMint].filter(
-      selectedTierId => selectedTierId !== tierId,
-    )
+    const idxToRemove = payMetadata.tierIdsToMint.indexOf(tierId)
+    const newSelectedTierIds = payMetadata.tierIdsToMint
+    newSelectedTierIds.splice(idxToRemove, 1)
 
     setPayMetadata?.({
       tierIdsToMint: newSelectedTierIds,
@@ -92,7 +91,7 @@ export function NftRewardsSection() {
     validatePayAmount?.(newPayAmount)
   }
 
-  const onTierSelect = (tierId: number | undefined) => {
+  const handleTierSelect = (tierId: number | undefined) => {
     if (!tierId || !rewardTiers) return
 
     const newSelectedTierIds = [...(payMetadata?.tierIdsToMint ?? []), tierId]
@@ -132,23 +131,22 @@ export function NftRewardsSection() {
           className="-mt-3 -ml-3 -mr-5 max-h-[500px] overflow-auto pb-3 pt-3 pl-3 pr-5"
         >
           <Row gutter={isMobile ? 12 : 24}>
-            {renderRewardTiers?.map((rewardTier, idx) => (
+            {renderRewardTiers?.map(rewardTier => (
               <Col
                 className="mb-4"
                 md={8}
-                xs={8}
+                xs={12}
                 key={`${rewardTier.contributionFloor}-${rewardTier.name}`}
               >
                 <NftTierCard
                   rewardTier={rewardTier}
-                  rewardTierUpperLimit={
-                    rewardTiers?.[idx + 1]?.contributionFloor
+                  quantitySelected={
+                    payMetadata?.tierIdsToMint.filter(
+                      id => id === rewardTier.id ?? -1,
+                    ).length
                   }
-                  isSelected={payMetadata?.tierIdsToMint.includes(
-                    rewardTier.id ?? -1,
-                  )}
-                  onClick={() => onTierSelect(rewardTier.id)}
-                  onRemove={() => onTierDeselect(rewardTier.id)}
+                  onClick={() => handleTierSelect(rewardTier.id)}
+                  onRemove={() => handleTierDeselect(rewardTier.id)}
                 />
               </Col>
             ))}

--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -1,14 +1,12 @@
-import { CheckOutlined, LoadingOutlined } from '@ant-design/icons'
+import { LoadingOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Skeleton, Tooltip } from 'antd'
-import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
+import { Skeleton } from 'antd'
 import { NftRewardTier } from 'models/nftRewardTier'
-import { MouseEventHandler, useContext, useState } from 'react'
-import { stopPropagation } from 'react-stop-propagation'
+import { useState } from 'react'
 import { classNames } from 'utils/classNames'
 import { ipfsToHttps } from 'utils/ipfs'
-import { payMetadataOverrides } from 'utils/nftRewards'
 import { NftPreview } from './NftPreview'
+import { QuantitySelector } from './QuantitySelector'
 
 const MAX_REMAINING_SUPPLY = 10000
 
@@ -16,76 +14,39 @@ const MAX_REMAINING_SUPPLY = 10000
 export function NftTierCard({
   loading,
   rewardTier,
-  rewardTierUpperLimit,
   isSelected,
+  quantitySelected,
   onClick,
   onRemove,
   previewDisabled,
   hideAttributes,
 }: {
   rewardTier?: NftRewardTier
-  rewardTierUpperLimit?: number
   loading?: boolean
   isSelected?: boolean
-  onClick?: MouseEventHandler<HTMLDivElement>
-  onRemove?: () => void
+  quantitySelected?: number
+  onClick?: VoidFunction
+  onRemove?: VoidFunction
   previewDisabled?: boolean
   hideAttributes?: boolean
 }) {
   const [previewVisible, setPreviewVisible] = useState<boolean>(false)
 
-  const { projectId } = useContext(ProjectMetadataContext)
-
   const imageUrl = rewardTier?.imageUrl
     ? ipfsToHttps(rewardTier.imageUrl)
     : rewardTier?.imageUrl
 
-  const _onRemove = onRemove ?? onClick
+  const canSelect = onRemove && onClick
 
-  function RewardIcon() {
-    return (
-      <Tooltip
-        title={
-          !hideAttributes ? (
-            <span className="text-xs">
-              {payMetadataOverrides(projectId ?? 0).dontOverspend ? (
-                <Trans>
-                  Receive this NFT when you contribute{' '}
-                  <strong>{rewardTier?.contributionFloor} ETH</strong>.
-                </Trans>
-              ) : rewardTierUpperLimit ? (
-                <Trans>
-                  Receive this NFT when you contribute{' '}
-                  <strong>{rewardTier?.contributionFloor}</strong> - {'<'}
-                  <strong>{rewardTierUpperLimit} ETH</strong>.
-                </Trans>
-              ) : (
-                <Trans>
-                  Receive this NFT when you contribute at least{' '}
-                  <strong>{rewardTier?.contributionFloor} ETH</strong>.
-                </Trans>
-              )}
-            </span>
-          ) : undefined
-        }
-        overlayInnerStyle={{
-          padding: '7px 10px',
-          lineHeight: '1rem',
-          maxWidth: '210px',
-        }}
-        placement={'bottom'}
-      >
-        <div
-          className={classNames(
-            'absolute right-2 top-2 h-6 w-6 items-center justify-center rounded-full text-base',
-            isSelected ? 'flex bg-haze-400 text-smoke-25' : 'hidden',
-          )}
-          onClick={_onRemove ? stopPropagation(_onRemove) : undefined}
-        >
-          <CheckOutlined />
-        </div>
-      </Tooltip>
-    )
+  const hasQuantitySelected =
+    quantitySelected !== undefined && quantitySelected > 0
+  const _isSelected = isSelected || hasQuantitySelected
+
+  // When previewDisabled, we want card to deselect when clicked while it is selected.
+  const onClickNoPreview = _isSelected ? onRemove : onClick
+
+  const openPreview = () => {
+    setPreviewVisible(true)
   }
 
   const remainingSupply =
@@ -99,16 +60,12 @@ export function NftTierCard({
       <div
         className={classNames(
           'flex h-full w-full cursor-pointer flex-col rounded-sm transition-shadow duration-100',
-          isSelected
+          _isSelected
             ? 'shadow-[2px_0px_10px_0px_var(--boxShadow-primary)] outline outline-2 outline-haze-400'
             : '',
         )}
         onClick={
-          !isSelected || previewDisabled
-            ? onClick
-            : () => {
-                setPreviewVisible(true)
-              }
+          _isSelected && !previewDisabled ? openPreview : onClickNoPreview
         }
         role="button"
       >
@@ -117,7 +74,7 @@ export function NftTierCard({
           className={classNames(
             'relative flex w-full items-center justify-center',
             !loading ? 'pt-[100%]' : 'pt-[unset]',
-            isSelected
+            _isSelected
               ? 'bg-smoke-25 dark:bg-slate-800'
               : 'bg-smoke-100 dark:bg-slate-600',
           )}
@@ -134,25 +91,28 @@ export function NftTierCard({
               alt={rewardTier?.name}
               src={imageUrl}
               style={{
-                filter: isSelected ? 'unset' : 'brightness(50%)',
+                filter: _isSelected ? 'unset' : 'brightness(50%)',
               }}
               crossOrigin="anonymous"
             />
           )}
-          {isSelected ? <RewardIcon /> : null}
+          {canSelect && hasQuantitySelected ? (
+            <QuantitySelector
+              value={quantitySelected}
+              onIncrement={onClick}
+              onDecrement={onRemove}
+            />
+          ) : null}
         </div>
         {/* Details section below image */}
         <div
           className={classNames(
             'flex h-full w-full flex-col justify-center px-3 pb-1.5',
-            isSelected
+            _isSelected
               ? 'bg-smoke-25 dark:bg-slate-800'
               : 'bg-smoke-100 dark:bg-slate-600',
             !loading ? 'pt-2' : 'pt-1',
           )}
-          onClick={
-            isSelected && _onRemove ? stopPropagation(_onRemove) : undefined
-          }
         >
           <Skeleton
             loading={loading}
@@ -165,7 +125,7 @@ export function NftTierCard({
                 'text-xs',
                 'text-ellipsis',
                 'overflow-hidden',
-                isSelected
+                _isSelected
                   ? 'text-black dark:text-slate-100'
                   : 'text-grey-600 dark:text-slate-100',
               )}

--- a/src/components/NftRewards/QuantitySelector.tsx
+++ b/src/components/NftRewards/QuantitySelector.tsx
@@ -1,0 +1,52 @@
+import useMobile from 'hooks/Mobile'
+import { PlusOutlined, MinusOutlined } from '@ant-design/icons'
+import { twJoin } from 'tailwind-merge'
+
+// + / - buttons that appear in top-right of selected NFT cards on project page
+export function QuantitySelector({
+  value,
+  maxValue,
+  onIncrement,
+  onDecrement,
+}: {
+  value: number
+  maxValue?: number
+  onIncrement: VoidFunction
+  onDecrement: VoidFunction
+}) {
+  const isMobile = useMobile()
+  const iconClasses = twJoin(
+    'h-full flex items-center justify-center hover:bg-haze-600',
+    isMobile ? 'w-5/12' : 'w-[27px]',
+  )
+  const valueIsMax = value === maxValue
+
+  return (
+    <div
+      className={twJoin(
+        'absolute right-1.5 top-1.5 items-center text-sm',
+        'flex justify-between rounded-full bg-haze-400 text-smoke-25',
+        isMobile ? 'h-9 w-3/5' : 'h-7 w-1/2',
+      )}
+      onClick={e => e.stopPropagation()}
+    >
+      <div
+        onClick={onDecrement}
+        className={twJoin(iconClasses, 'rounded-l-full pl-0.5')}
+      >
+        <MinusOutlined />
+      </div>
+      <div className="flex items-center font-medium">{value}</div>
+      <div
+        onClick={valueIsMax ? undefined : onIncrement}
+        className={twJoin(
+          iconClasses,
+          'rounded-r-full pr-0.5',
+          valueIsMax ? 'bg-haze-700' : '',
+        )}
+      >
+        <PlusOutlined />
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
@@ -5,7 +5,6 @@ import {
   NFT_METADATA_CONTRIBUTION_FLOOR_ATTRIBUTES_INDEX,
 } from 'models/nftRewardTier'
 import { JB721DelegateToken } from 'models/subgraph-entities/v2/jb-721-delegate-tokens'
-import { MouseEventHandler } from 'react'
 import { useQuery, UseQueryResult } from 'react-query'
 import { cidFromIpfsUri, openIpfsUrl } from 'utils/ipfs'
 import { NftTierCard } from 'components/NftRewards/NftTierCard'
@@ -29,13 +28,15 @@ function useJB721DelegateTokenMetadata(
 
 export function RedeemNftCard({
   nft,
-  onClick,
   isSelected,
+  onClick,
+  onRemove,
   loading,
 }: {
   nft: JB721DelegateToken
-  onClick?: MouseEventHandler<HTMLDivElement>
-  isSelected?: boolean
+  isSelected: boolean
+  onClick?: VoidFunction
+  onRemove?: VoidFunction
   loading?: boolean
 }) {
   const { data: tierData } = useJB721DelegateTokenMetadata(nft.tokenUri)
@@ -60,6 +61,7 @@ export function RedeemNftCard({
     <NftTierCard
       rewardTier={rewardTier}
       onClick={onClick}
+      onRemove={onRemove}
       isSelected={isSelected}
       loading={loading}
       previewDisabled

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -50,14 +50,15 @@ export function RedeemNftsModal({
 
   if (!fundingCycle || !fundingCycleMetadata || isLoading) return null
 
-  const onNftClick = (nft: JB721DelegateToken) => {
-    if (tokenIdsToRedeem.includes(nft.tokenId)) {
-      setTokenIdsToRedeem([
-        ...tokenIdsToRedeem.filter(id => id !== nft.tokenId),
-      ])
-    } else {
-      setTokenIdsToRedeem([...tokenIdsToRedeem, nft.tokenId])
-    }
+  const handleTierSelect = (nft: JB721DelegateToken) => {
+    setTokenIdsToRedeem([...(tokenIdsToRedeem ?? []), nft.tokenId])
+  }
+
+  const handleTierDeselect = (nft: JB721DelegateToken) => {
+    const idxToRemove = tokenIdsToRedeem.indexOf(nft.tokenId)
+    const newSelectedTierIds = tokenIdsToRedeem
+    newSelectedTierIds.splice(idxToRemove, 1)
+    setTokenIdsToRedeem([...newSelectedTierIds])
   }
 
   const executeRedeemTransaction = async () => {
@@ -187,15 +188,19 @@ export function RedeemNftsModal({
           <Form form={form} layout="vertical">
             <Form.Item label={t`Select NFTs to redeem`}>
               <Row gutter={[20, 20]}>
-                {nfts?.map(nft => (
-                  <Col span={8} key={nft.tokenId}>
-                    <RedeemNftCard
-                      nft={nft}
-                      onClick={() => onNftClick(nft)}
-                      isSelected={tokenIdsToRedeem.includes(nft.tokenId)}
-                    />
-                  </Col>
-                ))}
+                {nfts?.map(nft => {
+                  const isSelected = tokenIdsToRedeem.includes(nft.tokenId)
+                  return (
+                    <Col span={8} key={nft.tokenId}>
+                      <RedeemNftCard
+                        nft={nft}
+                        onClick={() => handleTierSelect(nft)}
+                        onRemove={() => handleTierDeselect(nft)}
+                        isSelected={isSelected}
+                      />
+                    </Col>
+                  )
+                })}
               </Row>
             </Form.Item>
 

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/NftRewardCell.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/NftRewardCell.tsx
@@ -9,30 +9,43 @@ export function NftRewardCell({
 }: {
   nftRewards: NftRewardTier[]
 }): JSX.Element {
+  const uniqueTiersIdsAndCounts = nftRewards.reduce(
+    (acc: Record<number, number>, curr) => {
+      acc[curr.id ?? -1] = (acc[curr.id ?? -1] || 0) + 1
+      return acc
+    },
+    {},
+  )
   return (
     <Space size={'middle'} direction={'vertical'} className="w-full">
-      {nftRewards.map((tier: NftRewardTier, idx) => {
+      {Object.keys(uniqueTiersIdsAndCounts).map((tierId, idx) => {
+        const tier = nftRewards.find(tier => tier.id === parseInt(tierId))
+        if (!tier?.id) return
+        const tierCount = uniqueTiersIdsAndCounts[tier.id]
         const isLink = tier.externalLink
 
         return (
-          <div className="flex items-center justify-end" key={idx}>
-            <ExternalLink
-              className={classNames(
-                'font-medium text-black dark:text-grey-100',
-                isLink
-                  ? 'cursor-pointer text-black hover:text-haze-400 hover:underline dark:text-grey-100 dark:hover:text-haze-400'
-                  : 'cursor-default',
-              )}
-              href={isLink ? tier.externalLink : undefined}
-            >
-              {tier.name}
-            </ExternalLink>
-            <Tooltip
-              title={tier.description}
-              open={tier.description ? undefined : false}
-            >
-              <NftRewardImagePreview rewardTier={tier} />
-            </Tooltip>
+          <div className="flex items-center justify-between" key={idx}>
+            <div className="flex items-center justify-start">
+              <Tooltip
+                title={tier.description}
+                open={tier.description ? undefined : false}
+              >
+                <NftRewardImagePreview rewardTier={tier} />
+              </Tooltip>
+              <ExternalLink
+                className={classNames(
+                  'ml-3 font-medium text-black dark:text-grey-100',
+                  isLink
+                    ? 'cursor-pointer text-black hover:text-haze-400 hover:underline dark:text-grey-100 dark:hover:text-haze-400'
+                    : 'cursor-default',
+                )}
+                href={isLink ? tier.externalLink : undefined}
+              >
+                {tier.name}
+              </ExternalLink>
+            </div>
+            <div>x {tierCount} </div>
           </div>
         )
       })}

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/NftRewardImagePreview.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/NftRewardImagePreview.tsx
@@ -14,7 +14,7 @@ export function NftRewardImagePreview({
   const [imageLoading, setImageLoading] = useState<boolean>(true)
 
   return (
-    <div className="ml-4 flex items-center">
+    <div className="flex items-center">
       {imageLoading ? <LoadingOutlined className="text-xl" /> : null}
       <Image
         className={classNames(

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
@@ -24,6 +24,7 @@ import { formattedNum, formatWad } from 'utils/format/formatNumber'
 import {
   encodeJB721DelegatePayMetadata,
   payMetadataOverrides,
+  rewardTiersFromIds,
   sumTierFloors,
 } from 'utils/nftRewards'
 import { emitErrorNotification } from 'utils/notifications'
@@ -95,9 +96,15 @@ export function V2V3ConfirmPayModal({
     plural: true,
   })
 
-  const nftRewardTiers = rewardTiers?.filter(r =>
-    payProjectForm?.payMetadata?.tierIdsToMint.includes(r.id ?? -1),
-  )
+  const nftTierIdsToMint = payProjectForm?.payMetadata?.tierIdsToMint.sort()
+
+  const nftRewardTiers =
+    rewardTiers && nftTierIdsToMint
+      ? rewardTiersFromIds({
+          tierIds: payProjectForm?.payMetadata?.tierIdsToMint || [],
+          rewardTiers,
+        })
+      : undefined
 
   const handlePaySuccess = () => {
     onCancel?.()
@@ -253,7 +260,7 @@ export function V2V3ConfirmPayModal({
           </Descriptions.Item>
           {nftRewardTiers?.length ? (
             <Descriptions.Item
-              className="py-2 px-6"
+              className="py-3 px-6"
               label={
                 <TooltipLabel
                   label={t`NFTs for you`}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2348,15 +2348,6 @@ msgstr ""
 msgid "Receive ERC-20 tokens"
 msgstr ""
 
-msgid "Receive this NFT when you contribute <0>{0} ETH</0>."
-msgstr ""
-
-msgid "Receive this NFT when you contribute <0>{0}</0> - <<1>{rewardTierUpperLimit} ETH</1>."
-msgstr ""
-
-msgid "Receive this NFT when you contribute at least <0>{0} ETH</0>."
-msgstr ""
-
 msgid "Receive {receiveText}"
 msgstr ""
 

--- a/src/utils/nftRewards.ts
+++ b/src/utils/nftRewards.ts
@@ -320,14 +320,36 @@ export function decodeJB721DelegateRedeemMetadata(
   }
 }
 
+// returns an array of NftRewardTiers corresponding to a given list of tier IDs
+//    Note: If ids contains multiple of the same ID, the return value
+//          will contain corresponding rewardTier multiple times.
+export function rewardTiersFromIds({
+  tierIds,
+  rewardTiers,
+}: {
+  tierIds: number[]
+  rewardTiers: NftRewardTier[]
+}) {
+  return tierIds
+    .map(id => rewardTiers.find(tier => tier.id === id))
+    .filter(tier => Boolean(tier)) as NftRewardTier[]
+}
+
 // sums the contribution floors of a given list of nftRewardTiers
 //    - optional select only an array of ids
-export function sumTierFloors(rewardTiers: NftRewardTier[], ids?: number[]) {
-  if (ids) {
-    rewardTiers = rewardTiers.filter(tier => ids.includes(tier.id ?? -1))
-  }
+export function sumTierFloors(
+  rewardTiers: NftRewardTier[],
+  tierIds?: number[],
+) {
+  if (!tierIds) return 0
+
+  const selectedTiers = rewardTiersFromIds({
+    tierIds,
+    rewardTiers,
+  })
+
   return round(
-    rewardTiers.reduce((subSum, tier) => subSum + tier.contributionFloor, 0),
+    selectedTiers.reduce((subSum, tier) => subSum + tier.contributionFloor, 0),
     6,
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Implements @strath-m's designs here: https://www.figma.com/file/XEBCjxletE7rDdbj3Mk8lV/JBX---NFT-Rewards-UI---July-2022?node-id=609%3A7179

- Updates NFT cards on project page (desktop and mobile)
- Enables pay confirmation modal to accept multiple of same tier
- Allows selecting multiple of the same tier in the `RedeemNftsModal`

## Screenshots or screen recordings

**Updates NFT cards on project page:**

https://user-images.githubusercontent.com/96150256/211250309-0773b2c5-0ac1-464f-bb8e-2ca051343bcf.mp4

**Mobile:**
<img width="512" alt="Screen Shot 2023-01-09 at 4 00 33 pm" src="https://user-images.githubusercontent.com/96150256/211250273-a9a318df-644e-41c5-bdde-9a6dae6c0e1d.png">

**Pay confirmation modal:**

https://user-images.githubusercontent.com/96150256/211250411-cf3b9ac6-58fb-4556-bb5f-771806d1f7fb.mp4


**Redeem NFT modal:**

https://user-images.githubusercontent.com/96150256/211708874-24dbcddd-eb18-4ca6-8ac6-32f402c4ebcd.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
