### PR TITLE
Minor NFT card style updates

### DIFF
--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -29,7 +29,7 @@ export function NftPreview({
   const hasLimitedSupply = Boolean(
     rewardTier.remainingSupply &&
       rewardTier.maxSupply &&
-      rewardTier.remainingSupply !== DEFAULT_NFT_MAX_SUPPLY,
+      rewardTier.maxSupply !== DEFAULT_NFT_MAX_SUPPLY,
   )
 
   return (

--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -52,7 +52,7 @@ export function NftTierCard({
   const remainingSupply =
     rewardTier?.remainingSupply &&
     rewardTier.remainingSupply < MAX_REMAINING_SUPPLY
-      ? rewardTier?.remainingSupply
+      ? t`${rewardTier?.remainingSupply} remaining`
       : t`Unlimited`
 
   return (
@@ -122,7 +122,7 @@ export function NftTierCard({
           >
             <span
               className={classNames(
-                'text-xs',
+                'text-xs font-medium',
                 'text-ellipsis',
                 'overflow-hidden',
                 _isSelected
@@ -154,7 +154,7 @@ export function NftTierCard({
                 paragraph={{ rows: 1, width: ['50%'] }}
               >
                 <span className="mt-2 text-xs text-grey-500 dark:text-slate-200">
-                  <Trans>{remainingSupply} remaining</Trans>
+                  <Trans>{remainingSupply}</Trans>
                 </span>
               </Skeleton>
             </>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3827,6 +3827,9 @@ msgstr ""
 msgid "{0} must be numeric"
 msgstr ""
 
+msgid "{0} remaining"
+msgstr ""
+
 msgid "{0} reserved"
 msgstr ""
 
@@ -3923,7 +3926,7 @@ msgstr ""
 msgid "{paymentCount, plural, one {# payment} other {# payments}}"
 msgstr ""
 
-msgid "{remainingSupply} remaining"
+msgid "{remainingSupply}"
 msgstr ""
 
 msgid "{tokenSymbolDisplayText} range"


### PR DESCRIPTION
## What does this PR do and why?

**Addresses Strath's comments here:**
<img width="1004" alt="Screen Shot 2023-01-11 at 2 06 43 pm" src="https://user-images.githubusercontent.com/96150256/211716505-5833537b-ac1d-4c7b-acfb-c0e3aabe6242.png">

<img width="199" alt="Screen Shot 2023-01-11 at 2 17 09 pm" src="https://user-images.githubusercontent.com/96150256/211716586-b4b91198-bafb-4152-8d05-6bef6ed3e27f.png">

Also removes this display of the remaining supply is the NFT preview when it is unlimited:
<img width="312" alt="Screen Shot 2023-01-11 at 2 11 06 pm" src="https://user-images.githubusercontent.com/96150256/211716513-be24a6ce-d176-4590-b0b7-5b4e12b1462f.png">

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
