### PR TITLE
Improve redemption rate in reconfig

### DIFF
--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/TokenDrawer/TokenForm/TokenForm.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/TokenDrawer/TokenForm/TokenForm.tsx
@@ -9,7 +9,6 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { useForm } from 'antd/lib/form/Form'
 import { Callout } from 'components/Callout'
 import { FormItems } from 'components/formItems'
-import { DEFAULT_BONDING_CURVE_RATE_PERCENTAGE } from 'components/formItems/ProjectRedemptionRate'
 import FormItemWarningText from 'components/FormItemWarningText'
 import NumberSlider from 'components/inputs/NumberSlider'
 import SwitchHeading from 'components/SwitchHeading'
@@ -184,11 +183,6 @@ export function TokenForm({
     fundingCycleData?.discountRate !== DEFAULT_FUNDING_CYCLE_DATA.discountRate,
   )
 
-  const [redemptionRateChecked, setRedemptionRateChecked] = useState<boolean>(
-    fundingCycleMetadata?.redemptionRate !==
-      DEFAULT_FUNDING_CYCLE_METADATA.redemptionRate,
-  )
-
   const [reservedTokensSplits, setReservedTokensSplits] = useState<Split[]>(
     reservedTokensGroupedSplits?.splits,
   )
@@ -339,12 +333,6 @@ export function TokenForm({
             label={
               <>
                 <Trans>Redemption rate</Trans>
-                {!redemptionRateChecked && canSetRedemptionRate && (
-                  <span className="text-grey-400 dark:text-slate-200">
-                    {' '}
-                    ({DEFAULT_BONDING_CURVE_RATE_PERCENTAGE}%)
-                  </span>
-                )}
               </>
             }
             value={formatRedemptionRate(BigNumber.from(redemptionRate))}
@@ -355,8 +343,7 @@ export function TokenForm({
                 ).toString(),
               )
             }}
-            onToggled={setRedemptionRateChecked}
-            checked={redemptionRateChecked}
+            checked={canSetRedemptionRate}
             disabled={!canSetRedemptionRate}
           />
         </div>


### PR DESCRIPTION
## What does this PR do and why?

Closes #3001

Just removes the toggle from the redemption rate field when it's able to be set (`distributeLimit !== infinite`).  Clearly 'disabling' the redemption rate (setting it to 100%) is confusing and doesn't really make sense. 

## Screenshots or screen recordings

When `distributeLimit === infinite` (same as now): 

<img width="644" alt="Screen Shot 2023-02-09 at 3 30 16 pm" src="https://user-images.githubusercontent.com/96150256/217726931-07c43c46-c185-4279-ae5a-2322135975c8.png">

When `distributeLimit !== infinite` (**BEFORE**): 

<img width="626" alt="Screen Shot 2023-02-09 at 3 36 07 pm" src="https://user-images.githubusercontent.com/96150256/217727209-ed074863-ecfa-4e9d-a000-35f55c3638db.png">

<img width="619" alt="Screen Shot 2023-02-09 at 3 36 14 pm" src="https://user-images.githubusercontent.com/96150256/217727216-e52c676b-0640-4ae1-a094-49a769050bad.png">


When `distributeLimit !== infinite` (**AFTER**): 
<img width="619" alt="Screen Shot 2023-02-09 at 3 25 32 pm" src="https://user-images.githubusercontent.com/96150256/217727069-b2d6a02b-acd3-4113-b34d-0c8b83dd04b3.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
