### PR TITLE
feat: create flow - hide nft collection configuration when no nft added [1/n]

### DIFF
--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro'
-import { Callout } from 'components/Callout'
 import { DeployButtonText } from 'components/buttons/DeployProjectButtonText'
+import { Callout } from 'components/Callout'
 import ExternalLink from 'components/ExternalLink'
 import Loading from 'components/Loading'
 import { useRouter } from 'next/router'

--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -2,6 +2,7 @@ import { EyeOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Form, Radio, Space } from 'antd'
 import { CreateButton } from 'components/buttons/CreateButton'
+import { useLockPageRulesWrapper } from 'components/Create/hooks/useLockPageRulesWrapper'
 import ExternalLink from 'components/ExternalLink'
 import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
 import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
@@ -11,7 +12,7 @@ import { RadioItem } from 'components/RadioItem'
 import TooltipLabel from 'components/TooltipLabel'
 import {
   PREVENT_OVERSPENDING_EXPLAINATION,
-  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION
+  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { CREATE_FLOW } from 'constants/fathomEvents'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
@@ -21,6 +22,7 @@ import { JB721GovernanceType } from 'models/nftRewardTier'
 import { useContext } from 'react'
 import { useAppSelector } from 'redux/hooks/AppSelector'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/EditingCreateFurthestPageReached'
+import { inputMustExistRule } from 'utils/antdRules'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { helpPagePath } from 'utils/routes'
 import { CreateBadge } from '../../CreateBadge'
@@ -34,6 +36,7 @@ import { useNftRewardsForm } from './hooks'
 export const NftRewardsPage = () => {
   useSetCreateFurthestPageReached('nftRewards')
   const { form, initialValues } = useNftRewardsForm()
+  const lockPageRulesWrapper = useLockPageRulesWrapper()
   const { goToNextPage } = useContext(PageContext)
 
   const postPayModal = useModal()
@@ -42,6 +45,7 @@ export const NftRewardsPage = () => {
   )
 
   const delegateV1_1Enabled = featureFlagEnabled(FEATURE_FLAGS.DELEGATE_V1_1)
+  const hasNfts = !!Form.useWatch('rewards', form)?.length
 
   return (
     <>
@@ -62,210 +66,218 @@ export const NftRewardsPage = () => {
             <RewardsList allowCreate />
           </Form.Item>
 
-          <Space
-            className="w-full pt-3 pb-2"
-            direction="vertical"
-            size="middle"
-          >
-            <Form.Item
-              name="collectionName"
-              label={
-                <TooltipLabel
-                  label={t`Collection Name`}
-                  tip={
-                    <Trans>
-                      Your collection's name is used on NFT marketplaces (for
-                      example, OpenSea).
-                    </Trans>
-                  }
-                />
-              }
-              required
+          {hasNfts && (
+            <Space
+              className="w-full pt-3 pb-2"
+              direction="vertical"
+              size="middle"
             >
-              <JuiceInput />
-            </Form.Item>
-
-            <Form.Item
-              name="collectionSymbol"
-              label={
-                <TooltipLabel
-                  label={t`Collection Symbol`}
-                  tip={
-                    <Trans>
-                      Your collection's symbol is used on NFT marketplaces (for
-                      example, OpenSea).
-                    </Trans>
-                  }
-                />
-              }
-              required
-            >
-              <JuiceInput />
-            </Form.Item>
-
-            <Form.Item
-              name="collectionDescription"
-              label={<Trans>Collection Description</Trans>}
-            >
-              <JuiceInput />
-            </Form.Item>
-
-            <CreateCollapse>
-              <CreateCollapse.Panel
-                key={1}
-                header={<OptionalHeader header={t`On-chain Governance`} />}
-                hideDivider
+              <Form.Item
+                name="collectionName"
+                label={
+                  <TooltipLabel
+                    label={t`Collection Name`}
+                    tip={
+                      <Trans>
+                        Your collection's name is used on NFT marketplaces (for
+                        example, OpenSea).
+                      </Trans>
+                    }
+                  />
+                }
+                required
+                rules={lockPageRulesWrapper([
+                  inputMustExistRule({ label: t`Collection Name` }),
+                ])}
               >
-                <Form.Item name="onChainGovernance">
-                  <Radio.Group className="flex flex-col gap-5">
-                    <RadioItem
-                      value={JB721GovernanceType.NONE}
-                      title={
-                        <>
-                          <Trans>No on-chain governance</Trans>{' '}
-                          <CreateBadge.Default />
-                        </>
-                      }
-                      description={t`Your project's NFTs will not have on-chain governance capabilities.`}
-                    />
-                    <RadioItem
-                      value={JB721GovernanceType.GLOBAL}
-                      title={t`Standard on-chain governance`}
-                      description={
-                        <Trans>
-                          Track the historical voting weight of each token
-                          holder across all tiers of NFTs.{' '}
-                          <ExternalLink
-                            href={helpPagePath(
-                              '/user/configuration/#on-chain-governance',
-                            )}
-                          >
-                            Learn more.
-                          </ExternalLink>
-                        </Trans>
-                      }
-                    />
-                    <RadioItem
-                      value={JB721GovernanceType.TIERED}
-                      title={t`Tier-based on-chain governance`}
-                      description={
-                        <Trans>
-                          Track the historical voting weight of each token
-                          holder within each tier of NFTs.{' '}
-                          <ExternalLink
-                            href={helpPagePath(
-                              '/user/configuration/#on-chain-governance',
-                            )}
-                          >
-                            Learn more.
-                          </ExternalLink>
-                        </Trans>
-                      }
-                    />
-                  </Radio.Group>
-                </Form.Item>
-              </CreateCollapse.Panel>
-              <CreateCollapse.Panel
-                key={2}
-                header={<OptionalHeader header={t`Payment Success Popup`} />}
-                hideDivider
+                <JuiceInput />
+              </Form.Item>
+
+              <Form.Item
+                name="collectionSymbol"
+                label={
+                  <TooltipLabel
+                    label={t`Collection Symbol`}
+                    tip={
+                      <Trans>
+                        Your collection's symbol is used on NFT marketplaces
+                        (for example, OpenSea).
+                      </Trans>
+                    }
+                  />
+                }
+                required
+                rules={lockPageRulesWrapper([
+                  inputMustExistRule({ label: t`Collection Symbol` }),
+                ])}
               >
-                <Space
-                  className="w-full pt-3 pb-2"
-                  direction="vertical"
-                  size="middle"
+                <JuiceInput />
+              </Form.Item>
+
+              <Form.Item
+                name="collectionDescription"
+                label={<Trans>Collection Description</Trans>}
+              >
+                <JuiceInput />
+              </Form.Item>
+
+              <CreateCollapse>
+                <CreateCollapse.Panel
+                  key={1}
+                  header={<OptionalHeader header={t`On-chain Governance`} />}
+                  hideDivider
                 >
-                  <p>
-                    <Trans>
-                      Show contributors a popup when they receive an NFT.
-                    </Trans>
-                  </p>
-                  <Form.Item
-                    name="postPayMessage"
-                    label={
-                      <TooltipLabel
-                        label={t`Message`}
-                        tip={
+                  <Form.Item name="onChainGovernance">
+                    <Radio.Group className="flex flex-col gap-5">
+                      <RadioItem
+                        value={JB721GovernanceType.NONE}
+                        title={
+                          <>
+                            <Trans>No on-chain governance</Trans>{' '}
+                            <CreateBadge.Default />
+                          </>
+                        }
+                        description={t`Your project's NFTs will not have on-chain governance capabilities.`}
+                      />
+                      <RadioItem
+                        value={JB721GovernanceType.GLOBAL}
+                        title={t`Standard on-chain governance`}
+                        description={
                           <Trans>
-                            The message that will be shown to the user after
-                            they pay for an NFT.
+                            Track the historical voting weight of each token
+                            holder across all tiers of NFTs.{' '}
+                            <ExternalLink
+                              href={helpPagePath(
+                                '/user/configuration/#on-chain-governance',
+                              )}
+                            >
+                              Learn more.
+                            </ExternalLink>
                           </Trans>
                         }
                       />
-                    }
-                  >
-                    <JuiceTextArea autoSize={{ minRows: 4, maxRows: 6 }} />
-                  </Form.Item>
-                  <Form.Item
-                    name="postPayButtonText"
-                    label={
-                      <TooltipLabel
-                        label={t`Button Text`}
-                        tip={
+                      <RadioItem
+                        value={JB721GovernanceType.TIERED}
+                        title={t`Tier-based on-chain governance`}
+                        description={
                           <Trans>
-                            The text that will be shown to the user on the
-                            button post pay popup.
-                            <br />
-                            <strong>
-                              For more information, see the preview.
-                            </strong>
+                            Track the historical voting weight of each token
+                            holder within each tier of NFTs.{' '}
+                            <ExternalLink
+                              href={helpPagePath(
+                                '/user/configuration/#on-chain-governance',
+                              )}
+                            >
+                              Learn more.
+                            </ExternalLink>
                           </Trans>
                         }
                       />
-                    }
-                  >
-                    <JuiceInput />
+                    </Radio.Group>
                   </Form.Item>
-                  <Form.Item
-                    name="postPayButtonLink"
-                    label={
-                      <TooltipLabel
-                        label={t`Button link`}
-                        tip={
-                          <Trans>
-                            Link contributors to another page after they
-                            successfully mint one of your project's NFTs.
-                          </Trans>
-                        }
-                      />
-                    }
-                    extra={t`Button will close the modal if no link is given.`}
-                  >
-                    <JuiceInput prefix={'https://'} />
-                  </Form.Item>
-                  <CreateButton
-                    className="border border-solid"
-                    disabled={!postPayModalData}
-                    icon={<EyeOutlined />}
-                    onClick={postPayModal.open}
-                  >
-                    Preview
-                  </CreateButton>
-                </Space>
-              </CreateCollapse.Panel>
-
-              <CreateCollapse.Panel
-                key={3}
-                header={<OptionalHeader header={t`Advanced options`} />}
-                hideDivider
-              >
-                <Form.Item
-                  name="useDataSourceForRedeem"
-                  extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+                </CreateCollapse.Panel>
+                <CreateCollapse.Panel
+                  key={2}
+                  header={<OptionalHeader header={t`Payment Success Popup`} />}
+                  hideDivider
                 >
-                  <JuiceSwitch label={t`Redeemable NFTs`} />
-                </Form.Item>
-                {delegateV1_1Enabled ? (
-                  <Form.Item
-                    name="preventOverspending"
-                    extra={PREVENT_OVERSPENDING_EXPLAINATION}
+                  <Space
+                    className="w-full pt-3 pb-2"
+                    direction="vertical"
+                    size="middle"
                   >
-                    <JuiceSwitch label={t`Prevent NFT overspending`} />
+                    <p>
+                      <Trans>
+                        Show contributors a popup when they receive an NFT.
+                      </Trans>
+                    </p>
+                    <Form.Item
+                      name="postPayMessage"
+                      label={
+                        <TooltipLabel
+                          label={t`Message`}
+                          tip={
+                            <Trans>
+                              The message that will be shown to the user after
+                              they pay for an NFT.
+                            </Trans>
+                          }
+                        />
+                      }
+                    >
+                      <JuiceTextArea autoSize={{ minRows: 4, maxRows: 6 }} />
+                    </Form.Item>
+                    <Form.Item
+                      name="postPayButtonText"
+                      label={
+                        <TooltipLabel
+                          label={t`Button Text`}
+                          tip={
+                            <Trans>
+                              The text that will be shown to the user on the
+                              button post pay popup.
+                              <br />
+                              <strong>
+                                For more information, see the preview.
+                              </strong>
+                            </Trans>
+                          }
+                        />
+                      }
+                    >
+                      <JuiceInput />
+                    </Form.Item>
+                    <Form.Item
+                      name="postPayButtonLink"
+                      label={
+                        <TooltipLabel
+                          label={t`Button link`}
+                          tip={
+                            <Trans>
+                              Link contributors to another page after they
+                              successfully mint one of your project's NFTs.
+                            </Trans>
+                          }
+                        />
+                      }
+                      extra={t`Button will close the modal if no link is given.`}
+                    >
+                      <JuiceInput prefix={'https://'} />
+                    </Form.Item>
+                    <CreateButton
+                      className="border border-solid"
+                      disabled={!postPayModalData}
+                      icon={<EyeOutlined />}
+                      onClick={postPayModal.open}
+                    >
+                      Preview
+                    </CreateButton>
+                  </Space>
+                </CreateCollapse.Panel>
+
+                <CreateCollapse.Panel
+                  key={3}
+                  header={<OptionalHeader header={t`Advanced options`} />}
+                  hideDivider
+                >
+                  <Form.Item
+                    name="useDataSourceForRedeem"
+                    extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+                  >
+                    <JuiceSwitch label={t`Redeemable NFTs`} />
                   </Form.Item>
-                ) : null}
-              </CreateCollapse.Panel>
-            </CreateCollapse>
-          </Space>
+                  {delegateV1_1Enabled ? (
+                    <Form.Item
+                      name="preventOverspending"
+                      extra={PREVENT_OVERSPENDING_EXPLAINATION}
+                    >
+                      <JuiceSwitch label={t`Prevent NFT overspending`} />
+                    </Form.Item>
+                  ) : null}
+                </CreateCollapse.Panel>
+              </CreateCollapse>
+            </Space>
+          )}
         </Space>
         <Wizard.Page.ButtonControl />
       </Form>

--- a/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RewardsReview/RewardsReview.tsx
@@ -2,9 +2,10 @@ import { t } from '@lingui/macro'
 import { Row } from 'antd'
 import { Reward, RewardsList } from 'components/Create/components/RewardsList'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
+import { JB721GovernanceType } from 'models/nftRewardTier'
+import { useCallback, useMemo } from 'react'
 import { useAppDispatch } from 'redux/hooks/AppDispatch'
 import { useAppSelector } from 'redux/hooks/AppSelector'
-import { useCallback, useMemo } from 'react'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
 import { featureFlagEnabled } from 'utils/featureFlags'
 import { formatEnabled } from 'utils/format/formatBoolean'
@@ -13,7 +14,7 @@ import { DescriptionCol } from '../DescriptionCol'
 
 export const RewardsReview = () => {
   const {
-    nftRewards: { rewardTiers, flags },
+    nftRewards: { rewardTiers, flags, governanceType },
     fundingCycleMetadata,
   } = useAppSelector(state => state.editingV2Project)
 
@@ -68,6 +69,18 @@ export const RewardsReview = () => {
 
   const delegateV1_1Enabled = featureFlagEnabled(FEATURE_FLAGS.DELEGATE_V1_1)
 
+  const onChainGovernance = useMemo(() => {
+    switch (governanceType) {
+      case JB721GovernanceType.GLOBAL:
+        return t`Standard`
+      case JB721GovernanceType.TIERED:
+        return `Tiered`
+      case JB721GovernanceType.NONE:
+      default:
+        return t`None`
+    }
+  }, [governanceType])
+
   return (
     <>
       <RewardsList value={rewards} onChange={setRewards} />
@@ -79,6 +92,13 @@ export const RewardsReview = () => {
             <div className="text-base font-medium">
               {shouldUseDataSourceForRedeem}
             </div>
+          }
+        />
+        <DescriptionCol
+          span={6}
+          title={t`Governance type`}
+          desc={
+            <div className="text-base font-medium">{onChainGovernance}</div>
           }
         />
         {delegateV1_1Enabled ? (

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1475,6 +1475,9 @@ msgstr ""
 msgid "Governance"
 msgstr ""
 
+msgid "Governance type"
+msgstr ""
+
 msgid "Grant permission"
 msgstr ""
 
@@ -2070,6 +2073,9 @@ msgid "No, keep editing"
 msgstr ""
 
 msgid "Nominate an Ethereum wallet address to become the ‘owner’ of this project. If you intend to manage this project from the address that deployed it, leave this blank."
+msgstr ""
+
+msgid "None"
 msgstr ""
 
 msgid "Not a valid ETH address"
@@ -2937,6 +2943,9 @@ msgid "Staked balance"
 msgstr ""
 
 msgid "Staked {tokenSymbolDisplayText}"
+msgstr ""
+
+msgid "Standard"
 msgstr ""
 
 msgid "Standard on-chain governance"


### PR DESCRIPTION
## What does this PR do and why?

Hides NFT configuration settings on NFT Page in create when there is no NFTs added yet.

I didn't add the skip button as its a pretty big hassle. Unsure the ROI is worth it.

Also added a Goverance type review to r&deploy

Closes https://github.com/jbx-protocol/juice-interface/issues/2901

## Screenshots or screen recordings

![image](https://user-images.githubusercontent.com/104132113/218242076-2430308e-c1c5-402d-a9bd-cc297429a299.png)

![image](https://user-images.githubusercontent.com/104132113/218242091-66b2a973-0acb-4a4e-ad93-7353719f964e.png)

![image](https://user-images.githubusercontent.com/104132113/218242102-975c423b-c16c-42d6-a79e-d2ed0fce2b18.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
