### PR TITLE
Reconfigure fc with start time

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectUpgradesPage/UpgradeWizard/steps/FundingCycleStep/LaunchFundingCycleForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectUpgradesPage/UpgradeWizard/steps/FundingCycleStep/LaunchFundingCycleForm.tsx
@@ -150,6 +150,7 @@ export function LaunchFundingCycleForm() {
             nftRewards={
               editingFundingCycleConfig.editingNftRewards?.rewardTiers
             }
+            projectOwnerAddress={projectOwnerAddress}
           />
         </div>
 

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectUpgradesPage/UpgradeWizard/steps/FundingCycleStep/LaunchFundingCycleForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectUpgradesPage/UpgradeWizard/steps/FundingCycleStep/LaunchFundingCycleForm.tsx
@@ -86,7 +86,12 @@ export function LaunchFundingCycleForm() {
           </Form.Item>
           {syncStartTime ? null : (
             <Form.Item
-              label={<Trans>Start time (seconds, Unix time)</Trans>}
+              label={<Trans>Start time</Trans>}
+              extra={
+                <Trans>
+                  Unix timestamp in seconds. Leave blank to start immediately.
+                </Trans>
+              }
               className={'mt-5'}
             >
               <Input

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Col, Row, Space } from 'antd'
 import { parseEther } from 'ethers/lib/utils'
-import { useWallet } from 'hooks/Wallet'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { Split } from 'models/splits'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
@@ -61,8 +60,6 @@ export default function ReconfigurePreview({
   projectOwnerAddress?: string
   mustStartAtOrAfter?: string
 }) {
-  const { userAddress } = useWallet()
-
   const fundingCycle: V2V3FundingCycle = {
     ...fundingCycleData,
     number: BigNumber.from(1),
@@ -198,7 +195,7 @@ export default function ReconfigurePreview({
           splits={payoutSplits}
           currency={fundAccessConstraint?.distributionLimitCurrency}
           totalValue={distributionLimit}
-          projectOwnerAddress={userAddress}
+          projectOwnerAddress={projectOwnerAddress}
           showSplitValues={hasDistributionLimit}
           fundingCycleDuration={duration}
         />
@@ -207,7 +204,7 @@ export default function ReconfigurePreview({
         <ReservedSplitsStatistic
           splits={reserveSplits}
           reservedPercentage={reservedPercentage}
-          projectOwnerAddress={userAddress}
+          projectOwnerAddress={projectOwnerAddress}
         />
       )}
       {nftRewards ? <NftSummarySection /> : null}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview.tsx
@@ -11,6 +11,8 @@ import {
   V2V3FundingCycleData,
   V2V3FundingCycleMetadata,
 } from 'models/v2v3/fundingCycle'
+import { DEFAULT_MUST_START_AT_OR_AFTER } from 'redux/slices/editingV2Project'
+import { formatDate } from 'utils/format/formatDate'
 
 import { formattedNum } from 'utils/format/formatNumber'
 import { V2V3CurrencyName } from 'utils/v2v3/currency'
@@ -47,6 +49,8 @@ export default function ReconfigurePreview({
   fundingCycleData,
   fundAccessConstraints,
   nftRewards,
+  projectOwnerAddress,
+  mustStartAtOrAfter,
 }: {
   payoutSplits: Split[]
   reserveSplits: Split[]
@@ -54,6 +58,8 @@ export default function ReconfigurePreview({
   fundingCycleData: V2V3FundingCycleData
   fundAccessConstraints: V2V3FundAccessConstraint[]
   nftRewards?: NftRewardTier[]
+  projectOwnerAddress?: string
+  mustStartAtOrAfter?: string
 }) {
   const { userAddress } = useWallet()
 
@@ -62,7 +68,9 @@ export default function ReconfigurePreview({
     number: BigNumber.from(1),
     configuration: BigNumber.from(0),
     basedOn: BigNumber.from(0),
-    start: BigNumber.from(Date.now()).div(1000),
+    start: mustStartAtOrAfter
+      ? BigNumber.from(mustStartAtOrAfter)
+      : BigNumber.from(Date.now()).div(1000),
     metadata: BigNumber.from(0),
   }
 
@@ -117,6 +125,11 @@ export default function ReconfigurePreview({
       <Row gutter={gutter}>
         <Col md={12} sm={12}>
           <DurationStatistic duration={fundingCycle.duration} />
+          {!fundingCycle.start.eq(
+            BigNumber.from(DEFAULT_MUST_START_AT_OR_AFTER),
+          ) ? (
+            <span>Starting at {formatDate(fundingCycle.start.mul(1000))}</span>
+          ) : null}
         </Col>
         <Col md={12} sm={12}>
           <DistributionLimitStatistic

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/fundingHasSavedChanges.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/fundingHasSavedChanges.ts
@@ -1,6 +1,7 @@
 import isEqual from 'lodash/isEqual'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { useMemo } from 'react'
+import { DEFAULT_MUST_START_AT_OR_AFTER } from 'redux/slices/editingV2Project'
 import { tiersEqual } from 'utils/nftRewards'
 import {
   serializeFundAccessConstraint,
@@ -25,6 +26,7 @@ export const useFundingHasSavedChanges = ({
     editingFundingCycleData,
     editingFundAccessConstraints,
     editingNftRewards,
+    editingMustStartAtOrAfter,
   } = editingFundingCycleConfig
 
   const fundingHasSavedChanges = useMemo(() => {
@@ -45,7 +47,10 @@ export const useFundingHasSavedChanges = ({
         reservedTokensGroupedSplits: editingReservedTokensGroupedSplits.splits,
       },
       nftRewards: editingNftRewards,
+      mustStartAtOrAfter:
+        editingMustStartAtOrAfter || DEFAULT_MUST_START_AT_OR_AFTER,
     }
+
     return !isEqual(initialEditingData, editedChanges)
   }, [
     editingFundAccessConstraints,
@@ -55,6 +60,7 @@ export const useFundingHasSavedChanges = ({
     editingReservedTokensGroupedSplits,
     editingNftRewards,
     initialEditingData,
+    editingMustStartAtOrAfter,
   ])
 
   const fundingDrawerHasSavedChanges = useMemo(() => {

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/initialEditingData.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/initialEditingData.ts
@@ -14,6 +14,7 @@ import useProjectSplits from 'hooks/v2v3/contractReader/ProjectSplits'
 import { Split } from 'models/splits'
 import { useContext, useState } from 'react'
 import {
+  DEFAULT_MUST_START_AT_OR_AFTER,
   editingV2ProjectActions,
   NftRewardsData,
 } from 'redux/slices/editingV2Project'
@@ -37,6 +38,7 @@ export interface InitialEditingData {
     reservedTokensGroupedSplits: Split[]
   }
   nftRewards: NftRewardsData | undefined
+  mustStartAtOrAfter: string | undefined
 }
 
 /**
@@ -200,6 +202,7 @@ export const useInitialEditingData = ({
         reservedTokensGroupedSplits: effectiveReservedTokensSplits ?? [],
       },
       nftRewards,
+      mustStartAtOrAfter: DEFAULT_MUST_START_AT_OR_AFTER,
     })
   }, [
     contracts,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/reconfigureFundingCycle.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/reconfigureFundingCycle.ts
@@ -69,6 +69,7 @@ export const useReconfigureFundingCycle = ({
     editingFundingCycleData,
     editingFundAccessConstraints,
     editingNftRewards,
+    editingMustStartAtOrAfter,
   } = editingFundingCycleConfig
 
   const reconfigureFundingCycle = useCallback(async () => {
@@ -110,6 +111,7 @@ export const useReconfigureFundingCycle = ({
         editingReservedTokensGroupedSplits,
       ],
       memo,
+      mustStartAtOrAfter: editingMustStartAtOrAfter,
     }
 
     const txOpts = {
@@ -158,6 +160,7 @@ export const useReconfigureFundingCycle = ({
     editingNftRewards,
     editingPayoutGroupedSplits,
     editingReservedTokensGroupedSplits,
+    editingMustStartAtOrAfter,
     nftRewardsCids,
     fundingCycle,
     memo,

--- a/src/components/v2v3/V2V3Project/banners/RelaunchFundingCycleBanner/RelaunchFundingCycleModal.tsx
+++ b/src/components/v2v3/V2V3Project/banners/RelaunchFundingCycleBanner/RelaunchFundingCycleModal.tsx
@@ -202,9 +202,15 @@ export function RelaunchFundingCycleModal(props: ModalProps) {
               </Form.Item>
 
               <Form.Item
-                label={<Trans>Start time (seconds, Unix time)</Trans>}
+                label={<Trans>Start time</Trans>}
+                required={false}
+                requiredMark="optional"
+                extra={
+                  <Trans>
+                    Unix timestamp in seconds. Leave blank to start immediately.
+                  </Trans>
+                }
                 className="w-full"
-                extra={<Trans>Leave blank to start immediately.</Trans>}
               >
                 <Input
                   type="number"

--- a/src/components/v2v3/V2V3Project/banners/RelaunchFundingCycleBanner/RelaunchFundingCycleModal.tsx
+++ b/src/components/v2v3/V2V3Project/banners/RelaunchFundingCycleBanner/RelaunchFundingCycleModal.tsx
@@ -14,6 +14,7 @@ import {
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { V2V3ContractsContext } from 'contexts/v2v3/V2V3ContractsContext'
+import { V2V3ProjectContext } from 'contexts/v2v3/V2V3ProjectContext'
 import useProjectCurrentFundingCycle from 'hooks/v2v3/contractReader/ProjectCurrentFundingCycle'
 import useProjectDistributionLimit from 'hooks/v2v3/contractReader/ProjectDistributionLimit'
 import useProjectSplits from 'hooks/v2v3/contractReader/ProjectSplits'
@@ -31,6 +32,7 @@ import ReconfigurePreview from '../../V2V3ProjectSettings/pages/ReconfigureFundi
 export function RelaunchFundingCycleModal(props: ModalProps) {
   const { projectId } = useContext(ProjectMetadataContext)
   const { contracts } = useContext(V2V3ContractsContext)
+  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
 
   const [newDuration, setNewDuration] = useState<BigNumber>(BigNumber.from(0))
   const [newStart, setNewStart] = useState<string>('1')
@@ -244,6 +246,7 @@ export function RelaunchFundingCycleModal(props: ModalProps) {
               ballot: newBallot ?? deprecatedFundingCycle.ballot,
             }}
             fundAccessConstraints={[deprecatedFundAccessConstraint]}
+            projectOwnerAddress={projectOwnerAddress}
           />
         </>
       )}

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/FundingDrawer/FundingForm/FundingForm.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/FundingDrawer/FundingForm/FundingForm.tsx
@@ -59,6 +59,7 @@ export function FundingForm({
 }) {
   const { contracts } = useContext(V2V3ContractsContext)
   const { payoutSplits } = useContext(V2V3ProjectContext)
+  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
 
   const [splits, setSplits] = useState<Split[]>([])
   // Must differentiate between splits loaded from redux and
@@ -344,6 +345,7 @@ export function FundingForm({
           }
           editableSplits={editingSplits}
           lockedSplits={lockedSplits}
+          projectOwnerAddress={projectOwnerAddress}
           onSplitsChanged={newSplits => {
             setEditingSplits(newSplits)
             fundingForm.setFieldsValue({

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1691,9 +1691,6 @@ msgstr ""
 msgid "Launch {projectTitle}"
 msgstr ""
 
-msgid "Leave blank to start immediately."
-msgstr ""
-
 msgid "Leave unchecked to have Juicebox track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
@@ -2822,7 +2819,7 @@ msgstr ""
 msgid "Start the V3 cycle as soon as the current V2 cycle ends <0>({0})</0>."
 msgstr ""
 
-msgid "Start time (seconds, Unix time)"
+msgid "Start time"
 msgstr ""
 
 msgid "Start upgrade"
@@ -3339,6 +3336,12 @@ msgid "Unavailable"
 msgstr ""
 
 msgid "Unclaimed token spending enabled"
+msgstr ""
+
+msgid "Unix timestamp in seconds (for example, {0}). Leave blank to start as soon as possible."
+msgstr ""
+
+msgid "Unix timestamp in seconds. Leave blank to start immediately."
 msgstr ""
 
 msgid "Unknown Project"


### PR DESCRIPTION
Adds this to FC reconfigure v3

<img width="803" alt="Screenshot 2023-01-12 at 2 46 03 PM" src="https://user-images.githubusercontent.com/12551741/211974619-5d6000a8-4fef-4376-927f-b22502fb930c.png">


Also fixes a bug where we were showing the user wallet address instead of the project owner address in a few places: https://github.com/jbx-protocol/juice-interface/pull/2752/commits/f442a0a72a566fcdeb79b3bb0c7a644d9e15416a