### PR TITLE
[1/n] Move pauseTransfers to Tokens section

### DIFF
--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
@@ -227,22 +227,32 @@ export const CustomTokenSettings = () => {
 
       <Divider className="my-8" />
 
-      <>
+      <Space direction="vertical">
+        <div>
+          <Form.Item
+            extra={t`When enabled, the project owner can manually mint any amount of tokens to any address.`}
+            name="tokenMinting"
+          >
+            <JuiceSwitch label={t`Allow token minting`} />
+          </Form.Item>
+          {tokenMinting && (
+            <Callout.Warning className="mb-5">
+              <Trans>
+                Token minting isn't recommended as it allows the project owner
+                to create unlimited tokens. This is a risk factor for
+                contributors.
+              </Trans>
+            </Callout.Warning>
+          )}
+        </div>
+
         <Form.Item
-          extra={t`When enabled, the project owner can manually mint any amount of tokens to any address.`}
-          name="tokenMinting"
+          name="pauseTransfers"
+          extra={t`When enabled, project's token holders can't transfer their tokens to other addresses. This doesn't apply to your project's ERC-20 tokens (if you've issued them).`}
         >
-          <JuiceSwitch label={t`Allow token minting`} />
+          <JuiceSwitch label={t`Pause project token transfers`} />
         </Form.Item>
-        {tokenMinting && (
-          <Callout.Warning>
-            <Trans>
-              Token minting is not recommended as it allows the project owner to
-              create unlimited tokens. This is a risk factor for contributors.
-            </Trans>
-          </Callout.Warning>
-        )}
-      </>
+      </Space>
     </>
   )
 }

--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
@@ -227,7 +227,7 @@ export const CustomTokenSettings = () => {
 
       <Divider className="my-8" />
 
-      <Space direction="vertical">
+      <div className="flex flex-col gap-y-5">
         <div>
           <Form.Item
             extra={t`When enabled, the project owner can manually mint any amount of tokens to any address.`}
@@ -252,7 +252,7 @@ export const CustomTokenSettings = () => {
         >
           <JuiceSwitch label={t`Pause project token transfers`} />
         </Form.Item>
-      </Space>
+      </div>
     </>
   )
 }

