### PR TITLE
Conditionally disable sepana in quick project search

### DIFF
--- a/src/components/QuickProjectSearch.tsx
+++ b/src/components/QuickProjectSearch.tsx
@@ -19,8 +19,8 @@ import { twMerge } from 'tailwind-merge'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { formatWad } from 'utils/format/formatNumber'
 import { v2v3ProjectRoute } from 'utils/routes'
-import CurrencySymbol from './CurrencySymbol'
 
+import CurrencySymbol from './CurrencySymbol'
 import Loading from './Loading'
 import { ProjectVersionBadge } from './ProjectVersionBadge'
 import V1ProjectHandle from './v1/shared/V1ProjectHandle'
@@ -53,10 +53,13 @@ export default function QuickProjectSearch() {
   const sepanaEnabled = featureFlagEnabled(FEATURE_FLAGS.SEPANA_SEARCH)
 
   const { data: sepanaSearchResults, isLoading: isLoadingSepanaSearch } =
-    useSepanaProjectsSearch(searchText, { pageSize: MAX_RESULTS })
+    useSepanaProjectsSearch(searchText, {
+      pageSize: MAX_RESULTS,
+      enabled: sepanaEnabled,
+    })
 
   const { data: graphSearchResults, isLoading: isLoadingGraphSearch } =
-    useProjectsSearch(searchText)
+    useProjectsSearch(searchText, { enabled: !sepanaEnabled })
 
   const searchResults = sepanaEnabled ? sepanaSearchResults : graphSearchResults
   const isLoadingSearch = sepanaEnabled


### PR DESCRIPTION
## What does this PR do and why?

In the quick project search menu, use only one of subgraph or sepana projects search depending on `sepanaSearch` feature flag.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
