### PR TITLE
Always set discountRate to 0 when discountRate is/should be disabled

### DIFF
--- a/src/components/Create/components/pages/ProjectToken/hooks/ProjectTokenForm.ts
+++ b/src/components/Create/components/pages/ProjectToken/hooks/ProjectTokenForm.ts
@@ -51,6 +51,7 @@ export const useProjectTokensForm = () => {
     useAppSelector(state => state.editingV2Project)
   const [tokenSplits] = useEditingReservedTokensSplits()
   useDebugValue(form.getFieldsValue())
+  const discountRateDisabled = !parseInt(fundingCycleData.duration)
 
   const initialValues: ProjectTokensFormProps | undefined = useMemo(() => {
     const selection = projectTokensSelection
@@ -62,12 +63,13 @@ export const useProjectTokensForm = () => {
       : DefaultSettings.reservedTokensPercentage
     const reservedTokenAllocation: AllocationSplit[] =
       tokenSplits.map(splitToAllocation)
-    const discountRate = fundingCycleData.discountRate
-      ? parseFloat(formatDiscountRate(fundingCycleData.discountRate))
-      : DefaultSettings.discountRate
     const redemptionRate = fundingCycleMetadata.redemptionRate
       ? parseFloat(formatRedemptionRate(fundingCycleMetadata.redemptionRate))
       : DefaultSettings.redemptionRate
+    const discountRate =
+      !discountRateDisabled && fundingCycleData.discountRate
+        ? parseFloat(formatDiscountRate(fundingCycleData.discountRate))
+        : DefaultSettings.discountRate
     const tokenMinting =
       fundingCycleMetadata.allowMinting !== undefined
         ? fundingCycleMetadata.allowMinting
@@ -83,6 +85,7 @@ export const useProjectTokensForm = () => {
       tokenMinting,
     }
   }, [
+    discountRateDisabled,
     fundingCycleData.discountRate,
     fundingCycleData.weight,
     fundingCycleMetadata.allowMinting,


### PR DESCRIPTION
## What does this PR do and why?

Sets discount rate in create custom token settings to 0 when it is disabled.

To test:
1. Go to create
2. Set the funding cycle to specific any days
3. Go to Token settings and choose custom
4. Set a discount rate of any value
5. Go back to funding cycle and set to manual
6. Go back to Token settings
7. Observe discount rate is 0

Also make sure to check that the discount rate is persistent. Best way to do this is to go to review and make sure it reflects what is shown in the custom token settings

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
