### PR TITLE
Custom image preview to fix Defifa image previews not loading

### DIFF
--- a/src/components/Create/components/JuiceImgPreview.tsx
+++ b/src/components/Create/components/JuiceImgPreview.tsx
@@ -1,0 +1,45 @@
+import { CloseOutlined } from '@ant-design/icons'
+import { Image, ImageProps } from 'antd'
+import useMobile from 'hooks/Mobile'
+import { classNames } from 'utils/classNames'
+
+export const JUICE_IMG_PREVIEW_CONTAINER_CLASS =
+  'fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-[rgba(0,0,0,0.8)]'
+
+export function JuiceImgPreview({
+  src,
+  alt,
+  visible,
+  onClose,
+  ...props
+}: ImageProps & {
+  visible: boolean
+  onClose: VoidFunction
+}) {
+  const isMobile = useMobile()
+  if (!visible) return null
+  return (
+    <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
+      <div className={classNames(!isMobile ? 'w-[600px]' : 'w-[90vw]')}>
+        <div className={'mb-4 flex w-full items-center justify-end'}>
+          <CloseOutlined className="pl-4 text-slate-100" onClick={onClose} />
+        </div>
+        <div className="flex justify-center">
+          <Image
+            className={classNames(
+              !isMobile
+                ? 'max-h-[60vh] max-w-[600px]'
+                : 'max-h-[50vh] max-w-[90vw]',
+            )}
+            alt={alt}
+            src={src}
+            onClick={e => e.stopPropagation()}
+            crossOrigin="anonymous"
+            preview={false}
+            {...props}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Create/components/JuiceImgPreview.tsx
+++ b/src/components/Create/components/JuiceImgPreview.tsx
@@ -1,10 +1,8 @@
 import { CloseOutlined } from '@ant-design/icons'
 import { Image, ImageProps } from 'antd'
-import useMobile from 'hooks/Mobile'
-import { classNames } from 'utils/classNames'
 
 export const JUICE_IMG_PREVIEW_CONTAINER_CLASS =
-  'fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-[rgba(0,0,0,0.8)]'
+  'fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-black/0.8'
 
 export function JuiceImgPreview({
   src,
@@ -16,21 +14,17 @@ export function JuiceImgPreview({
   visible: boolean
   onClose: VoidFunction
 }) {
-  const isMobile = useMobile()
   if (!visible) return null
+
   return (
     <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
-      <div className={classNames(!isMobile ? 'w-[600px]' : 'w-[90vw]')}>
+      <div className="md:w-xl w-[90vw]">
         <div className={'mb-4 flex w-full items-center justify-end'}>
           <CloseOutlined className="pl-4 text-slate-100" onClick={onClose} />
         </div>
         <div className="flex justify-center">
           <Image
-            className={classNames(
-              !isMobile
-                ? 'max-h-[60vh] max-w-[600px]'
-                : 'max-h-[50vh] max-w-[90vw]',
-            )}
+            className="max-h-[50vh] max-w-[90vw] md:max-h-[60vh] md:max-w-xl"
             alt={alt}
             src={src}
             onClick={e => e.stopPropagation()}

--- a/src/components/Create/components/JuiceImgPreview.tsx
+++ b/src/components/Create/components/JuiceImgPreview.tsx
@@ -22,7 +22,7 @@ export function JuiceImgPreview({
         className="absolute top-10 right-10 pl-4 text-2xl text-slate-100"
         onClick={onClose}
       />
-      <div className="flex max-w-prose justify-center">
+      <div className="text-center">
         <Image
           className="max-h-[50vh] md:max-h-[60vh]"
           alt={alt}

--- a/src/components/Create/components/JuiceImgPreview.tsx
+++ b/src/components/Create/components/JuiceImgPreview.tsx
@@ -2,7 +2,7 @@ import { CloseOutlined } from '@ant-design/icons'
 import { Image, ImageProps } from 'antd'
 
 export const JUICE_IMG_PREVIEW_CONTAINER_CLASS =
-  'fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-black/0.8'
+  'fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-[rgba(0,0,0,0.8)] p-5'
 
 export function JuiceImgPreview({
   src,
@@ -18,21 +18,20 @@ export function JuiceImgPreview({
 
   return (
     <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
-      <div className="md:w-xl w-[90vw]">
-        <div className={'mb-4 flex w-full items-center justify-end'}>
-          <CloseOutlined className="pl-4 text-slate-100" onClick={onClose} />
-        </div>
-        <div className="flex justify-center">
-          <Image
-            className="max-h-[50vh] max-w-[90vw] md:max-h-[60vh] md:max-w-xl"
-            alt={alt}
-            src={src}
-            onClick={e => e.stopPropagation()}
-            crossOrigin="anonymous"
-            preview={false}
-            {...props}
-          />
-        </div>
+      <CloseOutlined
+        className="absolute top-10 right-10 pl-4 text-2xl text-slate-100"
+        onClick={onClose}
+      />
+      <div className="flex max-w-prose justify-center">
+        <Image
+          className="max-h-[50vh] md:max-h-[60vh]"
+          alt={alt}
+          src={src}
+          onClick={e => e.stopPropagation()}
+          crossOrigin="anonymous"
+          preview={false}
+          {...props}
+        />
       </div>
     </div>
   )

--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -40,7 +40,7 @@ export function NftPreview({
         className="max-w-prose pt-24 md:pt-0"
         onClick={e => e.stopPropagation()}
       >
-        <div className="mb-5 flex justify-center" onClick={onClose}>
+        <div className="mb-5 text-center">
           <img
             className={'max-h-[50vh] max-w-[90vw] md:max-h-[60vh] md:max-w-xl'}
             alt={rewardTier.name}

--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -1,11 +1,9 @@
 import { CloseOutlined, LinkOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import ExternalLink from 'components/ExternalLink'
-import useMobile from 'hooks/Mobile'
 import { DEFAULT_NFT_MAX_SUPPLY } from 'hooks/NftRewards'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { useContext } from 'react'
-
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { classNames } from 'utils/classNames'
 import { JUICE_IMG_PREVIEW_CONTAINER_CLASS } from 'components/Create/components/JuiceImgPreview'
@@ -23,8 +21,6 @@ export function NftPreview({
 }) {
   const { projectMetadata } = useContext(ProjectMetadataContext)
 
-  const isMobile = useMobile()
-
   if (!open) return null
 
   const hasLimitedSupply = Boolean(
@@ -35,10 +31,7 @@ export function NftPreview({
 
   return (
     <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
-      <div
-        className={classNames(!isMobile ? 'w-[600px]' : 'w-[90vw]')}
-        onClick={e => e.stopPropagation()}
-      >
+      <div className="md:w-xl w-[90vw]" onClick={e => e.stopPropagation()}>
         <div className="mb-4 flex w-full items-center justify-between">
           <h3 className="mb-0 uppercase text-slate-100">
             <Trans>{projectMetadata?.name}</Trans>
@@ -47,18 +40,14 @@ export function NftPreview({
         </div>
         <div className="flex justify-center" onClick={onClose}>
           <img
-            className={classNames(
-              !isMobile
-                ? 'max-h-[60vh] max-w-[600px]'
-                : 'max-h-[50vh] max-w-[90vw]',
-            )}
+            className={'max-h-[50vh] max-w-[90vw] md:max-h-[60vh] md:max-w-xl'}
             alt={rewardTier.name}
             src={imageUrl}
             onClick={e => e.stopPropagation()}
             crossOrigin="anonymous"
           />
         </div>
-        <h3 className='"mb-0 text-slate-100" mt-5'>{rewardTier.name}</h3>
+        <h3 className="mb-0 mt-5 text-slate-100">{rewardTier.name}</h3>
         <p className="mt-2 text-slate-100">{rewardTier.description}</p>
         {hasLimitedSupply || rewardTier.externalLink ? (
           <div className="mt-5 flex text-xs text-slate-100">

--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -31,14 +31,16 @@ export function NftPreview({
 
   return (
     <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
-      <div className="md:w-xl w-[90vw]" onClick={e => e.stopPropagation()}>
-        <div className="mb-4 flex w-full items-center justify-between">
-          <h3 className="mb-0 uppercase text-slate-100">
-            <Trans>{projectMetadata?.name}</Trans>
-          </h3>
-          <CloseOutlined className="pl-4 text-slate-100" onClick={onClose} />
-        </div>
-        <div className="flex justify-center" onClick={onClose}>
+      <CloseOutlined
+        className="absolute top-10 right-10 text-2xl text-slate-100"
+        onClick={onClose}
+      />
+
+      <div
+        className="max-w-prose pt-24 md:pt-0"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="mb-5 flex justify-center" onClick={onClose}>
           <img
             className={'max-h-[50vh] max-w-[90vw] md:max-h-[60vh] md:max-w-xl'}
             alt={rewardTier.name}
@@ -47,8 +49,15 @@ export function NftPreview({
             crossOrigin="anonymous"
           />
         </div>
-        <h3 className="mb-0 mt-5 text-slate-100">{rewardTier.name}</h3>
-        <p className="mt-2 text-slate-100">{rewardTier.description}</p>
+
+        <h1 className="text-slate-100">{rewardTier.name}</h1>
+        <span className="uppercase text-slate-100">
+          <Trans>{projectMetadata?.name}</Trans>
+        </span>
+
+        <p className="mt-2 max-w-prose text-slate-100">
+          {rewardTier.description}
+        </p>
         {hasLimitedSupply || rewardTier.externalLink ? (
           <div className="mt-5 flex text-xs text-slate-100">
             {hasLimitedSupply ? (

--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -8,6 +8,7 @@ import { useContext } from 'react'
 
 import { ProjectMetadataContext } from 'contexts/projectMetadataContext'
 import { classNames } from 'utils/classNames'
+import { JUICE_IMG_PREVIEW_CONTAINER_CLASS } from 'components/Create/components/JuiceImgPreview'
 
 export function NftPreview({
   open,
@@ -33,10 +34,7 @@ export function NftPreview({
   )
 
   return (
-    <div
-      className="fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-[rgba(0,0,0,0.8)]"
-      onClick={onClose}
-    >
+    <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
       <div
         className={classNames(!isMobile ? 'w-[600px]' : 'w-[90vw]')}
         onClick={e => e.stopPropagation()}

--- a/src/components/RichImgPreview.tsx
+++ b/src/components/RichImgPreview.tsx
@@ -1,19 +1,21 @@
 import { t } from '@lingui/macro'
-import { Image } from 'antd'
+import { Image, ImageProps } from 'antd'
 import { useContentType } from 'hooks/ContentType'
-import { CSSProperties } from 'react'
+import { CSSProperties, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { JuiceImgPreview } from './Create/components/JuiceImgPreview'
 
 export default function RichImgPreview({
   className,
   src,
 }: {
   className?: string
-  src: string | undefined
+  src: string
   maxWidth?: CSSProperties['maxWidth']
   maxHeight?: CSSProperties['maxHeight']
 }) {
   const contentType = useContentType(src)
+  const [previewVisible, setPreviewVisible] = useState<boolean>(false)
 
   if (
     contentType === 'image/jpeg' ||
@@ -22,14 +24,30 @@ export default function RichImgPreview({
     contentType === 'image/png' ||
     contentType === 'image/svg'
   ) {
+    const alt = t`Payment memo image`
+    const imageProps: ImageProps = {
+      src,
+      alt,
+      loading: 'lazy',
+      crossOrigin: 'anonymous',
+    }
     return (
-      <Image
-        className={twMerge('h-24 w-24', className)}
-        src={src}
-        alt={t`Payment memo image`}
-        loading="lazy"
-        crossOrigin="anonymous"
-      />
+      <>
+        <Image
+          className={twMerge(
+            'h-24 w-24 cursor-pointer hover:brightness-50',
+            className,
+          )}
+          onClick={() => setPreviewVisible(true)}
+          preview={false}
+          {...imageProps}
+        />
+        <JuiceImgPreview
+          visible={previewVisible}
+          onClose={() => setPreviewVisible(false)}
+          {...imageProps}
+        />
+      </>
     )
   }
 


### PR DESCRIPTION
## What does this PR do and why?

Closes #2776 
Some image preview were failing because Ant-D wasn't passing `crossOrigin` prop to the preview image. Didn't appear to be any way to do this with Ant-D, so just made a new preview component. 

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/212595729-7e88458d-254e-400d-b031-97753ed01799.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
