### PR TITLE
Update project creation success screen and next steps modal

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
@@ -1,4 +1,4 @@
-import { ShareAltOutlined } from '@ant-design/icons'
+import { RocketOutlined, TwitterOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Space } from 'antd'
 import ExternalLink from 'components/ExternalLink'
@@ -60,12 +60,20 @@ export const DeploySuccess = ({ projectId }: { projectId: number }) => {
       <div className="pt-8 text-4xl font-medium">Congratulations!</div>
       <div className="mt-6 text-xl font-normal">{deployGreeting}</div>
       <div className="flex gap-2 pt-16">
+        <ExternalLink href="https://discord.gg/juicebox">
+          <Button>
+            <Space>
+              <RocketOutlined />
+              <Trans> Share in JuiceboxDAO's Discord</Trans>
+            </Space>
+          </Button>
+        </ExternalLink>
         <ExternalLink href={twitterShareUrl}>
           <Button>
             {/* Spacing is weird when you use button icon - do this instead */}
             <Space>
-              <ShareAltOutlined />
-              <Trans> Share project</Trans>
+              <TwitterOutlined />
+              <Trans> Share on Twitter</Trans>
             </Space>
           </Button>
         </ExternalLink>

--- a/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
@@ -1,6 +1,6 @@
-import { RocketOutlined, TwitterOutlined } from '@ant-design/icons'
+import { TwitterOutlined, ShareAltOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Button, Space } from 'antd'
+import { Button } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import { NEW_DEPLOY_QUERY_PARAM } from 'components/v2v3/V2V3Project/modals/NewDeployModal'
 import { readNetwork } from 'constants/networks'
@@ -59,31 +59,31 @@ export const DeploySuccess = ({ projectId }: { projectId: number }) => {
       <Image src="/assets/dancing.gif" width={218} height={218} />
       <div className="pt-8 text-4xl font-medium">Congratulations!</div>
       <div className="mt-6 text-xl font-normal">{deployGreeting}</div>
-      <div className="flex gap-2 pt-16">
-        <ExternalLink href="https://discord.gg/juicebox">
-          <Button>
-            <Space>
-              <RocketOutlined />
-              <Trans> Share on Discord</Trans>
-            </Space>
-          </Button>
-        </ExternalLink>
-        <ExternalLink href={twitterShareUrl}>
-          <Button>
-            {/* Spacing is weird when you use button icon - do this instead */}
-            <Space>
-              <TwitterOutlined />
-              <Trans> Share on Twitter</Trans>
-            </Space>
-          </Button>
-        </ExternalLink>
+      <div className="flex flex-col gap-2 pt-16">
         <Button
           type="primary"
           onClick={handleGoToProject}
           loading={gotoProjectClicked}
+          className="gap-3"
         >
-          <Trans>Go to project</Trans>
+          <span>
+            <Trans>Go to project</Trans>
+          </span>
         </Button>
+        <ExternalLink href={twitterShareUrl}>
+          <Button icon={<TwitterOutlined />}>
+            <span>
+              <Trans> Share on Twitter</Trans>
+            </span>
+          </Button>
+        </ExternalLink>
+        <ExternalLink href="https://discord.gg/juicebox">
+          <Button icon={<ShareAltOutlined />}>
+            <span>
+              <Trans> Share on Discord</Trans>
+            </span>
+          </Button>
+        </ExternalLink>
       </div>
     </div>
   )

--- a/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
@@ -64,7 +64,7 @@ export const DeploySuccess = ({ projectId }: { projectId: number }) => {
           <Button>
             <Space>
               <RocketOutlined />
-              <Trans> Share in JuiceboxDAO's Discord</Trans>
+              <Trans> Share on Discord</Trans>
             </Space>
           </Button>
         </ExternalLink>

--- a/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/DeploySuccess/DeploySuccess.tsx
@@ -4,17 +4,14 @@ import { Button } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import { NEW_DEPLOY_QUERY_PARAM } from 'components/v2v3/V2V3Project/modals/NewDeployModal'
 import { readNetwork } from 'constants/networks'
-import useMobile from 'hooks/Mobile'
 import { useWallet } from 'hooks/Wallet'
 import { NetworkName } from 'models/network-name'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo, useState } from 'react'
-import { classNames } from 'utils/classNames'
 
 export const DeploySuccess = ({ projectId }: { projectId: number }) => {
   console.info('Deploy: SUCCESS', projectId)
-  const isMobile = useMobile()
   const router = useRouter()
   const { chain } = useWallet()
   let deployGreeting = t`Your project has successfully launched!`
@@ -50,21 +47,15 @@ export const DeploySuccess = ({ projectId }: { projectId: number }) => {
   }, [projectId, router])
 
   return (
-    <div
-      className={classNames(
-        'flex flex-col items-center justify-center text-center',
-        isMobile ? 'mt-4' : 'mt-28',
-      )}
-    >
+    <div className="mt-4 flex flex-col items-center justify-center text-center">
       <Image src="/assets/dancing.gif" width={218} height={218} />
       <div className="pt-8 text-4xl font-medium">Congratulations!</div>
       <div className="mt-6 text-xl font-normal">{deployGreeting}</div>
-      <div className="flex flex-col gap-2 pt-16">
+      <div className="flex flex-col gap-2 py-12">
         <Button
           type="primary"
           onClick={handleGoToProject}
           loading={gotoProjectClicked}
-          className="gap-3"
         >
           <span>
             <Trans>Go to project</Trans>

--- a/src/components/v2v3/V2V3Project/modals/NewDeployModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/NewDeployModal.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { useContext, useState } from 'react'
 import { settingsPagePath } from 'utils/routes'
 import { LaunchProjectPayerModal } from './LaunchProjectPayerModal'
+import ExternalLink from 'components/ExternalLink'
 
 export const NEW_DEPLOY_QUERY_PARAM = 'np'
 
@@ -48,8 +49,12 @@ export default function NewDeployModal({
       </h2>
       <p>
         <Trans>
-          Congratulations on launching your project! The next steps are optional
-          and can be completed at any time.
+          Congratulations on launching your project! For help planning your next
+          steps, share your project in the{' '}
+          <ExternalLink href="https://discord.gg/juicebox">
+            JuiceboxDAO Discord
+          </ExternalLink>
+          . Optionally, you can:
         </Trans>
       </p>
       <div>
@@ -60,7 +65,7 @@ export default function NewDeployModal({
             heading={<Trans>Set a project handle (optional)</Trans>}
             description={
               <Trans>
-                Set a unique name that will be visible in your project's URL,
+                Set a unique handle that will be visible in your project's URL,
                 and that will allow your project to appear in search results.
               </Trans>
             }
@@ -81,8 +86,9 @@ export default function NewDeployModal({
           heading={<Trans>Issue an ERC-20 token (optional)</Trans>}
           description={
             <Trans>
-              Create your own ERC-20 token to represent stake in your project.
-              Contributors will receive these tokens when they pay your project.
+              Allow contributors to claim your project's tokens as an ERC-20.
+              This makes your project's tokens compatible with tools like
+              Uniswap.
             </Trans>
           }
           onClick={() => setIssueTokenModalVisible(true)}
@@ -102,8 +108,8 @@ export default function NewDeployModal({
           heading={<Trans>Create a Payment Address (optional)</Trans>}
           description={
             <Trans>
-              Create an Ethereum address for your project. Enables direct
-              payments without going through your project's Juicebox page.
+              Deploy an address which forwards funds to your project. This makes
+              it easier to pay your project outside of juicebox.money.
             </Trans>
           }
           onClick={() => setLaunchProjectPayerModalVisible(true)}

--- a/src/components/v2v3/V2V3Project/modals/NewDeployModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/NewDeployModal.tsx
@@ -54,7 +54,7 @@ export default function NewDeployModal({
           <ExternalLink href="https://discord.gg/juicebox">
             JuiceboxDAO Discord
           </ExternalLink>
-          . Optionally, you can:
+          . Optionally, you can also:
         </Trans>
       </p>
       <div>
@@ -109,7 +109,7 @@ export default function NewDeployModal({
           description={
             <Trans>
               Deploy an address which forwards funds to your project. This makes
-              it easier to pay your project outside of juicebox.money.
+              it easier to pay your project with third-party tools.
             </Trans>
           }
           onClick={() => setLaunchProjectPayerModalVisible(true)}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -386,6 +386,9 @@ msgstr ""
 msgid "Allow a few days for your project to appear in the \"archived\" projects list on the Projects page."
 msgstr ""
 
+msgid "Allow contributors to claim your project's tokens as an ERC-20. This makes your project's tokens compatible with tools like Uniswap."
+msgstr ""
+
 msgid "Allow minting tokens"
 msgstr ""
 
@@ -704,7 +707,7 @@ msgstr ""
 msgid "Confirm Stake"
 msgstr ""
 
-msgid "Congratulations on launching your project! The next steps are optional and can be completed at any time."
+msgid "Congratulations on launching your project! For help planning your next steps, share your project in the <0>JuiceboxDAO Discord</0>. Optionally, you can:"
 msgstr ""
 
 msgid "Connect"
@@ -809,16 +812,10 @@ msgstr ""
 msgid "Create a project on Juicebox"
 msgstr ""
 
-msgid "Create an Ethereum address for your project. Enables direct payments without going through your project's Juicebox page."
-msgstr ""
-
 msgid "Create an Ethereum address that can be used to pay your project directly."
 msgstr ""
 
 msgid "Create project"
-msgstr ""
-
-msgid "Create your own ERC-20 token to represent stake in your project. Contributors will receive these tokens when they pay your project."
 msgstr ""
 
 msgid "Created"
@@ -927,6 +924,9 @@ msgid "Deploy Snapshot space"
 msgstr ""
 
 msgid "Deploy a <0/> migration token from legacy tokens."
+msgstr ""
+
+msgid "Deploy an address which forwards funds to your project. This makes it easier to pay your project outside of juicebox.money."
 msgstr ""
 
 msgid "Deploy funding cycle configuration"
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Set a text record for {0} with the key <0>\"{projectHandleENSTextRecordKey}\"</0> and the value <1>\"{projectId}\"</1> (this project's ID). You can do this on the <2>ENS app</2>, or use the button below (as long as your connected wallet owns or controls that ENS name)."
 msgstr ""
 
-msgid "Set a unique name that will be visible in your project's URL, and that will allow your project to appear in search results."
+msgid "Set a unique handle that will be visible in your project's URL, and that will allow your project to appear in search results."
 msgstr ""
 
 msgid "Set aside a percentage of freshly minted tokens, which you can allocate below."
@@ -2702,7 +2702,10 @@ msgstr ""
 msgid "Setting a reconfiguration delay means changes to your funding cycle settings only take effect after the delay period has passed. This helps build trust with your contributors."
 msgstr ""
 
-msgid "Share project"
+msgid "Share in JuiceboxDAO's Discord"
+msgstr ""
+
+msgid "Share on Twitter"
 msgstr ""
 
 msgid "Show contributors a popup when they receive an NFT."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Confirm Stake"
 msgstr ""
 
-msgid "Congratulations on launching your project! For help planning your next steps, share your project in the <0>JuiceboxDAO Discord</0>. Optionally, you can:"
+msgid "Congratulations on launching your project! For help planning your next steps, share your project in the <0>JuiceboxDAO Discord</0>. Optionally, you can also:"
 msgstr ""
 
 msgid "Connect"
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Deploy a <0/> migration token from legacy tokens."
 msgstr ""
 
-msgid "Deploy an address which forwards funds to your project. This makes it easier to pay your project outside of juicebox.money."
+msgid "Deploy an address which forwards funds to your project. This makes it easier to pay your project with third-party tools."
 msgstr ""
 
 msgid "Deploy funding cycle configuration"
@@ -2702,7 +2702,7 @@ msgstr ""
 msgid "Setting a reconfiguration delay means changes to your funding cycle settings only take effect after the delay period has passed. This helps build trust with your contributors."
 msgstr ""
 
-msgid "Share in JuiceboxDAO's Discord"
+msgid "Share on Discord"
 msgstr ""
 
 msgid "Share on Twitter"


### PR DESCRIPTION
## What does this PR do and why?

Update project creation success screen and next steps modal. Clarify language and add CTA to join the Discord.

Would love some help testing this one, /create dev mode proved too intensive for my machine. Will test in preview.

**Update:** tested this and it's working well.

https://user-images.githubusercontent.com/96905094/213941472-3ac241de-5fc4-42cb-b6fb-511160e1245c.mp4

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
