### PR TITLE
Add cover image upload

### DIFF
--- a/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
+++ b/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
@@ -133,7 +133,6 @@ export const ProjectDetailsPage: React.FC = () => {
             <Form.Item
               name="coverImage"
               label={t`Cover image`}
-              required={false}
               tooltip={t`Add a cover image to your project page. This will be displayed at the top of your project page.`}
               extra={t`1400px x 256px image size recommended.`}
             >

--- a/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
+++ b/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
@@ -135,7 +135,7 @@ export const ProjectDetailsPage: React.FC = () => {
               label={t`Cover image`}
               required={false}
               tooltip={t`Add a cover image to your project page. This will be displayed at the top of your project page.`}
-              extra={t`1400px x 350px image size recommended.`}
+              extra={t`1400px x 256px image size recommended.`}
             >
               <FormImageUploader text={t`Upload`} maxSizeKBs={10000} />
             </Form.Item>

--- a/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
+++ b/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { RightCircleOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { ADDRESS_ZERO } from '@uniswap/v3-sdk'
 import { Col, Form, Row, Space } from 'antd'
@@ -8,10 +9,10 @@ import { FormImageUploader } from 'components/inputs/FormImageUploader'
 import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
 import { JuiceInput } from 'components/inputs/JuiceTextInput'
 import PrefixedInput from 'components/PrefixedInput'
-import TooltipIcon from 'components/TooltipIcon'
 import { CREATE_FLOW } from 'constants/fathomEvents'
 import { useWallet } from 'hooks/Wallet'
 import { trackFathomGoal } from 'lib/fathom'
+import Link from 'next/link'
 import { useContext } from 'react'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/EditingCreateFurthestPageReached'
 import { inputMustBeEthAddressRule, inputMustExistRule } from 'utils/antdRules'
@@ -20,8 +21,6 @@ import { OptionalHeader } from '../../OptionalHeader'
 import { Wizard } from '../../Wizard'
 import { PageContext } from '../../Wizard/contexts/PageContext'
 import { useProjectDetailsForm } from './hooks/ProjectDetailsForm'
-import Link from 'next/link'
-import { RightCircleOutlined } from '@ant-design/icons'
 
 export const ProjectDetailsPage: React.FC = () => {
   useSetCreateFurthestPageReached('projectDetails')
@@ -128,21 +127,25 @@ export const ProjectDetailsPage: React.FC = () => {
           </CreateCollapse.Panel>
           <CreateCollapse.Panel
             key={2}
-            header={<OptionalHeader header={t`Customize Pay Button`} />}
+            header={<OptionalHeader header={t`Project page customizations`} />}
             hideDivider
           >
+            <Form.Item
+              name="coverImage"
+              label={t`Cover image`}
+              required={false}
+              tooltip={t`Add a cover image to your project page. This will be displayed at the top of your project page.`}
+              extra={t`1400px x 350px image size recommended.`}
+            >
+              <FormImageUploader text={t`Upload`} maxSizeKBs={10000} />
+            </Form.Item>
+
             <Row className="pb-8 pt-5" gutter={32}>
               <Col span={12}>
                 <Form.Item
                   name="payButtonText"
-                  label={
-                    <span>
-                      <Trans>Pay Button Text</Trans>{' '}
-                      <TooltipIcon
-                        tip={t`This is the button that contributors will click to pay your project`}
-                      />
-                    </span>
-                  }
+                  label={<Trans>Pay Button Text</Trans>}
+                  tooltip={t`This is the button that contributors will click to pay your project`}
                 >
                   <JuiceInput placeholder={t`Pay`} />
                 </Form.Item>
@@ -150,14 +153,8 @@ export const ProjectDetailsPage: React.FC = () => {
             </Row>
             <Form.Item
               name="payDisclosure"
-              label={
-                <span>
-                  <Trans>Pay Disclosure</Trans>{' '}
-                  <TooltipIcon
-                    tip={t`Display a message or warning to contributors before they approve a payment to your project`}
-                  />
-                </span>
-              }
+              label={<Trans>Pay Disclosure</Trans>}
+              tooltip={t`Display a message or warning to contributors before they approve a payment to your project`}
             >
               <JuiceTextArea autoSize={{ minRows: 4, maxRows: 6 }} />
             </Form.Item>

--- a/src/components/Create/components/pages/ProjectDetails/hooks/ProjectDetailsForm.ts
+++ b/src/components/Create/components/pages/ProjectDetails/hooks/ProjectDetailsForm.ts
@@ -1,6 +1,6 @@
 import { useForm } from 'antd/lib/form/Form'
-import { useAppSelector } from 'redux/hooks/AppSelector'
 import { useMemo } from 'react'
+import { useAppSelector } from 'redux/hooks/AppSelector'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
 import { useFormDispatchWatch } from '../../hooks'
 
@@ -8,6 +8,7 @@ type ProjectDetailsFormProps = Partial<{
   projectName: string
   projectDescription: string
   logo: string
+  coverImage: string
   projectWebsite: string
   projectTwitter: string
   projectTelegram: string
@@ -28,6 +29,7 @@ export const useProjectDetailsForm = () => {
       projectName: projectMetadata.name,
       projectDescription: projectMetadata.description,
       logo: projectMetadata.logoUri,
+      coverImage: projectMetadata.coverImageUri,
       projectWebsite: projectMetadata.infoUri,
       projectTwitter: projectMetadata.twitter,
       projectTelegram: projectMetadata.telegram,
@@ -42,6 +44,7 @@ export const useProjectDetailsForm = () => {
       projectMetadata.discord,
       projectMetadata.infoUri,
       projectMetadata.logoUri,
+      projectMetadata.coverImageUri,
       projectMetadata.name,
       projectMetadata.payButton,
       projectMetadata.payDisclosure,
@@ -69,6 +72,13 @@ export const useProjectDetailsForm = () => {
     fieldName: 'logo',
     ignoreUndefined: true,
     dispatchFunction: editingV2ProjectActions.setLogoUri,
+    formatter: v => v ?? '',
+  })
+  useFormDispatchWatch({
+    form,
+    fieldName: 'coverImage',
+    ignoreUndefined: true,
+    dispatchFunction: editingV2ProjectActions.setCoverImageUri,
     formatter: v => v ?? '',
   })
   useFormDispatchWatch({

--- a/src/components/Project/ProjectHeader/EditProjectHandleButton.tsx
+++ b/src/components/Project/ProjectHeader/EditProjectHandleButton.tsx
@@ -23,7 +23,7 @@ export function EditProjectHandleButton() {
             handle,
           })}
         >
-          <Button className="pl-0" type="link" icon={<EditOutlined />}>
+          <Button className="px-0" type="link" icon={<EditOutlined />}>
             <span>
               <Trans>Add handle</Trans>
             </span>

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -9,6 +9,7 @@ import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { useGnosisSafe } from 'hooks/safe/GnosisSafe'
 import { useContext } from 'react'
 import { classNames } from 'utils/classNames'
+import { ipfsUriToGatewayUrl } from 'utils/ipfs'
 import { EditProjectHandleButton } from './EditProjectHandleButton'
 import SocialLinks from './SocialLinks'
 
@@ -28,7 +29,7 @@ function ProjectSubheading({
 
   return (
     <div className="flex items-center gap-x-4 text-grey-500 dark:text-grey-300">
-      <span className="font-medium">
+      <span className="flex items-center justify-between gap-3 font-medium">
         {handle ? (
           <Tooltip title={t`Project ID: ${projectId}`}>
             <span>@{handle}</span>
@@ -117,10 +118,10 @@ export function ProjectHeader({
 
   return (
     <header>
-      {hasBanner && (
+      {projectMetadata?.coverImageUri && (
         <div className="w-full">
           <img
-            src={projectMetadata?.coverImageUri}
+            src={ipfsUriToGatewayUrl(projectMetadata.coverImageUri)}
             className="h-64 w-full object-cover"
             crossOrigin="anonymous"
           />

--- a/src/components/ProjectLogo.tsx
+++ b/src/components/ProjectLogo.tsx
@@ -1,11 +1,6 @@
 import { useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
-import {
-  cidFromUrl,
-  ipfsGatewayUrl,
-  ipfsUriToGatewayUrl,
-  isIpfsUri,
-} from 'utils/ipfs'
+import { cidFromUrl, ipfsGatewayUrl, ipfsUriToGatewayUrl } from 'utils/ipfs'
 
 // Override some project logos.
 const IMAGE_URI_OVERRIDES: { [k: number]: string } = {
@@ -40,9 +35,6 @@ export default function ProjectLogo({
       return ipfsGatewayUrl(cid)
     }
 
-    if (!isIpfsUri(uri)) {
-      return uri
-    }
     return ipfsUriToGatewayUrl(uri)
   }, [uri, projectId])
 
@@ -50,7 +42,7 @@ export default function ProjectLogo({
     <div
       className={twMerge(
         'flex h-20 w-20 items-center justify-center overflow-hidden rounded-sm',
-        !validImg ? 'bg-smoke-100 dark:bg-slate-600' : 'undefined',
+        'bg-smoke-100 dark:bg-slate-600',
         className,
       )}
     >

--- a/src/components/v2v3/V2V3Project/V2V3Project.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3Project.tsx
@@ -84,7 +84,7 @@ export function V2V3Project() {
       />
 
       <V2V3PayProjectFormProvider>
-        <div className="my-0 mx-auto flex max-w-5xl flex-col gap-y-5 p-5">
+        <div className="my-0 mx-auto flex max-w-5xl flex-col gap-y-5 px-5 pb-5">
           <Row className="gap-y-10" gutter={GUTTER_PX} align={'bottom'}>
             <Col md={colSizeMd} xs={24}>
               <section>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsForm.tsx
@@ -2,6 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Form, FormInstance, Space } from 'antd'
 import { useWatch } from 'antd/lib/form/Form'
 import { FormItems } from 'components/formItems'
+import { FormImageUploader } from 'components/inputs/FormImageUploader'
 import { MinimalCollapse } from 'components/MinimalCollapse'
 import { normalizeHandle } from 'utils/format/formatHandle'
 
@@ -11,6 +12,7 @@ export type ProjectDetailsFormFields = {
   infoUri: string
   handle: string
   logoUri: string
+  coverImageUri: string
   twitter: string
   telegram: string
   discord: string
@@ -18,7 +20,7 @@ export type ProjectDetailsFormFields = {
   payDisclosure: string
 }
 
-export default function ProjectDetailsForm({
+export function ProjectDetailsForm({
   form,
   onFinish,
   hideProjectHandle = false,
@@ -34,6 +36,7 @@ export default function ProjectDetailsForm({
   onValuesChange?: VoidFunction
 }) {
   const initialLogoUrl = useWatch('logoUri', form)
+  const initialCoverImageUri = useWatch('coverImageUri', form)
 
   return (
     <Form
@@ -90,6 +93,19 @@ export default function ProjectDetailsForm({
 
         <div>
           <MinimalCollapse header={<Trans>Project page customizations</Trans>}>
+            <Form.Item
+              name={'coverImageUri'}
+              label={t`Cover image`}
+              tooltip={t`Add a cover image to your project page. This will be displayed at the top of your project page.`}
+              extra={t`1400px x 350px image size recommended.`}
+            >
+              <FormImageUploader
+                value={initialCoverImageUri}
+                maxSizeKBs={10000}
+                text={t`Upload`}
+              />
+            </Form.Item>
+
             <FormItems.ProjectPayButton name="payButton" />
             <FormItems.ProjectPayDisclosure name="payDisclosure" />
           </MinimalCollapse>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsForm.tsx
@@ -72,15 +72,14 @@ export function ProjectDetailsForm({
             />
           )}
           <FormItems.ProjectDescription name="description" />
-          <FormItems.ProjectLogoUri
-            name="logoUri"
-            initialUrl={initialLogoUrl}
-            onSuccess={logoUri => {
-              form.setFieldsValue({ logoUri })
-              onValuesChange?.()
-            }}
-            formItemProps={{ style: { marginBottom: 0 } }}
-          />
+
+          <Form.Item name={'logoUri'} label={t`Logo`}>
+            <FormImageUploader
+              value={initialLogoUrl}
+              maxSizeKBs={10000}
+              text={t`Upload`}
+            />
+          </Form.Item>
         </div>
         <div>
           <MinimalCollapse header={<Trans>Project links</Trans>}>
@@ -97,7 +96,7 @@ export function ProjectDetailsForm({
               name={'coverImageUri'}
               label={t`Cover image`}
               tooltip={t`Add a cover image to your project page. This will be displayed at the top of your project page.`}
-              extra={t`1400px x 350px image size recommended.`}
+              extra={t`1400px x 256px image size recommended.`}
             >
               <FormImageUploader
                 value={initialCoverImageUri}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useForm } from 'antd/lib/form/Form'
-import ProjectDetailsForm, {
+import {
+  ProjectDetailsForm,
   ProjectDetailsFormFields,
 } from 'components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsForm'
 import { PROJECT_PAY_CHARACTER_LIMIT } from 'constants/numbers'
@@ -9,6 +10,7 @@ import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetail
 import { uploadProjectMetadata } from 'lib/api/ipfs'
 import { revalidateProject } from 'lib/api/nextjs'
 import { useCallback, useContext, useEffect, useState } from 'react'
+import { reloadWindow } from 'utils/windowUtils'
 
 export function ProjectDetailsSettingsPage() {
   const { projectId } = useContext(ProjectMetadataContext)
@@ -30,6 +32,7 @@ export function ProjectDetailsSettingsPage() {
       name: fields.name,
       description: fields.description,
       logoUri: fields.logoUri,
+      coverImageUri: fields.coverImageUri,
       infoUri: fields.infoUri,
       twitter: fields.twitter,
       discord: fields.discord,
@@ -57,6 +60,7 @@ export function ProjectDetailsSettingsPage() {
             })
           }
           refetchProjectMetadata()
+          reloadWindow()
         },
         onError: () => {
           setLoadingSaveChanges(false)
@@ -77,6 +81,7 @@ export function ProjectDetailsSettingsPage() {
       name: projectMetadata?.name ?? '',
       infoUri: projectMetadata?.infoUri ?? '',
       logoUri: projectMetadata?.logoUri ?? '',
+      coverImageUri: projectMetadata?.coverImageUri ?? '',
       description: projectMetadata?.description ?? '',
       twitter: projectMetadata?.twitter ?? '',
       discord: projectMetadata?.discord ?? '',
@@ -88,6 +93,7 @@ export function ProjectDetailsSettingsPage() {
     projectMetadata?.name,
     projectMetadata?.infoUri,
     projectMetadata?.logoUri,
+    projectMetadata?.coverImageUri,
     projectMetadata?.description,
     projectMetadata?.twitter,
     projectMetadata?.discord,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
@@ -10,7 +10,6 @@ import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/EditProjectDetail
 import { uploadProjectMetadata } from 'lib/api/ipfs'
 import { revalidateProject } from 'lib/api/nextjs'
 import { useCallback, useContext, useEffect, useState } from 'react'
-import { reloadWindow } from 'utils/windowUtils'
 
 export function ProjectDetailsSettingsPage() {
   const { projectId } = useContext(ProjectMetadataContext)
@@ -60,7 +59,6 @@ export function ProjectDetailsSettingsPage() {
             })
           }
           refetchProjectMetadata()
-          reloadWindow()
         },
         onError: () => {
           setLoadingSaveChanges(false)

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -272,6 +272,9 @@ msgstr ""
 msgid "Add NFTs to funding cycle"
 msgstr ""
 
+msgid "Add a cover image to your project page. This will be displayed at the top of your project page."
+msgstr ""
+
 msgid "Add a note about this reconfiguration on-chain."
 msgstr ""
 
@@ -854,6 +857,9 @@ msgstr ""
 msgid "Copy to clipboard"
 msgstr ""
 
+msgid "Cover image"
+msgstr ""
+
 msgid "Create Payment Address"
 msgstr ""
 
@@ -906,9 +912,6 @@ msgid "Custom strategy"
 msgstr ""
 
 msgid "Custom token beneficiary"
-msgstr ""
-
-msgid "Customize Pay Button"
 msgstr ""
 
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -41,6 +41,9 @@ msgstr ""
 msgid "100% overflow"
 msgstr ""
 
+msgid "1400px x 350px image size recommended."
+msgstr ""
+
 msgid "2. Build trust"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -41,7 +41,7 @@ msgstr ""
 msgid "100% overflow"
 msgstr ""
 
-msgid "1400px x 350px image size recommended."
+msgid "1400px x 256px image size recommended."
 msgstr ""
 
 msgid "2. Build trust"

--- a/src/redux/slices/editingV2Project/editingV2Project.ts
+++ b/src/redux/slices/editingV2Project/editingV2Project.ts
@@ -47,6 +47,9 @@ const editingV2ProjectSlice = createSlice({
     setLogoUri: (state, action: PayloadAction<string>) => {
       state.projectMetadata.logoUri = action.payload
     },
+    setCoverImageUri: (state, action: PayloadAction<string>) => {
+      state.projectMetadata.coverImageUri = action.payload
+    },
     setTwitter: (state, action: PayloadAction<string>) => {
       state.projectMetadata.twitter = action.payload
     },


### PR DESCRIPTION
## What does this PR do and why?

Per title. Adds cover image upload to create flow, and project settings.

<img width="1913" alt="Screenshot 2023-02-26 at 4 00 59 PM" src="https://user-images.githubusercontent.com/12551741/221402609-01c4514a-f00f-438c-bddd-87ef66122054.png">
<img width="475" alt="Screenshot 2023-02-26 at 4 01 03 PM" src="https://user-images.githubusercontent.com/12551741/221402611-c2cab6d4-6e63-4ee5-a102-9b7391a9a2cb.png">
<img width="1915" alt="Screenshot 2023-02-26 at 4 01 35 PM" src="https://user-images.githubusercontent.com/12551741/221402613-6a47f1c8-39e3-4ca8-a44a-5d94737d4d07.png">

