### PR TITLE
Improve sold out NFT UI

### DIFF
--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -59,8 +59,8 @@ export function NftTierCard({
   }
 
   const remainingSupply = rewardTier?.remainingSupply
-  const isSoldOut = remainingSupply && remainingSupply > 0
-  const remainingSupplyText = !isSoldOut
+  const hasRemainingSupply = remainingSupply && remainingSupply > 0
+  const remainingSupplyText = !hasRemainingSupply
     ? t`SOLD OUT`
     : rewardTier.maxSupply === MAX_REMAINING_SUPPLY
     ? t`Unlimited`
@@ -104,7 +104,7 @@ export function NftTierCard({
             : '',
         )}
         onClick={
-          (_isSelected && !previewDisabled) || !isSoldOut
+          (_isSelected && !previewDisabled) || !hasRemainingSupply
             ? openPreview
             : () => onClickNoPreview()
         }

--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -58,11 +58,13 @@ export function NftTierCard({
     setPreviewVisible(true)
   }
 
-  const remainingSupplyText =
-    rewardTier?.remainingSupply !== undefined &&
-    rewardTier.remainingSupply < MAX_REMAINING_SUPPLY
-      ? t`${rewardTier?.remainingSupply} remaining`
-      : t`Unlimited`
+  const remainingSupply = rewardTier?.remainingSupply
+  const isSoldOut = remainingSupply && remainingSupply > 0
+  const remainingSupplyText = !isSoldOut
+    ? t`SOLD OUT`
+    : rewardTier.maxSupply === MAX_REMAINING_SUPPLY
+    ? t`Unlimited`
+    : t`${rewardTier?.remainingSupply} remaining`
 
   const handleBottomSectionClick = () => {
     if (_isSelected) {
@@ -102,7 +104,7 @@ export function NftTierCard({
             : '',
         )}
         onClick={
-          _isSelected && !previewDisabled
+          (_isSelected && !previewDisabled) || !isSoldOut
             ? openPreview
             : () => onClickNoPreview()
         }

--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from 'antd'
 import { MP4_FILE_TYPE } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload'
 import { JuiceVideoThumbnail } from 'components/v2v3/shared/NftVideo/JuiceVideoThumbnail'
 import { useContentType } from 'hooks/ContentType'
+import { DEFAULT_NFT_MAX_SUPPLY } from 'hooks/JB721Delegate/NftRewards'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { useState } from 'react'
 import { stopPropagation } from 'react-stop-propagation'
@@ -11,8 +12,6 @@ import { classNames } from 'utils/classNames'
 import { ipfsToHttps } from 'utils/ipfs'
 import { NftPreview } from './NftPreview'
 import { QuantitySelector } from './QuantitySelector'
-
-const MAX_REMAINING_SUPPLY = 10000
 
 // The clickable cards on the project page
 export function NftTierCard({
@@ -62,7 +61,7 @@ export function NftTierCard({
   const hasRemainingSupply = remainingSupply && remainingSupply > 0
   const remainingSupplyText = !hasRemainingSupply
     ? t`SOLD OUT`
-    : rewardTier.maxSupply === MAX_REMAINING_SUPPLY
+    : rewardTier.maxSupply === DEFAULT_NFT_MAX_SUPPLY
     ? t`Unlimited`
     : t`${rewardTier?.remainingSupply} remaining`
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2666,6 +2666,9 @@ msgstr ""
 msgid "Rules for how this project's funding cycles can be reconfigured."
 msgstr ""
 
+msgid "SOLD OUT"
+msgstr ""
+
 msgid "Safe transactions"
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

Closes #2911 

- Shows 'SOLD OUT' text when sold out (rather than 'Remaining supply: 0'
- Prevents NFT being selected for purchase (just opens preview straight away on first click)

## Screenshots or screen recordings

https://user-images.githubusercontent.com/96150256/217412802-b4c9aebb-4338-410b-b842-5a881a5c880b.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
