### PR TITLE
[3/n] Add AllowSetController to create flow

### DIFF
--- a/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
+++ b/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
@@ -4,11 +4,13 @@ import { useWatch } from 'antd/lib/form/Form'
 import { Callout } from 'components/Callout'
 import { Selection } from 'components/Create/components/Selection'
 import { useAvailableReconfigurationStrategies } from 'components/Create/hooks/AvailableReconfigurationStrategies'
+import ExternalLink from 'components/ExternalLink'
 import { JuiceSwitch } from 'components/JuiceSwitch'
 import { HOLD_FEES_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { readNetwork } from 'constants/networks'
 import { useContext } from 'react'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/EditingCreateFurthestPageReached'
+import { helpPagePath } from 'utils/routes'
 import { CreateCollapse } from '../../CreateCollapse'
 import { Wizard } from '../../Wizard'
 import { PageContext } from '../../Wizard/contexts/PageContext'
@@ -73,9 +75,37 @@ export const ReconfigurationRulesPage = () => {
             </Form.Item>
             <Form.Item
               name="allowTerminalConfiguration"
-              extra={t`When enabled, the project owner can set the project's payment terminals.`}
+              extra={
+                <Trans>
+                  When enabled, the project owner can change the project's
+                  Payment Terminals.{' '}
+                  <ExternalLink
+                    href={helpPagePath('dev/learn/glossary/payment-terminal')}
+                  >
+                    Learn more
+                  </ExternalLink>
+                </Trans>
+              }
             >
-              <JuiceSwitch label={t`Allow terminal configuration`} />
+              <JuiceSwitch label={t`Allow Payment Terminal configuration`} />
+            </Form.Item>
+            <Form.Item
+              name="allowControllerConfiguration"
+              extra={
+                <Trans>
+                  When enabled, the project owner can change the project's
+                  Controller.{' '}
+                  <ExternalLink
+                    href={helpPagePath(
+                      'dev/api/contracts/or-controllers/jbcontroller',
+                    )}
+                  >
+                    Learn more
+                  </ExternalLink>
+                </Trans>
+              }
+            >
+              <JuiceSwitch label={t`Allow Controller configuration`} />
             </Form.Item>
           </CreateCollapse.Panel>
         </CreateCollapse>

--- a/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
+++ b/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
@@ -15,6 +15,7 @@ type ReconfigurationRulesFormProps = Partial<{
   customAddress?: string
   pausePayments: boolean
   allowTerminalConfiguration: boolean
+  allowControllerConfiguration: boolean
   holdFees: boolean
 }>
 
@@ -48,6 +49,8 @@ export const useReconfigurationRulesForm = () => {
       const pausePayments = fundingCycleMetadata.pausePay
       const allowTerminalConfiguration =
         fundingCycleMetadata.global.allowSetTerminals
+      const allowControllerConfiguration =
+        fundingCycleMetadata.global.allowSetController
       const pauseTransfers = fundingCycleMetadata.global.pauseTransfers
       const holdFees = fundingCycleMetadata.holdFees
       // By default, ballot is addressZero
@@ -56,6 +59,7 @@ export const useReconfigurationRulesForm = () => {
           selection: defaultStrategy.name,
           pausePayments,
           allowTerminalConfiguration,
+          allowControllerConfiguration,
           pauseTransfers,
         }
 
@@ -66,6 +70,7 @@ export const useReconfigurationRulesForm = () => {
           customAddress: ballot,
           pausePayments,
           allowTerminalConfiguration,
+          allowControllerConfiguration,
           pauseTransfers,
           holdFees,
         }
@@ -75,13 +80,13 @@ export const useReconfigurationRulesForm = () => {
         selection: found.name,
         pausePayments,
         allowTerminalConfiguration,
+        allowControllerConfiguration,
         pauseTransfers,
         holdFees,
       }
     }, [
       fundingCycleMetadata.pausePay,
-      fundingCycleMetadata.global.allowSetTerminals,
-      fundingCycleMetadata.global.pauseTransfers,
+      fundingCycleMetadata.global,
       fundingCycleMetadata.holdFees,
       reconfigurationRuleSelection,
       ballot,
@@ -125,6 +130,14 @@ export const useReconfigurationRulesForm = () => {
     fieldName: 'allowTerminalConfiguration',
     ignoreUndefined: true,
     dispatchFunction: editingV2ProjectActions.setAllowSetTerminals,
+    formatter: v => !!v,
+  })
+
+  useFormDispatchWatch({
+    form,
+    fieldName: 'allowControllerConfiguration',
+    ignoreUndefined: true,
+    dispatchFunction: editingV2ProjectActions.setAllowSetController,
     formatter: v => !!v,
   })
 

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/MobileRulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/MobileRulesReview.tsx
@@ -10,6 +10,7 @@ export const MobileRulesReview = () => {
     pausePayments,
     strategy,
     terminalConfiguration,
+    controllerConfiguration,
     holdFees,
   } = useRulesReview()
 
@@ -37,6 +38,11 @@ export const MobileRulesReview = () => {
       />
       <DescriptionCol
         span={12}
+        title={t`Hold fees`}
+        desc={<div className="text-base font-medium">{holdFees}</div>}
+      />
+      <DescriptionCol
+        span={12}
         title={t`Terminal configuration`}
         desc={
           <div className="text-base font-medium">{terminalConfiguration}</div>
@@ -44,8 +50,10 @@ export const MobileRulesReview = () => {
       />
       <DescriptionCol
         span={12}
-        title={t`Hold fees`}
-        desc={<div className="text-base font-medium">{holdFees}</div>}
+        title={t`Controller configuration`}
+        desc={
+          <div className="text-base font-medium">{controllerConfiguration}</div>
+        }
       />
     </Row>
   )

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro'
-import { Row } from 'antd'
 import FormattedAddress from 'components/FormattedAddress'
 import useMobile from 'hooks/Mobile'
 import { DescriptionCol } from '../DescriptionCol'
@@ -22,7 +21,7 @@ export const RulesReview = () => {
       {isMobile ? (
         <MobileRulesReview />
       ) : (
-        <Row gutter={20} className="gap-y-5">
+        <div className="flex flex-wrap gap-5">
           <DescriptionCol
             span={5}
             title={t`Reconfiguration`}
@@ -44,10 +43,11 @@ export const RulesReview = () => {
             desc={<div className="text-base font-medium">{pausePayments}</div>}
           />
           <DescriptionCol
-            span={14}
+            span={5}
             title={t`Hold fees`}
             desc={<div className="text-base font-medium">{holdFees}</div>}
           />
+
           <DescriptionCol
             span={5}
             title={t`Terminal configuration`}
@@ -66,7 +66,7 @@ export const RulesReview = () => {
               </div>
             }
           />
-        </Row>
+        </div>
       )}
     </div>
   )

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
@@ -13,6 +13,7 @@ export const RulesReview = () => {
     pausePayments,
     strategy,
     terminalConfiguration,
+    controllerConfiguration,
     holdFees,
   } = useRulesReview()
 
@@ -21,7 +22,7 @@ export const RulesReview = () => {
       {isMobile ? (
         <MobileRulesReview />
       ) : (
-        <Row gutter={20}>
+        <Row gutter={20} className="gap-y-5">
           <DescriptionCol
             span={5}
             title={t`Reconfiguration`}
@@ -43,6 +44,11 @@ export const RulesReview = () => {
             desc={<div className="text-base font-medium">{pausePayments}</div>}
           />
           <DescriptionCol
+            span={14}
+            title={t`Hold fees`}
+            desc={<div className="text-base font-medium">{holdFees}</div>}
+          />
+          <DescriptionCol
             span={5}
             title={t`Terminal configuration`}
             desc={
@@ -53,8 +59,12 @@ export const RulesReview = () => {
           />
           <DescriptionCol
             span={5}
-            title={t`Hold fees`}
-            desc={<div className="text-base font-medium">{holdFees}</div>}
+            title={t`Controller configuration`}
+            desc={
+              <div className="text-base font-medium">
+                {controllerConfiguration}
+              </div>
+            }
           />
         </Row>
       )}

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/hooks/RulesReview.ts
@@ -2,7 +2,11 @@ import { useAvailableReconfigurationStrategies } from 'components/Create/hooks/A
 import { readNetwork } from 'constants/networks'
 import { useAppSelector } from 'hooks/AppSelector'
 import { useMemo } from 'react'
-import { formatBoolean, formatPaused } from 'utils/format/formatBoolean'
+import {
+  formatBoolean,
+  formatEnabled,
+  formatPaused,
+} from 'utils/format/formatBoolean'
 
 export const useRulesReview = () => {
   const availableBallotStrategies = useAvailableReconfigurationStrategies(
@@ -19,8 +23,12 @@ export const useRulesReview = () => {
   }, [fundingCycleMetadata.pausePay])
 
   const terminalConfiguration = useMemo(() => {
-    return formatBoolean(fundingCycleMetadata.global.allowSetTerminals)
+    return formatEnabled(fundingCycleMetadata.global.allowSetTerminals)
   }, [fundingCycleMetadata.global.allowSetTerminals])
+
+  const controllerConfiguration = useMemo(() => {
+    return formatEnabled(fundingCycleMetadata.global.allowSetController)
+  }, [fundingCycleMetadata.global.allowSetController])
 
   const strategy = useMemo(() => {
     return availableBallotStrategies.find(
@@ -36,6 +44,7 @@ export const useRulesReview = () => {
     customAddress,
     pausePayments,
     terminalConfiguration,
+    controllerConfiguration,
     strategy,
     holdFees,
   }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3290,9 +3290,6 @@ msgstr ""
 msgid "Transfer {tokenTextShort}"
 msgstr ""
 
-msgid "Transfers"
-msgstr ""
-
 msgid "Transparently set your terms ahead of time, or take control when you need to. Juicebox lets you define elegant token issuance & redemption, payouts, and other rules in advance, acting as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -380,6 +380,12 @@ msgstr ""
 msgid "Allocate reserved tokens to Ethereum addresses or Juicebox projects. Unallocated reserved tokens are sent to the project owner."
 msgstr ""
 
+msgid "Allow Controller configuration"
+msgstr ""
+
+msgid "Allow Payment Terminal configuration"
+msgstr ""
+
 msgid "Allow a few days for your project to appear in the \"active\" projects list on the Projects page."
 msgstr ""
 
@@ -3284,6 +3290,9 @@ msgstr ""
 msgid "Transfer {tokenTextShort}"
 msgstr ""
 
+msgid "Transfers"
+msgstr ""
+
 msgid "Transparently set your terms ahead of time, or take control when you need to. Juicebox lets you define elegant token issuance & redemption, payouts, and other rules in advance, acting as a safeguard against rug pulls. Your supporters don't have to trust you — even though they already do."
 msgstr ""
 
@@ -3519,6 +3528,12 @@ msgid "When enabled, all project token transfers will be paused. Does not apply 
 msgstr ""
 
 msgid "When enabled, project's token holders can't transfer their tokens to other addresses. This doesn't apply to your project's ERC-20 tokens (if you've issued them)."
+msgstr ""
+
+msgid "When enabled, the project owner can change the project's Controller. <0>Learn more</0>"
+msgstr ""
+
+msgid "When enabled, the project owner can change the project's Payment Terminals. <0>Learn more</0>"
 msgstr ""
 
 msgid "When enabled, the project owner can manually mint any amount of tokens to any address."

--- a/src/redux/slices/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project.ts
@@ -350,6 +350,9 @@ const editingV2ProjectSlice = createSlice({
     setAllowSetTerminals: (state, action: PayloadAction<boolean>) => {
       state.fundingCycleMetadata.global.allowSetTerminals = action.payload
     },
+    setAllowSetController: (state, action: PayloadAction<boolean>) => {
+      state.fundingCycleMetadata.global.allowSetController = action.payload
+    },
     setPauseTransfers: (state, action: PayloadAction<boolean>) => {
       state.fundingCycleMetadata.global.pauseTransfers = action.payload
     },


### PR DESCRIPTION
## What does this PR do and why?

⚠️ depends on https://github.com/jbx-protocol/juice-interface/pull/2930

Adds yet another metadata toggle. Reconfig UI will come in the next PR.

## Screenshots or screen recordings

### Form
<img width="663" alt="Screenshot 2023-02-01 at 3 15 01 PM" src="https://user-images.githubusercontent.com/12551741/215952582-910e93af-a3a6-4abd-a5e3-8d8ec111cb80.png">

### Review

<img width="834" alt="Screenshot 2023-02-01 at 3 15 06 PM" src="https://user-images.githubusercontent.com/12551741/215952576-4105e2ed-5d47-4bae-a470-f44c9045e975.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
