### PR TITLE
Fix project-handles contract + update goerli ENS resolver address

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@jbx-protocol/juice-contracts-v3": "2.0.2",
     "@jbx-protocol/juice-v1-token-terminal": "1.0.1",
     "@jbx-protocol/juice-v3-migration": "^1.0.0",
-    "@jbx-protocol/project-handles": "2.0.2",
+    "@jbx-protocol/project-handles": "^2.0.4",
     "@jbx-protocol/ve-nft": "0.0.6",
     "@lingui/cli": "^3.13.0",
     "@lingui/detect-locale": "^3.13.0",

--- a/src/constants/contracts/goerli/PublicResolver.ts
+++ b/src/constants/contracts/goerli/PublicResolver.ts
@@ -1,5 +1,5 @@
 export const goerliPublicResolver = {
-  address: '0x4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
+  address: '0x19c2d5D0f035563344dBB7bE5fD09c8dad62b001',
   abi: [
     {
       constant: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3678,10 +3678,10 @@
   resolved "https://registry.yarnpkg.com/@jbx-protocol/juice-v3-migration/-/juice-v3-migration-1.0.0.tgz#008663d8e09005d19a4837d98b519a1058c9060a"
   integrity sha512-+jmoiGcvVlbYrs510UDGWcUy7r2+pkhP+BI2ZqAjH4numZ7FWMvyRFjyaWLhzVHnKNZCSTUvvTIwU4wH5n6LSg==
 
-"@jbx-protocol/project-handles@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@jbx-protocol/project-handles/-/project-handles-2.0.2.tgz#276f2530092455136d00d0a78d18a17cb1450111"
-  integrity sha512-8ebDxeT+2G2+e+54/Jn82TBg+qT5a5Vwa7fu9ihjkmHe3SWt1GwzzKA/cVeN6xu2N/tM4Mbjz1xqbUS0hdn8oQ==
+"@jbx-protocol/project-handles@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@jbx-protocol/project-handles/-/project-handles-2.0.4.tgz#08db2fc1f6fd51419566f0a217c47f5374e839fd"
+  integrity sha512-NT8G0yt0cnpm1N+IqpKnej6xTC2D42/j9zv/DdLXhvyU+rCXqQ//oUg3cezZdL8AGi2l74rC5odE1j6FFrUrxA==
   dependencies:
     "@jbx-protocol/juice-contracts-v3" "^2.0.0"
 


### PR DESCRIPTION
## What does this PR do and why?

- updates the @jbx-protocol/project-handles package
- updates the goerli ENS resolver address to latest deployed PublicResolver contract

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
