### PR TITLE
NFT governance

### DIFF
--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -1,7 +1,12 @@
-import { CloseCircleFilled, UploadOutlined } from '@ant-design/icons'
-import { t } from '@lingui/macro'
-import { Form, Modal, Progress, Space } from 'antd'
+import {
+  CloseCircleFilled,
+  QuestionCircleOutlined,
+  UploadOutlined,
+} from '@ant-design/icons'
+import { t, Trans } from '@lingui/macro'
+import { Form, Modal, Progress, Space, Tooltip } from 'antd'
 import InputAccessoryButton from 'components/InputAccessoryButton'
+import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
 import { JuiceInput } from 'components/inputs/JuiceTextInput'
@@ -21,7 +26,11 @@ import {
   inputIsValidUrlRule,
   inputNonZeroRule,
   inputMustExistRule,
+  inputMustBeEthAddressRule,
+  inputIsIntegerRule,
 } from 'utils/antd-rules'
+import { CreateCollapse } from '../CreateCollapse'
+import { OptionalHeader } from '../OptionalHeader'
 import { RewardImage } from '../RewardImage'
 import { Reward } from './types'
 
@@ -30,7 +39,10 @@ interface AddEditRewardModalFormProps {
   rewardName: string
   description?: string | undefined
   minimumContribution?: string | undefined
-  maxSupply?: number | undefined
+  maxSupply?: string | undefined
+  nftReservedRate?: number | undefined
+  beneficiary?: string | undefined
+  votingWeight?: number | undefined
   externalUrl?: string | undefined
 }
 
@@ -52,6 +64,7 @@ export const AddEditRewardModal = ({
   } = useContext(ThemeContext)
   const [form] = Form.useForm<AddEditRewardModalFormProps>()
   const [limitedSupply, setLimitedSupply] = useState<boolean>(false)
+  const [isReservingNfts, setIsReservingNfts] = useState<boolean>(false)
 
   const pinFileToIpfs = usePinFileToIpfs()
   const wallet = useWallet()
@@ -65,13 +78,17 @@ export const AddEditRewardModal = ({
     }
 
     setLimitedSupply(!!editingData.maximumSupply)
+    setIsReservingNfts(!!editingData.beneficiary && !!editingData.reservedRate)
     form.setFieldsValue({
       imgUrl: editingData.imgUrl.toString(),
       rewardName: editingData.title,
       description: editingData.description,
       minimumContribution: editingData.minimumContribution.toString(),
-      maxSupply: editingData.maximumSupply,
+      maxSupply: editingData.maximumSupply?.toString(),
       externalUrl: editingData.url,
+      beneficiary: editingData.beneficiary,
+      nftReservedRate: editingData.reservedRate,
+      votingWeight: editingData.votingWeight,
     })
   }, [editingData, form, open])
 
@@ -82,9 +99,14 @@ export const AddEditRewardModal = ({
       title: fields.rewardName,
       minimumContribution: parseFloat(fields.minimumContribution ?? '0'),
       description: fields.description,
-      maximumSupply: fields.maxSupply,
+      maximumSupply: fields.maxSupply ? parseInt(fields.maxSupply) : undefined,
       url: fields.externalUrl ? `https://${fields.externalUrl}` : undefined,
       imgUrl: fields.imgUrl,
+      beneficiary: fields.beneficiary,
+      reservedRate: fields.nftReservedRate,
+      votingWeight: fields.votingWeight
+        ? parseInt(fields.votingWeight.toString())
+        : undefined,
     }
     onOk(result)
     form.resetFields()
@@ -236,19 +258,105 @@ export const AddEditRewardModal = ({
             )}
           </Space>
         </Form.Item>
-        <Form.Item
-          name="externalUrl"
-          label={t`External link`}
-          rules={[
-            inputIsValidUrlRule({
-              label: t`External link`,
-              prefix: 'https://',
-              validateTrigger: 'onCreate',
-            }),
-          ]}
-        >
-          <PrefixedInput prefix="https://" />
-        </Form.Item>
+        <CreateCollapse>
+          <CreateCollapse.Panel
+            header={<OptionalHeader header={t`Advanced options`} />}
+            key={0}
+            hideDivider
+          >
+            <Form.Item
+              extra={
+                <span className="text-sm">
+                  <Trans>Set aside a percentage of freshly minted NFTs.</Trans>
+                </span>
+              }
+            >
+              <JuiceSwitch
+                value={isReservingNfts}
+                onChange={setIsReservingNfts}
+                label={
+                  <span className="flex items-center gap-2">
+                    <Trans>Reserve NFTs</Trans>
+                    <Tooltip
+                      className="cursor-help text-grey-500 dark:text-grey-300"
+                      title={t`If Reserved NFTs are set, the first reserved NFT from the tier will be distributable once the tier receives its first mint.`}
+                    >
+                      <QuestionCircleOutlined />
+                    </Tooltip>
+                  </span>
+                }
+              />
+            </Form.Item>
+            {isReservingNfts && (
+              <>
+                <span className="mb-4 flex flex-col gap-2 whitespace-nowrap md:flex-row md:items-center">
+                  <Trans>Reserve 1 NFT of every</Trans>
+                  <div className="max-w-[78px]">
+                    <Form.Item
+                      className="mb-0"
+                      name="nftReservedRate"
+                      rules={[
+                        inputMustExistRule({ label: t`Reserved rate` }),
+                        inputIsIntegerRule({
+                          stringOkay: true,
+                        }),
+                      ]}
+                    >
+                      <FormattedNumberInput min={2} placeholder="0" />
+                    </Form.Item>
+                  </div>{' '}
+                  <Trans>NFTs minted for:</Trans>
+                </span>
+                <Form.Item
+                  className="mb-8"
+                  name="beneficiary"
+                  label={t`Ethereum wallet address`}
+                  extra={t`Reserved NFTs will be sent to this address once minted.`}
+                  rules={[
+                    inputMustExistRule({ label: t`Wallet address` }),
+                    inputMustBeEthAddressRule({ label: t`Wallet address` }),
+                  ]}
+                >
+                  <EthAddressInput />
+                </Form.Item>
+              </>
+            )}
+            <Form.Item
+              name="votingWeight"
+              label={t`Voting weight`}
+              tooltip={t`Give this NFT a voting weight to be used for on-chain governance. The number you set is only used in relation to other NFTs in this collection.`}
+              extra={
+                <Trans>
+                  Voting weight is only applicable if this NFT will be used for
+                  on-chain governance, and can also be read on-chain for other
+                  purposes if needed.
+                </Trans>
+              }
+              rules={[
+                inputIsIntegerRule({
+                  label: t`Voting weight`,
+                  stringOkay: true,
+                }),
+              ]}
+            >
+              <FormattedNumberInput placeholder="300" />
+            </Form.Item>
+            <Form.Item
+              name="externalUrl"
+              label={t`External link`}
+              tooltip={t`Link minters of this NFT to your project's website, discord etc.`}
+              rules={[
+                inputIsValidUrlRule({
+                  label: t`External link`,
+                  prefix: 'https://',
+                  validateTrigger: 'onCreate',
+                }),
+              ]}
+            >
+              <PrefixedInput prefix="https://" />
+            </Form.Item>
+          </CreateCollapse.Panel>
+        </CreateCollapse>
       </Form>
     </Modal>
   )

