### PR TITLE
Add troubleshoot and reset buttons to error notifications

### DIFF
--- a/src/components/ErrorNotificationButtons.tsx
+++ b/src/components/ErrorNotificationButtons.tsx
@@ -2,6 +2,7 @@ import { Button, Space } from 'antd'
 import { helpPagePath } from 'utils/routes'
 import { WarningOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
+import LanguageProvider from 'contexts/Language/LanguageProvider'
 
 const resetSite = () => {
   localStorage.clear()
@@ -12,23 +13,25 @@ const resetSite = () => {
 
 export default function ErrorNotificationButtons() {
   return (
-    <Space>
-      <Button
-        type="link"
-        size="small"
-        href={helpPagePath('/user/resources/troubleshoot/')}
-      >
-        <Trans>Troubleshoot</Trans>
-      </Button>
-      <Button
-        icon={<WarningOutlined />}
-        className="bg-error-500 dark:bg-error-300"
-        type="primary"
-        size="small"
-        onClick={resetSite}
-      >
-        <Trans>Reset Website</Trans>
-      </Button>
-    </Space>
+    <LanguageProvider>
+      <Space>
+        <Button
+          type="link"
+          size="small"
+          href={helpPagePath('/user/resources/troubleshoot/')}
+        >
+          <Trans>Troubleshoot</Trans>
+        </Button>
+        <Button
+          icon={<WarningOutlined />}
+          className="bg-error-500 dark:bg-error-300"
+          type="primary"
+          size="small"
+          onClick={resetSite}
+        >
+          <Trans> Reset Website</Trans>
+        </Button>
+      </Space>
+    </LanguageProvider>
   )
 }

--- a/src/components/ErrorNotificationButtons.tsx
+++ b/src/components/ErrorNotificationButtons.tsx
@@ -1,0 +1,34 @@
+import { Button, Space } from 'antd'
+import { helpPagePath } from 'utils/routes'
+import { WarningOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
+
+const resetSite = () => {
+  localStorage.clear()
+  sessionStorage.clear()
+  // eslint-disable-next-line no-self-assign
+  window.location.href = window.location.href
+}
+
+export default function ErrorNotificationButtons() {
+  return (
+    <Space>
+      <Button
+        type="link"
+        size="small"
+        href={helpPagePath('/user/resources/troubleshoot/')}
+      >
+        <Trans>Troubleshoot</Trans>
+      </Button>
+      <Button
+        icon={<WarningOutlined />}
+        className="bg-error-500 dark:bg-error-300"
+        type="primary"
+        size="small"
+        onClick={resetSite}
+      >
+        <Trans>Reset Website</Trans>
+      </Button>
+    </Space>
+  )
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2666,6 +2666,9 @@ msgstr ""
 msgid "Reserved {tokenTextPlural}: <0>{reservedTokensFormatted} {tokenTextPlural}</0>"
 msgstr ""
 
+msgid "Reset Website"
+msgstr ""
+
 msgid "Resources"
 msgstr ""
 
@@ -3444,6 +3447,9 @@ msgid "Trending"
 msgstr ""
 
 msgid "Trending projects"
+msgstr ""
+
+msgid "Troubleshoot"
 msgstr ""
 
 msgid "Twitter"

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,4 +1,5 @@
 import { notification } from 'antd'
+import ErrorNotificationButtons from 'components/ErrorNotificationButtons'
 
 /**
  * @param message Title of notification
@@ -15,6 +16,7 @@ export const emitErrorNotification = (
   const key = new Date().valueOf().toString()
   return notification.error({
     key,
+    btn: ErrorNotificationButtons(),
     message,
     ...opts,
     duration: opts?.duration ?? null,


### PR DESCRIPTION
## What does this PR do and why?

Add troubleshoot and reset buttons to error notifications

## Screenshots or screen recordings

![1676380079](https://user-images.githubusercontent.com/96905094/218749130-1c48234a-635d-41ab-96e3-d40281dc8acc.png)

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
