### PR TITLE
Support NFT mp4 in reconfig FC

### DIFF
--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -192,7 +192,7 @@ export const AddEditRewardModal = ({
           label={t`File`}
           extra={NFT_FILE_UPLOAD_EXTRA}
           required
-          rules={[inputMustExistRule({ label: t`Image file` })]}
+          rules={[inputMustExistRule({ label: t`File` })]}
         >
           <UploadNoStyle
             sizeLimit={100 * 1024 * 1024} // 100 MB

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftRewardTierModal.tsx
@@ -17,7 +17,7 @@ export type NftFormFields = {
   name: string
   externalLink: string
   description: string
-  imageUrl: string // IPFS link
+  fileUrl: string // IPFS link
 }
 
 const MAX_DESCRIPTION_CHARS = 256
@@ -46,7 +46,7 @@ export default function NftRewardTierModal({
       contributionFloor: parseFloat(nftForm.getFieldValue('contributionFloor')),
       maxSupply,
       remainingSupply: maxSupply,
-      fileUrl: nftForm.getFieldValue('imageUrl'),
+      fileUrl: nftForm.getFieldValue('fileUrl'),
       name: nftForm.getFieldValue('name'),
       externalLink: withHttps(nftForm.getFieldValue('externalLink')),
       description: nftForm.getFieldValue('description'),
@@ -64,7 +64,7 @@ export default function NftRewardTierModal({
     () =>
       rewardTier
         ? {
-            imageUrl: rewardTier.fileUrl,
+            fileUrl: rewardTier.fileUrl,
             maxSupply: rewardTier.maxSupply,
             name: rewardTier.name,
             externalLink: rewardTier.externalLink?.slice(8), // removes 'https://'

--- a/src/components/veNft/VeNftRewardTierModal.tsx
+++ b/src/components/veNft/VeNftRewardTierModal.tsx
@@ -13,7 +13,7 @@ import TokensStakedMinInput from 'components/veNft/formControls/TokensStakedMinI
 export type VeNftFormFields = {
   name: string
   tokensStakedMin: number
-  imageUrl: string
+  fileUrl: string
 }
 
 export default function VeNftRewardTierModal({
@@ -40,7 +40,7 @@ export default function VeNftRewardTierModal({
       id,
       name: nftForm.getFieldValue('name'),
       tokensStakedMin: nftForm.getFieldValue('tokensStakedMin'),
-      imageUrl: nftForm.getFieldValue('imageUrl'),
+      fileUrl: nftForm.getFieldValue('fileUrl'),
     } as VeNftVariant
 
     onChange(variant)
@@ -56,7 +56,7 @@ export default function VeNftRewardTierModal({
       nftForm.setFieldsValue({
         name: variant.name,
         tokensStakedMin: variant.tokensStakedMin,
-        imageUrl: variant.imageUrl,
+        fileUrl: variant.fileUrl,
       })
     }
   })

--- a/src/components/veNft/VeNftSetupModal.tsx
+++ b/src/components/veNft/VeNftSetupModal.tsx
@@ -22,25 +22,25 @@ const DEFAULT_VARIANTS: VeNftVariant[] = [
     id: 1,
     name: 'Cool guy',
     tokensStakedMin: 1,
-    imageUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
+    fileUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
   },
   {
     id: 2,
     name: 'Rich guy',
     tokensStakedMin: 1000,
-    imageUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
+    fileUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
   },
   {
     id: 3,
     name: 'Extra rich guy',
     tokensStakedMin: 1000000,
-    imageUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
+    fileUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
   },
   {
     id: 3,
     name: 'Top Baller',
     tokensStakedMin: 1000000000,
-    imageUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
+    fileUrl: `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_HOSTNAME}/ipfs/QmTqHj8L5S2B7w1pqUn9hHyzddB27pgKEwFTwPRRQoqj96`,
   },
 ]
 

--- a/src/components/veNft/VeNftVariantCard.tsx
+++ b/src/components/veNft/VeNftVariantCard.tsx
@@ -56,7 +56,7 @@ export default function VeNftVariantCard({
               'max-w-[90px] object-cover',
               imageLoading ? 'hidden' : '',
             )}
-            src={variant.imageUrl}
+            src={variant.fileUrl}
             alt={variant.name}
             height={'60px'}
             onLoad={() => setImageLoading(false)}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Attach a sticker"
 msgstr ""
 
-msgid "Attach the image to be associated with this NFT."
+msgid "Attach the image/video to be associated with this NFT."
 msgstr ""
 
 msgid "Automate funding cycles"
@@ -1565,12 +1565,6 @@ msgstr ""
 msgid "If you're unsure if you need to claim, you probably don't."
 msgstr ""
 
-msgid "Image file"
-msgstr ""
-
-msgid "Image will be cropped to a square in thumbnail previews on the Juicebox app."
-msgstr ""
-
 msgid "In Juicebox"
 msgstr ""
 
@@ -1920,6 +1914,9 @@ msgid "NFT rules"
 msgstr ""
 
 msgid "NFT will be cropped to a 1:1 square in thumbnail previews on the Juicebox app."
+msgstr ""
+
+msgid "NFT will be cropped to a square in thumbnail previews on the Juicebox app."
 msgstr ""
 
 msgid "NFTs"
@@ -3485,7 +3482,7 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-msgid "Upload an image"
+msgid "Upload a file"
 msgstr ""
 
 msgid "Uploaded to: <0>{imageUrl}</0>"

--- a/src/models/veNft.ts
+++ b/src/models/veNft.ts
@@ -3,7 +3,7 @@ export type VeNftVariant = {
   name: string
   tokensStakedMin: number
   tokensStakedMax?: number
-  imageUrl?: string
+  fileUrl?: string
 }
 
 export type VeNftTokenMetadata = {


### PR DESCRIPTION
## What does this PR do and why?

- Allows MP4s to be uploaded in NFT section of reconfigure FC (behind `nftMp4` feature flag)
- Applies necessary architectural changes to parts of VeNFT as a result of changing the `imageUrl` attribute to `fileUrl` in a type definition

## Screenshots or screen recordings

<img width="556" alt="Screen Shot 2023-02-09 at 12 03 40 pm" src="https://user-images.githubusercontent.com/96150256/217699436-7f68a01a-e904-4729-94a3-b23019224ca4.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
