### PR TITLE
Consolidate reserved token listing components across create and settings

### DIFF
--- a/src/components/Allocation/components/AllocationItemTitle.tsx
+++ b/src/components/Allocation/components/AllocationItemTitle.tsx
@@ -1,0 +1,35 @@
+import { LockFilled } from '@ant-design/icons'
+import { t } from '@lingui/macro'
+import { Space, Tooltip } from 'antd'
+import FormattedAddress from 'components/FormattedAddress'
+import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
+import { formatDate } from 'utils/format/formatDate'
+import { isProjectSplit } from 'utils/splits'
+import { AllocationSplit } from '../Allocation'
+
+export function AllocationItemTitle({
+  allocation,
+}: {
+  allocation: AllocationSplit
+}) {
+  return (
+    <Space>
+      {isProjectSplit(allocation) && allocation.projectId ? (
+        <V2V3ProjectHandleLink projectId={parseInt(allocation.projectId)} />
+      ) : (
+        <FormattedAddress address={allocation.beneficiary} />
+      )}
+
+      {!!allocation.lockedUntil && (
+        <Tooltip
+          title={t`Locked until ${formatDate(
+            allocation.lockedUntil * 1000,
+            'yyyy-MM-DD',
+          )}`}
+        >
+          <LockFilled />
+        </Tooltip>
+      )}
+    </Space>
+  )
+}

--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/components/ReservedTokensList/ReservedTokensList.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/components/ReservedTokensList/ReservedTokensList.tsx
@@ -1,12 +1,11 @@
 import { DeleteOutlined } from '@ant-design/icons'
 import { t } from '@lingui/macro'
-import { Space, Tooltip } from 'antd'
+import { Space } from 'antd'
 import { Allocation, AllocationSplit } from 'components/Allocation'
+import { AllocationItemTitle } from 'components/Allocation/components/AllocationItemTitle'
 import { OwnerPayoutCard } from 'components/PayoutCard'
-import { formatPercent } from 'utils/format/formatPercent'
-import FormattedAddress from 'components/FormattedAddress'
 import { FormItemInput } from 'models/formItemInput'
-import { formatDate } from 'utils/format/formatDate'
+import { formatPercent } from 'utils/format/formatPercent'
 
 export const ReservedTokensList: React.FC<
   FormItemInput<AllocationSplit[]> & { isEditable?: boolean }
