### PR TITLE
Support distributePayoutsOf for JB 3.1

### DIFF
--- a/src/components/NftRewards/NftRewardsSection.tsx
+++ b/src/components/NftRewards/NftRewardsSection.tsx
@@ -4,9 +4,9 @@ import {
   NftPostPayModal,
   NFT_PAYMENT_CONFIRMED_QUERY_PARAM,
 } from 'components/NftRewards/NftPostPayModal'
-import { DEFAULT_ALLOW_OVERSPENDING } from 'components/Project/PayProjectForm/hooks/PayProjectForm'
 import { PayProjectFormContext } from 'components/Project/PayProjectForm/payProjectFormContext'
 import SectionHeader from 'components/SectionHeader'
+import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
 import { NftRewardsContext } from 'contexts/NftRewards/NftRewardsContext'
 import { CurrencyContext } from 'contexts/shared/CurrencyContext'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'

--- a/src/components/Project/PayProjectForm/hooks/PayProjectForm.ts
+++ b/src/components/Project/PayProjectForm/hooks/PayProjectForm.ts
@@ -23,8 +23,6 @@ type PayMetadata =
   | JB721DELAGATE_V1_PAY_METADATA
   | JB721DELAGATE_V1_1_PAY_METADATA // in future, maybe more
 
-export const DEFAULT_ALLOW_OVERSPENDING = true
-
 const DEFAULT_PAY_METADATA: PayMetadata = {
   tierIdsToMint: [],
 }

--- a/src/components/Project/ProjectHeader/EditProjectHandleButton.tsx
+++ b/src/components/Project/ProjectHeader/EditProjectHandleButton.tsx
@@ -23,7 +23,7 @@ export function EditProjectHandleButton() {
             handle,
           })}
         >
