### PR TITLE
Part 1: Support JBController 3.1 reserved tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@jbx-protocol/contracts-v2-4.0.0": "npm:@jbx-protocol/contracts-v2@4.0.0",
     "@jbx-protocol/contracts-v2-latest": "npm:@jbx-protocol/contracts-v2@8.0.4",
     "@jbx-protocol/juice-721-delegate": "3.0.0",
-    "@jbx-protocol/juice-contracts-v3": "2.0.5",
+    "@jbx-protocol/juice-contracts-v3": "3.1.0",
     "@jbx-protocol/juice-v1-token-terminal": "1.0.1",
     "@jbx-protocol/juice-v3-migration": "^1.0.0",
     "@jbx-protocol/project-handles": "^2.0.4",

--- a/src/hooks/v2v3/JBController/IsJBControllerV3_0.ts
+++ b/src/hooks/v2v3/JBController/IsJBControllerV3_0.ts
@@ -1,0 +1,12 @@
+import { V2V3ContractsContext } from 'contexts/v2v3/Contracts/V2V3ContractsContext'
+import { useContext } from 'react'
+import { isEqualAddress } from 'utils/address'
+
+export function useIsJBControllerV3_0({
+  controllerAddress,
+}: {
+  controllerAddress: string | undefined
+}): boolean {
+  const { contracts } = useContext(V2V3ContractsContext)
+  return isEqualAddress(controllerAddress, contracts?.JBController?.address)
+}

--- a/src/hooks/v2v3/JBController/IsJBControllerV3_0_1.ts
+++ b/src/hooks/v2v3/JBController/IsJBControllerV3_0_1.ts
@@ -1,0 +1,15 @@
+import { V2V3ContractsContext } from 'contexts/v2v3/Contracts/V2V3ContractsContext'
+import { useContext } from 'react'
+import { isEqualAddress } from 'utils/address'
+
+export function useIsJBControllerV3_0_1({
+  controllerAddress,
+}: {
+  controllerAddress: string | undefined
+}): boolean {
+  const { contracts } = useContext(V2V3ContractsContext)
+  return isEqualAddress(
+    controllerAddress,
+    contracts?.JBController3_0_1?.address,
+  )
+}

--- a/src/hooks/v2v3/JBController/IsJBControllerV3_1.ts
+++ b/src/hooks/v2v3/JBController/IsJBControllerV3_1.ts
@@ -1,0 +1,12 @@
+import { V2V3ContractsContext } from 'contexts/v2v3/Contracts/V2V3ContractsContext'
+import { useContext } from 'react'
+import { isEqualAddress } from 'utils/address'
+
+export function useIsJBControllerV3_1({
+  controllerAddress,
+}: {
+  controllerAddress: string | undefined
+}): boolean {
+  const { contracts } = useContext(V2V3ContractsContext)
+  return isEqualAddress(controllerAddress, contracts?.JBController3_1?.address)
+}

--- a/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectController.ts
+++ b/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectController.ts
@@ -22,6 +22,8 @@ export function useProjectController({ projectId }: { projectId: number }) {
       ? V2V3ContractName.JBController
       : isEqualAddress(controllerAddress, contracts?.JBController3_0_1?.address)
       ? V2V3ContractName.JBController3_0_1
+      : isEqualAddress(controllerAddress, contracts?.JBController3_1?.address)
+      ? V2V3ContractName.JBController3_1
       : undefined,
     address: controllerAddress,
   })

--- a/src/hooks/v2v3/contractReader/ProjectReservedTokens.ts
+++ b/src/hooks/v2v3/contractReader/ProjectReservedTokens.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { V2V3ProjectContractsContext } from 'contexts/v2v3/ProjectContracts/V2V3ProjectContractsContext'
 import { useContext, useMemo } from 'react'
 import { useIsJBControllerV3_0 } from '../JBController/IsJBControllerV3_0'
+import { useIsJBControllerV3_0_1 } from '../JBController/IsJBControllerV3_0_1'
 import { useIsJBControllerV3_1 } from '../JBController/IsJBControllerV3_1'
 import useContractReader from './V2ContractReader'
 
