### PR TITLE
Fix editing sold out NFTs limited supply bug

### DIFF
--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/MaxSupplyFormItem.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/MaxSupplyFormItem.tsx
@@ -1,20 +1,15 @@
 import { t } from '@lingui/macro'
 import { Form, Switch } from 'antd'
+import { useWatch } from 'antd/lib/form/Form'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import TooltipLabel from 'components/TooltipLabel'
 
-import { useState } from 'react'
+import { NftFormFields } from './NftRewardTierModal'
 
-export default function MaxSupplyFormItem({
-  value,
-  onChange,
-}: {
-  value: number | undefined
-  onChange: (value: number | undefined) => void
-}) {
-  const [limitedSupplyEnabled, setLimitedSupplyEnabled] = useState<boolean>(
-    Boolean(value),
-  )
+export default function MaxSupplyFormItem() {
+  const form = Form.useFormInstance<NftFormFields>()
+  const value = useWatch('maxSupply', form)
+  const hasLimitedSupply = value !== undefined
 
   return (
     <>
@@ -23,10 +18,9 @@ export default function MaxSupplyFormItem({
           <div className="flex">
             <Switch
               className="mr-2"
-              checked={limitedSupplyEnabled}
+              checked={hasLimitedSupply}
               onChange={() => {
-                setLimitedSupplyEnabled(!limitedSupplyEnabled)
-                onChange(undefined)
+                form.setFieldsValue({ maxSupply: value ? undefined : 1 })
               }}
             />
             <TooltipLabel
@@ -35,14 +29,15 @@ export default function MaxSupplyFormItem({
             />
           </div>
         }
+        name="maxSupply"
         className="w-full"
       >
         <div className="flex">
-          {limitedSupplyEnabled ? (
+          {hasLimitedSupply ? (
             <Form.Item
               className="mb-0 w-full"
               extra={
-                limitedSupplyEnabled
+                hasLimitedSupply
                   ? t`The maximum supply of this NFT in circulation.`
                   : null
               }

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
@@ -95,10 +95,7 @@ export default function NftRewardTierModal({
         </Form.Item>
         <ContributionFloorFormItem form={nftForm} />
         <NftUpload form={nftForm} />
-        <MaxSupplyFormItem
-          value={nftForm.getFieldValue('maxSupply')}
-          onChange={value => nftForm.setFieldsValue({ maxSupply: value })}
-        />
+        <MaxSupplyFormItem />
         <Form.Item
           name={'externalLink'}
           label={


### PR DESCRIPTION
## What does this PR do and why?

Closes the first two points of #2853 (made an issue for the 3rd point about deleting NFT tiers not being clear)
1. Limited supply field loads properly when editing sold out NFTs 
2. Can set it to something different

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
