### PR TITLE
Reduce nft filesize upload limit to 5mb

### DIFF
--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -45,7 +45,7 @@ interface AddEditRewardModalFormProps {
 }
 
 const NFT_FILE_UPLOAD_EXTRA = t`Images will be cropped to a 1:1 square in thumbnail previews on the Juicebox app.`
-const MAX_NFT_FILE_SIZE_MB = 100
+const MAX_NFT_FILE_SIZE_MB = 5
 
 export const AddEditRewardModal = ({
   className,


### PR DESCRIPTION
Anything above 5mb seems to be failing to prod! Like this:

<img width="702" alt="Screen Shot 2023-02-21 at 10 01 23 pm" src="https://user-images.githubusercontent.com/96150256/220339568-23d12892-2f0b-4f79-9812-3066c7cfbcfd.png">