@@ -15,6 +16,9 @@ export default function useProjectReservedTokens({
   const { contracts } = useContext(V2V3ProjectContractsContext)
 
   const isJBControllerV3_0 = useIsJBControllerV3_0({
+    controllerAddress: contracts?.JBController?.address,
+  })
+  const isJBControllerV3_0_1 = useIsJBControllerV3_0_1({
     controllerAddress: contracts?.JBController?.address,
   })
   const isJBControllerV3_1 = useIsJBControllerV3_1({
@@ -32,17 +36,18 @@ export default function useProjectReservedTokens({
     return {
       contract: contracts.JBController,
       functionName: 'reservedTokenBalanceOf(uint256)',
-      args: projectId ? [projectId] : null,
+      args: projectId ? [projectId] : null, // JBControllerV3_1 doesn't need reservedRate
     }
   }, [contracts, projectId])
 
   const args = useMemo(() => {
-    if (isJBControllerV3_0) return JBControllerArgsV3_0
+    if (isJBControllerV3_0 || isJBControllerV3_0_1) return JBControllerArgsV3_0
     if (isJBControllerV3_1) return JBControllerArgsV3_1
 
     return { contract: undefined, functionName: undefined, args: undefined }
   }, [
     isJBControllerV3_0,
+    isJBControllerV3_0_1,
     JBControllerArgsV3_0,
     isJBControllerV3_1,
     JBControllerArgsV3_1,

--- a/src/hooks/v2v3/contractReader/ProjectReservedTokens.ts
+++ b/src/hooks/v2v3/contractReader/ProjectReservedTokens.ts
@@ -1,6 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { V2V3ProjectContractsContext } from 'contexts/v2v3/ProjectContracts/V2V3ProjectContractsContext'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
+import { useIsJBControllerV3_0 } from '../JBController/IsJBControllerV3_0'
+import { useIsJBControllerV3_1 } from '../JBController/IsJBControllerV3_1'
 import useContractReader from './V2ContractReader'
 
 export default function useProjectReservedTokens({
@@ -12,9 +14,39 @@ export default function useProjectReservedTokens({
 }) {
   const { contracts } = useContext(V2V3ProjectContractsContext)
 
-  return useContractReader<BigNumber>({
-    contract: contracts.JBController,
-    functionName: 'reservedTokenBalanceOf(uint256,uint256)',
-    args: projectId && reservedRate ? [projectId, reservedRate] : null,
+  const isJBControllerV3_0 = useIsJBControllerV3_0({
+    controllerAddress: contracts?.JBController?.address,
   })
+  const isJBControllerV3_1 = useIsJBControllerV3_1({
+    controllerAddress: contracts?.JBController?.address,
+  })
+
+  const JBControllerArgsV3_0 = useMemo(() => {
+    return {
+      contract: contracts.JBController,
+      functionName: 'reservedTokenBalanceOf(uint256,uint256)',
+      args: projectId && reservedRate ? [projectId, reservedRate] : null,
+    }
+  }, [contracts, projectId, reservedRate])
+  const JBControllerArgsV3_1 = useMemo(() => {
+    return {
+      contract: contracts.JBController,
+      functionName: 'reservedTokenBalanceOf(uint256)',
+      args: projectId ? [projectId] : null,
+    }
+  }, [contracts, projectId])
+
+  const args = useMemo(() => {
+    if (isJBControllerV3_0) return JBControllerArgsV3_0
+    if (isJBControllerV3_1) return JBControllerArgsV3_1
+
+    return { contract: undefined, functionName: undefined, args: undefined }
+  }, [
+    isJBControllerV3_0,
+    JBControllerArgsV3_0,
+    isJBControllerV3_1,
+    JBControllerArgsV3_1,
+  ])
+
+  return useContractReader<BigNumber>(args)
 }

--- a/src/models/v2v3/contracts.ts
+++ b/src/models/v2v3/contracts.ts
@@ -3,6 +3,7 @@ import { Contract } from '@ethersproject/contracts'
 export enum V2V3ContractName {
   JBController = 'JBController',
   JBController3_0_1 = 'JBController3_0_1',
+  JBController3_1 = 'JBController3_1',
   JBDirectory = 'JBDirectory',
   JBETHPaymentTerminal = 'JBETHPaymentTerminal',
   JBFundingCycleStore = 'JBFundingCycleStore',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,10 +3777,10 @@
     "@paulrberg/contracts" "^3.7.0"
     prb-math "^2.4.3"
 
-"@jbx-protocol/juice-contracts-v3@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@jbx-protocol/juice-contracts-v3/-/juice-contracts-v3-2.0.5.tgz#b75e5547d3ffe660a3fb9124e5e747fc52b5d642"
-  integrity sha512-pQSJbzz96nzHc2HDlN0Xx6uJufnRPAiUsilSwGRLjX38KZaeOtC7LU+YY0G5OHpH8tQPyAC/G/m5EwjpObIh3A==
+"@jbx-protocol/juice-contracts-v3@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jbx-protocol/juice-contracts-v3/-/juice-contracts-v3-3.1.0.tgz#84b7805510a84f0b26ff2d74bc22e2aa82e84660"
+  integrity sha512-r9T03mFY0p5RScWYWijNPyCz/DwalJ76p0izIb3yLSLLY802c1t+DZaI516E23dP500wBUjgxj7wUseI4loEew==
 
 "@jbx-protocol/juice-contracts-v3@^2.0.0":
   version "2.0.2"


### PR DESCRIPTION
## What does this PR do and why?

Initial support for JBController 3.1. Make useProjectReservedTokens controller-version-aware, so it calls the correct contract with the correct arguments and function signature for both v3, 3.0.1 and 3.1