### PR TITLE
Fix create flow redemption rate disabled bug

### DIFF
--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
@@ -45,8 +45,9 @@ export const CustomTokenSettings = () => {
 
   const discountRateDisabled = !parseInt(duration)
 
-  const redemptionRateDisabled =
-    !distributionLimit || distributionLimit.amount.eq(MAX_DISTRIBUTION_LIMIT)
+  const redemptionRateDisabled = distributionLimit?.amount.eq(
+    MAX_DISTRIBUTION_LIMIT,
+  )
 
   const initalMintRateAccessory = (
     <span className="mr-5">


### PR DESCRIPTION
## What does this PR do and why?

Currently, setting the redemption rate is disabled during the create flow when a project has payouts set to "none". This is not desired.

## Acceptance checklist

- [x] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
