### PR TITLE
Fix various NFT MP4 loading states

### DIFF
--- a/src/components/Create/components/JuiceVideoOrImgPreview.tsx
+++ b/src/components/Create/components/JuiceVideoOrImgPreview.tsx
@@ -2,6 +2,7 @@ import { CloseOutlined } from '@ant-design/icons'
 import { Image, ImageProps } from 'antd'
 import { JuiceVideoPreview } from 'components/NftRewards/NftVideo/JuiceVideoPreview'
 import { useContentType } from 'hooks/ContentType'
+import { stopPropagation } from 'react-stop-propagation'
 import { fileTypeIsVideo } from 'utils/nftRewards'
 
 export const JUICE_IMG_PREVIEW_CONTAINER_CLASS =
@@ -22,11 +23,13 @@ export function JuiceVideoOrImgPreview({
   const { data: contentType } = useContentType(src)
   const isVideo = fileTypeIsVideo(contentType)
 
+  const _onClose = stopPropagation(onClose)
+
   return (
-    <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={onClose}>
+    <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={_onClose}>
       <CloseOutlined
         className="absolute top-10 right-10 pl-4 text-2xl text-slate-100"
-        onClick={onClose}
+        onClick={_onClose}
       />
       <div className="text-center">
         {isVideo ? (

--- a/src/components/Create/components/RewardsList/RewardsList.tsx
+++ b/src/components/Create/components/RewardsList/RewardsList.tsx
@@ -1,10 +1,10 @@
 import { PlusCircleOutlined } from '@ant-design/icons'
 import { Divider } from 'antd'
+import { CreateButton } from 'components/buttons/CreateButton'
 import { useModal } from 'hooks/Modal'
 import { FormItemInput } from 'models/formItemInput'
 import { createContext, useCallback, useContext, useState } from 'react'
 import { MAX_NFT_REWARD_TIERS } from 'utils/nftRewards'
-import { CreateButton } from 'components/buttons/CreateButton'
 import { AddEditRewardModal } from './AddEditRewardModal'
 import { useRewards } from './hooks'
 import { RewardItem } from './RewardItem'
@@ -46,7 +46,6 @@ export const RewardsList: React.FC<RewardsListProps> &
   const [selectedReward, setSelectedReward] = useState<Reward>()
   const modal = useModal()
   const { rewards, upsertReward, removeReward } = rewardsHook
-
   const onModalOk = useCallback(
     (reward: Reward) => {
       upsertReward(reward)

--- a/src/components/NftRewards/NftPreview.tsx
+++ b/src/components/NftRewards/NftPreview.tsx
@@ -1,6 +1,5 @@
 import { CloseOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
-import { JUICE_IMG_PREVIEW_CONTAINER_CLASS } from 'components/Create/components/JuiceVideoOrImgPreview'
 import ExternalLink from 'components/ExternalLink'
 import { JuiceVideoPreview } from 'components/NftRewards/NftVideo/JuiceVideoPreview'
 import { DEFAULT_NFT_MAX_SUPPLY } from 'contexts/NftRewards/NftRewards'
@@ -10,6 +9,7 @@ import { NftRewardTier } from 'models/nftRewardTier'
 import { useContext } from 'react'
 import { classNames } from 'utils/classNames'
 import { fileTypeIsVideo } from 'utils/nftRewards'
+import { JUICE_IMG_PREVIEW_CONTAINER_CLASS } from './NftVideo/JuiceVideoOrImgPreview'
 
 export const IMAGE_OR_VIDEO_PREVIEW_CLASSES =
   'max-h-[50vh] max-w-[90vw] md:max-h-[60vh] md:max-w-xl'

--- a/src/components/NftRewards/NftTierCard.tsx
+++ b/src/components/NftRewards/NftTierCard.tsx
@@ -103,7 +103,7 @@ export function NftTierCard({
             <JuiceVideoThumbnailOrImage
               src={fileUrl}
               alt={rewardTier?.name ?? 'Juicebox NFT reward'}
-              isSelected={_isSelected}
+              darkened={!_isSelected}
               className="absolute w-full"
               heightClass={NFT_DISPLAY_HEIGHT_CLASS}
             />

--- a/src/components/NftRewards/NftVideo/JuiceVideoOrImgPreview.tsx
+++ b/src/components/NftRewards/NftVideo/JuiceVideoOrImgPreview.tsx
@@ -1,0 +1,51 @@
+import { CloseOutlined } from '@ant-design/icons'
+import { Image, ImageProps } from 'antd'
+import { JuiceVideoPreview } from 'components/NftRewards/NftVideo/JuiceVideoPreview'
+import { useContentType } from 'hooks/ContentType'
+import { stopPropagation } from 'react-stop-propagation'
+import { fileTypeIsVideo } from 'utils/nftRewards'
+
+export const JUICE_IMG_PREVIEW_CONTAINER_CLASS =
+  'fixed top-0 left-0 z-[10000] flex h-full w-full items-center justify-center overflow-auto bg-[rgba(0,0,0,0.8)] p-5'
+
+export function JuiceVideoOrImgPreview({
+  src,
+  alt,
+  visible,
+  onClose,
+  ...props
+}: ImageProps & {
+  visible: boolean
+  onClose: VoidFunction
+}) {
+  if (!visible || !src) return null
+
+  const { data: contentType } = useContentType(src)
+  const isVideo = fileTypeIsVideo(contentType)
+
+  const _onClose = stopPropagation(onClose)
+
+  return (
+    <div className={JUICE_IMG_PREVIEW_CONTAINER_CLASS} onClick={_onClose}>
+      <CloseOutlined
+        className="absolute top-10 right-10 pl-4 text-2xl text-slate-100"
+        onClick={_onClose}
+      />
+      <div className="text-center">
+        {isVideo ? (
+          <JuiceVideoPreview src={src} />
+        ) : (
+          <Image
+            className="max-h-[50vh] md:max-h-[60vh]"
+            alt={alt}
+            src={src}
+            onClick={e => e.stopPropagation()}
+            crossOrigin="anonymous"
+            preview={false}
+            {...props}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/NftRewards/NftVideo/JuiceVideoThumbnail.tsx
+++ b/src/components/NftRewards/NftVideo/JuiceVideoThumbnail.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { JuicePlayIcon } from './JuicePlayIcon'
 
 export type PlayIconPosition = 'hidden' | 'default' | 'center'
@@ -19,13 +20,14 @@ export function JuiceVideoThumbnail({
   className?: string
   onLoaded?: VoidFunction
 }) {
+  const [loading, setLoading] = useState<boolean>(true)
   const _width = widthClass ?? 'w-full'
   const _height = heightClass ?? 'h-full'
 
   const playIconContainerClassName = 'bottom-3 right-2'
   return (
     <div className={`relative top-0 ${_width} ${_height}`}>
-      {playIconPosition !== 'hidden' ? (
+      {!loading && playIconPosition !== 'hidden' ? (
         <div className={`absolute z-[1] ${playIconContainerClassName}`}>
           <JuicePlayIcon />
         </div>
@@ -36,7 +38,10 @@ export function JuiceVideoThumbnail({
         style={{
           filter: isSelected ? 'unset' : 'brightness(50%)',
         }}
-        onLoadedData={onLoaded}
+        onLoadedData={() => {
+          setLoading(false)
+          onLoaded?.()
+        }}
       >
         <source src={src} type="video/mp4" />
         Your browser does not support the video tag.

--- a/src/components/NftRewards/NftVideo/JuiceVideoThumbnail.tsx
+++ b/src/components/NftRewards/NftVideo/JuiceVideoThumbnail.tsx
@@ -5,7 +5,7 @@ export type PlayIconPosition = 'hidden' | 'default' | 'center'
 
 export function JuiceVideoThumbnail({
   src,
-  isSelected,
+  darkened,
   widthClass,
   heightClass,
   playIconPosition = 'default',
@@ -13,7 +13,7 @@ export function JuiceVideoThumbnail({
   onLoaded,
 }: {
   src: string
-  isSelected?: boolean
+  darkened?: boolean
   widthClass?: string | number // rem width
   heightClass?: string | number // rem height
   playIconPosition?: PlayIconPosition
@@ -36,7 +36,7 @@ export function JuiceVideoThumbnail({
         muted
         className={`h-full w-full ${className}`}
         style={{
-          filter: isSelected ? 'unset' : 'brightness(50%)',
+          filter: darkened ? 'brightness(50%)' : 'unset',
         }}
         onLoadedData={() => {
           setLoading(false)

--- a/src/components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage.tsx
+++ b/src/components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage.tsx
@@ -3,12 +3,13 @@ import { ImageProps } from 'antd'
 import { JuiceVideoOrImgPreview } from 'components/Create/components/JuiceVideoOrImgPreview'
 import { useContentType } from 'hooks/ContentType'
 import { useState } from 'react'
+import { stopPropagation } from 'react-stop-propagation'
 import { classNames } from 'utils/classNames'
 import { fileTypeIsVideo } from 'utils/nftRewards'
 import { JuiceVideoThumbnail, PlayIconPosition } from './JuiceVideoThumbnail'
 
 export function JuiceVideoThumbnailOrImage({
-  isSelected,
+  isSelected = true,
   playIconPosition,
   heightClass,
   widthClass,
@@ -39,11 +40,16 @@ export function JuiceVideoThumbnailOrImage({
         <div
           className={`flex items-center justify-center border border-solid border-smoke-200 dark:border-grey-600 ${widthClass} ${heightClass}`}
         >
-          <LoadingOutlined />
+          <LoadingOutlined className="text-primary" />
         </div>
       ) : null}
       <div
-        onClick={showPreviewOnClick ? () => setPreviewVisible(true) : undefined}
+        onClick={
+          showPreviewOnClick
+            ? stopPropagation(() => setPreviewVisible(true))
+            : undefined
+        }
+        className="h-full w-full"
       >
         {isVideo ? (
           <JuiceVideoThumbnail

--- a/src/components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage.tsx
+++ b/src/components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage.tsx
@@ -36,7 +36,9 @@ export function JuiceVideoThumbnailOrImage({
   return (
     <div className={_className}>
       {loading ? (
-        <div className="flex h-full w-full items-center justify-center border border-solid border-smoke-200 dark:border-grey-600">
+        <div
+          className={`flex items-center justify-center border border-solid border-smoke-200 dark:border-grey-600 ${widthClass} ${heightClass}`}
+        >
           <LoadingOutlined />
         </div>
       ) : null}

--- a/src/components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage.tsx
+++ b/src/components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage.tsx
@@ -1,27 +1,27 @@
 import { LoadingOutlined } from '@ant-design/icons'
 import { ImageProps } from 'antd'
-import { JuiceVideoOrImgPreview } from 'components/Create/components/JuiceVideoOrImgPreview'
 import { useContentType } from 'hooks/ContentType'
 import { useState } from 'react'
 import { stopPropagation } from 'react-stop-propagation'
 import { classNames } from 'utils/classNames'
 import { fileTypeIsVideo } from 'utils/nftRewards'
+import { JuiceVideoOrImgPreview } from './JuiceVideoOrImgPreview'
 import { JuiceVideoThumbnail, PlayIconPosition } from './JuiceVideoThumbnail'
 
 export function JuiceVideoThumbnailOrImage({
-  isSelected = true,
   playIconPosition,
   heightClass,
   widthClass,
   showPreviewOnClick,
+  darkened,
   ...props
 }: ImageProps & {
-  isSelected?: boolean
   playIconPosition?: PlayIconPosition
   heightClass?: string
   widthClass?: string
   src: string
   showPreviewOnClick?: boolean
+  darkened?: boolean
 }) {
   const [loading, setLoading] = useState<boolean>(true)
   const [previewVisible, setPreviewVisible] = useState<boolean>(false)
@@ -54,7 +54,7 @@ export function JuiceVideoThumbnailOrImage({
         {isVideo ? (
           <JuiceVideoThumbnail
             src={props.src}
-            isSelected={isSelected}
+            darkened={darkened}
             className={props.className}
             widthClass={widthClass}
             heightClass={heightClass}
@@ -67,7 +67,7 @@ export function JuiceVideoThumbnailOrImage({
               props.className ?? ''
             } top-0 h-full w-full object-cover`}
             style={{
-              filter: isSelected ? 'unset' : 'brightness(50%)',
+              filter: darkened ? 'brightness(50%)' : 'unset',
             }}
             src={props.src}
             onClick={props.onClick}

--- a/src/components/RichNote/RichNote.tsx
+++ b/src/components/RichNote/RichNote.tsx
@@ -47,10 +47,7 @@ export default function RichNote({
             {formattedMediaLinks.map((link, i) => (
               <JuiceVideoThumbnailOrImage
                 key={i}
-                className={twMerge(
-                  'cursor-pointer hover:brightness-50',
-                  className,
-                )}
+                className={twMerge('cursor-pointer', className)}
                 heightClass="h-24"
                 widthClass="w-24"
                 src={link}

--- a/src/components/RichNote/RichNote.tsx
+++ b/src/components/RichNote/RichNote.tsx
@@ -48,9 +48,11 @@ export default function RichNote({
               <JuiceVideoThumbnailOrImage
                 key={i}
                 className={twMerge(
-                  'h-24 w-24 cursor-pointer hover:brightness-50',
+                  'cursor-pointer hover:brightness-50',
                   className,
                 )}
+                heightClass="h-24"
+                widthClass="w-24"
                 src={link}
                 showPreviewOnClick
               />

--- a/src/components/inputs/UploadNoStyle.tsx
+++ b/src/components/inputs/UploadNoStyle.tsx
@@ -8,11 +8,11 @@ import Loading from 'components/Loading'
 import { JuiceVideoPreview } from 'components/NftRewards/NftVideo/JuiceVideoPreview'
 import { ThemeContext } from 'contexts/Theme/ThemeContext'
 import { useContentType } from 'hooks/ContentType'
-import { round } from 'lodash'
 import { FormItemInput } from 'models/formItemInput'
 import { UploadRequestOption } from 'rc-upload/lib/interface'
 import { ReactNode, useCallback, useContext, useState } from 'react'
 import { stopPropagation } from 'react-stop-propagation'
+import { percentFromUploadProgressEvent } from 'utils/ipfs'
 import { fileTypeIsVideo } from 'utils/nftRewards'
 import { emitErrorNotification } from 'utils/notifications'
 
@@ -100,8 +100,7 @@ export const UploadNoStyle = (props: UploadNoStyleProps) => {
           onProgress: e => {
             req.onProgress?.(e)
             if (e) {
-              const _percent = (e.loaded / e.total) * 100
-              setPercent(round(_percent, 0))
+              setPercent(percentFromUploadProgressEvent(e))
             }
           },
         })

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/NftRewardCell.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/NftRewardCell.tsx
@@ -45,7 +45,6 @@ export function NftRewardCell({
                   heightClass={NFT_DISPLAY_HEIGHT_CLASS}
                   widthClass={NFT_DISPLAY_WIDTH_CLASS}
                   playIconPosition="hidden"
-                  isSelected
                   showPreviewOnClick
                 />
               </Tooltip>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview/NftSummarySection.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/ReconfigurePreview/NftSummarySection.tsx
@@ -1,8 +1,8 @@
 import { Trans } from '@lingui/macro'
-import { Col, Image, Row } from 'antd'
+import { Col, Row } from 'antd'
 import ExternalLink from 'components/ExternalLink'
+import { JuiceVideoThumbnailOrImage } from 'components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage'
 import Paragraph from 'components/Paragraph'
-import { NFT_IMAGE_SIDE_LENGTH } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/AddNftsSection/NftRewardTierModal/NftUpload'
 import { DEFAULT_NFT_MAX_SUPPLY } from 'contexts/NftRewards/NftRewards'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useContext } from 'react'
@@ -41,12 +41,11 @@ export default function NftSummarySection() {
             gutter={16}
           >
             <Col md={4} className="flex items-center justify-center">
-              <Image
-                className="object-cover"
+              <JuiceVideoThumbnailOrImage
                 src={rewardTier.fileUrl ?? '/assets/banana-od.webp'}
                 alt={rewardTier.name}
-                height={NFT_IMAGE_SIDE_LENGTH}
-                width={NFT_IMAGE_SIDE_LENGTH}
+                heightClass="h-24"
+                widthClass="w-24"
               />
             </Col>
             <Col className="flex flex-col justify-center" md={8}>

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/AddNftsSection/NftRewardTierCard.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/NftDrawer/AddNftsSection/NftRewardTierCard.tsx
@@ -1,13 +1,12 @@
-import { CloseOutlined, LoadingOutlined } from '@ant-design/icons'
+import { CloseOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Button, Image, Statistic, Tooltip } from 'antd'
+import { Button, Statistic, Tooltip } from 'antd'
+import { JuiceVideoThumbnailOrImage } from 'components/NftRewards/NftVideo/JuiceVideoThumbnailOrImage'
 import Paragraph from 'components/Paragraph'
 import { DEFAULT_NFT_MAX_SUPPLY } from 'contexts/NftRewards/NftRewards'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { useState } from 'react'
-import { classNames } from 'utils/classNames'
 import NftRewardTierModal from './NftRewardTierModal/NftRewardTierModal'
-import { NFT_IMAGE_SIDE_LENGTH } from './NftRewardTierModal/NftUpload'
 
 export default function NftRewardTierCard({
   rewardTier,
@@ -20,7 +19,6 @@ export default function NftRewardTierCard({
 }) {
   const [editTierModalVisible, setEditTierModalVisible] =
     useState<boolean>(false)
-  const [imageLoading, setImageLoading] = useState<boolean>(true)
 
   if (!rewardTier) return null
 
@@ -63,26 +61,12 @@ export default function NftRewardTierCard({
           )}
         </div>
         <div className="flex">
-          <div
-            className={classNames(
-              'flex items-center justify-center',
-              imageLoading ? 'h-24 w-24' : '',
-            )}
-          >
-            {imageLoading ? <LoadingOutlined className="text-3xl" /> : null}
-            <Image
-              className={classNames(
-                'object-cover',
-                imageLoading ? 'hidden' : '',
-              )}
-              src={rewardTier.fileUrl}
-              alt={rewardTier.name}
-              height={imageLoading ? 0 : NFT_IMAGE_SIDE_LENGTH}
-              width={imageLoading ? 0 : NFT_IMAGE_SIDE_LENGTH}
-              onLoad={() => setImageLoading(false)}
-              onClick={e => e.stopPropagation()}
-            />
-          </div>
+          <JuiceVideoThumbnailOrImage
+            src={rewardTier.fileUrl}
+            alt={rewardTier.name}
+            heightClass="h-24"
+            widthClass="w-24"
+          />
           <div>
             <Tooltip title={<Trans>Discontinue mints</Trans>}>
               <Button

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1619,6 +1619,9 @@ msgstr ""
 msgid "Images will be cropped to a 1:1 square in thumbnail previews on the Juicebox app."
 msgstr ""
 
+msgid "Images will be cropped to a square in thumbnail previews on the Juicebox app."
+msgstr ""
+
 msgid "In Juicebox"
 msgstr ""
 
@@ -1974,9 +1977,6 @@ msgid "NFT projects"
 msgstr ""
 
 msgid "NFT rules"
-msgstr ""
-
-msgid "NFT will be cropped to a square in thumbnail previews on the Juicebox app."
 msgstr ""
 
 msgid "NFTs"

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,5 +1,7 @@
 import { OPEN_IPFS_GATEWAY_HOSTNAME } from 'constants/ipfs'
 import { base58 } from 'ethers/lib/utils'
+import { round } from 'lodash'
+import { UploadProgressEvent } from 'rc-upload/lib/interface'
 
 const IPFS_URL_REGEX = /ipfs:\/\/(.+)/
 
@@ -74,4 +76,9 @@ export function isIpfsCID(cid: string) {
   return (
     cid.startsWith('Qm') || cid.startsWith('bafy') || cid.startsWith('bafk')
   )
+}
+
+export function percentFromUploadProgressEvent(e: UploadProgressEvent) {
+  const _percent = (e.loaded / e.total) * 100
+  return round(_percent, 0)
 }

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -79,6 +79,6 @@ export function isIpfsCID(cid: string) {
 }
 
 export function percentFromUploadProgressEvent(e: UploadProgressEvent) {
-  const _percent = (e.loaded / e.total) * 100
-  return round(_percent, 0)
+  const percent = (e.loaded / e.total) * 100
+  return round(percent, 0)
 }


### PR DESCRIPTION
## What does this PR do and why?

- **Activity feed:**
BEFORE:
<img width="322" alt="Screen Shot 2023-02-23 at 3 51 31 pm" src="https://user-images.githubusercontent.com/96150256/220830252-01cb19f2-c133-40eb-9a1f-50325717ec29.png">

AFTER:
<img width="544" alt="Screen Shot 2023-02-23 at 3 48 22 pm" src="https://user-images.githubusercontent.com/96150256/220830230-94191223-d3f6-4d5b-8210-e9dafeec109d.png">

- **Reconfigure:**

https://user-images.githubusercontent.com/96150256/221079689-35eb6ec8-3878-4675-9e11-1d16b256ec73.mp4

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
