### PR TITLE
Add Metamask Onboarding to Homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@lingui/detect-locale": "^3.13.0",
     "@lingui/macro": "^3.13.0",
     "@lingui/react": "^3.13.0",
+    "@metamask/onboarding": "^1.0.1",
     "@metamask/providers": "^10.0.0",
     "@pinata/sdk": "^1.1.23",
     "@reduxjs/toolkit": "^1.6.2",

--- a/src/components/Navbar/Account.tsx
+++ b/src/components/Navbar/Account.tsx
@@ -2,6 +2,8 @@ import { WarningOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Button, Space } from 'antd'
 import { useWallet } from 'hooks/Wallet'
+import MetaMaskOnboardingModal from 'components/modals/MetaMaskOnboardingModal'
+import { useState } from 'react'
 
 import Wallet from './Wallet'
 
@@ -13,6 +15,26 @@ export default function Account() {
     chainUnsupported,
     changeNetworks,
   } = useWallet()
+
+  if (!window.ethereum) {
+    const [metaMaskOnboardingModalVisible, setMetaMaskOnboardingModalVisible] =
+      useState<boolean>(false)
+
+    return (
+      <div className="flex items-center gap-6">
+        <Button onClick={() => setMetaMaskOnboardingModalVisible(true)} block>
+          <Trans>Create a Wallet</Trans>
+        </Button>
+        <Button onClick={() => connect()} block>
+          <Trans>Connect</Trans>
+        </Button>
+        <MetaMaskOnboardingModal
+          open={metaMaskOnboardingModalVisible}
+          onCancel={() => setMetaMaskOnboardingModalVisible(false)}
+        />
+      </div>
+    )
+  }
 
   if (!isConnected) {
     return (

--- a/src/components/modals/MetaMaskOnboardingModal.tsx
+++ b/src/components/modals/MetaMaskOnboardingModal.tsx
@@ -1,0 +1,70 @@
+import { t, Trans } from '@lingui/macro'
+import { Modal, Button, Divider } from 'antd'
+import ExternalLink from 'components/ExternalLink'
+import MetaMaskOnboarding from '@metamask/onboarding'
+
+export default function MetaMaskOnboardingModal({
+  open,
+  onCancel,
+}: {
+  open: boolean | undefined
+  onCancel: VoidFunction | undefined
+}) {
+  return (
+    <Modal
+      open={open}
+      onOk={() => window.location.reload()}
+      okText={t`Reload`}
+      okButtonProps={{ type: 'primary' }}
+      onCancel={onCancel}
+      centered
+      destroyOnClose
+    >
+      <h3>
+        <Trans>1. Set up your wallet</Trans>
+      </h3>
+      <p>
+        <Trans>
+          <ExternalLink href="https://ethereum.org/en/wallets/">
+            Ethereum wallets
+          </ExternalLink>{' '}
+          let you interact with the Ethereum blockchain — you can use them to
+          view your balance, send transactions, and connect to applications.
+        </Trans>
+      </p>
+      <p>
+        <Trans>
+          MetaMask is a free wallet which works with almost all Ethereum
+          applications. The button below will help you set up a MetaMask wallet.
+        </Trans>
+      </p>
+      <Button
+        onClick={() => new MetaMaskOnboarding().startOnboarding()}
+        type="primary"
+      >
+        Set up MetaMask
+      </Button>
+      <Divider />
+      <h3>
+        <Trans>2. Connect to Juicebox</Trans>
+      </h3>
+      <p>
+        <Trans>
+          <ExternalLink href="https://ethereum.org/en/eth/">ETH</ExternalLink>{' '}
+          is the main currency for Ethereum applications. You can buy ETH in
+          MetaMask by opening the extension, signing in, and clicking "Buy".
+        </Trans>
+      </p>
+      <p>
+        <Trans>
+          Once your wallet is funded with ETH, click the <b>Reload</b> button
+          below to refresh the page. Then, connect your wallet to Juicebox by
+          clicking "Connect".
+        </Trans>
+      </p>
+      <Button onClick={() => window.location.reload()} type="primary">
+        Reload page
+      </Button>
+    </Modal>
+  )
+}

--- a/src/components/modals/MetaMaskOnboardingModal.tsx
+++ b/src/components/modals/MetaMaskOnboardingModal.tsx
@@ -57,9 +57,18 @@ export default function MetaMaskOnboardingModal({
       </p>
       <p>
         <Trans>
-          Once your wallet is funded with ETH, click the <b>Reload</b> button
-          below to refresh the page. Then, connect your wallet to Juicebox by
-          clicking "Connect".
+          Once your wallet is funded with ETH, click "Reload Page" below to
+          refresh the page. Then, connect your wallet to Juicebox by clicking
+          "Connect".
+        </Trans>
+      </p>
+      <p>
+        <Trans>
+          If you have issues or questions, ask for help in the{' '}
+          <ExternalLink href="https://discord.gg/juicebox">
+            Juicebox Discord
+          </ExternalLink>
+          .
         </Trans>
       </p>
       <Button onClick={() => window.location.reload()} type="primary">

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -32,7 +32,13 @@ msgstr ""
 msgid "1. Set ENS name"
 msgstr ""
 
+msgid "1. Set up your wallet"
+msgstr ""
+
 msgid "100% overflow"
+msgstr ""
+
+msgid "2. Connect to Juicebox"
 msgstr ""
 
 msgid "2. Give ownership"
@@ -117,6 +123,12 @@ msgid "<0>Description:</0><1/>"
 msgstr ""
 
 msgid "<0>Discount rate</0>, to reduce your project token's issuance rate (tokens per ETH) each funding cycle."
+msgstr ""
+
+msgid "<0>ETH</0> is the main currency for Ethereum applications. You can buy ETH in MetaMask by opening the extension, signing in, and clicking \"Buy\"."
+msgstr ""
+
+msgid "<0>Ethereum wallets</0> let you interact with the Ethereum blockchain — you can use them to view your balance, send transactions, and connect to applications."
 msgstr ""
 
 msgid "<0>If you know how much your project needs to earn over some period of time to be sustainable, you can set a funding target with that amount. If your project earns more than that, the surplus funds are locked in an overflow pool. Anyone holding your project's tokens can claim a portion of the overflow pool in exchange for redeeming their tokens.</0><1>For more info, check out this <2>short video</2>.</1>"
@@ -840,6 +852,9 @@ msgid "Create Payment Address"
 msgstr ""
 
 msgid "Create a Payment Address (optional)"
+msgstr ""
+
+msgid "Create a Wallet"
 msgstr ""
 
 msgid "Create a project"
@@ -1796,6 +1811,9 @@ msgstr ""
 msgid "Message"
 msgstr ""
 
+msgid "MetaMask is a free wallet which works with almost all Ethereum applications. The button below will help you set up a MetaMask wallet."
+msgstr ""
+
 msgid "Migrate to Juicebox V1.1"
 msgstr ""
 
@@ -2010,6 +2028,9 @@ msgid "Note: Tokens can be minted manually when allowed in the current funding c
 msgstr ""
 
 msgid "Notice from {0}"
+msgstr ""
+
+msgid "Once your wallet is funded with ETH, click the <0>Reload</0> button below to refresh the page. Then, connect your wallet to Juicebox by clicking \"Connect\"."
 msgstr ""
 
 msgid "Only lowercase letters"
@@ -2505,6 +2526,9 @@ msgid "Redemptions"
 msgstr ""
 
 msgid "Relaunch your funding cycle on the new Juicebox V2 contracts."
+msgstr ""
+
+msgid "Reload"
 msgstr ""
 
 msgid "Required"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1547,6 +1547,9 @@ msgstr ""
 msgid "If you have <0/> or <1/> legacy Juicebox projects, we recommend you migrate to <2/> exclusively."
 msgstr ""
 
+msgid "If you have issues or questions, ask for help in the <0>Juicebox Discord</0>."
+msgstr ""
+
 msgid "If you're interested in creating a project but still confused on how to get started, consider watching this <0>instructional video</0>. Also feel free to reach out in the <1>Juicebox Discord</1> where our team will be happy to help bring your project idea to life!"
 msgstr ""
 
@@ -2030,7 +2033,7 @@ msgstr ""
 msgid "Notice from {0}"
 msgstr ""
 
-msgid "Once your wallet is funded with ETH, click the <0>Reload</0> button below to refresh the page. Then, connect your wallet to Juicebox by clicking \"Connect\"."
+msgid "Once your wallet is funded with ETH, click \"Reload Page\" below to refresh the page. Then, connect your wallet to Juicebox by clicking \"Connect\"."
 msgstr ""
 
 msgid "Only lowercase letters"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4519,6 +4519,13 @@
     "@metamask/safe-event-emitter" "^2.0.0"
     through2 "^2.0.3"
 
+"@metamask/onboarding@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/onboarding/-/onboarding-1.0.1.tgz#14a36e1e175e2f69f09598e2008ab6dc1b3297e6"
+  integrity sha512-FqHhAsCI+Vacx2qa5mAFcWNSrTcVGMNjzxVgaX8ECSny/BJ9/vgXP9V7WF/8vb9DltPeQkxr+Fnfmm6GHfmdTQ==
+  dependencies:
+    bowser "^2.9.0"
+
 "@metamask/providers@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/providers/-/providers-10.0.0.tgz#8858f3a0d991fe3462cd056a52a74f3ffabc9373"
@@ -7128,7 +7135,7 @@ bottleneck@^2.19.5:
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
-bowser@^2.11.0:
+bowser@^2.11.0, bowser@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==


### PR DESCRIPTION
## What does this PR do and why?

If window.ethereum is undefined (meaning the user has no injected wallets installed in their current session), display a "Create a Wallet" button next to the connect button. When clicked, it brings up a modal which gives a brief explainer on how wallets work, and how to fund one with ETH. It will trigger the MetaMask onboarding flow, meaning it works across browsers and devices.

This will ease onboarding for project creators with communities new to web3, as well as for large-scale fundraisers.

## Screenshots or screen recordings

[YouTube Demo](https://youtu.be/LVJqg8w5l-8)

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