--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -293,7 +293,7 @@ export const AddEditRewardModal = ({
           >
             <Form.Item
               extra={
-                <span className="text-sm">
+                <span className="text-xs">
                   <Trans>Set aside a percentage of freshly minted NFTs.</Trans>
                 </span>
               }
@@ -303,7 +303,7 @@ export const AddEditRewardModal = ({
                 onChange={setIsReservingNfts}
                 label={
                   <span className="flex items-center gap-2">
-                    <Trans>Reserve NFTs</Trans>
+                    <Trans>Reserved NFTs</Trans>
                     <Tooltip
                       className="cursor-help text-grey-500 dark:text-grey-300"
                       title={t`If Reserved NFTs are set, the first reserved NFT from the tier will be distributable once the tier receives its first mint.`}
@@ -323,7 +323,7 @@ export const AddEditRewardModal = ({
                       className="mb-0"
                       name="nftReservedRate"
                       rules={[
-                        inputMustExistRule({ label: t`Reserved rate` }),
+                        inputMustExistRule(),
                         inputIsIntegerRule({
                           stringOkay: true,
                         }),
@@ -351,12 +351,12 @@ export const AddEditRewardModal = ({
             <Form.Item
               name="votingWeight"
               label={t`Voting weight`}
-              tooltip={t`Give this NFT a voting weight to be used for on-chain governance. The number you set is only used in relation to other NFTs in this collection.`}
-              extra={
+              extra={t`Give this NFT a voting weight to be used for on-chain governance. The number you set is only used in relation to other NFTs in this collection.`}
+              tooltip={
                 <Trans>
                   If you use the default governance option (no governance), the
                   voting weight will still be accessible on the blockchain for
-                  use in snapshot strategies or any other desired purpose.
+                  use in Snapshot strategies or any other desired purpose.
                 </Trans>
               }
               rules={[
@@ -371,7 +371,7 @@ export const AddEditRewardModal = ({
             <Form.Item
               name="externalUrl"
               label={t`External link`}
-              tooltip={t`Link minters of this NFT to your project's website, discord etc.`}
+              tooltip={t`Link minters of this NFT to your project's website, Discord, etc.`}
               rules={[
                 inputIsValidUrlRule({
                   label: t`External link`,

--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -366,7 +366,7 @@ export const AddEditRewardModal = ({
                 }),
               ]}
             >
-              <FormattedNumberInput placeholder="300" />
+              <FormattedNumberInput />
             </Form.Item>
             <Form.Item
               name="externalUrl"

--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -65,6 +65,7 @@ export const AddEditRewardModal = ({
   const [form] = Form.useForm<AddEditRewardModalFormProps>()
   const [limitedSupply, setLimitedSupply] = useState<boolean>(false)
   const [isReservingNfts, setIsReservingNfts] = useState<boolean>(false)
+  const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState<boolean>(false)
 
   const pinFileToIpfs = usePinFileToIpfs()
   const wallet = useWallet()
@@ -91,6 +92,29 @@ export const AddEditRewardModal = ({
       votingWeight: editingData.votingWeight,
     })
   }, [editingData, form, open])
+
+  // Due to the way antd works, if advanced options are set, we need to open it on load
+  useEffect(() => {
+    const openAdvancedOptions =
+      !!editingData?.reservedRate ||
+      !!editingData?.beneficiary ||
+      !!editingData?.votingWeight ||
+      !!editingData?.url
+
+    setAdvancedOptionsOpen(openAdvancedOptions)
+  }, [
+    open,
+    editingData?.beneficiary,
+    editingData?.reservedRate,
+    editingData?.url,
+    editingData?.votingWeight,
+  ])
+
+  const onCollapseChanged = useCallback((key: string | string[]) => {
+    const isAdvancedOptionsOpen =
+      typeof key === 'string' ? key === '0' : key.includes('0')
+    setAdvancedOptionsOpen(isAdvancedOptionsOpen)
+  }, [])
 
   const onModalOk = useCallback(async () => {
     const fields = await form.validateFields()
@@ -258,7 +282,10 @@ export const AddEditRewardModal = ({
             )}
           </Space>
         </Form.Item>
-        <CreateCollapse>
+        <CreateCollapse
+          activeKey={advancedOptionsOpen ? ['0'] : []}
+          onChange={onCollapseChanged}
+        >
           <CreateCollapse.Panel
             header={<OptionalHeader header={t`Advanced options`} />}
             key={0}
@@ -327,9 +354,9 @@ export const AddEditRewardModal = ({
               tooltip={t`Give this NFT a voting weight to be used for on-chain governance. The number you set is only used in relation to other NFTs in this collection.`}
               extra={
                 <Trans>
-                  Voting weight is only applicable if this NFT will be used for
-                  on-chain governance, and can also be read on-chain for other
-                  purposes if needed.
+                  If you use the default governance option (no governance), the
+                  voting weight will still be accessible on the blockchain for
+                  use in snapshot strategies or any other desired purpose.
                 </Trans>
               }
               rules={[

--- a/src/components/Create/components/RewardsList/RewardItem.tsx
+++ b/src/components/Create/components/RewardsList/RewardItem.tsx
@@ -1,15 +1,31 @@
 import { DeleteOutlined, EditOutlined, LinkOutlined } from '@ant-design/icons'
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import ExternalLink from 'components/ExternalLink'
-import useMobile from 'hooks/Mobile'
+import FormattedAddress from 'components/FormattedAddress'
+import TooltipLabel from 'components/TooltipLabel'
 import { ReactNode } from 'react'
-import { classNames } from 'utils/classNames'
 import { prettyUrl } from 'utils/url'
 import { RewardImage } from '../RewardImage'
 import { RewardItemButton } from './RewardItemButton'
 import { Reward } from './types'
 
-// END: CSS
+const SIGNIFICANT_FIGURE_LIMIT = 6
+
+function numberUpToPrecisionFormat(
+  num: number,
+  precision = SIGNIFICANT_FIGURE_LIMIT,
+) {
+  let formattedNum = num.toPrecision(precision)
+  const trailingZeroes = /\.0+$/
+  if (trailingZeroes.test(formattedNum)) {
+    const decimalIndex = formattedNum.indexOf('.')
+    formattedNum = formattedNum.slice(0, decimalIndex)
+  }
+
+  const parts = formattedNum.toString().split('.')
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  return parts.join('.')
+}
 
 export const RewardItem = ({
   reward,
@@ -20,10 +36,12 @@ export const RewardItem = ({
   onEditClicked?: () => void
   onDeleteClicked?: () => void
 }) => {
-  const isMobile = useMobile()
   const {
     title,
     minimumContribution,
+    votingWeight,
+    beneficiary,
+    reservedRate,
     description,
     maximumSupply,
     url,
@@ -46,51 +64,78 @@ export const RewardItem = ({
         </div>
       </div>
 
-      <div className="relative flex flex-col gap-6">
-        {/* Main Body */}
-        <div className="flex gap-8">
-          {/* Image Col */}
-          <div className="flex flex-col gap-2">
-            {/* Image */}
-            <RewardImage className="h-44 w-44" src={imgUrl.toString()} />
-            {!isMobile && (
-              <TertiaryDetails maximumSupply={maximumSupply} url={url} />
-            )}
-          </div>
-          {/* Description Col */}
-          <div className="flex flex-1 flex-col gap-8 overflow-hidden">
-            {/* Top */}
-            <div
-              className={classNames(
-                'flex justify-between',
-                isMobile ? 'flex-col gap-6' : 'flex-row',
-              )}
-            >
-              <div className="flex flex-col gap-2">
-                <div className="text-xs font-normal uppercase text-grey-600 dark:text-slate-200">
-                  <Trans>Minimum Contribution</Trans>
-                </div>
-                <div className="text-base font-medium">
-                  {minimumContribution.toString()} ETH
-                </div>
+      <div className="flex flex-col gap-8 md:flex-row">
+        <div className="flex flex-col gap-3">
+          <RewardImage className="h-44 w-44" src={imgUrl.toString()} />
+          {url && (
+            <div className="flex max-w-[11rem] items-center gap-2 overflow-hidden overflow-ellipsis whitespace-nowrap text-xs font-normal">
+              <LinkOutlined />
+              <div className="overflow-hidden overflow-ellipsis">
+                <ExternalLink href={url}>{prettyUrl(url)}</ExternalLink>
               </div>
             </div>
-            {/* Bottom */}
-            {!isMobile && description && (
-              <Description description={description} />
+          )}
+        </div>
+
+        <div className="flex flex-col gap-6">
+          {description && <Description description={description} />}
+
+          <div className="grid grid-cols-2 gap-y-6 gap-x-16">
+            <RewardStatLine
+              title={t`Minimum contribution`}
+              stat={`${numberUpToPrecisionFormat(minimumContribution)} ETH`}
+            />
+            {!!maximumSupply && (
+              <RewardStatLine
+                title={t`Supply`}
+                stat={numberUpToPrecisionFormat(maximumSupply)}
+              />
+            )}
+            {!!reservedRate && (
+              <RewardStatLine
+                title={t`Reserved NFTS`}
+                stat={`1/${reservedRate}`}
+              />
+            )}
+            {!!beneficiary && (
+              <RewardStatLine
+                title={
+                  <TooltipLabel
+                    label={<Trans>Beneficiary address</Trans>}
+                    tip={t`The wallet address that reserved NFTs will be sent to`}
+                  />
+                }
+                stat={<FormattedAddress address={beneficiary} />}
+              />
+            )}
+            {!!votingWeight && (
+              <RewardStatLine
+                title={t`Voting weight`}
+                stat={numberUpToPrecisionFormat(votingWeight)}
+              />
             )}
           </div>
         </div>
-        {isMobile ? (
-          <>
-            {description && <Description description={description} />}
-            <TertiaryDetails maximumSupply={maximumSupply} url={url} />
-          </>
-        ) : null}
       </div>
     </div>
   )
 }
+
+// Contains the formatting for NFT Reward stat
+const RewardStatLine = ({
+  title,
+  stat,
+}: {
+  title: ReactNode
+  stat: ReactNode
+}) => (
+  <div>
+    <div className="whitespace-nowrap text-xs font-normal uppercase text-grey-600 dark:text-slate-200">
+      {title}
+    </div>
+    <div className="text-base font-medium">{stat}</div>
+  </div>
+)
 
 const Description = ({ description }: { description: ReactNode }) => {
   return (
@@ -101,32 +146,6 @@ const Description = ({ description }: { description: ReactNode }) => {
       <div className="overflow-hidden text-ellipsis text-sm font-normal">
         {description}
       </div>
-    </div>
-  )
-}
-
-const TertiaryDetails = ({
-  maximumSupply,
-  url,
-}: {
-  maximumSupply: ReactNode
-  url: string | undefined
-}) => {
-  return (
-    <div className="flex max-w-[11rem] flex-col gap-1 overflow-hidden overflow-ellipsis whitespace-nowrap">
-      {maximumSupply && (
-        <div className="text-xs font-normal">
-          <Trans>Supply: {maximumSupply}</Trans>
-        </div>
-      )}
-      {url && (
-        <div className="flex items-center gap-2 text-xs font-normal">
-          <LinkOutlined />
-          <div className="overflow-hidden overflow-ellipsis">
-            <ExternalLink href={url}>{prettyUrl(url)}</ExternalLink>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/Create/components/RewardsList/RewardsList.tsx
+++ b/src/components/Create/components/RewardsList/RewardsList.tsx
@@ -69,7 +69,7 @@ export const RewardsList: React.FC<RewardsListProps> &
 
   return (
     <RewardsListContext.Provider value={rewardsHook}>
-      <div className="flex flex-col gap-16">
+      <div className="flex flex-col gap-12">
         {!!rewards.length && (
           <>
             {rewards
@@ -87,7 +87,7 @@ export const RewardsList: React.FC<RewardsListProps> &
                     }}
                   />
                   {shouldRenderNftDivider(i) ? (
-                    <Divider className="m-0 mt-16" />
+                    <Divider className="m-0 mt-12" />
                   ) : null}
                 </div>
               ))}

--- a/src/components/Create/components/RewardsList/types/Reward.ts
+++ b/src/components/Create/components/RewardsList/types/Reward.ts
@@ -5,5 +5,8 @@ export interface Reward {
   description: string | undefined
   maximumSupply?: number
   url: string | undefined
+  reservedRate: number | undefined
+  beneficiary: string | undefined
+  votingWeight: number | undefined
   imgUrl: string
 }

--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -128,11 +128,11 @@ export const NftRewardsPage = () => {
                       value={JB721GovernanceType.NONE}
                       title={
                         <>
-                          <Trans>No on-chain governance capabilities</Trans>{' '}
+                          <Trans>No on-chain governance</Trans>{' '}
                           <CreateBadge.Default />
                         </>
                       }
-                      description={t`Your project's NFTs will not have any governance capabilities.`}
+                      description={t`Your project's NFTs will not have any on-chain governance capabilities.`}
                     />
                     <RadioItem
                       value={JB721GovernanceType.GLOBAL}

--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -1,21 +1,46 @@
 import { EyeOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Form, Space } from 'antd'
+import { Form, Radio, Space } from 'antd'
 import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
 import { JuiceInput } from 'components/inputs/JuiceTextInput'
 import { NftPostPayModal } from 'components/NftRewards/NftPostPayModal'
 import TooltipLabel from 'components/TooltipLabel'
 import { useAppSelector } from 'hooks/AppSelector'
 import { useModal } from 'hooks/Modal'
-import { useContext } from 'react'
+import { JB721GovernanceType } from 'models/nftRewardTier'
+import { ReactNode, useContext } from 'react'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/EditingCreateFurthestPageReached'
 import { CreateButton } from 'components/CreateButton'
+import { CreateBadge } from '../../CreateBadge'
 import { CreateCollapse } from '../../CreateCollapse'
 import { OptionalHeader } from '../../OptionalHeader'
 import { RewardsList } from '../../RewardsList'
 import { Wizard } from '../../Wizard'
 import { PageContext } from '../../Wizard/contexts/PageContext'
 import { useNftRewardsForm } from './hooks'
+
+const RadioItem = ({
+  value,
+  title,
+  description,
+}: {
+  value: JB721GovernanceType
+  title?: ReactNode
+  description?: ReactNode
+}) => {
+  return (
+    <Radio value={value}>
+      <span className="text-sm">
+        {title && <div className="font-medium">{title}</div>}
+        {description && (
+          <div className="mt-1 font-normal text-grey-500 dark:text-grey-300">
+            {description}
+          </div>
+        )}
+      </span>
+    </Radio>
+  )
+}
 
 export const NftRewardsPage = () => {
   useSetCreateFurthestPageReached('nftRewards')
@@ -94,6 +119,36 @@ export const NftRewardsPage = () => {
             <CreateCollapse>
               <CreateCollapse.Panel
                 key={1}
+                header={<OptionalHeader header={t`On-chain Governance`} />}
+                hideDivider
+              >
+                <Form.Item name="onChainGovernance">
+                  <Radio.Group className="flex flex-col gap-5">
+                    <RadioItem
+                      value={JB721GovernanceType.NONE}
+                      title={
+                        <>
+                          <Trans>No on-chain governance capabilities</Trans>{' '}
+                          <CreateBadge.Default />
+                        </>
+                      }
+                      description={t`Your project's NFTs will not have any governance capabilities.`}
+                    />
+                    <RadioItem
+                      value={JB721GovernanceType.GLOBAL}
+                      title={t`Standard on-chain governance`}
+                      description={t`All NFTs will carry the same voting weight when used for governance.`}
+                    />
+                    <RadioItem
+                      value={JB721GovernanceType.TIERED}
+                      title={t`Tier-based on-chain governance`}
+                      description={t`Set a specific voting weight for each of your project's NFTs.`}
+                    />
+                  </Radio.Group>
+                </Form.Item>
+              </CreateCollapse.Panel>
+              <CreateCollapse.Panel
+                key={2}
                 header={<OptionalHeader header={t`Payment Success Popup`} />}
                 hideDivider
               >

--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -132,17 +132,17 @@ export const NftRewardsPage = () => {
                           <CreateBadge.Default />
                         </>
                       }
-                      description={t`Your project's NFTs will not have any on-chain governance capabilities.`}
+                      description={t`Your project's NFTs will not have on-chain governance capabilities.`}
                     />
                     <RadioItem
                       value={JB721GovernanceType.GLOBAL}
                       title={t`Standard on-chain governance`}
-                      description={t`All NFTs will carry the same voting weight when used for governance.`}
+                      description={t`Track the historical voting weight of each token holder across all tiers of NFTs.`}
                     />
                     <RadioItem
                       value={JB721GovernanceType.TIERED}
                       title={t`Tier-based on-chain governance`}
-                      description={t`Set a specific voting weight for each of your project's NFTs.`}
+                      description={t`Track the historical voting weight of each token holder within each tier of NFTs.`}
                     />
                   </Radio.Group>
                 </Form.Item>

--- a/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
@@ -21,6 +21,9 @@ export const RewardsReview = () => {
         maximumSupply: t.maxSupply,
         url: t.externalLink,
         imgUrl: t.imageUrl,
+        beneficiary: t.beneficiary,
+        reservedRate: t.reservedRate,
+        votingWeight: t.votingWeight,
       })) ?? []
     )
   }, [rewardTiers])
@@ -37,6 +40,9 @@ export const RewardsReview = () => {
             name: reward.title,
             externalLink: reward.url,
             description: reward.description,
+            beneficiary: reward.beneficiary,
+            reservedRate: reward.reservedRate,
+            votingWeight: reward.votingWeight,
           })),
         ),
       )

--- a/src/components/Create/hooks/DeployProject/hooks/NFT/DeployNftProject.ts
+++ b/src/components/Create/hooks/DeployProject/hooks/NFT/DeployNftProject.ts
@@ -42,6 +42,10 @@ export const useDeployNftProject = () => {
     () => nftRewards.collectionMetadata.symbol ?? '',
     [nftRewards.collectionMetadata.symbol],
   )
+  const governanceType = useMemo(
+    () => nftRewards.governanceType,
+    [nftRewards.governanceType],
+  )
 
   /**
    * Deploy a project with NFT rewards.
@@ -82,6 +86,7 @@ export const useDeployNftProject = () => {
             collectionUri: nftCollectionMetadataUri,
             collectionName,
             collectionSymbol,
+            governanceType,
             tiers,
           },
           projectData: {
@@ -111,6 +116,7 @@ export const useDeployNftProject = () => {
       reservedTokensGroupedSplits,
       launchProjectWithNftsTx,
       collectionSymbol,
+      governanceType,
       inputProjectOwner,
       fundingCycleData,
       mustStartAtOrAfter,

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
@@ -55,6 +55,9 @@ export function RedeemNftCard({
     imageUrl: image,
     externalLink: undefined,
     description: undefined,
+    beneficiary: undefined,
+    reservedRate: undefined,
+    votingWeight: undefined,
   }
 
   return (

--- a/src/contexts/nftRewardsContext.ts
+++ b/src/contexts/nftRewardsContext.ts
@@ -1,3 +1,4 @@
+import { JB721GovernanceType } from 'models/nftRewardTier'
 import { createContext } from 'react'
 import {
   EMPTY_NFT_COLLECTION_METADATA,
@@ -15,6 +16,7 @@ export const NftRewardsContext = createContext<NftRewardsContextType>({
     rewardTiers: undefined,
     postPayModal: undefined,
     collectionMetadata: EMPTY_NFT_COLLECTION_METADATA,
+    governanceType: JB721GovernanceType.NONE,
   },
   loading: false,
 })

--- a/src/hooks/JB721Delegate/transactor/LaunchFundingCyclesWithNftsTx.ts
+++ b/src/hooks/JB721Delegate/transactor/LaunchFundingCyclesWithNftsTx.ts
@@ -55,7 +55,12 @@ export function useLaunchFundingCyclesWithNftsTx(): TransactorInstance<LaunchFun
   return async (
     {
       projectId,
-      tiered721DelegateData: { rewardTiers, CIDs, collectionMetadata },
+      tiered721DelegateData: {
+        governanceType,
+        rewardTiers,
+        CIDs,
+        collectionMetadata,
+      },
       launchFundingCyclesData: {
         fundingCycleData,
         fundingCycleMetadata,
@@ -113,6 +118,7 @@ export function useLaunchFundingCyclesWithNftsTx(): TransactorInstance<LaunchFun
       collectionUri: collectionMetadata.uri ?? '',
       collectionName,
       collectionSymbol: collectionMetadata.symbol ?? '',
+      governanceType,
       tiers,
       ownerAddress: projectOwnerAddress,
       contractAddresses: {

--- a/src/hooks/JB721Delegate/transactor/LaunchProjectWithNftsTx.ts
+++ b/src/hooks/JB721Delegate/transactor/LaunchProjectWithNftsTx.ts
@@ -7,7 +7,7 @@ import { TransactorInstance } from 'hooks/Transactor'
 import { LaunchProjectData } from 'hooks/v2v3/transactor/LaunchProjectTx'
 import { useWallet } from 'hooks/Wallet'
 import omit from 'lodash/omit'
-import { JB721TierParams } from 'models/nftRewardTier'
+import { JB721GovernanceType, JB721TierParams } from 'models/nftRewardTier'
 import { JBPayDataSourceFundingCycleMetadata } from 'models/v2v3/fundingCycle'
 import { useContext } from 'react'
 import { DEFAULT_MUST_START_AT_OR_AFTER } from 'redux/slices/editingV2Project'
@@ -27,6 +27,7 @@ interface DeployTiered721DelegateData {
   collectionUri: string
   collectionName: string
   collectionSymbol: string
+  governanceType: JB721GovernanceType
   tiers: JB721TierParams[]
 }
 
@@ -49,6 +50,7 @@ export function useLaunchProjectWithNftsTx(): TransactorInstance<LaunchProjectWi
         collectionName,
         collectionSymbol,
         tiers,
+        governanceType,
       },
       projectData: {
         projectMetadataCID,
@@ -100,6 +102,7 @@ export function useLaunchProjectWithNftsTx(): TransactorInstance<LaunchProjectWi
       collectionSymbol,
       tiers,
       ownerAddress: _owner,
+      governanceType,
       contractAddresses: {
         JBDirectoryAddress: getAddress(contracts.JBDirectory.address),
         JBFundingCycleStoreAddress: getAddress(

--- a/src/hooks/JB721Delegate/transactor/ReconfigureV2V3FundingCycleWithNftsTx.ts
+++ b/src/hooks/JB721Delegate/transactor/ReconfigureV2V3FundingCycleWithNftsTx.ts
@@ -44,7 +44,12 @@ export function useReconfigureV2V3FundingCycleWithNftsTx(): TransactorInstance<R
         mustStartAtOrAfter = DEFAULT_MUST_START_AT_OR_AFTER,
         memo,
       },
-      tiered721DelegateData: { rewardTiers, CIDs, collectionMetadata },
+      tiered721DelegateData: {
+        governanceType,
+        rewardTiers,
+        CIDs,
+        collectionMetadata,
+      },
     },
     txOpts,
   ) => {
@@ -78,6 +83,7 @@ export function useReconfigureV2V3FundingCycleWithNftsTx(): TransactorInstance<R
       collectionUri: collectionMetadata.uri ?? '',
       collectionName,
       collectionSymbol: collectionMetadata.symbol ?? '',
+      governanceType,
       tiers,
       ownerAddress: projectOwnerAddress,
       contractAddresses: {

--- a/src/hooks/NftRewards.ts
+++ b/src/hooks/NftRewards.ts
@@ -39,6 +39,9 @@ async function fetchRewardTierFromIPFS({
     maxSupply,
     remainingSupply: tier.remainingQuantity?.toNumber() ?? maxSupply,
     imageUrl: tierMetadata.image,
+    beneficiary: tier.reservedTokenBeneficiary,
+    reservedRate: tier.reservedRate.toNumber(),
+    votingWeight: tier.votingUnits.toNumber(),
   }
 }
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1256,10 +1256,10 @@ msgstr ""
 msgid "Error uploading file"
 msgstr ""
 
-msgid "Expenses cannot exceed the current funding target"
+msgid "Ethereum wallet address"
 msgstr ""
 
-msgid "Ethereum wallet address"
+msgid "Expenses cannot exceed the current funding target"
 msgstr ""
 
 msgid "Explore projects"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1517,7 +1517,7 @@ msgstr ""
 msgid "If you have a V1 project, add the project's handle here. Otherwise, leave this blank."
 msgstr ""
 
-msgid "If you use the default governance option (no governance), the voting weight will still be accessible on the blockchain for use in snapshot strategies or any other desired purpose."
+msgid "If you use the default governance option (no governance), the voting weight will still be accessible on the blockchain for use in Snapshot strategies or any other desired purpose."
 msgstr ""
 
 msgid "If you're unsure if you need to claim, you probably don't."
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Link contributors to another page after they successfully mint one of your project's NFTs."
 msgstr ""
 
-msgid "Link minters of this NFT to your project's website, discord etc."
+msgid "Link minters of this NFT to your project's website, Discord, etc."
 msgstr ""
 
 msgid "Load more"
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr ""
 
-msgid "No on-chain governance capabilities"
+msgid "No on-chain governance"
 msgstr ""
 
 msgid "No past funding cycles"
@@ -2504,13 +2504,13 @@ msgstr ""
 msgid "Reserve 1 NFT of every"
 msgstr ""
 
-msgid "Reserve NFTs"
-msgstr ""
-
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr ""
 
 msgid "Reserved NFTS"
+msgstr ""
+
+msgid "Reserved NFTs"
 msgstr ""
 
 msgid "Reserved NFTs will be sent to this address once minted."
@@ -3698,7 +3698,7 @@ msgstr ""
 msgid "Your project will withhold all funds raised. Funds can be distributed to payout addresses you set, and the project owner will receive any unallocated funds. Your project will have no overflow, so token holders can't redeem their tokens for ETH."
 msgstr ""
 
-msgid "Your project's NFTs will not have any governance capabilities."
+msgid "Your project's NFTs will not have any on-chain governance capabilities."
 msgstr ""
 
 msgid "Your project's current funding cycle has no duration. Changes you make below will take effect immediately."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -353,7 +353,13 @@ msgstr ""
 msgid "Advanced Rules"
 msgstr ""
 
+msgid "Advanced options"
+msgstr ""
+
 msgid "All"
+msgstr ""
+
+msgid "All NFTs will carry the same voting weight when used for governance."
 msgstr ""
 
 msgid "All assets"
@@ -1256,6 +1262,9 @@ msgstr ""
 msgid "Expenses cannot exceed the current funding target"
 msgstr ""
 
+msgid "Ethereum wallet address"
+msgstr ""
+
 msgid "Explore projects"
 msgstr ""
 
@@ -1397,6 +1406,9 @@ msgstr ""
 msgid "Give this NFT a name."
 msgstr ""
 
+msgid "Give this NFT a voting weight to be used for on-chain governance. The number you set is only used in relation to other NFTs in this collection."
+msgstr ""
+
 msgid "Go to <0>{snapshotUrl}</0>"
 msgstr ""
 
@@ -1479,6 +1491,9 @@ msgid "I have read and accept the <0>Terms of Service</0>, and understand that a
 msgstr ""
 
 msgid "I understand"
+msgstr ""
+
+msgid "If Reserved NFTs are set, the first reserved NFT from the tier will be distributable once the tier receives its first mint."
 msgstr ""
 
 msgid "If locked, this can't be edited or removed until the lock expires or the funding cycle is reconfigured."
@@ -1664,6 +1679,9 @@ msgstr ""
 msgid "Link contributors to another page after they successfully mint one of your project's NFTs."
 msgstr ""
 
+msgid "Link minters of this NFT to your project's website, discord etc."
+msgstr ""
+
 msgid "Load more"
 msgstr ""
 
@@ -1763,6 +1781,9 @@ msgstr ""
 msgid "Minimum Contribution"
 msgstr ""
 
+msgid "Minimum contribution"
+msgstr ""
+
 msgid "Mint NFT to a custom address"
 msgstr ""
 
@@ -1850,6 +1871,9 @@ msgstr ""
 msgid "NFTs for you"
 msgstr ""
 
+msgid "NFTs minted for:"
+msgstr ""
+
 msgid "NO LIMIT"
 msgstr ""
 
@@ -1916,6 +1940,9 @@ msgstr ""
 msgid "No more than the funding cycle target can be distributed by the project in a single funding cycle."
 msgstr ""
 
+msgid "No on-chain governance capabilities"
+msgstr ""
+
 msgid "No past funding cycles"
 msgstr ""
 
@@ -1965,6 +1992,9 @@ msgid "Note: Tokens can be minted manually when allowed in the current funding c
 msgstr ""
 
 msgid "Notice from {0}"
+msgstr ""
+
+msgid "On-chain Governance"
 msgstr ""
 
 msgid "Only lowercase letters"
@@ -2468,7 +2498,19 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+msgid "Reserve 1 NFT of every"
+msgstr ""
+
+msgid "Reserve NFTs"
+msgstr ""
+
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
+msgstr ""
+
+msgid "Reserved NFTS"
+msgstr ""
+
+msgid "Reserved NFTs will be sent to this address once minted."
 msgstr ""
 
 msgid "Reserved rate"
@@ -2663,10 +2705,16 @@ msgstr ""
 msgid "Set a specific amount to distribute to nominated addresses each funding cycle."
 msgstr ""
 
+msgid "Set a specific voting weight for each of your project's NFTs."
+msgstr ""
+
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
 msgid "Set a unique handle that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgstr ""
+
+msgid "Set aside a percentage of freshly minted NFTs."
 msgstr ""
 
 msgid "Set aside a percentage of freshly minted tokens, which you can allocate below."
@@ -2765,6 +2813,9 @@ msgstr ""
 msgid "Staked {tokenSymbolDisplayText}"
 msgstr ""
 
+msgid "Standard on-chain governance"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
@@ -2795,7 +2846,7 @@ msgstr ""
 msgid "Sum of percentages cannot exceed 100%."
 msgstr ""
 
-msgid "Supply: {maximumSupply}"
+msgid "Supply"
 msgstr ""
 
 msgid "Switch network to {0}"
@@ -2960,6 +3011,9 @@ msgstr ""
 msgid "The veNFT contract is currently unable to lock project token. Contact the project owner regarding adding this permission."
 msgstr ""
 
+msgid "The wallet address that reserved NFTs will be sent to"
+msgstr ""
+
 msgid "There are no payouts defined for this funding cycle. The project owner will receive all available funds."
 msgstr ""
 
@@ -3033,6 +3087,9 @@ msgid "This will enable your project's veNFT contract to spend unclaimed tokens 
 msgstr ""
 
 msgid "This will give your <0/> or <1/> project's token holders the ability to migrate their tokens to <2/>."
+msgstr ""
+
+msgid "Tier-based on-chain governance"
 msgstr ""
 
 msgid "Time Remaining"
@@ -3383,6 +3440,12 @@ msgstr ""
 msgid "VotePWR"
 msgstr ""
 
+msgid "Voting weight"
+msgstr ""
+
+msgid "Voting weight is only applicable if this NFT will be used for on-chain governance, and can also be read on-chain for other purposes if needed."
+msgstr ""
+
 msgid "WAGMI!"
 msgstr ""
 
@@ -3633,6 +3696,9 @@ msgid "Your project will appear as 'archived'."
 msgstr ""
 
 msgid "Your project will withhold all funds raised. Funds can be distributed to payout addresses you set, and the project owner will receive any unallocated funds. Your project will have no overflow, so token holders can't redeem their tokens for ETH."
+msgstr ""
+
+msgid "Your project's NFTs will not have any governance capabilities."
 msgstr ""
 
 msgid "Your project's current funding cycle has no duration. Changes you make below will take effect immediately."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -359,9 +359,6 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-msgid "All NFTs will carry the same voting weight when used for governance."
-msgstr ""
-
 msgid "All assets"
 msgstr ""
 
@@ -2708,9 +2705,6 @@ msgstr ""
 msgid "Set a specific amount to distribute to nominated addresses each funding cycle."
 msgstr ""
 
-msgid "Set a specific voting weight for each of your project's NFTs."
-msgstr ""
-
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
@@ -3242,6 +3236,12 @@ msgstr ""
 msgid "Total: {0}%"
 msgstr ""
 
+msgid "Track the historical voting weight of each token holder across all tiers of NFTs."
+msgstr ""
+
+msgid "Track the historical voting weight of each token holder within each tier of NFTs."
+msgstr ""
+
 msgid "Transaction failed"
 msgstr ""
 
@@ -3698,7 +3698,7 @@ msgstr ""
 msgid "Your project will withhold all funds raised. Funds can be distributed to payout addresses you set, and the project owner will receive any unallocated funds. Your project will have no overflow, so token holders can't redeem their tokens for ETH."
 msgstr ""
 
-msgid "Your project's NFTs will not have any on-chain governance capabilities."
+msgid "Your project's NFTs will not have on-chain governance capabilities."
 msgstr ""
 
 msgid "Your project's current funding cycle has no duration. Changes you make below will take effect immediately."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1517,6 +1517,9 @@ msgstr ""
 msgid "If you have a V1 project, add the project's handle here. Otherwise, leave this blank."
 msgstr ""
 
+msgid "If you use the default governance option (no governance), the voting weight will still be accessible on the blockchain for use in snapshot strategies or any other desired purpose."
+msgstr ""
+
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr ""
 
@@ -3441,9 +3444,6 @@ msgid "VotePWR"
 msgstr ""
 
 msgid "Voting weight"
-msgstr ""
-
-msgid "Voting weight is only applicable if this NFT will be used for on-chain governance, and can also be read on-chain for other purposes if needed."
 msgstr ""
 
 msgid "WAGMI!"

--- a/src/models/nftRewardTier.ts
+++ b/src/models/nftRewardTier.ts
@@ -11,6 +11,9 @@ export type NftRewardTier = {
   imageUrl: string // link to ipfs
   name: string
   id?: number
+  reservedRate: number | undefined
+  beneficiary: string | undefined
+  votingWeight: number | undefined
   externalLink: string | undefined
   description: string | undefined
 }

--- a/src/providers/v2v3/NftRewardsProvider.tsx
+++ b/src/providers/v2v3/NftRewardsProvider.tsx
@@ -5,6 +5,7 @@ import { useNftCollectionMetadataUri } from 'hooks/JB721Delegate/contractReader/
 import { useNftRewardTiersOf } from 'hooks/JB721Delegate/contractReader/NftRewardTiersOf'
 import { useHasNftRewards } from 'hooks/JB721Delegate/HasNftRewards'
 import useNftRewards from 'hooks/NftRewards'
+import { JB721GovernanceType } from 'models/nftRewardTier'
 import { useContext } from 'react'
 import { EMPTY_NFT_COLLECTION_METADATA } from 'redux/slices/editingV2Project'
 import { CIDsOfNftRewardTiersResponse } from 'utils/nftRewards'
@@ -53,6 +54,7 @@ export const NftRewardsProvider: React.FC = ({ children }) => {
       value={{
         nftRewards: {
           rewardTiers,
+          governanceType: JB721GovernanceType.NONE,
           CIDs,
           collectionMetadata: {
             ...EMPTY_NFT_COLLECTION_METADATA, // only load the metadata CID in the context - other data not necessary

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -10,6 +10,7 @@ import {
 import { CreatePage } from 'models/create-page'
 import { FundingTargetType } from 'models/fundingTargetType'
 import {
+  JB721GovernanceType,
   NftCollectionMetadata,
   NftPostPayModalConfig,
   NftRewardTier,
@@ -44,6 +45,7 @@ export type NftRewardsData = {
   CIDs: string[] | undefined // points to locations of the NFTs' json on IPFS
   collectionMetadata: NftCollectionMetadata
   postPayModal: NftPostPayModalConfig | undefined
+  governanceType: JB721GovernanceType
 }
 
 export interface CreateState {
@@ -72,10 +74,10 @@ interface ReduxState extends CreateState, ProjectState {
   version: number
 }
 
-// Increment this version by 1 when making breaking changes.
+// Increment this version by 1 when making breaking or major changes.
 // When users return to the site and their local version is less than
 // this number, their state will be reset.
-export const REDUX_STORE_V2_PROJECT_VERSION = 10
+export const REDUX_STORE_V2_PROJECT_VERSION = 11
 
 export const DEFAULT_MUST_START_AT_OR_AFTER = '1'
 
@@ -164,6 +166,7 @@ const defaultProjectState: ProjectState = {
     CIDs: undefined,
     collectionMetadata: EMPTY_NFT_COLLECTION_METADATA,
     postPayModal: undefined,
+    governanceType: JB721GovernanceType.NONE,
   },
   mustStartAtOrAfter: DEFAULT_MUST_START_AT_OR_AFTER,
   inputProjectOwner: undefined,
@@ -325,6 +328,12 @@ const editingV2ProjectSlice = createSlice({
       action: PayloadAction<string | undefined>,
     ) => {
       state.nftRewards.collectionMetadata.description = action.payload
+    },
+    setNftRewardsGovernance: (
+      state,
+      action: PayloadAction<JB721GovernanceType>,
+    ) => {
+      state.nftRewards.governanceType = action.payload
     },
     setNftPostPayModalConfig: (
       state,

--- a/src/utils/antd-rules/inputIsIntegerRule.ts
+++ b/src/utils/antd-rules/inputIsIntegerRule.ts
@@ -5,15 +5,22 @@ import { isInteger } from 'lodash'
 /**
  * Rule to determine that the input is an integer.
  */
-export const inputIsIntegerRule = (props: { label?: string }) => ({
+export const inputIsIntegerRule = (props: {
+  label?: string
+  stringOkay?: boolean
+}) => ({
   validator: (rule: RuleObject, value: unknown) => {
     if (value === undefined) return Promise.resolve()
-    if (typeof value !== 'number')
+    if (props.stringOkay && typeof value === 'string') {
+      value = parseFloat(value)
+    }
+    if (typeof value !== 'number' || isNaN(value)) {
       return Promise.reject(
         props.label
           ? t`${props.label} must be numeric`
           : t`Is not a valid integer`,
       )
+    }
     if (!isInteger(value)) {
       return Promise.reject(
         props.label

--- a/src/utils/nftRewards.ts
+++ b/src/utils/nftRewards.ts
@@ -219,13 +219,21 @@ export function buildJB721TierParams({
       )
       const encodedIPFSUri = encodeIPFSUri(cid)
 
+      const reservedRate = rewardTiers[index].reservedRate
+        ? BigNumber.from(rewardTiers[index].reservedRate! - 1)
+        : undefined
+      const reservedTokenBeneficiary = rewardTiers[index].beneficiary
+      const votingUnits = rewardTiers[index].votingWeight
+        ? BigNumber.from(rewardTiers[index].votingWeight)
+        : undefined
+
       return {
         contributionFloor: contributionFloorWei,
         lockedUntil: BigNumber.from(0),
         initialQuantity,
-        votingUnits: BigNumber.from(0),
-        reservedRate: BigNumber.from(0),
-        reservedTokenBeneficiary: constants.AddressZero,
+        votingUnits,
+        reservedRate,
+        reservedTokenBeneficiary,
         encodedIPFSUri,
         allowManualMint: false,
         shouldUseBeneficiaryAsDefault: false,
@@ -333,6 +341,7 @@ export function buildJBDeployTiered721DelegateData({
   collectionSymbol,
   tiers,
   ownerAddress,
+  governanceType,
   contractAddresses: {
     JBDirectoryAddress,
     JBFundingCycleStoreAddress,
@@ -345,6 +354,7 @@ export function buildJBDeployTiered721DelegateData({
   collectionSymbol: string
   tiers: JB721TierParams[]
   ownerAddress: string
+  governanceType: JB721GovernanceType
   contractAddresses: {
     JBDirectoryAddress: string
     JBFundingCycleStoreAddress: string
@@ -376,7 +386,7 @@ export function buildJBDeployTiered721DelegateData({
       lockVotingUnitChanges: false,
       lockManualMintingChanges: false,
     },
-    governanceType: JB721GovernanceType.NONE,
+    governanceType: governanceType,
   }
 }
 

--- a/src/utils/nftRewards.ts
+++ b/src/utils/nftRewards.ts
@@ -221,11 +221,12 @@ export function buildJB721TierParams({
 
       const reservedRate = rewardTiers[index].reservedRate
         ? BigNumber.from(rewardTiers[index].reservedRate! - 1)
-        : undefined
-      const reservedTokenBeneficiary = rewardTiers[index].beneficiary
+        : BigNumber.from(0)
+      const reservedTokenBeneficiary =
+        rewardTiers[index].beneficiary ?? constants.AddressZero
       const votingUnits = rewardTiers[index].votingWeight
         ? BigNumber.from(rewardTiers[index].votingWeight)
-        : undefined
+        : BigNumber.from(0)
 
       return {
         contributionFloor: contributionFloorWei,


### PR DESCRIPTION
## What does this PR do and why?

Adds the ability to:
- Add on-chain governance flags to NFT collection
- Add reserved rate to each NFT
- Add owner of reserved minted NFT
- Add governance weight of NFT

Also updated formatting of the NFT view

closes https://github.com/jbx-protocol/juice-interface/issues/2857

## Screenshots or screen recordings

![Screen Shot 2023-01-23 at 11 17 45 am](https://user-images.githubusercontent.com/104132113/213948492-f6d4eb08-9af5-474c-993f-85b00d59636e.png)
![Screen Shot 2023-01-23 at 11 18 34 am](https://user-images.githubusercontent.com/104132113/213948498-a3fda9f2-ba52-4eb5-b904-5498b84a9164.png)
![Screen Shot 2023-01-23 at 11 20 07 am](https://user-images.githubusercontent.com/104132113/213948502-710e81d0-e8b7-45ba-b8b9-99eb55c9e482.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
