### PR TITLE
MP4 NFTs in review NFTs sections

### DIFF
--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -176,7 +176,7 @@ export const AddEditRewardModal = ({
     <Modal
       className={className}
       title={
-        <h2 className="text-xl font-medium text-black dark:text-grey-200">
+        <h2 className="z-20 text-xl font-medium text-black dark:text-grey-200">
           {isEditing ? t`Edit NFT` : t`Add NFT`}
         </h2>
       }

--- a/src/components/Create/components/RewardsList/RewardItem.tsx
+++ b/src/components/Create/components/RewardsList/RewardItem.tsx
@@ -3,6 +3,9 @@ import { t, Trans } from '@lingui/macro'
 import ExternalLink from 'components/ExternalLink'
 import FormattedAddress from 'components/FormattedAddress'
 import TooltipLabel from 'components/TooltipLabel'
+import { MP4_FILE_TYPE } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/NftUpload'
+import { JuiceVideoThumbnail } from 'components/v2v3/shared/NftVideo/JuiceVideoThumbnail'
+import { useContentType } from 'hooks/ContentType'
 import { ReactNode } from 'react'
 import { prettyUrl } from 'utils/url'
 import { RewardImage } from '../RewardImage'
@@ -47,6 +50,10 @@ export const RewardItem = ({
     url,
     fileUrl,
   } = reward
+
+  const { data: contentType } = useContentType(fileUrl)
+  const isVideo = contentType === MP4_FILE_TYPE
+
   return (
     <div className="flex flex-col gap-4">
       {/* Title line */}
@@ -66,7 +73,14 @@ export const RewardItem = ({
 
       <div className="flex flex-col gap-8 md:flex-row">
         <div className="flex flex-col gap-3">
-          <RewardImage className="h-44 w-44" src={fileUrl.toString()} />
+          {isVideo ? (
+            <div className="relative h-44 w-44">
+              <JuiceVideoThumbnail src={fileUrl.toString()} />
+            </div>
+          ) : (
+            <RewardImage className="h-44 w-44" src={fileUrl.toString()} />
+          )}
+
           {url && (
             <div className="flex max-w-[11rem] items-center gap-2 overflow-hidden overflow-ellipsis whitespace-nowrap text-xs font-normal">
               <LinkOutlined />
@@ -93,7 +107,7 @@ export const RewardItem = ({
             )}
             {!!reservedRate && (
               <RewardStatLine
-                title={t`Reserved NFTS`}
+                title={t`Reserved NFTs`}
                 stat={`1/${reservedRate}`}
               />
             )}

--- a/src/components/v2v3/shared/NftVideo/JuiceVideoThumbnail.tsx
+++ b/src/components/v2v3/shared/NftVideo/JuiceVideoThumbnail.tsx
@@ -23,7 +23,7 @@ export function JuiceVideoThumbnail({
         </div>
         {loading ? (
           <div
-            className={`flex h-[144px] w-full items-center justify-center border border-solid border-smoke-200 dark:border-grey-600`}
+            className={`flex h-full w-full items-center justify-center border border-solid border-smoke-200 dark:border-grey-600`}
           >
             <LoadingOutlined />
           </div>
@@ -35,7 +35,6 @@ export function JuiceVideoThumbnail({
             filter: isSelected ? 'unset' : 'brightness(50%)',
           }}
           onLoadedData={() => setLoading(false)}
-          preload="none"
         >
           <source src={src} type="video/mp4" />
           Your browser does not support the video tag.

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2588,9 +2588,6 @@ msgstr ""
 msgid "Reserve a percentage of freshly minted tokens for your project to use."
 msgstr ""
 
-msgid "Reserved NFTS"
-msgstr ""
-
 msgid "Reserved NFTs"
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

Will show MP4s in these review sections of the create flow (when IPFS not being fucky):

**NFT tab:**
<img width="921" alt="Screen Shot 2023-02-10 at 11 21 00 am" src="https://user-images.githubusercontent.com/96150256/217977384-0975c49b-c4f2-40fd-922b-ecfefd34ad21.png">

**Review and deploy:**
<img width="638" alt="Screen Shot 2023-02-10 at 11 20 31 am" src="https://user-images.githubusercontent.com/96150256/217977394-cf810b45-7c37-4c73-9b1e-f8373d6e7a83.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
