### PR TITLE
Remove NFTs from sticker selection

### DIFF
--- a/src/components/IconedImage.tsx
+++ b/src/components/IconedImage.tsx
@@ -7,13 +7,13 @@ import { ReactNode } from 'react'
 export const IconedImage = ({
   url,
   width,
-  onClick,
+  onIconClick,
   icon,
 }: {
   url: string
   width: number
   icon: ReactNode
-  onClick: VoidFunction
+  onIconClick?: VoidFunction
 }) => {
   return (
     <div className="relative py-4">
@@ -21,7 +21,7 @@ export const IconedImage = ({
       <div
         className="absolute top-0 right-0 cursor-pointer"
         role="button"
-        onClick={onClick}
+        onClick={onIconClick}
       >
         {icon}
       </div>

--- a/src/components/MinimalCollapse.tsx
+++ b/src/components/MinimalCollapse.tsx
@@ -27,7 +27,7 @@ export function MinimalCollapse({
         light ? 'light' : '',
         className,
       )}
-      defaultActiveKey={defaultOpen ? ['1'] : []}
+      defaultActiveKey={defaultOpen ? '1' : []}
       {...props}
     >
       <CollapsePanel key="1" header={header}>

--- a/src/components/Project/StickerSelection.tsx
+++ b/src/components/Project/StickerSelection.tsx
@@ -1,7 +1,6 @@
 import { CloseCircleFilled } from '@ant-design/icons'
 import { Space } from 'antd'
 import { IconedImage } from 'components/IconedImage'
-import { IPFS_LINK_REGEX } from 'constants/ipfs'
 import { ipfsUriToGatewayUrl } from 'utils/ipfs'
 
 export const StickerSelection = ({
@@ -25,12 +24,12 @@ export const StickerSelection = ({
       {value?.map((url, i) => (
         <IconedImage
           key={`${i}-${url}`}
-          url={url.match(IPFS_LINK_REGEX) ? ipfsUriToGatewayUrl(url) : url}
+          url={ipfsUriToGatewayUrl(url)}
           width={50}
           icon={
             <CloseCircleFilled className="text-base text-black dark:text-slate-100" />
           }
-          onClick={() => handleImageDeletion(i)}
+          onIconClick={() => handleImageDeletion(i)}
         />
       ))}
     </Space>

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
@@ -34,7 +34,6 @@ export function V2V3ConfirmPayModal({
 
   const [loading, setLoading] = useState<boolean>()
   const [transactionPending, setTransactionPending] = useState<boolean>()
-  const [transactionCanceled, setTransactionCanceled] = useState<boolean>(false)
   const [form] = useForm<V2V3PayFormType>()
 
   const payProjectTx = usePayETHPaymentTerminalTx()
@@ -69,7 +68,7 @@ export function V2V3ConfirmPayModal({
     }
   }
 
-  async function pay() {
+  async function executePayTx() {
     if (!weiAmount || !projectId) return
 
     const {
@@ -101,6 +100,7 @@ export function V2V3ConfirmPayModal({
             text: textMemo,
             imageUrl: uploadedImage,
             stickerUrls,
+            nftUrls: nftRewardTiers?.map(tier => tier.fileUrl),
           }),
           preferClaimedTokens: Boolean(preferClaimedTokens),
           beneficiary: txBeneficiary,
@@ -122,7 +122,6 @@ export function V2V3ConfirmPayModal({
       )
 
       if (!txSuccess) {
-        setTransactionCanceled(true)
         setLoading(false)
         setTransactionPending(false)
       }
@@ -143,9 +142,6 @@ export function V2V3ConfirmPayModal({
       connectWalletText={t`Connect wallet to pay`}
       onCancel={() => {
         form.resetFields()
-        // resetFields sets to initialValues, which includes NFTs, so have to remove them manually
-        form.setFieldValue('stickerUrls', [])
-        setTransactionCanceled(false)
         onCancel?.()
       }}
       confirmLoading={loading}
@@ -168,11 +164,7 @@ export function V2V3ConfirmPayModal({
 
         <SummaryTable weiAmount={weiAmount} />
 
-        <V2V3PayForm
-          form={form}
-          transactionCanceled={transactionCanceled}
-          onFinish={() => pay()}
-        />
+        <V2V3PayForm form={form} onFinish={() => executePayTx()} />
       </Space>
     </TransactionModal>
   )

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3PayForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3PayForm.tsx
@@ -15,7 +15,6 @@ import { ProjectPreferences } from 'constants/projectPreferences'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { isAddress } from 'ethers/lib/utils'
-import { NftRewardTier } from 'models/nftRewardTier'
 import { useContext, useEffect, useState } from 'react'
 import { classNames } from 'utils/classNames'
 import {
@@ -34,11 +33,9 @@ export interface V2V3PayFormType {
 
 export const V2V3PayForm = ({
   form,
-  transactionCanceled,
   ...props
 }: {
   form: FormInstance<V2V3PayFormType>
-  transactionCanceled: boolean
 } & FormProps) => {
   const { tokenAddress, fundingCycle, fundingCycleMetadata } =
     useContext(V2V3ProjectContext)
@@ -62,24 +59,12 @@ export const V2V3PayForm = ({
   const canAddMoreStickers =
     (stickerUrls ?? []).length < ProjectPreferences.MAX_IMAGES_PAYMENT_MEMO
 
-  useEffect(() => {
-    if (transactionCanceled) return
-
-    const initialStickerUrls = nftRewardTiers?.map(
-      (tier: NftRewardTier) => tier.fileUrl,
-    )
-
-    form.setFieldsValue({
-      stickerUrls: initialStickerUrls,
-    })
-  }, [form, nftRewardTiers, transactionCanceled])
-
-  useEffect(() => {
-    if (!form.getFieldValue('beneficiary')) return
-
-    setCustomBeneficiaryEnabled(transactionCanceled)
-  }, [form, transactionCanceled])
-
+  useEffect(
+    () => {
+      setCustomBeneficiaryEnabled(Boolean(form.getFieldValue('beneficiary')))
+    },
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  )
   return (
     <>
       <Form form={form} layout="vertical" {...props}>
@@ -249,11 +234,13 @@ export const V2V3PayForm = ({
           }
           const url = new URL(`${window.location.origin}${sticker.filepath}`)
           const urlString = url.toString()
+
           const existingStickerUrls = (form.getFieldValue('stickerUrls') ??
             []) as string[]
+          const updatedStickerUrls = [...existingStickerUrls, urlString]
 
           form.setFieldsValue({
-            stickerUrls: existingStickerUrls.concat(urlString),
+            stickerUrls: updatedStickerUrls,
           })
         }}
       />

--- a/src/utils/buildPaymentMemo.ts
+++ b/src/utils/buildPaymentMemo.ts
@@ -1,17 +1,23 @@
 /**
  * Produce payment memo with the following schema:
- * <text memo> <sticker URLs> <uploaded image URL>
+ * <text memo> <NFTs> <sticker URLs>  <uploaded image URL>
  */
 export const buildPaymentMemo = ({
   text = '',
   imageUrl,
   stickerUrls,
+  nftUrls,
 }: {
   text?: string
   imageUrl?: string
   stickerUrls?: string[]
+  nftUrls?: string[]
 }) => {
   let memo = `${text}`
+
+  if (nftUrls?.length) {
+    memo += `\n${nftUrls.join(' ')}`
+  }
 
   if (stickerUrls?.length) {
     memo += `\n${stickerUrls.join(' ')}`


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/jbx-protocol/juice-interface/issues/3052

- removes NFTs from sticker selection. They ain't stickers, so i dont think they need to be coerced to be stickers
- Removes transactionCanceled logic. Pay form data is correctly retained when a tx is cancelled
