### PR TITLE
Add option to reverse filter on projects page

### DIFF
--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2681,6 +2681,9 @@ msgstr ""
 msgid "Restricted actions"
 msgstr ""
 
+msgid "Reverse"
+msgstr ""
+
 msgid "Review & Deploy"
 msgstr ""
 

--- a/src/pages/projects/AllProjects.tsx
+++ b/src/pages/projects/AllProjects.tsx
@@ -19,11 +19,13 @@ export default function AllProjects({
   searchText,
   orderBy,
   showArchived,
+  reversed,
 }: {
   pv: PV[] | undefined
   searchText: string
   orderBy: 'createdAt' | 'totalPaid' | 'currentBalance' | 'paymentsCount'
   showArchived: boolean
+  reversed: boolean
 }) {
   const loadMoreContainerRef = useRef<HTMLDivElement>(null)
   const pageSize = 20
@@ -37,7 +39,7 @@ export default function AllProjects({
   } = useInfiniteProjectsQuery({
     orderBy,
     pageSize,
-    orderDirection: 'desc',
+    orderDirection: reversed ? 'asc' : 'desc',
     state: showArchived ? 'archived' : 'active',
     pv,
   })

--- a/src/pages/projects/ProjectsFilterAndSort.tsx
+++ b/src/pages/projects/ProjectsFilterAndSort.tsx
@@ -21,6 +21,8 @@ export default function ProjectsFilterAndSort({
   setIncludeV2,
   showArchived,
   setShowArchived,
+  reversed,
+  setReversed,
   orderBy,
   setOrderBy,
 }: {
@@ -30,6 +32,8 @@ export default function ProjectsFilterAndSort({
   setIncludeV2: CheckboxOnChange
   showArchived: boolean
   setShowArchived: CheckboxOnChange
+  reversed: boolean
+  setReversed: CheckboxOnChange
   orderBy: OrderByOption
   setOrderBy: (value: OrderByOption) => void
 }) {
@@ -86,6 +90,11 @@ export default function ProjectsFilterAndSort({
               label={t`Archived`}
               checked={showArchived}
               onChange={setShowArchived}
+            />
+            <FilterCheckboxItem
+              label={t`Reverse`}
+              checked={reversed}
+              onChange={setReversed}
             />
           </div>
         </CollapsePanel>

--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -80,6 +80,7 @@ function Projects() {
   const [includeV1, setIncludeV1] = useState<boolean>(true)
   const [includeV2, setIncludeV2] = useState<boolean>(true)
   const [showArchived, setShowArchived] = useState<boolean>(false)
+  const [reversed, setReversed] = useState<boolean>(false)
 
   const pv: PV[] | undefined = useMemo(() => {
     const _pv: PV[] = []
@@ -157,6 +158,8 @@ function Projects() {
                 setIncludeV2={setIncludeV2}
                 showArchived={showArchived}
                 setShowArchived={setShowArchived}
+                reversed={reversed}
+                setReversed={setReversed}
                 orderBy={orderBy}
                 setOrderBy={setOrderBy}
               />
@@ -174,6 +177,7 @@ function Projects() {
               searchText={searchText}
               orderBy={orderBy}
               showArchived={showArchived}
+              reversed={reversed}
             />
           ) : selectedTab === 'holdings' ? (
             <HoldingsProjects />


### PR DESCRIPTION
## What does this PR do and why?

Add option to reverse filter on projects page. Lets you see earliest projects on various versions (or projects with no volume if you care to see them).

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [x] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [x] I have tested this PR in dark mode and light mode (if applicable).
