### PR TITLE
Compatibility with subgraph v6.0.0

### DIFF
--- a/src/components/Project/ArchiveProject.tsx
+++ b/src/components/Project/ArchiveProject.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Space, Statistic } from 'antd'
 import axios from 'axios'
 import { Callout } from 'components/Callout'
-import { PV_V1, PV_V1_1, PV_V2 } from 'constants/pv'
+import { PV_V1, PV_V2 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useWallet } from 'hooks/Wallet'
@@ -33,7 +33,6 @@ export function ArchiveProject({
   const revalidateProjectAfterArchive = async () => {
     switch (pv) {
       case PV_V1:
-      case PV_V1_1:
         if (handle) {
           await revalidateProject({
             pv,

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import * as constants from '@ethersproject/constants'
 import { Trans } from '@lingui/macro'
 import { Skeleton } from 'antd'
-import { PV_V1, PV_V1_1, PV_V2 } from 'constants/pv'
+import { PV_V1, PV_V2 } from 'constants/pv'
 import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
 import { V2ArchivedProjectIds } from 'constants/v2v3/archivedProjects'
 import { useProjectHandleText } from 'hooks/ProjectHandleText'
@@ -117,7 +117,7 @@ export default function ProjectCard({
       : projectCardHref
 
   const isArchived =
-    ((projectCardData.pv === PV_V1 || projectCardData.pv === PV_V1_1) &&
+    (projectCardData.pv === PV_V1 &&
       V1ArchivedProjectIds.includes(projectCardData.projectId)) ||
     (projectCardData.pv === PV_V2 &&
       V2ArchivedProjectIds.includes(projectCardData.projectId)) ||

--- a/src/components/activityEventElems/BurnEventElem.tsx
+++ b/src/components/activityEventElems/BurnEventElem.tsx
@@ -1,0 +1,32 @@
+import { t } from '@lingui/macro'
+import { BurnEvent } from 'models/subgraph-entities/vX/burn-event'
+import { formatWad } from 'utils/format/formatNumber'
+import { tokenSymbolText } from 'utils/tokenSymbolText'
+
+import { ActivityEvent } from './ActivityElement'
+
+export default function BurnEventElem({
+  event,
+  tokenSymbol,
+}: {
+  event:
+    | Pick<BurnEvent, 'amount' | 'timestamp' | 'caller' | 'id' | 'txHash'>
+    | undefined
+  tokenSymbol: string | undefined
+}) {
+  if (!event) return null
+  return (
+    <ActivityEvent
+      event={event}
+      header={t`Burned`}
+      subject={
+        <span className="text-base font-medium">
+          {formatWad(event.amount)}{' '}
+          {tokenSymbolText({
+            tokenSymbol,
+          })}
+        </span>
+      }
+    />
+  )
+}

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -1,6 +1,6 @@
 import { plural, t, Trans } from '@lingui/macro'
 import ETHAmount from 'components/currency/ETHAmount'
-import { ThemeContext } from 'contexts/Theme/ThemeContext'
+import RichNote from 'components/RichNote'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { RedeemEvent } from 'models/subgraph-entities/vX/redeem-event'
 import { useContext } from 'react'
@@ -26,13 +26,11 @@ export default function RedeemEventElem({
         | 'returnAmount'
         | 'terminal'
         | 'metadata'
+        | 'memo'
       >
     | undefined
 }) {
   const { tokenSymbol } = useContext(V1ProjectContext)
-  const {
-    theme: { colors },
-  } = useContext(ThemeContext)
 
   if (!event) return null
 
@@ -75,10 +73,16 @@ export default function RedeemEventElem({
         </div>
       }
       extra={
-        <div style={{ color: colors.text.secondary }}>
+        <div className="text-grey-900 dark:text-slate-100">
           <Trans>
             <ETHAmount amount={event.returnAmount} /> overflow received
           </Trans>
+          {event.memo && (
+            <>
+              <br />
+              <RichNote note={event.memo} />
+            </>
+          )}
         </div>
       }
     />

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -77,12 +77,7 @@ export default function RedeemEventElem({
           <Trans>
             <ETHAmount amount={event.returnAmount} /> overflow received
           </Trans>
-          {event.memo && (
-            <>
-              <br />
-              <RichNote note={event.memo} />
-            </>
-          )}
+          {event.memo && <RichNote className="mt-4" note={event.memo} />}
         </div>
       }
     />

--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -2,7 +2,6 @@ import { t, Trans } from '@lingui/macro'
 import { Modal } from 'antd'
 import InputAccessoryButton from 'components/buttons/InputAccessoryButton'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
-import { PV_V1, PV_V1_1 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { useBlockNumber } from 'hooks/BlockNumber'
 import { SGQueryOpts } from 'models/graph'
@@ -39,17 +38,10 @@ export function DownloadParticipantsModal({
     if (blockNumber === undefined || !projectId || !pv) return
 
     // Projects that migrate between 1 & 1.1 may change their PV without the PV of their participants being updated. This should be fixed by better subgraph infrastructure, but this fix will make sure the UI works for now.
-    const pvOpt: SGQueryOpts<'participant', keyof Participant>['where'] =
-      pv === PV_V1 || pv === PV_V1_1
-        ? {
-            key: 'pv',
-            operator: 'in',
-            value: [PV_V1, PV_V1_1],
-          }
-        : {
-            key: 'pv',
-            value: pv,
-          }
+    const pvOpt: SGQueryOpts<'participant', keyof Participant>['where'] = {
+      key: 'pv',
+      value: pv,
+    }
 
     const rows = [
       [

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -11,7 +11,6 @@ import { Callout } from 'components/Callout'
 import ETHAmount from 'components/currency/ETHAmount'
 import FormattedAddress from 'components/FormattedAddress'
 import Loading from 'components/Loading'
-import { PV_V1, PV_V1_1 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { SGOrderDir, SGQueryOpts } from 'models/graph'
 import { Participant } from 'models/subgraph-entities/vX/participant'
@@ -68,17 +67,10 @@ export default function ParticipantsModal({
     }
 
     // Projects that migrate between 1 & 1.1 may change their PV without the PV of their participants being updated. This should be fixed by better subgraph infrastructure, but this fix will make sure the UI works for now.
-    const pvOpt: SGQueryOpts<'participant', keyof Participant>['where'] =
-      pv === PV_V1 || pv === PV_V1_1
-        ? {
-            key: 'pv',
-            operator: 'in',
-            value: [PV_V1, PV_V1_1],
-          }
-        : {
-            key: 'pv',
-            value: pv,
-          }
+    const pvOpt: SGQueryOpts<'participant', keyof Participant>['where'] = {
+      key: 'pv',
+      value: pv,
+    }
 
     querySubgraph({
       entity: 'participant',

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/V1ConfigureEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/V1ConfigureEventElem.tsx
@@ -5,11 +5,13 @@ import FormattedAddress from 'components/FormattedAddress'
 import MinimalTable from 'components/MinimalTable'
 import { SECONDS_IN_DAY } from 'constants/numbers'
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
+import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { V1ConfigureEvent } from 'models/subgraph-entities/v1/v1-configure'
+import { useContext } from 'react'
 import {
   formatWad,
   perbicentToPercent,
-  permilleToPercent,
+  permilleToPercent
 } from 'utils/format/formatNumber'
 import { detailedTimeString } from 'utils/format/formatTime'
 import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
@@ -36,6 +38,8 @@ export default function V1ConfigureEventElem({
       >
     | undefined
 }) {
+  const { terminal } = useContext(V1ProjectContext)
+
   if (!event) return null
 
   function BallotStrategyElem(ballot: string) {
@@ -97,16 +101,20 @@ export default function V1ConfigureEventElem({
                 value: BallotStrategyElem(event.ballot),
               },
             ],
-            [
-              {
-                key: t`Token printing allowed`,
-                value: event.ticketPrintingIsAllowed,
-              },
-              {
-                key: t`Payments paused`,
-                value: event.payIsPaused,
-              },
-            ],
+            ...(terminal?.version === '1.1'
+              ? [
+                  [
+                    {
+                      key: t`Token printing allowed`,
+                      value: event.ticketPrintingIsAllowed,
+                    },
+                    {
+                      key: t`Payments paused`,
+                      value: event.payIsPaused,
+                    },
+                  ],
+                ]
+              : []),
           ]}
         />
       }

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -33,6 +33,7 @@ import { V1DownloadActivityModal } from './V1DownloadActivityModal'
 type EventFilter =
   | 'all'
   | 'pay'
+  | 'burn'
   | 'addToBalance'
   | 'redeem'
   | 'withdraw'
@@ -82,6 +83,9 @@ export default function ProjectActivity() {
         break
       case 'pay':
         key = 'payEvent'
+        break
+      case 'burn':
+        key = 'burnEvent'
         break
       case 'addToBalance':
         key = 'addToBalanceEvent'
@@ -341,6 +345,9 @@ export default function ProjectActivity() {
             </Select.Option>
             <Select.Option value="redeem">
               <Trans>Redeemed</Trans>
+            </Select.Option>
+            <Select.Option value="burn">
+              <Trans>Burned</Trans>
             </Select.Option>
             <Select.Option value="withdraw">
               <Trans>Distributed funds</Trans>

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -9,7 +9,7 @@ import ProjectCreateEventElem from 'components/activityEventElems/ProjectCreateE
 import RedeemEventElem from 'components/activityEventElems/RedeemEventElem'
 import Loading from 'components/Loading'
 import SectionHeader from 'components/SectionHeader'
-import { PV_V1, PV_V1_1 } from 'constants/pv'
+import { PV_V1 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
@@ -55,8 +55,7 @@ export default function ProjectActivity() {
     const _where: SGWhereArg<'projectEvent'>[] = [
       {
         key: 'pv',
-        operator: 'in',
-        value: [PV_V1, PV_V1_1],
+        value: PV_V1,
       },
       {
         key: 'mintTokensEvent',

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -2,6 +2,7 @@ import { DownloadOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Select, Space } from 'antd'
 import AddToBalanceEventElem from 'components/activityEventElems/AddToBalanceEventElem'
+import BurnEventElem from 'components/activityEventElems/BurnEventElem'
 import DeployedERC20EventElem from 'components/activityEventElems/DeployedERC20EventElem'
 import PayEventElem from 'components/activityEventElems/PayEventElem'
 import ProjectCreateEventElem from 'components/activityEventElems/ProjectCreateEventElem'
@@ -10,6 +11,7 @@ import Loading from 'components/Loading'
 import SectionHeader from 'components/SectionHeader'
 import { PV_V1, PV_V1_1 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
+import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import { SGWhereArg } from 'models/graph'
 import { PrintReservesEvent } from 'models/subgraph-entities/v1/print-reserves-event'
@@ -43,6 +45,7 @@ const pageSize = 50
 
 export default function ProjectActivity() {
   const { projectId } = useContext(ProjectMetadataContext)
+  const { tokenSymbol } = useContext(V1ProjectContext)
 
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
   const [eventFilter, setEventFilter] = useState<EventFilter>('all')
@@ -125,6 +128,10 @@ export default function ProjectActivity() {
       {
         entity: 'payEvent',
         keys: ['amount', 'timestamp', 'beneficiary', 'note', 'id', 'txHash'],
+      },
+      {
+        entity: 'burnEvent',
+        keys: ['id', 'timestamp', 'txHash', 'caller', 'holder', 'amount'],
       },
       {
         entity: 'addToBalanceEvent',
@@ -210,6 +217,11 @@ export default function ProjectActivity() {
           if (e.payEvent) {
             elem = <PayEventElem event={e.payEvent as PayEvent} />
           }
+          if (e.burnEvent) {
+            elem = (
+              <BurnEventElem event={e.burnEvent} tokenSymbol={tokenSymbol} />
+            )
+          }
           if (e.addToBalanceEvent) {
             elem = (
               <AddToBalanceEventElem
@@ -264,7 +276,7 @@ export default function ProjectActivity() {
           )
         }),
       ),
-    [projectEvents],
+    [projectEvents, tokenSymbol],
   )
 
   const listStatus = useMemo(() => {

--- a/src/components/v1/V1Project/modals/EditProjectModal.tsx
+++ b/src/components/v1/V1Project/modals/EditProjectModal.tsx
@@ -8,7 +8,7 @@ import { useSetProjectHandleTx } from 'hooks/v1/transactor/SetProjectHandleTx'
 import { useSetProjectUriTx } from 'hooks/v1/transactor/SetProjectUriTx'
 import { uploadProjectMetadata } from 'lib/api/ipfs'
 import { revalidateProject } from 'lib/api/nextjs'
-import { V1TerminalVersion } from 'models/v1/terminals'
+import { PV1 } from 'models/pv'
 import { useContext, useEffect, useState } from 'react'
 
 type ProjectInfoFormFields = {
@@ -102,7 +102,7 @@ export default function EditProjectModal({
           if (onSuccess) onSuccess()
 
           if (pv) {
-            await revalidateProject({ pv: pv as V1TerminalVersion, handle })
+            await revalidateProject({ pv: pv as PV1, handle })
           }
 
           projectInfoForm.resetFields()

--- a/src/components/v1/V1Project/modals/V1BalancesModal.tsx
+++ b/src/components/v1/V1Project/modals/V1BalancesModal.tsx
@@ -1,24 +1,21 @@
 import { SettingOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
+import { t, Trans } from '@lingui/macro'
 import { Button, Modal, Space } from 'antd'
 import ERC20TokenBalance from 'components/ERC20TokenBalance'
 import { FormItems } from 'components/formItems'
 import V1ProjectTokenBalance from 'components/v1/shared/V1ProjectTokenBalance'
+import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
+import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { useV1ConnectedWalletHasPermission } from 'hooks/v1/contractReader/V1ConnectedWalletHasPermission'
 import { useSetProjectUriTx } from 'hooks/v1/transactor/SetProjectUriTx'
 import { uploadProjectMetadata } from 'lib/api/ipfs'
+import { revalidateProject } from 'lib/api/nextjs'
+import { PV1 } from 'models/pv'
 import { TokenRef } from 'models/tokenRef'
 import { V1OperatorPermission } from 'models/v1/permissions'
 import { useContext, useEffect, useState } from 'react'
-
-import { t, Trans } from '@lingui/macro'
-
-import { revalidateProject } from 'lib/api/nextjs'
-import { V1TerminalVersion } from 'models/v1/terminals'
-
-import { V1_PROJECT_IDS } from 'constants/v1/projectIds'
-import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 
 export function V1BalancesModal({
   open,
@@ -67,7 +64,7 @@ export function V1BalancesModal({
       {
         onDone: async () => {
           if (pv) {
-            await revalidateProject({ pv: pv as V1TerminalVersion, handle })
+            await revalidateProject({ pv: pv as PV1, handle })
           }
           setLoading(false)
           setEditModalVisible(false)

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/ConfigureEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/ConfigureEventElem.tsx
@@ -2,11 +2,13 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
 import { MinimalCollapse } from 'components/MinimalCollapse'
+import RichNote from 'components/RichNote'
 import { ConfigureEvent } from 'models/subgraph-entities/v2/configure'
 import {
   V2V3FundingCycle,
-  V2V3FundingCycleMetadata,
+  V2V3FundingCycleMetadata
 } from 'models/v2v3/fundingCycle'
+
 import FundingCycleDetails from '../../V2V3FundingCycleSection/FundingCycleDetails'
 
 export default function ConfigureEventElem({
@@ -43,6 +45,7 @@ export default function ConfigureEventElem({
         | 'useDataSourceForPay'
         | 'useDataSourceForRedeem'
         | 'useTotalOverflowForRedemptions'
+        | 'memo'
       >
     | undefined
 }) {
@@ -96,6 +99,7 @@ export default function ConfigureEventElem({
             distributionLimitCurrency={undefined}
             mintRateZeroAsUnchanged
           />
+          {event.memo ? <RichNote className="mt-3" note={event.memo} /> : null}
         </MinimalCollapse>
       }
     />

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -26,6 +26,7 @@ import DistributeReservedTokensEventElem from './eventElems/DistributeReservedTo
 type EventFilter =
   | 'all'
   | 'pay'
+  | 'burn'
   | 'addToBalance'
   | 'mintTokens'
   | 'redeem'
@@ -77,6 +78,9 @@ export default function ProjectActivity() {
         break
       case 'pay':
         key = 'payEvent'
+        break
+      case 'burn':
+        key = 'burnEvent'
         break
       case 'addToBalance':
         key = 'addToBalanceEvent'
@@ -374,6 +378,9 @@ export default function ProjectActivity() {
             </Select.Option>
             <Select.Option value="redeem">
               <Trans>Redeemed</Trans>
+            </Select.Option>
+            <Select.Option value="burn">
+              <Trans>Burned</Trans>
             </Select.Option>
             <Select.Option value="distributePayouts">
               <Trans>Distributed funds</Trans>

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -2,6 +2,7 @@ import { DownloadOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Select, Space } from 'antd'
 import AddToBalanceEventElem from 'components/activityEventElems/AddToBalanceEventElem'
+import BurnEventElem from 'components/activityEventElems/BurnEventElem'
 import DeployedERC20EventElem from 'components/activityEventElems/DeployedERC20EventElem'
 import PayEventElem from 'components/activityEventElems/PayEventElem'
 import ProjectCreateEventElem from 'components/activityEventElems/ProjectCreateEventElem'
@@ -10,6 +11,7 @@ import Loading from 'components/Loading'
 import SectionHeader from 'components/SectionHeader'
 import { PV_V2 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
+import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useInfiniteSubgraphQuery } from 'hooks/SubgraphQuery'
 import { SGWhereArg } from 'models/graph'
 import { ProjectEvent } from 'models/subgraph-entities/vX/project-event'
@@ -39,6 +41,7 @@ const pageSize = 50
 
 export default function ProjectActivity() {
   const { projectId } = useContext(ProjectMetadataContext)
+  const { tokenSymbol } = useContext(V2V3ProjectContext)
 
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
   const [eventFilter, setEventFilter] = useState<EventFilter>('all')
@@ -135,6 +138,10 @@ export default function ProjectActivity() {
         ],
       },
       {
+        entity: 'burnEvent',
+        keys: ['id', 'timestamp', 'txHash', 'caller', 'holder', 'amount'],
+      },
+      {
         entity: 'addToBalanceEvent',
         keys: [
           'amount',
@@ -148,7 +155,7 @@ export default function ProjectActivity() {
       },
       {
         entity: 'deployedERC20Event',
-        keys: ['symbol', 'txHash', 'timestamp', 'id'],
+        keys: ['symbol', 'txHash', 'timestamp', 'id', 'caller'],
       },
       {
         entity: 'tapEvent',
@@ -252,6 +259,11 @@ export default function ProjectActivity() {
           if (e.payEvent) {
             elem = <PayEventElem event={e.payEvent} />
           }
+          if (e.burnEvent) {
+            elem = (
+              <BurnEventElem event={e.burnEvent} tokenSymbol={tokenSymbol} />
+            )
+          }
           if (e.addToBalanceEvent) {
             elem = <AddToBalanceEventElem event={e.addToBalanceEvent} />
           }
@@ -297,7 +309,7 @@ export default function ProjectActivity() {
           )
         }),
       ),
-    [projectEvents],
+    [projectEvents, tokenSymbol],
   )
 
   const listStatus = useMemo(() => {

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -185,6 +185,7 @@ export default function ProjectActivity() {
           'returnAmount',
           'terminal',
           'metadata',
+          'memo',
         ],
       },
       {
@@ -243,6 +244,7 @@ export default function ProjectActivity() {
           'controllerMigrationAllowed',
           'setTerminalsAllowed',
           'setControllerAllowed',
+          'memo',
         ],
       },
     ],

--- a/src/constants/pv.ts
+++ b/src/constants/pv.ts
@@ -1,6 +1,4 @@
-import { PV2 } from 'models/pv'
-import { V1TerminalVersion } from 'models/v1/terminals'
+import { PV1, PV2 } from 'models/pv'
 
 export const PV_V2: PV2 = '2'
-export const PV_V1_1: V1TerminalVersion = '1.1'
-export const PV_V1: V1TerminalVersion = '1'
+export const PV_V1: PV1 = '1'

--- a/src/contexts/v1/V1ProjectMetadataProvider.tsx
+++ b/src/contexts/v1/V1ProjectMetadataProvider.tsx
@@ -1,10 +1,9 @@
+import { PV_V1 } from 'constants/pv'
 import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import useProjectIdForHandle from 'hooks/v1/contractReader/ProjectIdForHandle'
-import useTerminalOfProject from 'hooks/v1/contractReader/TerminalOfProject'
 import { ProjectMetadataV6 } from 'models/projectMetadata'
 import { PropsWithChildren } from 'react'
-import { getTerminalVersion } from 'utils/v1/terminals'
 
 export function V1ProjectMetadataProvider({
   handle,
@@ -15,9 +14,6 @@ export function V1ProjectMetadataProvider({
   metadata: ProjectMetadataV6 | undefined
 }>) {
   const { data: projectId } = useProjectIdForHandle(handle)
-
-  const terminalAddress = useTerminalOfProject(projectId)
-  const terminalVersion = getTerminalVersion(terminalAddress)
 
   const isArchived = projectId
     ? V1ArchivedProjectIds.includes(projectId.toNumber()) || metadata?.archived
@@ -34,7 +30,7 @@ export function V1ProjectMetadataProvider({
         projectMetadata: metadata,
         isArchived,
         projectId: projectId?.toNumber(),
-        pv: terminalVersion,
+        pv: PV_V1,
       }}
     >
       {children}

--- a/src/lib/api/nextjs.ts
+++ b/src/lib/api/nextjs.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
-import { PV2 } from 'models/pv'
-import { V1TerminalVersion } from 'models/v1/terminals'
+import { PV1, PV2 } from 'models/pv'
 
 /**
  * Calls to the NextJS API `/api/nextjs/revalidate-project` to revalidate the
@@ -13,9 +12,7 @@ import { V1TerminalVersion } from 'models/v1/terminals'
  * @returns {Promise<AxiosResponse>} Promise related to the axios call.
  */
 export function revalidateProject(
-  project:
-    | { pv: V1TerminalVersion; handle: string }
-    | { pv: PV2; projectId: string },
+  project: { pv: PV1; handle: string } | { pv: PV2; projectId: string },
 ) {
   return axios.post('/api/nextjs/revalidate-project', { project })
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2129,9 +2129,6 @@ msgstr ""
 msgid "Not set"
 msgstr ""
 
-msgid "Note"
-msgstr ""
-
 msgid "Notice from {0}"
 msgstr ""
 
@@ -3633,9 +3630,6 @@ msgid "V1 Project handle"
 msgstr ""
 
 msgid "V1 project handle"
-msgstr ""
-
-msgid "V1.1"
 msgstr ""
 
 msgid "V2"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -590,6 +590,9 @@ msgstr ""
 msgid "Burn {tokensTextLong}"
 msgstr ""
 
+msgid "Burned"
+msgstr ""
+
 msgid "Button Text"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2129,6 +2129,9 @@ msgstr ""
 msgid "Not set"
 msgstr ""
 
+msgid "Note"
+msgstr ""
+
 msgid "Notice from {0}"
 msgstr ""
 

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -16,6 +16,7 @@ import { UseAllowanceEvent } from './subgraph-entities/v2/use-allowance-event'
 import { VeNftContract } from './subgraph-entities/v2/venft-contract'
 import { VeNftToken } from './subgraph-entities/v2/venft-token'
 import { AddToBalanceEvent } from './subgraph-entities/vX/add-to-balance-event'
+import { BurnEvent } from './subgraph-entities/vX/burn-event'
 import { DeployedERC20Event } from './subgraph-entities/vX/deployed-erc20-event'
 import { MintTokensEvent } from './subgraph-entities/vX/mint-tokens-event'
 import { Participant } from './subgraph-entities/vX/participant'
@@ -34,6 +35,7 @@ interface SGEntities {
   project: Project
   projectSearch: Project
   payEvent: PayEvent
+  burnEvent: BurnEvent
   addToBalanceEvent: AddToBalanceEvent
   redeemEvent: RedeemEvent
   participant: Participant

--- a/src/models/pv.ts
+++ b/src/models/pv.ts
@@ -1,5 +1,4 @@
-import { V1TerminalVersion } from 'models/v1/terminals'
-export type PV2 = '2'
-
 // PV = project version
-export type PV = V1TerminalVersion | PV2
+export type PV1 = '1'
+export type PV2 = '2'
+export type PV = PV1 | PV2

--- a/src/models/subgraph-entities/v2/configure.ts
+++ b/src/models/subgraph-entities/v2/configure.ts
@@ -11,6 +11,7 @@ import { Project } from '../vX/project'
 export interface ConfigureEvent extends BaseEventEntity {
   projectId: number
   project: Project
+  memo: string
 
   duration: number
   weight: BigNumber

--- a/src/models/subgraph-entities/v2/jb-721-delegate-tokens.ts
+++ b/src/models/subgraph-entities/v2/jb-721-delegate-tokens.ts
@@ -1,14 +1,30 @@
-import { subgraphEntityJsonToKeyVal } from 'utils/graph'
+import { BigNumber } from '@ethersproject/bignumber'
+import { JB721GovernanceType } from 'models/nftRewardTier'
+import {
+  parseBigNumberKeyVals,
+  parseSubgraphEntitiesFromJson,
+  subgraphEntityJsonToKeyVal,
+} from 'utils/graph'
 
 import { Json } from '../../json'
 import { Participant } from '../vX/participant'
+import { Project } from '../vX/project'
 
-// TODO incomplete type, add the rest of the fields.
 export interface JB721DelegateToken {
+  id: string
   tokenId: string
   address: string
   tokenUri: string
   owner: Participant
+  governanceType: JB721GovernanceType
+
+  project: Project
+  projectId: number
+  name: string
+  symbol: string
+
+  floorPrice: BigNumber | null
+  lockedUntil: BigNumber | null
 }
 
 export const parseJB721DelegateTokenJson = (
@@ -16,4 +32,6 @@ export const parseJB721DelegateTokenJson = (
 ): JB721DelegateToken => ({
   ...j,
   ...subgraphEntityJsonToKeyVal(j.owner, 'participant', 'owner'),
+  ...parseSubgraphEntitiesFromJson(j, ['project']),
+  ...parseBigNumberKeyVals(j, ['floorPrice', 'lockedUntil']),
 })

--- a/src/models/subgraph-entities/vX/burn-event.ts
+++ b/src/models/subgraph-entities/vX/burn-event.ts
@@ -1,0 +1,24 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { PV } from 'models/pv'
+import { parseBigNumberKeyVals } from 'utils/graph'
+
+import { Json, primitives } from '../../json'
+import { BaseEventEntity } from '../base/base-event-entity'
+import {
+  BaseProjectEntity,
+  parseBaseProjectEntityJson,
+} from '../base/base-project-entity'
+
+export interface BurnEvent extends BaseProjectEntity, BaseEventEntity {
+  pv: PV
+  holder: string
+  amount: BigNumber
+  stakedAmount: BigNumber
+  unstakedAmount: BigNumber
+}
+
+export const parseBurnEventJson = (j: Json<BurnEvent>): BurnEvent => ({
+  ...primitives(j),
+  ...parseBaseProjectEntityJson(j),
+  ...parseBigNumberKeyVals(j, ['amount', 'stakedAmount', 'unstakedAmount']),
+})

--- a/src/models/subgraph-entities/vX/project-event.ts
+++ b/src/models/subgraph-entities/vX/project-event.ts
@@ -20,6 +20,7 @@ import { DistributeToPayoutSplitEvent } from '../v2/distribute-to-payout-split-e
 import { DistributeToReservedTokenSplitEvent } from '../v2/distribute-to-reserved-token-split-event'
 import { UseAllowanceEvent } from '../v2/use-allowance-event'
 import { AddToBalanceEvent } from './add-to-balance-event'
+import { BurnEvent } from './burn-event'
 import { DeployedERC20Event } from './deployed-erc20-event'
 import { MintTokensEvent } from './mint-tokens-event'
 import { PayEvent } from './pay-event'
@@ -33,6 +34,7 @@ export interface ProjectEvent extends TerminalEventEntity, BaseProjectEntity {
 
   // V1 & V2
   payEvent: PayEvent | null
+  burnEvent: BurnEvent | null
   addToBalanceEvent: AddToBalanceEvent | null
   mintTokensEvent: MintTokensEvent | null
   redeemEvent: RedeemEvent | null
@@ -61,6 +63,7 @@ export const parseProjectEventJson = (j: Json<ProjectEvent>): ProjectEvent => ({
   ...parseBaseProjectEntityJson(j),
   ...parseSubgraphEntitiesFromJson(j, [
     'payEvent',
+    'burnEvent',
     'project',
     'addToBalanceEvent',
     'mintTokensEvent',

--- a/src/models/subgraph-entities/vX/project.ts
+++ b/src/models/subgraph-entities/vX/project.ts
@@ -14,6 +14,7 @@ import { TapEvent } from '../v1/tap-event'
 import { V1ConfigureEvent } from '../v1/v1-configure'
 import { ConfigureEvent } from '../v2/configure'
 import { VeNftContract } from '../v2/venft-contract'
+import { BurnEvent } from './burn-event'
 import { DeployedERC20Event } from './deployed-erc20-event'
 import { MintTokensEvent } from './mint-tokens-event'
 import { Participant } from './participant'
@@ -47,6 +48,7 @@ export type Project = {
   distributeToPayoutModEvents: DistributeToPayoutModEvent[]
   distributeToTicketModEvents: DistributeToTicketModEvent[]
   deployedERC20Events: DeployedERC20Event[]
+  burnEvents: BurnEvent[]
   veNftContract: VeNftContract
   metadataUri: string
   terminal: string | null // null in v2
@@ -77,6 +79,7 @@ export const parseProjectJson = (j: Json<Project>): Project => ({
     'printPremineEvents',
   ),
   ...subgraphEntityJsonArrayToKeyVal(j.payEvents, 'payEvent', 'payEvents'),
+  ...subgraphEntityJsonArrayToKeyVal(j.burnEvents, 'burnEvent', 'burnEvents'),
   ...subgraphEntityJsonArrayToKeyVal(j.tapEvents, 'tapEvent', 'tapEvents'),
   ...subgraphEntityJsonArrayToKeyVal(
     j.redeemEvents,

--- a/src/models/subgraph-entities/vX/redeem-event.ts
+++ b/src/models/subgraph-entities/vX/redeem-event.ts
@@ -21,6 +21,7 @@ export interface RedeemEvent
   returnAmount: BigNumber
   returnAmountUSD: BigNumber
   caller: string
+  memo: string
   metadata: string | undefined
 }
 

--- a/src/pages/api/nextjs/revalidate-project.page.ts
+++ b/src/pages/api/nextjs/revalidate-project.page.ts
@@ -1,9 +1,9 @@
 import axios from 'axios'
-import { PV_V1, PV_V1_1, PV_V2 } from 'constants/pv'
+import { PV_V1, PV_V2 } from 'constants/pv'
 import { PV } from 'models/pv'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VALID_PVS = [PV_V1, PV_V1_1, PV_V2]
+const VALID_PVS = [PV_V1, PV_V2]
 
 export default async function handler(
   req: NextApiRequest,
@@ -16,7 +16,6 @@ export default async function handler(
   let handle: string | undefined
   switch (pv) {
     case PV_V1:
-    case PV_V1_1:
       handle = project?.handle
       break
     case PV_V2:
@@ -62,7 +61,6 @@ function calculatePath({
 }) {
   switch (pv) {
     case PV_V1:
-    case PV_V1_1:
       return `/p/${handle}`
     case PV_V2:
       return `/v2/p/${projectId}`

--- a/src/pages/home/Payments.tsx
+++ b/src/pages/home/Payments.tsx
@@ -4,7 +4,7 @@ import Loading from 'components/Loading'
 import RichNote from 'components/RichNote'
 import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
-import { PV_V1, PV_V1_1 } from 'constants/pv'
+import { PV_V1 } from 'constants/pv'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { Project } from 'models/subgraph-entities/vX/project'
 import { classNames } from 'utils/classNames'
@@ -31,7 +31,7 @@ export default function Payments() {
 
     return (
       <div className="font-medium text-haze-400 dark:text-haze-300">
-        {project.pv === PV_V1 || project.pv === PV_V1_1 ? (
+        {project.pv === PV_V1 ? (
           <V1ProjectHandle
             projectId={project.projectId}
             handle={project.handle}

--- a/src/pages/p/[handle]/pageLoaders.ts
+++ b/src/pages/p/[handle]/pageLoaders.ts
@@ -1,4 +1,4 @@
-import { PV_V1, PV_V1_1 } from 'constants/pv'
+import { PV_V1 } from 'constants/pv'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import { findProjectMetadata } from 'utils/server'
@@ -8,7 +8,7 @@ export const getV1StaticPaths: GetStaticPaths = async () => {
   if (process.env.BUILD_CACHE_V1_PROJECTS === 'true') {
     const projects = await paginateDepleteProjectsQueryCall({
       variables: {
-        where: { pv_in: [PV_V1, PV_V1_1] },
+        where: { pv: PV_V1 },
       },
     })
     const paths = projects
@@ -35,7 +35,7 @@ export const getV1StaticProps: GetStaticProps<
   const handle = context.params.handle as string
   const projects = await paginateDepleteProjectsQueryCall({
     variables: {
-      where: { pv_in: [PV_V1, PV_V1_1], handle },
+      where: { pv: PV_V1, handle },
       first: 1,
     },
   })

--- a/src/pages/projects/ProjectsFilterAndSort.tsx
+++ b/src/pages/projects/ProjectsFilterAndSort.tsx
@@ -13,8 +13,6 @@ export type CheckboxOnChange = (checked: boolean) => void
 export default function ProjectsFilterAndSort({
   includeV1,
   setIncludeV1,
-  includeV1_1,
-  setIncludeV1_1,
   includeV2,
   setIncludeV2,
   showArchived,
@@ -24,8 +22,6 @@ export default function ProjectsFilterAndSort({
 }: {
   includeV1: boolean
   setIncludeV1: CheckboxOnChange
-  includeV1_1: boolean
-  setIncludeV1_1: CheckboxOnChange
   includeV2: boolean
   setIncludeV2: CheckboxOnChange
   showArchived: boolean
@@ -76,11 +72,6 @@ export default function ProjectsFilterAndSort({
               label={t`V1`}
               checked={includeV1}
               onChange={setIncludeV1}
-            />
-            <FilterCheckboxItem
-              label={t`V1.1`}
-              checked={includeV1_1}
-              onChange={setIncludeV1_1}
             />
             <FilterCheckboxItem
               label={t`V2`}

--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -6,7 +6,7 @@ import { AppWrapper } from 'components/common'
 import ExternalLink from 'components/ExternalLink'
 import { PROJECTS_PAGE } from 'constants/fathomEvents'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
-import { PV_V1, PV_V1_1, PV_V2 } from 'constants/pv'
+import { PV_V1, PV_V2 } from 'constants/pv'
 import { useWallet } from 'hooks/Wallet'
 import { trackFathomGoal } from 'lib/fathom'
 import { ProjectCategory } from 'models/projectVisibility'
@@ -74,17 +74,15 @@ function Projects() {
 
   const [orderBy, setOrderBy] = useState<OrderByOption>('totalPaid')
   const [includeV1, setIncludeV1] = useState<boolean>(true)
-  const [includeV1_1, setIncludeV1_1] = useState<boolean>(true)
   const [includeV2, setIncludeV2] = useState<boolean>(true)
   const [showArchived, setShowArchived] = useState<boolean>(false)
 
   const pv: PV[] | undefined = useMemo(() => {
     const _pv: PV[] = []
     if (includeV1) _pv.push(PV_V1)
-    if (includeV1_1) _pv.push(PV_V1_1)
     if (includeV2) _pv.push(PV_V2)
-    return _pv.length ? _pv : [PV_V1, PV_V1_1, PV_V2]
-  }, [includeV1, includeV1_1, includeV2])
+    return _pv.length ? _pv : [PV_V1, PV_V2]
+  }, [includeV1, includeV2])
 
   return (
     <div className="my-0 mx-auto max-w-5xl p-5">
@@ -150,10 +148,8 @@ function Projects() {
             {selectedTab === 'all' ? (
               <ProjectsFilterAndSort
                 includeV1={includeV1}
-                includeV1_1={includeV1_1}
                 includeV2={includeV2}
                 setIncludeV1={setIncludeV1}
-                setIncludeV1_1={setIncludeV1_1}
                 setIncludeV2={setIncludeV2}
                 showArchived={showArchived}
                 setShowArchived={setShowArchived}

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -29,6 +29,7 @@ import { parseUseAllowanceEventJson } from 'models/subgraph-entities/v2/use-allo
 import { parseVeNftContractJson } from 'models/subgraph-entities/v2/venft-contract'
 import { parseVeNftTokenJson } from 'models/subgraph-entities/v2/venft-token'
 import { parseAddToBalanceEventJson } from 'models/subgraph-entities/vX/add-to-balance-event'
+import { parseBurnEventJson } from 'models/subgraph-entities/vX/burn-event'
 import { parseDeployedERC20EventJson } from 'models/subgraph-entities/vX/deployed-erc20-event'
 import { parseMintTokensEventJson } from 'models/subgraph-entities/vX/mint-tokens-event'
 import { parseParticipantJson } from 'models/subgraph-entities/vX/participant'
@@ -190,6 +191,9 @@ export function parseSubgraphEntity<
       break
     case 'payEvent':
       fn = parsePayEventJson
+      break
+    case 'burnEvent':
+      fn = parseBurnEventJson
       break
     case 'project':
       fn = parseProjectJson


### PR DESCRIPTION
## What does this PR do and why?

This is ready to merge, though I haven't been able to test due to some blocking UI runtime errors

https://thegraph.com/explorer/subgraphs/FVmuv3TndQDNd2BWARV8Y27yuKKukryKXPzvAS5E7htC?view=Overview?chain=Ethereum

- Adds new BurnEvent model + element + event filter
- Adds some new properties:
    - Configure.memo
    - Redeem.memo
    - JB721DelegateToken.governanceType
- Adds memo to Configure and Redeem EventElems
- Remove PV 1.1

## Screenshots or screen recordings

<img width="522" alt="image" src="https://user-images.githubusercontent.com/79433522/219791757-12b868ee-0421-40cd-91f3-9121c48e85be.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