--- a/src/components/Create/components/pages/ProjectToken/hooks/ProjectTokenForm.ts
+++ b/src/components/Create/components/pages/ProjectToken/hooks/ProjectTokenForm.ts
@@ -214,6 +214,7 @@ export const useProjectTokensForm = () => {
     form,
     fieldName: 'pauseTransfers',
     dispatchFunction: editingV2ProjectActions.setPauseTransfers,
+    ignoreUndefined: true,
     formatter: v => {
       if (typeof v !== 'boolean') return false
       return v

--- a/src/components/Create/components/pages/ProjectToken/hooks/ProjectTokenForm.ts
+++ b/src/components/Create/components/pages/ProjectToken/hooks/ProjectTokenForm.ts
@@ -31,6 +31,7 @@ export type ProjectTokensFormProps = Partial<{
   discountRate: number | undefined
   redemptionRate: number | undefined
   tokenMinting: boolean | undefined
+  pauseTransfers: boolean | undefined
 }>
 
 export const DefaultSettings: Required<
@@ -42,6 +43,7 @@ export const DefaultSettings: Required<
   discountRate: 0,
   redemptionRate: 100,
   tokenMinting: false,
+  pauseTransfers: false,
 }
 
 /**
@@ -81,6 +83,10 @@ export const useProjectTokensForm = () => {
       fundingCycleMetadata.allowMinting !== undefined
         ? fundingCycleMetadata.allowMinting
         : DefaultSettings.tokenMinting
+    const pauseTransfers =
+      fundingCycleMetadata.global.pauseTransfers !== undefined
+        ? fundingCycleMetadata.global.pauseTransfers
+        : DefaultSettings.pauseTransfers
 
     return {
       selection,
@@ -90,6 +96,7 @@ export const useProjectTokensForm = () => {
       discountRate,
       redemptionRate,
       tokenMinting,
+      pauseTransfers,
     }
   }, [
     discountRateDisabled,
@@ -98,6 +105,7 @@ export const useProjectTokensForm = () => {
     fundingCycleMetadata.allowMinting,
     fundingCycleMetadata.redemptionRate,
     fundingCycleMetadata.reservedRate,
+    fundingCycleMetadata.global.pauseTransfers,
     projectTokensSelection,
     redemptionRateDisabled,
     tokenSplits,
@@ -196,6 +204,16 @@ export const useProjectTokensForm = () => {
     form,
     fieldName: 'tokenMinting',
     dispatchFunction: editingV2ProjectActions.setAllowMinting,
+    formatter: v => {
+      if (typeof v !== 'boolean') return false
+      return v
+    },
+  })
+
+  useFormDispatchWatch({
+    form,
+    fieldName: 'pauseTransfers',
+    dispatchFunction: editingV2ProjectActions.setPauseTransfers,
     formatter: v => {
       if (typeof v !== 'boolean') return false
       return v

--- a/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
+++ b/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
@@ -66,24 +66,19 @@ export const ReconfigurationRulesPage = () => {
             <Form.Item
               className="pt-8"
               name="pausePayments"
-              extra={t`When enabled, the payments to the project are paused, and no new tokens will be issued.`}
+              extra={t`When enabled, your project can't accept payments.`}
             >
               <JuiceSwitch label={t`Pause payments`} />
+            </Form.Item>
+
+            <Form.Item name="holdFees" extra={HOLD_FEES_EXPLAINATION}>
+              <JuiceSwitch label={t`Hold fees`} />
             </Form.Item>
             <Form.Item
               name="allowTerminalConfiguration"
               extra={t`When enabled, the project owner can set the project's payment terminals.`}
             >
               <JuiceSwitch label={t`Allow terminal configuration`} />
-            </Form.Item>
-            <Form.Item
-              name="pauseTransfers"
-              extra={t`When enabled, project token transfers will be paused. This does not apply to ERC-20 tokens if issued.`}
-            >
-              <JuiceSwitch label={t`Pause project token transfers`} />
-            </Form.Item>
-            <Form.Item name="holdFees" extra={HOLD_FEES_EXPLAINATION}>
-              <JuiceSwitch label={t`Hold fees`} />
             </Form.Item>
             <Form.Item
               name="useDataSourceForRedeem"

--- a/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
+++ b/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
@@ -16,7 +16,6 @@ type ReconfigurationRulesFormProps = Partial<{
   pausePayments: boolean
   allowTerminalConfiguration: boolean
   holdFees: boolean
-  pauseTransfers: boolean
   useDataSourceForRedeem: boolean
 }>
 
@@ -127,14 +126,6 @@ export const useReconfigurationRulesForm = () => {
     fieldName: 'allowTerminalConfiguration',
     ignoreUndefined: true,
     dispatchFunction: editingV2ProjectActions.setAllowSetTerminals,
-    formatter: v => !!v,
-  })
-
-  useFormDispatchWatch({
-    form,
-    fieldName: 'pauseTransfers',
-    ignoreUndefined: true,
-    dispatchFunction: editingV2ProjectActions.setPauseTransfers,
     formatter: v => !!v,
   })
 

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectTokenReview/MobileProjectTokenReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectTokenReview/MobileProjectTokenReview.tsx
@@ -20,6 +20,7 @@ export const MobileProjectTokenReview = () => {
     reservedRate,
     setAllocationSplits,
     weight,
+    pauseTransfers,
   } = useProjectTokenReview()
   return (
     <>
@@ -84,6 +85,10 @@ export const MobileProjectTokenReview = () => {
       <DescriptionCol
         title={t`Allow token minting`}
         desc={<div className="text-base font-medium">{allowTokenMinting}</div>}
+      />
+      <DescriptionCol
+        title={t`Token transfers`}
+        desc={<div className="text-base font-medium">{pauseTransfers}</div>}
       />
     </>
   )

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectTokenReview/ProjectTokenReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectTokenReview/ProjectTokenReview.tsx
@@ -19,12 +19,14 @@ export const ProjectTokenReview = () => {
   const {
     allocationSplits,
     allowTokenMinting,
+    pauseTransfers,
     discountRate,
     redemptionRate,
     reservedRate,
     setAllocationSplits,
     weight,
   } = useProjectTokenReview()
+
   return (
     <>
       <div className="flex flex-col gap-10 pt-5 pb-12">
@@ -100,12 +102,20 @@ export const ProjectTokenReview = () => {
                 }
               />
               <DescriptionCol
-                span={12}
+                span={6}
                 title={t`Allow token minting`}
                 desc={
                   <div className="text-base font-medium">
                     {allowTokenMinting}
                   </div>
+                }
+              />
+
+              <DescriptionCol
+                span={6}
+                title={t`Token transfers`}
+                desc={
+                  <div className="text-base font-medium">{pauseTransfers}</div>
                 }
               />
             </Row>

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectTokenReview/hooks/ProjectTokenReview.ts
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectTokenReview/hooks/ProjectTokenReview.ts
@@ -3,12 +3,17 @@ import { allocationToSplit, splitToAllocation } from 'utils/splitToAllocation'
 import { useAppSelector } from 'hooks/AppSelector'
 import { useCallback, useMemo } from 'react'
 import { useEditingReservedTokensSplits } from 'redux/hooks/EditingReservedTokensSplits'
-import { formatEnabled } from 'utils/format/formatBoolean'
+import { formatEnabled, formatPaused } from 'utils/format/formatBoolean'
 
 export const useProjectTokenReview = () => {
   const {
     fundingCycleData: { weight, discountRate },
-    fundingCycleMetadata: { allowMinting, reservedRate, redemptionRate },
+    fundingCycleMetadata: {
+      allowMinting,
+      reservedRate,
+      redemptionRate,
+      global,
+    },
   } = useAppSelector(state => state.editingV2Project)
   const [tokenSplits, setTokenSplits] = useEditingReservedTokensSplits()
 
@@ -27,10 +32,16 @@ export const useProjectTokenReview = () => {
     [allowMinting],
   )
 
+  const pauseTransfers = useMemo(
+    () => formatPaused(global.pauseTransfers),
+    [global.pauseTransfers],
+  )
+
   return {
     weight,
     discountRate,
     allowTokenMinting,
+    pauseTransfers,
     reservedRate,
     redemptionRate,
     allocationSplits,

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
@@ -13,10 +13,10 @@ export const RulesReview = () => {
     pausePayments,
     strategy,
     terminalConfiguration,
-    pauseTransfers,
     holdFees,
     useDataSourceForRedeem,
   } = useRulesReview()
+
   return (
     <div className="flex flex-col gap-10 pt-5 pb-8">
       {isMobile ? (
@@ -51,11 +51,6 @@ export const RulesReview = () => {
                 {terminalConfiguration}
               </div>
             }
-          />
-          <DescriptionCol
-            span={5}
-            title={t`Token transfers`}
-            desc={<div className="text-base font-medium">{pauseTransfers}</div>}
           />
           <DescriptionCol
             span={5}

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
@@ -22,10 +22,6 @@ export const useRulesReview = () => {
     return formatBoolean(fundingCycleMetadata.global.allowSetTerminals)
   }, [fundingCycleMetadata.global.allowSetTerminals])
 
-  const pauseTransfers = useMemo(() => {
-    return formatPaused(fundingCycleMetadata.global.pauseTransfers)
-  }, [fundingCycleMetadata.global.pauseTransfers])
-
   const strategy = useMemo(() => {
     return availableBallotStrategies.find(
       strategy => strategy.id === reconfigurationRuleSelection,
@@ -44,7 +40,6 @@ export const useRulesReview = () => {
     customAddress,
     pausePayments,
     terminalConfiguration,
-    pauseTransfers,
     strategy,
     holdFees,
     useDataSourceForRedeem,

--- a/src/components/Create/utils/projectTokenSettingsToReduxFormat.ts
+++ b/src/components/Create/utils/projectTokenSettingsToReduxFormat.ts
@@ -26,6 +26,7 @@ export const projectTokenSettingsToReduxFormat = (
     projectTokenSettings.redemptionRate,
   ).toHexString()
   const allowMinting = projectTokenSettings.tokenMinting
+  const pauseTransfers = projectTokenSettings.pauseTransfers
 
   return {
     weight,
@@ -34,5 +35,6 @@ export const projectTokenSettingsToReduxFormat = (
     discountRate,
     redemptionRate,
     allowMinting,
+    pauseTransfers,
   }
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3137,10 +3137,10 @@ msgstr ""
 msgid "Token minting enabled"
 msgstr ""
 
-msgid "Token minting is not recommended as it allows the project owner to create unlimited tokens. This is a risk factor for contributors."
+msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
 msgstr ""
 
-msgid "Token minting is only available for V1.1 projects. Token minting can be enabled or disabled by reconfiguring the project's funding cycle."
+msgid "Token minting isn't recommended as it allows the project owner to create unlimited tokens. This is a risk factor for contributors."
 msgstr ""
 
 msgid "Token name"
@@ -3515,13 +3515,10 @@ msgstr ""
 msgid "When enabled, all project token transfers will be paused. Does not apply to ERC-20 tokens if issued."
 msgstr ""
 
-msgid "When enabled, project token transfers will be paused. This does not apply to ERC-20 tokens if issued."
+msgid "When enabled, project's token holders can't transfer their tokens to other addresses. This doesn't apply to your project's ERC-20 tokens (if you've issued them)."
 msgstr ""
 
 msgid "When enabled, the data source will be used for redeem transactions."
-msgstr ""
-
-msgid "When enabled, the payments to the project are paused, and no new tokens will be issued."
 msgstr ""
 
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."
@@ -3531,6 +3528,9 @@ msgid "When enabled, the project owner can set the project's payment terminals."
 msgstr ""
 
 msgid "When enabled, the project will hold the fee amount in ETH instead of the fees being processed automatically. <0>Learn more.</0>"
+msgstr ""
+
+msgid "When enabled, your project can't accept payments."
 msgstr ""
 
 msgid "When enabled, your project cannot receive direct payments."

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -406,6 +406,7 @@ const editingV2ProjectSlice = createSlice({
         discountRate: number
         redemptionRate: number
         tokenMinting: boolean
+        pauseTransfers: boolean
       }>,
     ) => {
       const converted = projectTokenSettingsToReduxFormat(action.payload)


### PR DESCRIPTION
## What does this PR do and why?

Gonna have to add a few more flags to the Advanced Rules section soon. I felt it was getting too bulky.

This PR moves the `pauseTransfers` flag to the Tokens section. I think this is a better place for it.

## Screenshots or screen recordings

**New tokens section:**

<img width="676" alt="Screenshot 2023-02-01 at 10 58 13 AM" src="https://user-images.githubusercontent.com/12551741/215915353-8ef918dc-f654-48f2-a7c8-3ba4b080eb21.png">

**New rules section**
<img width="669" alt="Screenshot 2023-02-01 at 10 57 46 AM" src="https://user-images.githubusercontent.com/12551741/215915359-51b89a32-86e1-4b0c-bd4c-375cbc2ebe5a.png">


**New review section**
<img width="880" alt="Screenshot 2023-02-01 at 10 57 41 AM" src="https://user-images.githubusercontent.com/12551741/215915360-b4f5ae9a-6b52-4b49-80c6-bc47971c2a6a.png">