@@ -28,19 +27,7 @@ export const ReservedTokensList: React.FC<
               {allocations.map(allocation => (
                 <Allocation.Item
                   key={allocation.id}
-                  title={
-                    <Space>
-                      <FormattedAddress address={allocation.beneficiary} />
-                      {!!allocation.lockedUntil && (
-                        <Tooltip
-                          title={t`Locked until ${formatDate(
-                            allocation.lockedUntil * 1000,
-                            'yyyy-MM-DD',
-                          )}`}
-                        />
-                      )}
-                    </Space>
-                  }
+                  title={<AllocationItemTitle allocation={allocation} />}
                   amount={formatPercent(allocation.percent)}
                   extra={
                     <DeleteOutlined

--- a/src/components/PayoutCard/PayoutCard.tsx
+++ b/src/components/PayoutCard/PayoutCard.tsx
@@ -1,16 +1,13 @@
-import { DeleteOutlined, LockFilled } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
-import { Space, Tooltip } from 'antd'
+import { DeleteOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
 import { Allocation, AllocationSplit } from 'components/Allocation'
+import { AllocationItemTitle } from 'components/Allocation/components/AllocationItemTitle'
 import FormattedAddress from 'components/FormattedAddress'
 import { DeleteConfirmationModal } from 'components/modals/DeleteConfirmationModal'
-import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import { useModal } from 'hooks/Modal'
 import { PayoutsSelection } from 'models/payoutsSelection'
 import { useCallback } from 'react'
 import { stopPropagation } from 'react-stop-propagation'
-import { formatDate } from 'utils/format/formatDate'
-import { isProjectSplit } from 'utils/splits'
 import { Amount } from './Amount'
 
 export const PayoutCard = ({
@@ -33,28 +30,7 @@ export const PayoutCard = ({
   return (
     <>
       <Allocation.Item
-        title={
-          <Space>
-            {isProjectSplit(allocation) && allocation.projectId ? (
-              <V2V3ProjectHandleLink
-                projectId={parseInt(allocation.projectId)}
-              />
-            ) : (
-              <FormattedAddress address={allocation.beneficiary} />
-            )}
-
-            {!!allocation.lockedUntil && (
-              <Tooltip
-                title={t`Locked until ${formatDate(
-                  allocation.lockedUntil * 1000,
-                  'yyyy-MM-DD',
-                )}`}
-              >
-                <LockFilled />
-              </Tooltip>
-            )}
-          </Space>
-        }
+        title={<AllocationItemTitle allocation={allocation} />}
         amount={
           <Amount
             allocationId={allocation.id}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/ReservedTokensSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/ReservedTokensSettingsPage.tsx
@@ -69,6 +69,7 @@ export function ReservedTokensSettingsPage() {
         onClick={() => onSaveTokenAllocation()}
         disabled={totalPercentagesInvalid}
         type="primary"
+        className="mt-4"
       >
         <span>
           <Trans>Save token recipients</Trans>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/V2V3EditReservedTokens.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/V2V3EditReservedTokens.tsx
@@ -1,14 +1,14 @@
 import { Trans } from '@lingui/macro'
-import { Form, Space } from 'antd'
+import { Space } from 'antd'
+import { AllocationSplit } from 'components/Allocation'
 import { Callout } from 'components/Callout'
+import { ReservedTokensList } from 'components/Create/components/pages/ProjectToken/components/CustomTokenSettings/components/ReservedTokensList'
 import { CsvUpload } from 'components/inputs/CsvUpload'
-import { FormItems } from 'components/formItems'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { Split } from 'models/splits'
 import { useCallback, useContext, useEffect } from 'react'
 import { parseV2SplitsCsv } from 'utils/csv'
-import { toMod, toSplit } from 'utils/splits'
-import { formatReservedRate } from 'utils/v2v3/math'
+import { allocationToSplit, splitToAllocation } from 'utils/splitToAllocation'
 
 export function V2V3EditReservedTokens({
   editingReservedTokensSplits,
@@ -17,9 +17,7 @@ export function V2V3EditReservedTokens({
   editingReservedTokensSplits: Split[]
   setEditingReservedTokensSplits: (splits: Split[]) => void
 }) {
-  const { reservedTokensSplits, fundingCycleMetadata } =
-    useContext(V2V3ProjectContext)
-  const reservedRate = fundingCycleMetadata?.reservedRate
+  const { reservedTokensSplits } = useContext(V2V3ProjectContext)
 
   useEffect(() => {
     if (!reservedTokensSplits) return
@@ -32,6 +30,10 @@ export function V2V3EditReservedTokens({
     },
     [setEditingReservedTokensSplits],
   )
+
+  const onAllocationChanged = (newAllocations: AllocationSplit[]) => {
+    onSplitsChanged(newAllocations.map(allocationToSplit))
+  }
 
   return (
     <>
@@ -50,23 +52,10 @@ export function V2V3EditReservedTokens({
             parser={parseV2SplitsCsv}
           />
         </div>
-        <Form layout="vertical">
-          <FormItems.ProjectTicketMods
-            mods={editingReservedTokensSplits.map(toMod)}
-            onModsChanged={mods =>
-              setEditingReservedTokensSplits(mods.map(toSplit))
-            }
-            formItemProps={{
-              extra: (
-                <Trans>
-                  Set aside a percentage of token issuance for the Ethereum
-                  wallets or Juicebox projects of your choice.
-                </Trans>
-              ),
-            }}
-            reservedRate={parseInt(formatReservedRate(reservedRate))}
-          />
-        </Form>
+        <ReservedTokensList
+          onChange={onAllocationChanged}
+          value={editingReservedTokensSplits.map(splitToAllocation)}
+        />
       </Space>
     </>
   )

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/TokenDrawer/TokenForm/ReservedTokensFormItem.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/TokenDrawer/TokenForm/ReservedTokensFormItem.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react'
 import { FormItems } from 'components/formItems'
 import { FormItemExt } from 'components/formItems/formItemExt'
 import FormItemWarningText from 'components/FormItemWarningText'
+import { V2V3EditReservedTokens } from 'components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/V2V3EditReservedTokens'
 import { Split } from 'models/splits'
 import { DEFAULT_FUNDING_CYCLE_METADATA } from 'redux/slices/editingV2Project'
-import { toMod, toSplit } from 'utils/splits'
 
 export default function ReservedTokensFormItem({
   className,
@@ -74,22 +74,9 @@ export default function ReservedTokensFormItem({
               </Trans>
             </FormItemWarningText>
           )}
-          <FormItems.ProjectTicketMods
-            mods={reservedTokensSplits.map(split => toMod(split))}
-            onModsChanged={mods => {
-              const splits = mods.map(mod => toSplit(mod))
-              onReservedTokensSplitsChange(splits)
-            }}
-            formItemProps={{
-              label: <Trans>Reserved token recipients (optional)</Trans>,
-              extra: (
-                <Trans>
-                  Choose wallets or Juicebox projects to receive reserved
-                  tokens.
-                </Trans>
-              ),
-            }}
-            reservedRate={reservedRate ?? 0}
+          <V2V3EditReservedTokens
+            editingReservedTokensSplits={reservedTokensSplits}
+            setEditingReservedTokensSplits={onReservedTokensSplitsChange}
           />
         </>
       ) : null}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -635,9 +635,6 @@ msgstr ""
 msgid "Choose how you would like to set up payouts."
 msgstr ""
 
-msgid "Choose wallets or Juicebox projects to receive reserved tokens."
-msgstr ""
-
 msgid "Choosing zero will delete all payouts and remove any target."
 msgstr ""
 
@@ -2850,9 +2847,6 @@ msgid "Set aside a percentage of freshly minted NFTs."
 msgstr ""
 
 msgid "Set aside a percentage of freshly minted tokens, which you can allocate below."
-msgstr ""
-
-msgid "Set aside a percentage of token issuance for the Ethereum wallets or Juicebox projects of your choice."
 msgstr ""
 
 msgid "Set controller"


### PR DESCRIPTION
## What does this PR do and why?

Fixes JB-18
Fixes JB-73

## Screenshots or screen recordings

### Edit reserved tokens: 
<img width="1046" alt="Screen Shot 2023-03-09 at 11 48 27 am" src="https://user-images.githubusercontent.com/96150256/223899642-764ad755-582d-47ca-a69a-860257011d00.png">

### Reconfig FC:
<img width="1287" alt="Screen Shot 2023-03-09 at 12 01 11 pm" src="https://user-images.githubusercontent.com/96150256/223899703-20aedaf1-4010-4ad7-bbd5-88d5f28ef124.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
