### PR TITLE
Better address comparison

### DIFF
--- a/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
+++ b/src/components/Create/components/pages/ReconfigurationRules/hooks/ReconfigurationRulesForm.ts
@@ -3,11 +3,12 @@ import { Form } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
 import { useAvailableReconfigurationStrategies } from 'components/Create/hooks/AvailableReconfigurationStrategies'
 import { readNetwork } from 'constants/networks'
-import { useAppDispatch } from 'redux/hooks/AppDispatch'
-import { useAppSelector } from 'redux/hooks/AppSelector'
 import { ReconfigurationStrategy } from 'models/reconfigurationStrategy'
 import { useEffect, useMemo } from 'react'
+import { useAppDispatch } from 'redux/hooks/AppDispatch'
+import { useAppSelector } from 'redux/hooks/AppSelector'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
+import { isEqualAddress } from 'utils/address'
 import { useFormDispatchWatch } from '../../hooks'
 
 type ReconfigurationRulesFormProps = Partial<{
@@ -71,7 +72,9 @@ export const useReconfigurationRulesForm = () => {
           allowControllerMigration,
         }
 
-      const found = strategies.find(({ address }) => address === ballot)
+      const found = strategies.find(({ address }) =>
+        isEqualAddress(address, ballot),
+      )
       if (!found) {
         return {
           selection: 'custom',

--- a/src/components/Create/hooks/LoadInitialStateFromQuery.ts
+++ b/src/components/Create/hooks/LoadInitialStateFromQuery.ts
@@ -15,6 +15,7 @@ import {
   INITIAL_REDUX_STATE,
   ProjectState,
 } from 'redux/slices/editingV2Project'
+import { isEqualAddress } from 'utils/address'
 import { parseWad } from 'utils/format/formatNumber'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 import { DefaultSettings as DefaultTokenSettings } from '../components/pages/ProjectToken/hooks/ProjectTokenForm'
@@ -79,8 +80,8 @@ const parseCreateFlowStateFromInitialState = (
   }
 
   const reconfigurationRuleSelection =
-    BallotStrategies.find(
-      s => s.address === initialState.fundingCycleData.ballot,
+    BallotStrategies.find(s =>
+      isEqualAddress(s.address, initialState.fundingCycleData.ballot),
     )?.id ?? 'threeDay'
 
   let createFurthestPageReached: CreatePage = 'projectDetails'

--- a/src/components/Project/ArchiveProject.tsx
+++ b/src/components/Project/ArchiveProject.tsx
@@ -9,6 +9,7 @@ import { useWallet } from 'hooks/Wallet'
 import { uploadProjectMetadata } from 'lib/api/ipfs'
 import { revalidateProject } from 'lib/api/nextjs'
 import { useContext, useState } from 'react'
+import { isEqualAddress } from 'utils/address'
 import { emitErrorNotification } from 'utils/notifications'
 import { reloadWindow } from 'utils/windowUtils'
 
@@ -52,7 +53,7 @@ export function ArchiveProject({
   }
 
   const setArchived = (archived: boolean) => async () => {
-    if (!userAddress || userAddress.toLowerCase() !== owner?.toLowerCase()) {
+    if (!isEqualAddress(userAddress, owner)) {
       return emitErrorNotification(t`Connected wallet not authorized`)
     }
     setIsLoadingArchive(true)

--- a/src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
+++ b/src/components/ReconfigurationStrategy/ReconfigurationStrategySelector.tsx
@@ -1,8 +1,9 @@
 import { t, Trans } from '@lingui/macro'
 import { Space } from 'antd'
-import { useState } from 'react'
 import ReconfigurationStrategyOption from 'components/ReconfigurationStrategy/ReconfigurationStrategyOption'
 import { BallotStrategy } from 'models/ballot'
+import { useState } from 'react'
+import { isEqualAddress } from 'utils/address'
 import { createCustomStrategy } from 'utils/ballot'
 import FormItemWarningText from '../FormItemWarningText'
 import { CustomStrategyInput } from './CustomStrategyInput'
@@ -19,7 +20,7 @@ export default function ReconfigurationStrategySelector({
   onChange: (strategy: BallotStrategy) => void
 }) {
   const selectedStrategyIndex = ballotStrategies.findIndex(s => {
-    return s.address?.toLowerCase() === selectedStrategy.address?.toLowerCase()
+    return isEqualAddress(s.address, selectedStrategy.address)
   })
   const selectedIsCustom = selectedStrategyIndex === CUSTOM_STRATEGY_INDEX // selected strategy is the custom strategy
 
@@ -31,8 +32,10 @@ export default function ReconfigurationStrategySelector({
 
   return (
     <Space direction="vertical">
-      {ballotStrategies[selectedStrategyIndex]?.address ===
-        ballotStrategies[0].address && (
+      {isEqualAddress(
+        ballotStrategies[selectedStrategyIndex]?.address,
+        ballotStrategies[0].address,
+      ) && (
         <FormItemWarningText>
           <Trans>
             Using a reconfiguration strategy is recommended. Projects with no

--- a/src/components/formItems/formHelpers.tsx
+++ b/src/components/formItems/formHelpers.tsx
@@ -4,6 +4,7 @@ import { PayoutMod } from 'models/v1/mods'
 import { permyriadToPercent } from 'utils/format/formatNumber'
 
 import { Split } from 'models/splits'
+import { isEqualAddress } from 'utils/address'
 import { percentToPermyriad } from 'utils/format/formatNumber'
 
 export type ModalMode = 'Add' | 'Edit' | undefined
@@ -39,7 +40,7 @@ export function validateEthAddress(
   // If user edits an (already approved) address and doesn't change it, we accept
   if (
     modalMode === 'Edit' &&
-    address === mods[editingModIndex ?? 0]?.beneficiary
+    isEqualAddress(address, mods[editingModIndex ?? 0]?.beneficiary)
   )
     return Promise.resolve()
   else if (!address || !isAddress(address))

--- a/src/components/v2v3/shared/DistributionSplitCard.tsx
+++ b/src/components/v2v3/shared/DistributionSplitCard.tsx
@@ -13,6 +13,7 @@ import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
 import { PropsWithChildren, useContext, useState } from 'react'
+import { isEqualAddress } from 'utils/address'
 import { classNames } from 'utils/classNames'
 import { formatDate } from 'utils/format/formatDate'
 import { parseWad } from 'utils/format/formatNumber'
@@ -73,7 +74,8 @@ export function DistributionSplitCard({
   // !isProject added here because we don't want to show the crown next to
   // a project recipient whose token benefiary is the owner of this project
   const isOwner =
-    (projectOwnerAddress === split.beneficiary && !isProject) || isProjectOwner
+    (isEqualAddress(projectOwnerAddress, split.beneficiary) && !isProject) ||
+    isProjectOwner
 
   const distributionLimitIsInfinite =
     !distributionLimit || parseWad(distributionLimit).eq(MAX_DISTRIBUTION_LIMIT)

--- a/src/components/v2v3/shared/SplitItem/EthAddressBeneficiary.tsx
+++ b/src/components/v2v3/shared/SplitItem/EthAddressBeneficiary.tsx
@@ -1,7 +1,8 @@
+import { CrownFilled } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
 import FormattedAddress from 'components/FormattedAddress'
-import { CrownFilled } from '@ant-design/icons'
+import { isEqualAddress } from 'utils/address'
 
 export function ETHAddressBeneficiary({
   beneficaryAddress,
@@ -10,7 +11,7 @@ export function ETHAddressBeneficiary({
   beneficaryAddress: string | undefined
   projectOwnerAddress: string | undefined
 }) {
-  const isProjectOwner = projectOwnerAddress === beneficaryAddress
+  const isProjectOwner = isEqualAddress(projectOwnerAddress, beneficaryAddress)
 
   return (
     <div className="flex items-baseline font-medium">

--- a/src/components/v2v3/shared/SplitItem/JuiceboxProjectBeneficiary.tsx
+++ b/src/components/v2v3/shared/SplitItem/JuiceboxProjectBeneficiary.tsx
@@ -1,12 +1,13 @@
+import { CrownFilled } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Space, Tooltip } from 'antd'
+import FormattedAddress from 'components/FormattedAddress'
 import TooltipLabel from 'components/TooltipLabel'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
 import { Split } from 'models/splits'
+import { isEqualAddress } from 'utils/address'
 import { AllocatorBadge } from '../FundingCycleConfigurationDrawers/AllocatorBadge'
 import V2V3ProjectHandleLink from '../V2V3ProjectHandleLink'
-import { CrownFilled } from '@ant-design/icons'
-import FormattedAddress from 'components/FormattedAddress'
 
 export function JuiceboxProjectBeneficiary({
   projectOwnerAddress,
@@ -19,7 +20,7 @@ export function JuiceboxProjectBeneficiary({
 }) {
   if (!split.projectId) return null
 
-  const isProjectOwner = projectOwnerAddress === split.beneficiary
+  const isProjectOwner = isEqualAddress(projectOwnerAddress, split.beneficiary)
 
   return (
     <div>

--- a/src/constants/v1/ballotStrategies/getBallotStrategiesByAddress.ts
+++ b/src/constants/v1/ballotStrategies/getBallotStrategiesByAddress.ts
@@ -1,3 +1,4 @@
+import { isEqualAddress } from 'utils/address'
 import { createCustomStrategy } from 'utils/ballot'
 
 import { ballotStrategies } from '.'
@@ -5,8 +6,7 @@ import { ballotStrategies } from '.'
 // Put in separate files because lingui.js t macro was not working on ballot strategies
 export const getBallotStrategyByAddress = (address: string) => {
   const s =
-    ballotStrategies().find(
-      s => s.address.toLowerCase() === address.toLowerCase(),
-    ) ?? createCustomStrategy(address)
+    ballotStrategies().find(s => isEqualAddress(s.address, address)) ??
+    createCustomStrategy(address)
   return s
 }

--- a/src/hooks/IsUserAddress.ts
+++ b/src/hooks/IsUserAddress.ts
@@ -1,11 +1,8 @@
+import { isEqualAddress } from 'utils/address'
 import { useWallet } from './Wallet'
 
 export function useIsUserAddress(address: string | undefined) {
   const { userAddress } = useWallet()
 
-  return (
-    address !== undefined &&
-    userAddress !== undefined &&
-    address.toLowerCase() === userAddress.toLowerCase()
-  )
+  return isEqualAddress(address, userAddress)
 }

--- a/src/hooks/v1/contractReader/V1ConnectedWalletHasPermission.ts
+++ b/src/hooks/v1/contractReader/V1ConnectedWalletHasPermission.ts
@@ -2,6 +2,7 @@ import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { useWallet } from 'hooks/Wallet'
 import { V1OperatorPermission } from 'models/v1/permissions'
 import { useContext } from 'react'
+import { isEqualAddress } from 'utils/address'
 import { useProjectOwner } from './ProjectOwner'
 import { useV1HasPermissions } from './V1HasPermissions'
 
@@ -20,8 +21,7 @@ export function useV1ConnectedWalletHasPermission(
     permissionIndexes: Array.isArray(permission) ? permission : [permission],
   })
 
-  const isOwner =
-    userAddress && owner && userAddress.toLowerCase() === owner.toLowerCase()
+  const isOwner = isEqualAddress(userAddress, owner)
 
   return (
     isOwner || hasOperatorPermission || process.env.NODE_ENV === 'development'

--- a/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectController.ts
+++ b/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectController.ts
@@ -1,6 +1,7 @@
 import { V2V3ContractsContext } from 'contexts/v2v3/Contracts/V2V3ContractsContext'
 import { V2V3ContractName } from 'models/v2v3/contracts'
 import { useContext } from 'react'
+import { isEqualAddress } from 'utils/address'
 import useProjectControllerAddress from '../../contractReader/ProjectControllerAddress'
 import { useLoadV2V3Contract } from '../../LoadV2V3Contract'
 
@@ -14,12 +15,14 @@ export function useProjectController({ projectId }: { projectId: number }) {
 
   const JBController = useLoadV2V3Contract({
     cv,
-    contractName:
-      controllerAddress === contracts?.JBController
-        ? V2V3ContractName.JBController
-        : controllerAddress === contracts?.JBController3_0_1
-        ? V2V3ContractName.JBController3_0_1
-        : undefined,
+    contractName: isEqualAddress(
+      controllerAddress,
+      contracts?.JBController.address,
+    )
+      ? V2V3ContractName.JBController
+      : isEqualAddress(controllerAddress, contracts?.JBController3_0_1.address)
+      ? V2V3ContractName.JBController3_0_1
+      : undefined,
     address: controllerAddress,
   })
 

--- a/src/hooks/v2v3/contractReader/V2ConnectedWalletHasPermission.ts
+++ b/src/hooks/v2v3/contractReader/V2ConnectedWalletHasPermission.ts
@@ -3,6 +3,7 @@ import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useWallet } from 'hooks/Wallet'
 import { V2V3OperatorPermission } from 'models/v2v3/permissions'
 import { useContext } from 'react'
+import { isEqualAddress } from 'utils/address'
 import { useV2V3HasPermissions } from './V2V3HasPermissions'
 
 export function useV2ConnectedWalletHasPermission(
@@ -19,10 +20,7 @@ export function useV2ConnectedWalletHasPermission(
     permissions: Array.isArray(permission) ? permission : [permission],
   })
 
-  const isOwner =
-    userAddress &&
-    projectOwnerAddress &&
-    userAddress.toLowerCase() === projectOwnerAddress.toLowerCase()
+  const isOwner = isEqualAddress(userAddress, projectOwnerAddress)
 
   return (
     isOwner ||

--- a/src/utils/__tests__/address.test.ts
+++ b/src/utils/__tests__/address.test.ts
@@ -1,0 +1,24 @@
+import { isEqualAddress } from 'utils/address'
+
+describe('address utilities', () => {
+  describe('isEqualAddress', () => {
+    it.each`
+      addressA                                        | addressB                                        | expectedIsEqual
+      ${undefined}                                    | ${undefined}                                    | ${false}
+      ${''}                                           | ${''}                                           | ${false}
+      ${'not address'}                                | ${'not address'}                                | ${false}
+      ${'0x0028C35095D34C9C8a3bc84cB8542cB182fcfa8e'} | ${undefined}                                    | ${false}
+      ${undefined}                                    | ${'0x0028C35095D34C9C8a3bc84cB8542cB182fcfa8e'} | ${false}
+      ${'0x0028c35095d34c9c8a3bc84cb8542cb182fcfa8e'} | ${'0x0000000000000000000000000000000000000000'} | ${false}
+      ${'0x0000000000000000000000000000000000000000'} | ${'0x0028c35095d34c9c8a3bc84cb8542cb182fcfa8e'} | ${false}
+      ${'0x0028C35095D34C9C8a3bc84cB8542cB182fcfa8e'} | ${'0x0028C35095D34C9C8a3bc84cB8542cB182fcfa8e'} | ${true}
+      ${'0x0028C35095D34C9C8a3bc84cB8542cB182fcfa8e'} | ${'0x0028c35095d34c9c8a3bc84cb8542cb182fcfa8e'} | ${true}
+      ${'0x0028c35095d34c9c8a3bc84cb8542cb182fcfa8e'} | ${'0x0028C35095D34C9C8a3bc84cB8542cB182fcfa8e'} | ${true}
+    `(
+      'returns "$expectedIsEqual" when addressA is "$addressA" and addressB is "$addressB"',
+      ({ addressA, addressB, expectedIsEqual }) => {
+        expect(isEqualAddress(addressA, addressB)).toBe(expectedIsEqual)
+      },
+    )
+  })
+})

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,27 @@
+import { getAddress } from 'ethers/lib/utils'
+
+export function safeGetAddress(
+  address: string | undefined,
+): string | undefined {
+  if (!address) return undefined
+  try {
+    return getAddress(address)
+  } catch (e) {
+    return undefined
+  }
+}
+
+/**
+ * Compare two addresses. Returns true if:
+ * - both arguments exist
+ * - both arguments are valid Ethereum addresses
+ * - both arguments are the same address.
+ */
+export function isEqualAddress(
+  a: string | undefined,
+  b: string | undefined,
+): boolean {
+  const addressA = safeGetAddress(a)
+  const addressB = safeGetAddress(b)
+  return Boolean(addressA && addressB && addressA === addressB)
+}

--- a/src/utils/safe.ts
+++ b/src/utils/safe.ts
@@ -1,4 +1,5 @@
 import { GnosisSafe, SafeTransactionType } from 'models/safe'
+import { isEqualAddress } from './address'
 
 // e.g. [ {nonce: 69}, {nonce: 45}, {nonce: 69}] returns [69, 45]
 export function getUniqueNonces(
@@ -21,8 +22,8 @@ export function getUnsignedTxsForAddress({
 }) {
   return transactions?.filter(
     (tx: SafeTransactionType) =>
-      !tx?.confirmations?.some(
-        confirmation => confirmation.owner.toLowerCase() === address,
+      !tx?.confirmations?.some(confirmation =>
+        isEqualAddress(confirmation.owner, address),
       ),
   )
 }
@@ -36,7 +37,5 @@ export function isSafeSigner({
   safe: GnosisSafe
 }) {
   if (!address) return false
-  return safe.owners.some(
-    owner => owner.toLowerCase() === address.toLowerCase(),
-  )
+  return safe.owners.some(owner => isEqualAddress(owner, address))
 }

--- a/src/utils/v1/terminals.ts
+++ b/src/utils/v1/terminals.ts
@@ -5,6 +5,7 @@ import { V1TerminalVersion } from 'models/v1/terminals'
 import { V1TerminalName } from 'models/v1/terminals'
 
 import { readNetwork } from 'constants/networks'
+import { isEqualAddress } from 'utils/address'
 
 const loadTerminalAddress = (
   network: NetworkName,
@@ -30,21 +31,19 @@ export const getTerminalVersion = (
   if (!address) return
 
   if (
-    address.toLowerCase() ===
-    loadTerminalAddress(
-      readNetwork.name,
-      V1ContractName.TerminalV1,
-    ).toLowerCase()
+    isEqualAddress(
+      address,
+      loadTerminalAddress(readNetwork.name, V1ContractName.TerminalV1),
+    )
   ) {
     return '1'
   }
 
   if (
-    address.toLowerCase() ===
-    loadTerminalAddress(
-      readNetwork.name,
-      V1ContractName.TerminalV1_1,
-    ).toLowerCase()
+    isEqualAddress(
+      address,
+      loadTerminalAddress(readNetwork.name, V1ContractName.TerminalV1_1),
+    )
   ) {
     return '1.1'
   }

--- a/src/utils/v2v3/ballotStrategies.ts
+++ b/src/utils/v2v3/ballotStrategies.ts
@@ -1,12 +1,12 @@
 import { ballotStrategiesFn } from 'constants/v2v3/ballotStrategies'
 import { BallotStrategy } from 'models/ballot'
+import { isEqualAddress } from 'utils/address'
 import { createCustomStrategy } from 'utils/ballot'
 
 // Put in separate files because lingui.js t macro was not working on ballot strategies
 export const getBallotStrategyByAddress = (address: string): BallotStrategy => {
   const s =
-    ballotStrategiesFn().find(
-      s => s.address.toLowerCase() === address.toLowerCase(),
-    ) ?? createCustomStrategy(address)
+    ballotStrategiesFn().find(s => isEqualAddress(s.address, address)) ??
+    createCustomStrategy(address)
   return s
 }


### PR DESCRIPTION
## What does this PR do and why?

Introduces 2 util fns:
- safeGetAddress - ethers `getAddress` but doesn't throw if invalid
- isEqualAddress - compare two addresses

Uses `isEqualAddress` where ever we we previously comparing addresses using `toLowerCase` or otherwise.