-          <Button className="px-0" type="link" icon={<EditOutlined />}>
+          <Button type="link" icon={<EditOutlined />}>
             <span>
               <Trans>Add handle</Trans>
             </span>

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -29,7 +29,7 @@ function ProjectSubheading({
 
   return (
     <div className="flex items-center gap-x-4 text-grey-500 dark:text-grey-300">
-      <span className="flex items-center justify-between gap-3 font-medium">
+      <span className="flex items-center justify-between gap-2 font-medium">
         {handle ? (
           <Tooltip title={t`Project ID: ${projectId}`}>
             <span>@{handle}</span>

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/hooks/DelegateMetadata.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/hooks/DelegateMetadata.tsx
@@ -1,18 +1,18 @@
 import {
-  DEFAULT_ALLOW_OVERSPENDING,
   JB721DELAGATE_V1_1_PAY_METADATA,
-  JB721DELAGATE_V1_PAY_METADATA
+  JB721DELAGATE_V1_PAY_METADATA,
 } from 'components/Project/PayProjectForm/hooks/PayProjectForm'
 import { PayProjectFormContext } from 'components/Project/PayProjectForm/payProjectFormContext'
 import {
   JB721_DELEGATE_V1,
-  JB721_DELEGATE_V1_1
+  JB721_DELEGATE_V1_1,
 } from 'constants/delegateVersions'
+import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
 import { NftRewardsContext } from 'contexts/NftRewards/NftRewardsContext'
 import { useContext } from 'react'
 import {
   encodeJB721DelegateV1PayMetadata,
-  encodeJB721DelegateV1_1PayMetadata
+  encodeJB721DelegateV1_1PayMetadata,
 } from 'utils/nftRewards'
 
 export function useDelegateMetadata() {

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/hooks/UpdateCurrentCollection.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/hooks/UpdateCurrentCollection.ts
@@ -1,6 +1,6 @@
 import { NEW_NFT_ID_LOWER_LIMIT } from 'components/Create/components/RewardsList/AddEditRewardModal'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
-import { useNftRewardsAdjustTiersTx } from 'hooks/JB721Delegate/transactor/NftRewardsAdjustTiersTx'
+import { useAdjustTiersTx } from 'hooks/JB721Delegate/transactor/AdjustTiersTx'
 import { NftRewardTier } from 'models/nftRewardTier'
 import { useCallback, useContext } from 'react'
 import { buildJB721TierParams, pinNftRewards } from 'utils/nftRewards'
@@ -14,7 +14,7 @@ export function useUpdateCurrentCollection({
   editedRewardTierIds: number[]
 }) {
   const { fundingCycleMetadata } = useContext(V2V3ProjectContext)
-  const nftRewardsAdjustTiersTx = useNftRewardsAdjustTiersTx({
+  const nftRewardsAdjustTiersTx = useAdjustTiersTx({
     dataSourceAddress: fundingCycleMetadata?.dataSource,
   })
 

--- a/src/constants/transactionDefaults.ts
+++ b/src/constants/transactionDefaults.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_MEMO = ''
 export const DEFAULT_METADATA = 0
+export const DEFAULT_MIN_RETURNED_TOKENS = 0
+export const DEFAULT_ALLOW_OVERSPENDING = true

--- a/src/contexts/NftRewards/NftRewards.ts
+++ b/src/contexts/NftRewards/NftRewards.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { ONE_BILLION } from 'constants/numbers'
 import {
   IPFSNftRewardTier,
-  JB721TierParams,
+  JB721Tier,
   NftRewardTier,
 } from 'models/nftRewardTier'
 import { useQuery, UseQueryResult } from 'react-query'
@@ -16,7 +16,7 @@ export const DEFAULT_NFT_MAX_SUPPLY = ONE_BILLION - 1
 async function fetchRewardTierMetadata({
   tier,
 }: {
-  tier: JB721TierParams
+  tier: JB721Tier
 }): Promise<NftRewardTier> {
   const tierCid = decodeEncodedIpfsUri(tier.encodedIPFSUri)
   const url = ipfsGatewayUrl(tierCid)
@@ -48,7 +48,7 @@ async function fetchRewardTierMetadata({
 // Retreives each NftRewardTier from IPFS given an array of CIDs (IpfsHashes)
 // Returns an array of NftRewardTiers
 export default function useNftRewards(
-  tiers: JB721TierParams[],
+  tiers: JB721Tier[],
   projectId: number | undefined,
   dataSourceAddress: string | undefined,
 ): UseQueryResult<NftRewardTier[]> {

--- a/src/hooks/JB721Delegate/contractReader/NftRewardTiersOf.ts
+++ b/src/hooks/JB721Delegate/contractReader/NftRewardTiersOf.ts
@@ -1,5 +1,5 @@
 import { useStoreOfJB721TieredDelegate } from 'hooks/JB721Delegate/contracts/StoreofJB721TieredDelegate'
-import { JB721TierParams } from 'models/nftRewardTier'
+import { JB721Tier } from 'models/nftRewardTier'
 import { MAX_NFT_REWARD_TIERS } from 'utils/nftRewards'
 import useV2ContractReader from '../../v2v3/contractReader/V2ContractReader'
 
@@ -21,7 +21,7 @@ export function useNftRewardTiersOf({
     ? [dataSourceAddress, 0, limit ?? MAX_NFT_REWARD_TIERS]
     : null
 
-  return useV2ContractReader<JB721TierParams[]>({
+  return useV2ContractReader<JB721Tier[]>({
     contract: JBTiered721DelegateStore,
     functionName: 'tiers',
     args,

--- a/src/hooks/JB721Delegate/transactor/AdjustTiersTx.ts
+++ b/src/hooks/JB721Delegate/transactor/AdjustTiersTx.ts
@@ -5,7 +5,7 @@ import { TransactorInstance } from 'hooks/Transactor'
 import { JB721TierParams } from 'models/nftRewardTier'
 import { useContext } from 'react'
 
-export function useNftRewardsAdjustTiersTx({
+export function useAdjustTiersTx({
   dataSourceAddress,
 }: {
   dataSourceAddress: string | undefined

--- a/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal.ts
+++ b/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal.ts
@@ -6,8 +6,8 @@ import { useProjectPrimaryEthTerminalAddress } from '../../contractReader/Projec
 import { useLoadV2V3Contract } from '../../LoadV2V3Contract'
 
 export type JBETHPaymentTerminalVersion = '3' | '3.1'
-export const ETH_PAYMENT_TERMINAL_V_3: JBETHPaymentTerminalVersion = '3'
-export const ETH_PAYMENT_TERMINAL_V_3_1: JBETHPaymentTerminalVersion = '3.1'
+export const JB_ETH_PAYMENT_TERMINAL_V_3: JBETHPaymentTerminalVersion = '3'
+export const JB_ETH_PAYMENT_TERMINAL_V_3_1: JBETHPaymentTerminalVersion = '3.1'
 
 export function useProjectPrimaryEthTerminal({
   projectId,
@@ -25,21 +25,21 @@ export function useProjectPrimaryEthTerminal({
     primaryETHTerminal,
     contracts?.JBETHPaymentTerminal?.address,
   )
-    ? ETH_PAYMENT_TERMINAL_V_3
+    ? JB_ETH_PAYMENT_TERMINAL_V_3
     : isEqualAddress(
         primaryETHTerminal,
         contracts?.JBETHPaymentTerminal3_1?.address,
       )
-    ? ETH_PAYMENT_TERMINAL_V_3_1
+    ? JB_ETH_PAYMENT_TERMINAL_V_3_1
     : undefined
 
   const JBETHPaymentTerminal = useLoadV2V3Contract({
     cv,
     address: primaryETHTerminal,
     contractName:
-      version === ETH_PAYMENT_TERMINAL_V_3
+      version === JB_ETH_PAYMENT_TERMINAL_V_3
         ? V2V3ContractName.JBETHPaymentTerminal
-        : version === ETH_PAYMENT_TERMINAL_V_3_1
+        : version === JB_ETH_PAYMENT_TERMINAL_V_3_1
         ? V2V3ContractName.JBETHPaymentTerminal3_1
         : undefined,
   })

--- a/src/hooks/v2v3/transactor/AddToBalanceTx/AddToBalanceTx.ts
+++ b/src/hooks/v2v3/transactor/AddToBalanceTx/AddToBalanceTx.ts
@@ -9,9 +9,9 @@ import {
   TransactorInstance,
 } from 'hooks/Transactor'
 import {
-  ETH_PAYMENT_TERMINAL_V_3,
-  ETH_PAYMENT_TERMINAL_V_3_1,
   JBETHPaymentTerminalVersion,
+  JB_ETH_PAYMENT_TERMINAL_V_3,
+  JB_ETH_PAYMENT_TERMINAL_V_3_1,
 } from 'hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal'
 import { useContext } from 'react'
 import invariant from 'tiny-invariant'
@@ -19,7 +19,10 @@ import { useV2ProjectTitle } from '../../ProjectTitle'
 import { getAddToBalanceParamsV3 } from './AddToBalanceParamsV3'
 import { getAddToBalanceParamsV3_1 } from './AddToBalanceParamsV3_1'
 
-function getParams({
+/**
+ * Factory function for building the arguments for the `addToBalance` function, depending on the version of the JBETHPaymentTerminal contract.
+ */
+function buildTxArgs({
   JBETHPaymentTerminalVersion,
   projectId,
   value,
@@ -28,10 +31,10 @@ function getParams({
   projectId: number
   value: BigNumber
 }) {
-  if (JBETHPaymentTerminalVersion === ETH_PAYMENT_TERMINAL_V_3) {
+  if (JBETHPaymentTerminalVersion === JB_ETH_PAYMENT_TERMINAL_V_3) {
     return getAddToBalanceParamsV3({ projectId, value })
   }
-  if (JBETHPaymentTerminalVersion === ETH_PAYMENT_TERMINAL_V_3_1) {
+  if (JBETHPaymentTerminalVersion === JB_ETH_PAYMENT_TERMINAL_V_3_1) {
     return getAddToBalanceParamsV3_1({ projectId, value })
   }
 }
@@ -50,18 +53,18 @@ export function useAddToBalanceTx(): TransactorInstance<{
     try {
       invariant(projectId && contracts?.JBETHPaymentTerminal)
 
-      const params = getParams({
+      const txArgs = buildTxArgs({
         JBETHPaymentTerminalVersion: versions.JBETHPaymentTerminal,
         projectId,
         value,
       })
 
-      invariant(transactor && projectTitle && params)
+      invariant(transactor && projectTitle && txArgs)
 
       return transactor(
         contracts.JBETHPaymentTerminal,
-        params?.functionName,
-        params?.args,
+        txArgs?.functionName,
+        txArgs?.args,
         {
           ...txOpts,
           value,

--- a/src/hooks/v2v3/transactor/DistributePayouts.ts
+++ b/src/hooks/v2v3/transactor/DistributePayouts.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
+import { DEFAULT_MIN_RETURNED_TOKENS } from 'constants/transactionDefaults'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { TransactionContext } from 'contexts/Transaction/TransactionContext'
@@ -14,8 +15,6 @@ type DistributePayoutsTx = TransactorInstance<{
   amount: BigNumber | undefined
   currency: V2V3CurrencyOption | undefined
 }>
-
-const DEFAULT_MIN_RETURNED_TOKENS = 0
 
 export function useDistributePayoutsTx(): DistributePayoutsTx {
   const { transactor } = useContext(TransactionContext)

--- a/src/hooks/v2v3/transactor/DistributePayouts.ts
+++ b/src/hooks/v2v3/transactor/DistributePayouts.ts
@@ -12,26 +12,67 @@ import { V2V3ProjectContractsContext } from 'contexts/v2v3/ProjectContracts/V2V3
 import { TransactorInstance } from 'hooks/Transactor'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useContext } from 'react'
+import invariant from 'tiny-invariant'
 import { useV2ProjectTitle } from '../ProjectTitle'
-import { ETH_PAYMENT_TERMINAL_V_3_1 } from '../V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal'
+import {
+  JBETHPaymentTerminalVersion,
+  JB_ETH_PAYMENT_TERMINAL_V_3,
+  JB_ETH_PAYMENT_TERMINAL_V_3_1,
+} from '../V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal'
 
 interface DistributePayoutsTxBaseParams {
   amount: BigNumber | undefined
   currency: V2V3CurrencyOption | undefined
 }
 
-type DistributePayoutsTx3Params = DistributePayoutsTxBaseParams & {
+type DISTRIBUTE_PAYOUTS_TX_V3_PARAMS = DistributePayoutsTxBaseParams & {
   memo?: string
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-type DistributePayoutsTx3_1Params = DistributePayoutsTxBaseParams & {
+type DISTRIBUTE_PAYOUTS_TX_V3_1_PARAMS = DistributePayoutsTxBaseParams & {
   metadata?: string // JB terminal 3.1 replaced `memo` with `metadata`
 }
 
-type DistributePayoutsTx = TransactorInstance<
-  DistributePayoutsTx3Params | DistributePayoutsTx3_1Params
->
+type DistributePayoutsTxArgs =
+  | DISTRIBUTE_PAYOUTS_TX_V3_PARAMS
+  | DISTRIBUTE_PAYOUTS_TX_V3_1_PARAMS
+
+type DistributePayoutsTx = TransactorInstance<DistributePayoutsTxArgs>
+
+/**
+ * Factory function for building the arguments for the `distributePayoutsOf` function, depending on the version of the JBETHPaymentTerminal contract.
+ */
+function buildTxArgs({
+  JBETHPaymentTerminalVersion,
+  projectId,
+  args,
+}: {
+  JBETHPaymentTerminalVersion: JBETHPaymentTerminalVersion | undefined
+  projectId: number
+  args: DistributePayoutsTxArgs
+}) {
+  const baseArgs = [
+    projectId,
+    args.amount,
+    args.currency,
+    ETH_TOKEN_ADDRESS, // _token
+    DEFAULT_MIN_RETURNED_TOKENS, // _minReturnedTokens
+  ]
+
+  if (JBETHPaymentTerminalVersion === JB_ETH_PAYMENT_TERMINAL_V_3) {
+    return [
+      ...baseArgs,
+      (args as DISTRIBUTE_PAYOUTS_TX_V3_PARAMS).memo ?? DEFAULT_MEMO, // _memo
+    ]
+  }
+
+  if (JBETHPaymentTerminalVersion === JB_ETH_PAYMENT_TERMINAL_V_3_1) {
+    return [
+      ...baseArgs,
+      (args as DISTRIBUTE_PAYOUTS_TX_V3_1_PARAMS).metadata ?? DEFAULT_METADATA, // _metadata
+    ]
+  }
+}
 
 export function useDistributePayoutsTx(): DistributePayoutsTx {
   const { transactor } = useContext(TransactionContext)
@@ -52,19 +93,18 @@ export function useDistributePayoutsTx(): DistributePayoutsTx {
       return Promise.resolve(false)
     }
 
+    const txArgs = buildTxArgs({
+      JBETHPaymentTerminalVersion: versions.JBETHPaymentTerminal,
+      projectId,
+      args,
+    })
+
+    invariant(txArgs)
+
     return transactor(
       contracts.JBETHPaymentTerminal,
       'distributePayoutsOf',
-      [
-        projectId,
-        args.amount,
-        args.currency,
-        ETH_TOKEN_ADDRESS, // _token
-        DEFAULT_MIN_RETURNED_TOKENS, // _minReturnedTokens
-        versions.JBETHPaymentTerminal === ETH_PAYMENT_TERMINAL_V_3_1
-          ? (args as DistributePayoutsTx3_1Params).metadata ?? DEFAULT_METADATA // _metadata
-          : (args as DistributePayoutsTx3Params).memo ?? DEFAULT_MEMO, // _memo
-      ],
+      txArgs,
       {
         ...txOpts,
         title: t`Send ${projectTitle} payouts`,

--- a/src/hooks/v2v3/transactor/DistributePayouts.ts
+++ b/src/hooks/v2v3/transactor/DistributePayouts.ts
@@ -13,7 +13,7 @@ import { TransactorInstance } from 'hooks/Transactor'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useContext } from 'react'
 import { useV2ProjectTitle } from '../ProjectTitle'
-import { ETH_PAYMENT_TERMINAL_V_3 } from '../V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal'
+import { ETH_PAYMENT_TERMINAL_V_3_1 } from '../V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal'
 
 interface DistributePayoutsTxBaseParams {
   amount: BigNumber | undefined
@@ -26,7 +26,7 @@ type DistributePayoutsTx3Params = DistributePayoutsTxBaseParams & {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type DistributePayoutsTx3_1Params = DistributePayoutsTxBaseParams & {
-  metadata?: string
+  metadata?: string // JB terminal 3.1 replaced `memo` with `metadata`
 }
 
 type DistributePayoutsTx = TransactorInstance<
@@ -61,9 +61,9 @@ export function useDistributePayoutsTx(): DistributePayoutsTx {
         args.currency,
         ETH_TOKEN_ADDRESS, // _token
         DEFAULT_MIN_RETURNED_TOKENS, // _minReturnedTokens
-        versions.JBETHPaymentTerminal === ETH_PAYMENT_TERMINAL_V_3
-          ? (args as DistributePayoutsTx3Params).memo ?? DEFAULT_MEMO
-          : (args as DistributePayoutsTx3_1Params).metadata ?? DEFAULT_METADATA, // _metadata
+        versions.JBETHPaymentTerminal === ETH_PAYMENT_TERMINAL_V_3_1
+          ? (args as DistributePayoutsTx3_1Params).metadata ?? DEFAULT_METADATA // _metadata
+          : (args as DistributePayoutsTx3Params).memo ?? DEFAULT_MEMO, // _memo
       ],
       {
         ...txOpts,

--- a/src/hooks/v2v3/transactor/DistributePayouts.ts
+++ b/src/hooks/v2v3/transactor/DistributePayouts.ts
@@ -1,6 +1,10 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
-import { DEFAULT_MIN_RETURNED_TOKENS } from 'constants/transactionDefaults'
+import {
+  DEFAULT_MEMO,
+  DEFAULT_METADATA,
+  DEFAULT_MIN_RETURNED_TOKENS,
+} from 'constants/transactionDefaults'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { TransactionContext } from 'contexts/Transaction/TransactionContext'
@@ -9,27 +13,40 @@ import { TransactorInstance } from 'hooks/Transactor'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useContext } from 'react'
 import { useV2ProjectTitle } from '../ProjectTitle'
+import { ETH_PAYMENT_TERMINAL_V_3 } from '../V2V3ProjectContracts/projectContractLoaders/ProjectPrimaryEthTerminal'
 
-type DistributePayoutsTx = TransactorInstance<{
-  memo?: string
+interface DistributePayoutsTxBaseParams {
   amount: BigNumber | undefined
   currency: V2V3CurrencyOption | undefined
-}>
+}
+
+type DistributePayoutsTx3Params = DistributePayoutsTxBaseParams & {
+  memo?: string
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type DistributePayoutsTx3_1Params = DistributePayoutsTxBaseParams & {
+  metadata?: string
+}
+
+type DistributePayoutsTx = TransactorInstance<
+  DistributePayoutsTx3Params | DistributePayoutsTx3_1Params
+>
 
 export function useDistributePayoutsTx(): DistributePayoutsTx {
   const { transactor } = useContext(TransactionContext)
-  const { contracts } = useContext(V2V3ProjectContractsContext)
+  const { contracts, versions } = useContext(V2V3ProjectContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
 
   const projectTitle = useV2ProjectTitle()
 
-  return ({ amount, currency, memo = '' }, txOpts) => {
+  return (args, txOpts) => {
     if (
       !transactor ||
       !projectId ||
       !contracts?.JBETHPaymentTerminal ||
-      !amount ||
-      !currency
+      !args.amount ||
+      !args.currency
     ) {
       txOpts?.onDone?.()
       return Promise.resolve(false)
@@ -40,11 +57,13 @@ export function useDistributePayoutsTx(): DistributePayoutsTx {
       'distributePayoutsOf',
       [
         projectId,
-        amount,
-        currency,
+        args.amount,
+        args.currency,
         ETH_TOKEN_ADDRESS, // _token
         DEFAULT_MIN_RETURNED_TOKENS, // _minReturnedTokens
-        memo,
+        versions.JBETHPaymentTerminal === ETH_PAYMENT_TERMINAL_V_3
+          ? (args as DistributePayoutsTx3Params).memo ?? DEFAULT_MEMO
+          : (args as DistributePayoutsTx3_1Params).metadata ?? DEFAULT_METADATA, // _metadata
       ],
       {
         ...txOpts,

--- a/src/hooks/v2v3/transactor/DistributeReservedTokensTx.ts
+++ b/src/hooks/v2v3/transactor/DistributeReservedTokensTx.ts
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useContext } from 'react'
 
+import { DEFAULT_MEMO } from 'constants/transactionDefaults'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { TransactionContext } from 'contexts/Transaction/TransactionContext'
 import { V2V3ProjectContractsContext } from 'contexts/v2v3/ProjectContracts/V2V3ProjectContractsContext'
@@ -20,7 +21,7 @@ export function useDistributeReservedTokens(): DistributeReserveTokensTx {
   } = useContext(V2V3ProjectContractsContext)
   const { projectId } = useContext(ProjectMetadataContext)
 
-  return ({ memo = '' }, txOpts) => {
+  return ({ memo = DEFAULT_MEMO }, txOpts) => {
     if (!transactor || !projectId || !JBController) {
       txOpts?.onDone?.()
       return Promise.resolve(false)

--- a/src/hooks/v2v3/transactor/PayETHPaymentTerminalTx.ts
+++ b/src/hooks/v2v3/transactor/PayETHPaymentTerminalTx.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { t } from '@lingui/macro'
+import { DEFAULT_MIN_RETURNED_TOKENS } from 'constants/transactionDefaults'
 import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { TransactionContext } from 'contexts/Transaction/TransactionContext'
@@ -9,7 +10,6 @@ import { useContext } from 'react'
 import { useV2ProjectTitle } from '../ProjectTitle'
 
 const DEFAULT_DELEGATE_METADATA = 0
-const DEFAULT_MIN_RETURNED_TOKENS = 0
 
 type PayV2ProjectTx = TransactorInstance<{
   memo: string

--- a/src/models/nftRewardTier.ts
+++ b/src/models/nftRewardTier.ts
@@ -29,14 +29,11 @@ export type JBTiered721Flags = {
 }
 export type DelegateVersion = JB721DELEGATE_V1 | JB721DELEGATE_V1_1
 
-// How the reward tiers are stored in the contracts
-export type JB721TierParams = {
-  id: BigNumber
-  remainingQuantity?: BigNumber //undefined for outgoing tier (in launch or adjustTiers tx)
-
-  contributionFloor: BigNumber //uint128
+// Used when launching or adjusting tiers.
+export interface JB721TierParams {
+  contributionFloor: BigNumber // uint128
   lockedUntil: BigNumber
-  initialQuantity: BigNumber //uint64
+  initialQuantity: BigNumber // uint64
   votingUnits: BigNumber
   reservedRate: BigNumber
   reservedTokenBeneficiary: string
@@ -44,6 +41,12 @@ export type JB721TierParams = {
   allowManualMint: boolean
   shouldUseBeneficiaryAsDefault: boolean
   transfersPausable: boolean
+}
+
+// Tiers as they are stored on-chain.
+export type JB721Tier = JB721TierParams & {
+  id: BigNumber
+  remainingQuantity?: BigNumber
 }
 
 type OpenSeaAttribute = {

--- a/src/styles/antd-overrides/button.scss
+++ b/src/styles/antd-overrides/button.scss
@@ -94,12 +94,13 @@
 }
 
 .ant-btn-link {
+  @apply px-2;
   @apply text-action-primary;
   border: none;
   @apply font-medium;
 
   &:hover {
-    @apply text-action-primary-hover;
+    @apply bg-haze-50;
   }
   &:focus,
   &:active {

--- a/src/utils/nftRewards.ts
+++ b/src/utils/nftRewards.ts
@@ -2,7 +2,6 @@ import { BigNumber } from '@ethersproject/bignumber'
 import * as constants from '@ethersproject/constants'
 import { NftFileType } from 'components/inputs/UploadNoStyle'
 import {
-  DEFAULT_ALLOW_OVERSPENDING,
   JB721DELAGATE_V1_1_PAY_METADATA,
   JB721DELAGATE_V1_PAY_METADATA,
 } from 'components/Project/PayProjectForm/hooks/PayProjectForm'
@@ -10,6 +9,7 @@ import { VIDEO_FILE_TYPES } from 'constants/fileTypes'
 import { juiceboxEmojiImageUri } from 'constants/images'
 import { readNetwork } from 'constants/networks'
 import { WAD_DECIMALS } from 'constants/numbers'
+import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
 import { DEFAULT_NFT_MAX_SUPPLY } from 'contexts/NftRewards/NftRewards'
 import { defaultAbiCoder, parseEther } from 'ethers/lib/utils'
 import { pinJson } from 'lib/api/ipfs'

--- a/src/utils/nftRewards.ts
+++ b/src/utils/nftRewards.ts
@@ -266,7 +266,7 @@ export function buildJB721TierParams({
         allowManualMint: false,
         shouldUseBeneficiaryAsDefault: false,
         transfersPausable: false,
-      } as JB721TierParams
+      }
     })
     .sort((a, b) => {
       // Tiers MUST BE in ascending order when sent to contract.


### PR DESCRIPTION
## What does this PR do and why?

Closes JB-46

Makes distributePayoutsOf work if the project is using JBETHTerminal 3.1: https://github.com/jbx-protocol/juice-interface/pull/3169/files#r1128905499.

How it works:
- In V2V3ProjectContractsContext, we are loading the specific contracts that the project uses. We also determine the version of these contracts and provide that to the context too: https://github.com/jbx-protocol/juice-interface/blob/90b7112c4f1ee75af308d6d7295f82925ef74685/src/contexts/v2v3/ProjectContracts/V2V3ProjectContracts.ts#L16
- In teh `distributePayoutsOf` hook, we send different arguments depending on which version of the contract is in use. Lucky in this case, the args are pretty much the same!
- For a similar example, see `addToBalanceOf`: https://github.com/jbx-protocol/juice-interface/blob/74c48a6389662b09cfb29c7194c622dffab7d7cd/src/hooks/v2v3/transactor/AddToBalanceTx/AddToBalanceTx.ts#L22-L37

Has some other random unrelated changes too.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
