### PR TITLE
IPFS Retries for sepana projects + sepana db schema

### DIFF
--- a/src/lib/sepana/api/generic.ts
+++ b/src/lib/sepana/api/generic.ts
@@ -54,6 +54,16 @@ export async function getRecord<T extends object>(id: string) {
  * @param records Projects to write to Sepana database
  */
 export async function writeSepanaRecords(records: Json<SepanaProject>[]) {
+  const missingIds = records.filter(r => r.id === undefined || r.id === null)
+
+  if (missingIds.length) {
+    throw new Error(
+      `${missingIds.length} records are missing an id: ${missingIds
+        .map(p => JSON.stringify(p))
+        .join(', ')}`,
+    )
+  }
+
   const jobs: string[] = []
   const errors: (string | object)[] = []
   const written: Json<SepanaProject>[] = []
@@ -63,7 +73,14 @@ export async function writeSepanaRecords(records: Json<SepanaProject>[]) {
   let page = 0
 
   while (records.length > pageSize * page) {
-    const queue = records.slice(pageSize * page, pageSize * (page + 1))
+    const queue = records
+      .slice(pageSize * page, pageSize * (page + 1))
+      .map(r => ({
+        ...r,
+        // Upserting data in Sepana requires the `_id` param to be included, so we always include it here using `_source.id`
+        // https://docs.sepana.io/sepana-search-api/web3-search-cloud/search-api#request-example-2
+        _id: r.id,
+      }))
 
     await sepanaAxios('read/write')
       .post<{ job_id: string }>(SEPANA_ENDPOINTS.insert, {

--- a/src/lib/sepana/constants.ts
+++ b/src/lib/sepana/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Max number of attempts to resolve IPFS metadata for a project in sepana
+ */
+export const MAX_METADATA_RETRIES = 3
+
+/**
+ * Current version of sepana project model. Any projects not matching the current version will be forced to update.
+ */
+export const CURRENT_VERSION = '1'

--- a/src/models/sepana.ts
+++ b/src/models/sepana.ts
@@ -2,24 +2,30 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { AnyProjectMetadata } from 'models/projectMetadata'
 
 import { PV } from './pv'
+import { Project } from './subgraph-entities/vX/project'
+
+export type SGSepanaCompareKey = Extract<keyof Project, keyof SepanaProject>
 
 export type SepanaProject = {
   id: string
   projectId: number
   createdAt: number
   pv: PV
-  handle: string | null | undefined
+  handle: string | null
   metadataUri: string
   currentBalance: BigNumber
   trendingScore: BigNumber
   totalPaid: BigNumber
-  deployer: string | null | undefined
+  deployer: string | null
+  terminal: string | null
   name?: string
   description?: string
   logoUri?: string
-  hasUnresolvedMetadata?: boolean // Helper method to signify if metadata has been successfully resolved from IPFS
+  _hasUnresolvedMetadata?: boolean // Helper property to signify if metadata has been successfully resolved from IPFS
+  _metadataRetriesLeft?: number // Helper property allowing us to only retry resolving metadata a finite number of times. Useful for invalid metadataUris or uris pointing to unpinned content
+  _version?: string
 } & Pick<AnyProjectMetadata, 'description' | 'logoUri' | 'name'> & {
-    lastUpdated: number
+    _lastUpdated: number // Millis timestamp of last updated
   }
 
 export type SepanaQueryResponse<T> = {

--- a/src/pages/api/sepana/update.page.ts
+++ b/src/pages/api/sepana/update.page.ts
@@ -17,7 +17,7 @@ import {
 const handler: NextApiHandler = async (req, res) => {
   try {
     // This flag will let us know we should retry resolving IPFS data for projects that are missing it
-    const retryIpfs = req.body['retryIPFS'] === true
+    const retryIpfs = req.body.retryIPFS === true
 
     // Load all projects from Sepana, store in dict
     const sepanaProjects = (

--- a/src/pages/api/sepana/update.page.ts
+++ b/src/pages/api/sepana/update.page.ts
@@ -1,132 +1,80 @@
 import { isBigNumberish } from '@ethersproject/bignumber/lib/bignumber'
-import { readProvider } from 'constants/readProvider'
-import { infuraApi } from 'lib/infura/ipfs'
 import { queryAll, writeSepanaRecords } from 'lib/sepana/api'
 import { sepanaLog } from 'lib/sepana/log'
 import { Json } from 'models/json'
-import { AnyProjectMetadata } from 'models/projectMetadata'
 import { SepanaProject } from 'models/sepana'
-import { Project } from 'models/subgraph-entities/vX/project'
 import { NextApiHandler } from 'next'
 import { formatError } from 'utils/format/formatError'
 import { formatWad } from 'utils/format/formatNumber'
 import { querySubgraphExhaustiveRaw } from 'utils/graph'
-import { openIpfsUrl } from 'utils/ipfs'
-
-type ProjectKey =
-  | 'id'
-  | 'projectId'
-  | 'pv'
-  | 'handle'
-  | 'metadataUri'
-  | 'currentBalance'
-  | 'totalPaid'
-  | 'createdAt'
-  | 'trendingScore'
-  | 'deployer'
-
-const projectKeys: ProjectKey[] = [
-  'id',
-  'projectId',
-  'pv',
-  'handle',
-  'metadataUri',
-  'currentBalance',
-  'totalPaid',
-  'createdAt',
-  'trendingScore',
-  'deployer',
-]
+import {
+  getChangedSubgraphProjects,
+  sgSepanaCompareKeys,
+  tryResolveMetadata,
+} from 'utils/sepana'
 
 // Synchronizes the Sepana engine with the latest Juicebox Subgraph/IPFS data
 const handler: NextApiHandler = async (req, res) => {
   try {
     // This flag will let us know we should retry resolving IPFS data for projects that are missing it
-    const retryIPFS = req.method === 'POST' && req.body['retryIPFS'] === true
+    const retryIpfs = req.body['retryIPFS'] === true
 
-    // Load all projects from Sepana
-    const sepanaProjects = (await queryAll<Json<SepanaProject>>()).data.hits
-      .hits
+    // Load all projects from Sepana, store in dict
+    const sepanaProjects = (
+      await queryAll<Json<SepanaProject>>()
+    ).data.hits.hits.reduce(
+      (acc, curr) => ({ ...acc, [curr._source.id]: curr._source }),
+      {} as Record<string, Json<SepanaProject>>,
+    )
 
     // Load all projects from Subgraph
     const subgraphProjects = await querySubgraphExhaustiveRaw({
       entity: 'project',
-      keys: projectKeys,
+      keys: sgSepanaCompareKeys,
     })
 
-    // Store record of Sepana project properties that need updating
-    const updatedProperties: {
-      [id: string]: {
-        key: string
-        oldVal: string | undefined | null
-        newVal: string | undefined | null
-      }[]
-    } = {}
-    const idsOfNewProjects: Set<string> = new Set()
-    let missingMetadataCount = 0
-
-    // Get a list of Subgraph projects that aren't found in Sepana or don't match Sepana record
-    const changedSubgraphProjects = subgraphProjects.filter(subgraphProject => {
-      const id = subgraphProject.id
-
-      const sepanaProject = sepanaProjects.find(
-        p => subgraphProject.id === p._source.id,
-      )
-
-      if (!sepanaProject) {
-        idsOfNewProjects.add(id)
-        return true
-      }
-
-      if (sepanaProject._source.hasUnresolvedMetadata) {
-        missingMetadataCount++
-        if (retryIPFS) return true
-      }
-
-      // Deep compare Subgraph project vs. Sepana project and find any discrepancies
-      const propertiesToUpdate = projectKeys.filter(k => {
-        const oldVal = sepanaProject?._source[k]
-        const newVal = subgraphProject[k]
-
-        // Store a record of properties that need updating
-        if (oldVal !== newVal) {
-          updatedProperties[id] = [
-            ...(updatedProperties[id] ?? []),
-            {
-              key: k,
-              oldVal: oldVal?.toString(),
-              newVal: newVal?.toString(),
-            },
-          ]
-          return true
-        }
-
-        return false
-      })
-
-      // Return true if any properties are out of date
-      return propertiesToUpdate.length
+    const {
+      changedSubgraphProjects,
+      retryMetadataCount,
+      updatedProperties,
+      idsOfNewProjects,
+    } = getChangedSubgraphProjects({
+      subgraphProjects,
+      sepanaProjects,
+      retryIpfs,
     })
 
-    const lastUpdated = await readProvider.getBlockNumber()
+    const resolveMetadataResults = await Promise.all(
+      changedSubgraphProjects.map(subgraphProject => {
+        const sepanaProject = sepanaProjects[subgraphProject.id]
 
-    const metadataResults = await Promise.all(
-      changedSubgraphProjects.map(p => tryResolveMetadata(p, lastUpdated)),
+        return tryResolveMetadata({
+          subgraphProject,
+          ...sepanaProject,
+        })
+      }),
     )
 
-    const ipfsErrors = metadataResults.filter(r => r.error)
+    const _lastUpdated = Date.now()
+
+    const sepanaProjectResults = resolveMetadataResults.map(r => ({
+      ...r,
+      project: { ...r.project, _lastUpdated }, // add _lastUpdated to all projects
+    }))
+
+    const ipfsErrors = sepanaProjectResults.filter(r => r.error)
 
     // Write all updated projects (even those with missing metadata)
-    const { jobs, written: updatedProjects } = await writeSepanaRecords(
-      metadataResults.map(r => r.project),
+    const { jobs, written: updatedSepanaProjects } = await writeSepanaRecords(
+      sepanaProjectResults.map(r => r.project),
     )
 
     // Formatted message used for log reporting
     const reportString = `Jobs: ${jobs.join(',')}${
-      retryIPFS
-        ? `\nRetried resolving metadata for ${missingMetadataCount}`
+      retryMetadataCount
+        ? `\nRetried resolving metadata for ${retryMetadataCount}`
         : ''
-    }\n\n${metadataResults
+    }\n\n${sepanaProjectResults
       .filter(r => !r.error)
       .map(r => {
         const {
@@ -140,19 +88,19 @@ const handler: NextApiHandler = async (req, res) => {
           idsOfNewProjects.has(id as string)
             ? 'New'
             : updatedProperties[id]
-                .map(
+                ?.map(
                   prop =>
                     `${prop.key}: ${formatBigNumberish(
                       prop.oldVal,
                     )} -> ${formatBigNumberish(prop.newVal)}`,
                 )
-                .join(', ')
+                .join(', ') ?? 'no changes'
         })_`
       })
       .join('\n')}`
 
     // Log if any projects were updated
-    if (updatedProjects.length) {
+    if (updatedSepanaProjects.length) {
       await sepanaLog(
         ipfsErrors.length
           ? {
@@ -163,7 +111,7 @@ const handler: NextApiHandler = async (req, res) => {
               } projects:\n${ipfsErrors
                 .map(
                   e =>
-                    `\`[${e.project.id}]\` metadataURI: \`${e.project.metadataUri}\` _${e.error}_`,
+                    `\`[${e.project.id}]\` metadataURI: \`${e.project.metadataUri}\`, ${e.retriesRemaining} retries remaining. _${e.error}_`,
                 )
                 .join('\n')}\n\n${reportString}`,
             }
@@ -178,8 +126,8 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(200).json({
       network: process.env.NEXT_PUBLIC_INFURA_NETWORK,
       updates: {
-        projects: updatedProjects,
-        count: updatedProjects.length,
+        projects: updatedSepanaProjects,
+        count: updatedSepanaProjects.length,
         jobs,
       },
       errors: { ipfsErrors, count: ipfsErrors.length },
@@ -198,69 +146,6 @@ const handler: NextApiHandler = async (req, res) => {
       message: 'Error updating Sepana projects',
       error: _error,
     })
-  }
-}
-
-async function tryResolveMetadata(
-  project: Json<Pick<Project, ProjectKey>>,
-  lastUpdated: number,
-) {
-  // Upserting data in Sepana requires the `_id` param to be included, so we always include it here and use the subgraph ID
-  // https://docs.sepana.io/sepana-search-api/web3-search-cloud/search-api#request-example-2
-  const { id: _id, metadataUri } = project
-
-  if (!metadataUri) {
-    return {
-      project: {
-        ...project,
-        _id,
-        name: undefined,
-        description: undefined,
-        logoUri: undefined,
-        lastUpdated,
-        hasUnresolvedMetadata: false,
-      },
-    }
-  }
-
-  try {
-    const {
-      data: { logoUri, name, description },
-    } = await infuraApi.get<AnyProjectMetadata>(
-      openIpfsUrl(project.metadataUri),
-      {
-        responseType: 'json',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-
-    return {
-      project: {
-        ...project,
-        _id,
-        name,
-        description,
-        logoUri,
-        lastUpdated,
-        hasUnresolvedMetadata: false,
-      },
-    }
-  } catch (error) {
-    return {
-      error: formatError(error),
-      project: {
-        ...project,
-        _id,
-        name: undefined,
-        description: undefined,
-        logoUri: undefined,
-        lastUpdated,
-        hasUnresolvedMetadata: true, // If there is an error resolving metadata from IPFS, we'll flag it as `hasUnresolvedMetadata: true`. We'll try getting it again whenever `retryIPFS == true`.
-      },
-    }
   }
 }
 

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -100,3 +100,9 @@ export function decodeEncodedIPFSUri(hex: string) {
 export function isIpfsUrl(url: string) {
   return url.startsWith('ipfs://')
 }
+
+export function isIpfsCID(cid: string) {
+  return (
+    cid.startsWith('Qm') || cid.startsWith('bafy') || cid.startsWith('bafk')
+  )
+}

--- a/src/utils/sepana.ts
+++ b/src/utils/sepana.ts
@@ -1,6 +1,27 @@
+import { infuraApi } from 'lib/infura/ipfs'
+import { CURRENT_VERSION, MAX_METADATA_RETRIES } from 'lib/sepana/constants'
 import { Json } from 'models/json'
-import { SepanaProject } from 'models/sepana'
+import { AnyProjectMetadata } from 'models/projectMetadata'
+import { SepanaProject, SGSepanaCompareKey } from 'models/sepana'
+import { Project } from 'models/subgraph-entities/vX/project'
+
+import { formatError } from './format/formatError'
 import { parseBigNumberKeyVals } from './graph'
+import { isIpfsCID, openIpfsUrl } from './ipfs'
+
+export const sgSepanaCompareKeys: SGSepanaCompareKey[] = [
+  'id',
+  'projectId',
+  'pv',
+  'handle',
+  'metadataUri',
+  'currentBalance',
+  'totalPaid',
+  'createdAt',
+  'trendingScore',
+  'deployer',
+  'terminal',
+]
 
 export const parseSepanaProjectJson = (
   j: Json<SepanaProject>,
@@ -8,3 +29,145 @@ export const parseSepanaProjectJson = (
   ...j,
   ...parseBigNumberKeyVals(j, ['currentBalance', 'totalPaid', 'trendingScore']),
 })
+
+export function getChangedSubgraphProjects({
+  subgraphProjects,
+  sepanaProjects,
+  retryIpfs,
+}: {
+  subgraphProjects: Json<Pick<Project, SGSepanaCompareKey>>[]
+  sepanaProjects: Record<string, Json<SepanaProject>>
+  retryIpfs?: boolean
+}) {
+  const idsOfNewProjects = new Set<string>([])
+
+  const updatedProperties: {
+    [id: string]: {
+      key: string
+      oldVal: string | undefined | null
+      newVal: string | undefined | null
+    }[]
+  } = {}
+
+  let retryMetadataCount = 0
+
+  const changedSubgraphProjects = subgraphProjects.filter(subgraphProject => {
+    const id = subgraphProject.id
+
+    const sepanaProject = sepanaProjects[subgraphProject.id]
+
+    if (!sepanaProject) {
+      idsOfNewProjects.add(id)
+      return true
+    }
+
+    if (sepanaProject._version !== CURRENT_VERSION) {
+      return true
+    }
+
+    const { _hasUnresolvedMetadata, _metadataRetriesLeft } = sepanaProject
+
+    if (
+      retryIpfs &&
+      _hasUnresolvedMetadata &&
+      (_metadataRetriesLeft || _metadataRetriesLeft === undefined)
+    ) {
+      retryMetadataCount++
+      return true
+    }
+
+    // Deep compare Subgraph project vs. Sepana project and find any discrepancies
+    const propertiesToUpdate = sgSepanaCompareKeys.filter(k => {
+      const oldVal = sepanaProject[k]
+      const newVal = subgraphProject[k]
+
+      // Store a record of properties that need updating
+      if (oldVal !== newVal) {
+        updatedProperties[id] = [
+          ...(updatedProperties[id] ?? []),
+          {
+            key: k,
+            oldVal: oldVal?.toString(),
+            newVal: newVal?.toString(),
+          },
+        ]
+        return true
+      }
+
+      return false
+    })
+
+    // Return true if any properties are out of date
+    return propertiesToUpdate.length
+  })
+
+  return {
+    changedSubgraphProjects,
+    updatedProperties,
+    retryMetadataCount,
+    idsOfNewProjects,
+  }
+}
+
+export async function tryResolveMetadata({
+  subgraphProject,
+  _metadataRetriesLeft,
+  _hasUnresolvedMetadata,
+}: {
+  subgraphProject: Json<Pick<Project, SGSepanaCompareKey>>
+} & Partial<
+  Pick<SepanaProject, '_hasUnresolvedMetadata' | '_metadataRetriesLeft'>
+>) {
+  const { metadataUri } = subgraphProject
+
+  // if metadataUri is missing or invalid, or no retries remaining for unresolved metadata
+  if (
+    !metadataUri ||
+    !isIpfsCID(metadataUri) ||
+    (_hasUnresolvedMetadata && _metadataRetriesLeft === 0)
+  ) {
+    return {
+      project: {
+        ...subgraphProject,
+        _hasUnresolvedMetadata: true,
+        _metadataRetriesLeft: 0,
+      } as Json<SepanaProject>,
+    }
+  }
+
+  try {
+    const {
+      data: { name, description, logoUri },
+    } = await infuraApi.get<AnyProjectMetadata>(openIpfsUrl(metadataUri), {
+      responseType: 'json',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+
+    return {
+      project: {
+        ...subgraphProject,
+        name,
+        description,
+        logoUri,
+      } as Json<SepanaProject>,
+    }
+  } catch (error) {
+    // decrement metadataRetriesLeft, or set to max if previously unset
+    const retriesRemaining = _metadataRetriesLeft
+      ? _metadataRetriesLeft - 1
+      : MAX_METADATA_RETRIES
+
+    return {
+      error: formatError(error),
+      retriesRemaining,
+      project: {
+        ...subgraphProject,
+        _hasUnresolvedMetadata: true,
+        _metadataRetriesLeft: retriesRemaining,
+      } as Json<SepanaProject>,
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do and why?

- Introduces a new pattern for limiting the number of times we retry resolving IPFS metadata for projects on sepana. Especially important for projects with invalid `metadataUri`s, or unpinned metadata
- Updates to the project schema in the sepana db:
    - internal vars are prefixed with `_`
    - `_lastUpdated` is now a millis timestamp instead of a block number
    - adds new `_version` property useful for future changes to the schema, when we need to force projects to update
- general cleanup of sepana update routine

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
