### PR TITLE
[2/n] Move datasource flag

### DIFF
--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -18,6 +18,8 @@ import { RewardsList } from '../../RewardsList'
 import { Wizard } from '../../Wizard'
 import { PageContext } from '../../Wizard/contexts/PageContext'
 import { useNftRewardsForm } from './hooks'
+import { USE_DATASOURCE_FOR_REDEEM_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import { JuiceSwitch } from 'components/JuiceSwitch'
 
 const RadioItem = ({
   value,
@@ -224,6 +226,19 @@ export const NftRewardsPage = () => {
                     Preview
                   </CreateButton>
                 </Space>
+              </CreateCollapse.Panel>
+
+              <CreateCollapse.Panel
+                key={3}
+                header={<OptionalHeader header={t`Advanced options`} />}
+                hideDivider
+              >
+                <Form.Item
+                  name="useDataSourceForRedeem"
+                  extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+                >
+                  <JuiceSwitch label={t`Redeemable NFTs`} />
+                </Form.Item>
               </CreateCollapse.Panel>
             </CreateCollapse>
           </Space>

--- a/src/components/Create/components/pages/NftRewards/hooks/NftRewardsForm.ts
+++ b/src/components/Create/components/pages/NftRewards/hooks/NftRewardsForm.ts
@@ -22,13 +22,16 @@ type NftRewardsFormProps = Partial<{
   postPayButtonText?: string
   postPayButtonLink?: string
   onChainGovernance: JB721GovernanceType
+  useDataSourceForRedeem: boolean
 }>
 
 export const useNftRewardsForm = () => {
   const [form] = Form.useForm<NftRewardsFormProps>()
   const { collectionMetadata, rewardTiers, postPayModal, governanceType } =
     useAppSelector(state => state.editingV2Project.nftRewards)
-  const { projectMetadata } = useAppSelector(state => state.editingV2Project)
+  const { projectMetadata, fundingCycleMetadata } = useAppSelector(
+    state => state.editingV2Project,
+  )
   const initialValues: NftRewardsFormProps = useMemo(() => {
     const collectionName =
       collectionMetadata?.name ??
@@ -55,6 +58,7 @@ export const useNftRewardsForm = () => {
     return {
       rewards,
       onChainGovernance: governanceType,
+      useDataSourceForRedeem: fundingCycleMetadata.useDataSourceForRedeem,
       collectionName,
       collectionSymbol,
       collectionDescription,
@@ -72,6 +76,7 @@ export const useNftRewardsForm = () => {
     postPayModal?.content,
     postPayModal?.ctaText,
     postPayModal?.ctaLink,
+    fundingCycleMetadata.useDataSourceForRedeem,
   ])
 
   useFormDispatchWatch({
@@ -145,6 +150,14 @@ export const useNftRewardsForm = () => {
         return JB721GovernanceType.NONE
       return v
     },
+  })
+
+  useFormDispatchWatch({
+    form,
+    fieldName: 'useDataSourceForRedeem',
+    ignoreUndefined: true,
+    dispatchFunction: editingV2ProjectActions.setUseDataSourceForRedeem,
+    formatter: v => !!v,
   })
 
   const dispatch = useAppDispatch()

--- a/src/components/Create/components/pages/NftRewards/hooks/NftRewardsForm.ts
+++ b/src/components/Create/components/pages/NftRewards/hooks/NftRewardsForm.ts
@@ -146,7 +146,12 @@ export const useNftRewardsForm = () => {
     ignoreUndefined: true,
     dispatchFunction: editingV2ProjectActions.setNftRewardsGovernance,
     formatter: v => {
-      if (!v || typeof v === 'string' || typeof v === 'object')
+      if (
+        !v ||
+        typeof v === 'string' ||
+        typeof v === 'object' ||
+        typeof v === 'boolean'
+      )
         return JB721GovernanceType.NONE
       return v
     },

--- a/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
+++ b/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
@@ -5,10 +5,7 @@ import { Callout } from 'components/Callout'
 import { Selection } from 'components/Create/components/Selection'
 import { useAvailableReconfigurationStrategies } from 'components/Create/hooks/AvailableReconfigurationStrategies'
 import { JuiceSwitch } from 'components/JuiceSwitch'
-import {
-  HOLD_FEES_EXPLAINATION,
-  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION,
-} from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import { HOLD_FEES_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { readNetwork } from 'constants/networks'
 import { useContext } from 'react'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/EditingCreateFurthestPageReached'
@@ -79,12 +76,6 @@ export const ReconfigurationRulesPage = () => {
               extra={t`When enabled, the project owner can set the project's payment terminals.`}
             >
               <JuiceSwitch label={t`Allow terminal configuration`} />
-            </Form.Item>
-            <Form.Item
-              name="useDataSourceForRedeem"
-              extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
-            >
-              <JuiceSwitch label={t`Use data source for redeem`} />
             </Form.Item>
           </CreateCollapse.Panel>
         </CreateCollapse>

--- a/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
+++ b/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
@@ -16,7 +16,6 @@ type ReconfigurationRulesFormProps = Partial<{
   pausePayments: boolean
   allowTerminalConfiguration: boolean
   holdFees: boolean
-  useDataSourceForRedeem: boolean
 }>
 
 export const useReconfigurationRulesForm = () => {
@@ -134,14 +133,6 @@ export const useReconfigurationRulesForm = () => {
     fieldName: 'holdFees',
     ignoreUndefined: true,
     dispatchFunction: editingV2ProjectActions.setHoldFees,
-    formatter: v => !!v,
-  })
-
-  useFormDispatchWatch({
-    form,
-    fieldName: 'useDataSourceForRedeem',
-    ignoreUndefined: true,
-    dispatchFunction: editingV2ProjectActions.setUseDataSourceForRedeem,
     formatter: v => !!v,
   })
 

--- a/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
@@ -10,12 +10,10 @@ import { v4 } from 'uuid'
 import { DescriptionCol } from '../DescriptionCol'
 
 export const RewardsReview = () => {
-  const { rewardTiers } = useAppSelector(
-    state => state.editingV2Project.nftRewards,
-  )
-  const fundingCycleMetadata = useAppSelector(
-    state => state.editingV2Project.fundingCycleMetadata,
-  )
+  const {
+    nftRewards: { rewardTiers },
+    fundingCycleMetadata,
+  } = useAppSelector(state => state.editingV2Project)
 
   const dispatch = useAppDispatch()
 
@@ -58,7 +56,7 @@ export const RewardsReview = () => {
     [dispatch],
   )
 
-  const useDataSourceForRedeem = useMemo(() => {
+  const shouldUseDataSourceForRedeem = useMemo(() => {
     return formatEnabled(fundingCycleMetadata.useDataSourceForRedeem)
   }, [fundingCycleMetadata.useDataSourceForRedeem])
 
@@ -71,7 +69,7 @@ export const RewardsReview = () => {
           title={t`Redeemable NFTs`}
           desc={
             <div className="text-base font-medium">
-              {useDataSourceForRedeem}
+              {shouldUseDataSourceForRedeem}
             </div>
           }
         />

--- a/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
@@ -1,14 +1,22 @@
+import { t } from '@lingui/macro'
+import { Row } from 'antd'
 import { Reward, RewardsList } from 'components/Create/components/RewardsList'
 import { useAppDispatch } from 'hooks/AppDispatch'
 import { useAppSelector } from 'hooks/AppSelector'
 import { useCallback, useMemo } from 'react'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
+import { formatEnabled } from 'utils/format/formatBoolean'
 import { v4 } from 'uuid'
+import { DescriptionCol } from '../DescriptionCol'
 
 export const RewardsReview = () => {
   const { rewardTiers } = useAppSelector(
     state => state.editingV2Project.nftRewards,
   )
+  const fundingCycleMetadata = useAppSelector(
+    state => state.editingV2Project.fundingCycleMetadata,
+  )
+
   const dispatch = useAppDispatch()
 
   const rewards = useMemo(() => {
@@ -50,5 +58,24 @@ export const RewardsReview = () => {
     [dispatch],
   )
 
-  return <RewardsList value={rewards} onChange={setRewards} />
+  const useDataSourceForRedeem = useMemo(() => {
+    return formatEnabled(fundingCycleMetadata.useDataSourceForRedeem)
+  }, [fundingCycleMetadata.useDataSourceForRedeem])
+
+  return (
+    <>
+      <RewardsList value={rewards} onChange={setRewards} />
+      <Row gutter={20}>
+        <DescriptionCol
+          span={24}
+          title={t`Redeemable NFTs`}
+          desc={
+            <div className="text-base font-medium">
+              {useDataSourceForRedeem}
+            </div>
+          }
+        />
+      </Row>
+    </>
+  )
 }

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/MobileRulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/MobileRulesReview.tsx
@@ -11,8 +11,8 @@ export const MobileRulesReview = () => {
     strategy,
     terminalConfiguration,
     holdFees,
-    useDataSourceForRedeem,
   } = useRulesReview()
+
   return (
     <Row gutter={[20, 20]}>
       <DescriptionCol
@@ -46,13 +46,6 @@ export const MobileRulesReview = () => {
         span={12}
         title={t`Hold fees`}
         desc={<div className="text-base font-medium">{holdFees}</div>}
-      />
-      <DescriptionCol
-        span={12}
-        title={t`Use data source for redeem`}
-        desc={
-          <div className="text-base font-medium">{useDataSourceForRedeem}</div>
-        }
       />
     </Row>
   )

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
@@ -14,7 +14,6 @@ export const RulesReview = () => {
     strategy,
     terminalConfiguration,
     holdFees,
-    useDataSourceForRedeem,
   } = useRulesReview()
 
   return (
@@ -56,15 +55,6 @@ export const RulesReview = () => {
             span={5}
             title={t`Hold fees`}
             desc={<div className="text-base font-medium">{holdFees}</div>}
-          />
-          <DescriptionCol
-            span={4}
-            title={t`Use data source for redeem`}
-            desc={
-              <div className="text-base font-medium">
-                {useDataSourceForRedeem}
-              </div>
-            }
           />
         </Row>
       )}

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
@@ -32,16 +32,11 @@ export const useRulesReview = () => {
     return formatBoolean(fundingCycleMetadata.holdFees)
   }, [fundingCycleMetadata.holdFees])
 
-  const useDataSourceForRedeem = useMemo(() => {
-    return formatBoolean(fundingCycleMetadata.useDataSourceForRedeem)
-  }, [fundingCycleMetadata.useDataSourceForRedeem])
-
   return {
     customAddress,
     pausePayments,
     terminalConfiguration,
     strategy,
     holdFees,
-    useDataSourceForRedeem,
   }
 }

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
@@ -98,6 +98,11 @@ export const HOLD_FEES_EXPLAINATION = (
 
 export const USE_DATASOURCE_FOR_REDEEM_EXPLAINATION = (
   <Trans>
-    When enabled, the data source will be used for redeem transactions.
+    When enabled, NFT holders can redeem their NFTs for a portion of your
+    project's overflow.{' '}
+    <ExternalLink href={helpPagePath('dev/learn/glossary/overflow')}>
+      Learn more about overflow
+    </ExternalLink>
+    .
   </Trans>
 )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/FundingAttributes.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/FundingAttributes.tsx
@@ -16,9 +16,9 @@ import {
   RESERVED_RATE_WARNING_THRESHOLD_PERCENT,
 } from 'constants/fundingWarningText'
 import { Split } from 'models/splits'
-import { formatBoolean } from 'utils/format/formatBoolean'
 import { formatWad } from 'utils/format/formatNumber'
 import { detailedTimeString } from 'utils/format/formatTime'
+import { formatBoolean } from 'utils/format/formatBoolean'
 import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
 import {
   formatDiscountRate,

--- a/src/components/veNft/VeNftStakingForm.tsx
+++ b/src/components/veNft/VeNftStakingForm.tsx
@@ -235,7 +235,7 @@ const VeNftStakingForm = ({
                 <MinimalCollapse
                   header={
                     <h3 className="m-0">
-                      <Trans>Advanced Options</Trans>
+                      <Trans>Advanced options</Trans>
                     </h3>
                   }
                 >

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -347,9 +347,6 @@ msgstr ""
 msgid "Advanced (optional)"
 msgstr ""
 
-msgid "Advanced Options"
-msgstr ""
-
 msgid "Advanced Rules"
 msgstr ""
 
@@ -2474,6 +2471,9 @@ msgstr ""
 msgid "Redeem {tokensTextLong} for ETH"
 msgstr ""
 
+msgid "Redeemable NFTs"
+msgstr ""
+
 msgid "Redeemed"
 msgstr ""
 
@@ -3512,13 +3512,13 @@ msgstr ""
 msgid "When distributing, payouts to Ethereum addresses incur a 2.5% JBX membership fee. Payouts to other Juicebox projects don't incur fees. Your project will receive (the <0>JuiceboxDAO</0> token) in return at the current issuance rate."
 msgstr ""
 
+msgid "When enabled, NFT holders can redeem their NFTs for a portion of your project's overflow. <0>Learn more about overflow</0>."
+msgstr ""
+
 msgid "When enabled, all project token transfers will be paused. Does not apply to ERC-20 tokens if issued."
 msgstr ""
 
 msgid "When enabled, project's token holders can't transfer their tokens to other addresses. This doesn't apply to your project's ERC-20 tokens (if you've issued them)."
-msgstr ""
-
-msgid "When enabled, the data source will be used for redeem transactions."
 msgstr ""
 
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."


### PR DESCRIPTION
## What does this PR do and why?

⚠️ depends on https://github.com/jbx-protocol/juice-interface/pull/2922

- Move "Use data source for redeem" flag to NFT page
- Reworks the copy of this to be NFT-centric


## Screenshots or screen recordings

### NFT page
<img width="637" alt="Screenshot 2023-02-01 at 12 28 01 PM" src="https://user-images.githubusercontent.com/12551741/215926386-8ecb67ba-6a6c-40ae-a288-e93bd209317a.png">

### Rules page
<img width="664" alt="Screenshot 2023-02-01 at 12 28 10 PM" src="https://user-images.githubusercontent.com/12551741/215926380-eeaba4c2-5ebe-4e22-b2e4-c02b2fc37b24.png">

### Review section

<img width="870" alt="Screenshot 2023-02-01 at 12 29 35 PM" src="https://user-images.githubusercontent.com/12551741/215926557-d3bcc6f1-c523-4a58-a73c-e261ff1170a7.png">
