### PR TITLE
Sepana use ipfsGet() with timeout

### DIFF
--- a/src/lib/api/ipfs.ts
+++ b/src/lib/api/ipfs.ts
@@ -75,7 +75,7 @@ export const ipfsGet = async <T>(hash: string) => {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
-    timeout: 30,
+    timeout: 30000,
   })
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((response.data as any).Data?.['/'].bytes) {

--- a/src/lib/api/ipfs.ts
+++ b/src/lib/api/ipfs.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 import { consolidateMetadata, ProjectMetadataV6 } from 'models/projectMetadata'
 import { IpfsPinFileResponse } from 'pages/api/ipfs/pinFile.page'
 import { IpfsPinJSONResponse } from 'pages/api/ipfs/pinJSON.page'
@@ -67,15 +67,19 @@ export const clientRegister = async (): Promise<{
   }
 }
 
-export const ipfsGet = async <T>(hash: string) => {
+export const ipfsGet = async <T>(
+  hash: string,
+  opts?: AxiosRequestConfig<T>,
+) => {
   // Build config for axios get request
   const response = await axios.get<T>(ipfsOpenGatewayUrl(hash), {
+    ...opts,
     responseType: 'json',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      ...(opts?.headers ?? {}),
     },
-    timeout: 30000,
   })
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((response.data as any).Data?.['/'].bytes) {

--- a/src/lib/api/ipfs.ts
+++ b/src/lib/api/ipfs.ts
@@ -75,6 +75,7 @@ export const ipfsGet = async <T>(hash: string) => {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
+    timeout: 30,
   })
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((response.data as any).Data?.['/'].bytes) {

--- a/src/pages/api/sepana/health.page.ts
+++ b/src/pages/api/sepana/health.page.ts
@@ -62,7 +62,9 @@ const handler: NextApiHandler = async (_, res) => {
       }
 
       if (_hasUnresolvedMetadata && _metadataRetriesLeft) {
-        projectsMissingMetadata.push(`\`[${id}]\` metadataUri: ${metadataUri}`)
+        projectsMissingMetadata.push(
+          `\`[${id}]\` metadataUri: ${metadataUri}. ${_metadataRetriesLeft} retries left`,
+        )
       }
 
       const subgraphProject = subgraphProjects.splice(

--- a/src/utils/sepana.ts
+++ b/src/utils/sepana.ts
@@ -1,4 +1,4 @@
-import { infuraApi } from 'lib/infura/ipfs'
+import { ipfsGet } from 'lib/api/ipfs'
 import { CURRENT_VERSION, MAX_METADATA_RETRIES } from 'lib/sepana/constants'
 import { Json } from 'models/json'
 import { AnyProjectMetadata } from 'models/projectMetadata'
@@ -138,16 +138,7 @@ export async function tryResolveMetadata({
   try {
     const {
       data: { name, description, logoUri },
-    } = await infuraApi.get<AnyProjectMetadata>(
-      ipfsOpenGatewayUrl(metadataUri),
-      {
-        responseType: 'json',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      },
-    )
+    } = await ipfsGet<AnyProjectMetadata>(ipfsOpenGatewayUrl(metadataUri))
 
     return {
       project: {

--- a/src/utils/sepana.ts
+++ b/src/utils/sepana.ts
@@ -138,7 +138,9 @@ export async function tryResolveMetadata({
   try {
     const {
       data: { name, description, logoUri },
-    } = await ipfsGet<AnyProjectMetadata>(ipfsOpenGatewayUrl(metadataUri))
+    } = await ipfsGet<AnyProjectMetadata>(ipfsOpenGatewayUrl(metadataUri), {
+      timeout: 10000,
+    })
 
     return {
       project: {


### PR DESCRIPTION
## What does this PR do and why?

Small tweak to sepana routines. use `ipfsGet()` with 10s timeout instead of `infuraApi`

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
