### PR TITLE
PayEventElem handle caller != beneficiary

### DIFF
--- a/src/components/FormattedAddress.tsx
+++ b/src/components/FormattedAddress.tsx
@@ -9,6 +9,7 @@ import { twMerge } from 'tailwind-merge'
 export default function FormattedAddress({
   className,
   address,
+  title,
   label,
   tooltipDisabled,
   truncateTo,
@@ -16,6 +17,7 @@ export default function FormattedAddress({
 }: {
   className?: string
   address: string | undefined
+  title?: string
   label?: string
   tooltipDisabled?: boolean
   truncateTo?: number
@@ -43,6 +45,7 @@ export default function FormattedAddress({
     <Tooltip
       title={
         <span className="text-sm">
+          {title ? <div className="text-xs font-bold">{title}</div> : null}
           {address} <CopyTextButton value={address} />
         </span>
       }

--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -1,4 +1,5 @@
 import EtherscanLink from 'components/EtherscanLink'
+import { ArrowRightOutlined } from '@ant-design/icons'
 import FormattedAddress from 'components/FormattedAddress'
 import { ProjectVersionBadge } from 'components/ProjectVersionBadge'
 import { ThemeContext } from 'contexts/Theme/ThemeContext'
@@ -9,16 +10,36 @@ import { contentLineHeight, smallHeaderStyle } from '../styles'
 
 import { ActivityElementEvent } from './activityElementEvent'
 
-const DetailsContainer: React.FC = ({ children }) => {
-  return (
+const CallerBeneficiary = ({
+  caller,
+  beneficiary,
+}: {
+  caller?: string
+  beneficiary?: string
+}) => {
+  if (!beneficiary && !caller) return null
+
+  return beneficiary &&
+    caller &&
+    beneficiary.toLowerCase() !== caller.toLowerCase() ? (
     <div
       style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignContent: 'space-between',
+        lineHeight: contentLineHeight,
       }}
+      className="text-xs text-grey-500 dark:text-grey-300"
     >
-      {children}
+      <FormattedAddress address={caller} title="Caller" />{' '}
+      <ArrowRightOutlined />{' '}
+      <FormattedAddress address={beneficiary} title="Beneficiary" />
+    </div>
+  ) : (
+    <div
+      style={{
+        lineHeight: contentLineHeight,
+      }}
+      className="text-sm text-grey-500 dark:text-grey-300"
+    >
+      <FormattedAddress address={beneficiary} />
     </div>
   )
 }
@@ -43,18 +64,22 @@ function Header({ header }: { header: string | JSX.Element }) {
   )
 }
 
-function SideDetails({ event }: { event: ActivityElementEvent }) {
+function TimestampVersion({
+  timestamp,
+  txHash,
+  terminal,
+}: ActivityElementEvent) {
   const {
     theme: { colors },
   } = useContext(ThemeContext)
 
-  const terminalVersion = useV2V3TerminalVersion(event.terminal)
+  const terminalVersion = useV2V3TerminalVersion(terminal)
 
   return (
     <div style={{ textAlign: 'right' }}>
-      {event.timestamp && (
+      {timestamp && (
         <div className="text-xs text-grey-500 dark:text-grey-300">
-          {formatHistoricalDate(event.timestamp * 1000)}{' '}
+          {formatHistoricalDate(timestamp * 1000)}{' '}
           {terminalVersion && (
             <ProjectVersionBadge
               versionText={'V' + terminalVersion}
@@ -65,22 +90,12 @@ function SideDetails({ event }: { event: ActivityElementEvent }) {
             />
           )}{' '}
           <EtherscanLink
-            value={event.txHash}
+            value={txHash}
             type="tx"
             className="text-grey-500 dark:text-grey-300"
           />
         </div>
       )}
-      {event.beneficiary ? (
-        <div
-          style={{
-            lineHeight: contentLineHeight,
-          }}
-          className="text-sm text-grey-500 dark:text-grey-300"
-        >
-          <FormattedAddress address={event.beneficiary} />
-        </div>
-      ) : null}
     </div>
   )
 }
@@ -118,13 +133,30 @@ export function ActivityEvent({
 }) {
   return (
     <>
-      <DetailsContainer>
-        <div>
+      <div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+          }}
+        >
           <Header header={header} />
-          <Subject subject={subject} />
+          <TimestampVersion {...event} />
         </div>
-        <SideDetails event={event} />
-      </DetailsContainer>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+          }}
+        >
+          <Subject subject={subject} />
+          <CallerBeneficiary {...event} />
+        </div>
+      </div>
+
       {extra ? <ExtraContainer>{extra}</ExtraContainer> : null}
     </>
   )

--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -1,12 +1,12 @@
-import EtherscanLink from 'components/EtherscanLink'
 import { ArrowRightOutlined } from '@ant-design/icons'
+import EtherscanLink from 'components/EtherscanLink'
 import FormattedAddress from 'components/FormattedAddress'
 import { ProjectVersionBadge } from 'components/ProjectVersionBadge'
 import { ThemeContext } from 'contexts/Theme/ThemeContext'
 import { useV2V3TerminalVersion } from 'hooks/v2v3/V2V3TerminalVersion'
 import { useContext } from 'react'
 import { formatHistoricalDate } from 'utils/format/formatDate'
-import { contentLineHeight, smallHeaderStyle } from '../styles'
+import { smallHeaderStyle } from '../styles'
 
 import { ActivityElementEvent } from './activityElementEvent'
 
@@ -22,23 +22,13 @@ const CallerBeneficiary = ({
   return beneficiary &&
     caller &&
     beneficiary.toLowerCase() !== caller.toLowerCase() ? (
-    <div
-      style={{
-        lineHeight: contentLineHeight,
-      }}
-      className="text-xs text-grey-500 dark:text-grey-300"
-    >
+    <div className="text-xs text-grey-500 dark:text-grey-300">
       <FormattedAddress address={caller} title="Caller" />{' '}
       <ArrowRightOutlined />{' '}
       <FormattedAddress address={beneficiary} title="Beneficiary" />
     </div>
   ) : (
-    <div
-      style={{
-        lineHeight: contentLineHeight,
-      }}
-      className="text-sm text-grey-500 dark:text-grey-300"
-    >
+    <div className="text-sm text-grey-500 dark:text-grey-300">
       <FormattedAddress address={beneficiary} />
     </div>
   )
@@ -101,16 +91,7 @@ function TimestampVersion({
 }
 
 function Subject({ subject }: { subject: string | JSX.Element | null }) {
-  return (
-    <div
-      style={{
-        lineHeight: contentLineHeight,
-      }}
-      className="text-sm"
-    >
-      {subject}
-    </div>
-  )
+  return <div className="text-sm">{subject}</div>
 }
 
 /**

--- a/src/components/activityEventElems/ActivityElement/activityElementEvent.ts
+++ b/src/components/activityEventElems/ActivityElement/activityElementEvent.ts
@@ -1,6 +1,7 @@
 export interface ActivityElementEvent {
   timestamp: number
   txHash: string
+  caller: string
   beneficiary?: string
   terminal?: string
 }

--- a/src/components/activityEventElems/DeployedERC20EventElem.tsx
+++ b/src/components/activityEventElems/DeployedERC20EventElem.tsx
@@ -8,7 +8,10 @@ export default function DeployedERC20EventElem({
   event,
 }: {
   event:
-    | Pick<DeployedERC20Event, 'symbol' | 'id' | 'timestamp' | 'txHash'>
+    | Pick<
+        DeployedERC20Event,
+        'symbol' | 'id' | 'timestamp' | 'txHash' | 'caller'
+      >
     | undefined
 }) {
   if (!event) return null

--- a/src/components/activityEventElems/PayEventElem.tsx
+++ b/src/components/activityEventElems/PayEventElem.tsx
@@ -14,6 +14,7 @@ export default function PayEventElem({
         PayEvent,
         | 'amount'
         | 'timestamp'
+        | 'caller'
         | 'beneficiary'
         | 'note'
         | 'id'

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -20,6 +20,7 @@ export default function RedeemEventElem({
         | 'id'
         | 'amount'
         | 'beneficiary'
+        | 'caller'
         | 'txHash'
         | 'timestamp'
         | 'returnAmount'

--- a/src/components/activityEventElems/styles.ts
+++ b/src/components/activityEventElems/styles.ts
@@ -6,6 +6,4 @@ export const smallHeaderStyle = (colors: SemanticColors) => ({
   color: colors.text.tertiary,
 })
 
-export const contentLineHeight: CSSProperties['lineHeight'] = '1.4rem'
-
 export const primaryContentFontSize: CSSProperties['fontSize'] = '1rem'

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -125,6 +125,7 @@ export default function ProjectActivity() {
         keys: [
           'amount',
           'timestamp',
+          'caller',
           'beneficiary',
           'note',
           'id',

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -148,7 +148,7 @@ export default function ProjectActivity() {
       },
       {
         entity: 'deployedERC20Event',
-        keys: ['symbol', 'txHash', 'timestamp', 'id'],
+        keys: ['symbol', 'txHash', 'timestamp', 'id', 'caller'],
       },
       {
         entity: 'tapEvent',
@@ -166,6 +166,7 @@ export default function ProjectActivity() {
         entity: 'redeemEvent',
         keys: [
           'id',
+          'caller',
           'amount',
           'beneficiary',
           'txHash',


### PR DESCRIPTION
## What does this PR do and why?

Adds a case to PayEventElem to show both caller and beneficiary when they are not the same address.

- light refactoring to ActivityEventElem puts the `Subject` and caller/beneficiary on the same line, to allow aligning by baseline (needed because now in the case where caller != beneficiary, right side text uses a smaller font size)
- adds a "title" property to FormattedAddress
- adds missing "caller" key to a few project activity events, so we can show on all events

## Screenshots or screen recordings

<img width="499" alt="image" src="https://user-images.githubusercontent.com/79433522/217644094-6761d780-e7ba-4c15-8ac7-1a959c79428d.png">
<img width="330" alt="image" src="https://user-images.githubusercontent.com/79433522/217644140-b9dcd7a3-0342-46d2-a857-f42834251c76.png">
<img width="289" alt="image" src="https://user-images.githubusercontent.com/79433522/217644170-8b8cf8ce-91bf-4137-9230-a414fe4f4c84.png">


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
