### PR TITLE
Replace text area in collection description with input

### DIFF
--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -113,7 +113,7 @@ export const NftRewardsPage = () => {
               name="collectionDescription"
               label={<Trans>Collection Description</Trans>}
             >
-              <JuiceTextArea autoSize={{ minRows: 4, maxRows: 6 }} />
+              <JuiceInput />
             </Form.Item>
 
             <CreateCollapse>


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/2779

I've just added `JuiceInput` without any attributes since input by default is single-line, right?

Additionally, I'm cool if you want me to investigate why it is not allowing new lines to be applied to a description on OpenSea, just give the green light if you think it is a priority for us 🚦 

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/18723426/215989406-64d64e2f-4312-44e5-9aee-de804f621c2f.png)

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
