### PR TITLE
Use HEAD for content type request

### DIFF
--- a/src/utils/http/__tests__/loadURLContentType.test.ts
+++ b/src/utils/http/__tests__/loadURLContentType.test.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid'
 
 import { loadURLContentType } from '../loadURLContentType'
 
-const axiosSpy = jest.spyOn(axios, 'get')
+const axiosSpy = jest.spyOn(axios, 'head')
 
 describe('loadURLContentType', () => {
   it('returns undefined if input is undefined', async () => {

--- a/src/utils/http/loadURLContentType.ts
+++ b/src/utils/http/loadURLContentType.ts
@@ -4,7 +4,7 @@ export async function loadURLContentType(url: string | undefined) {
   if (url === undefined) return undefined
 
   try {
-    return await axios.get(url).then(res => res.headers['content-type'])
+    return await axios.head(url).then(res => res.headers['content-type'])
   } catch (e) {
     return undefined
   }


### PR DESCRIPTION
## What does this PR do and why?

This lets us load the content type without downloading the entire image. Better for security + performance.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
