### PR TITLE
Protect against previous sessions and changing wallets

### DIFF
--- a/src/lib/ssr/address.ts
+++ b/src/lib/ssr/address.ts
@@ -1,0 +1,23 @@
+import { readProvider } from 'constants/readProvider'
+import { isAddress } from 'ethers/lib/utils'
+
+export const resolveEnsNameAddressPair = async (addressOrEnsName: string) => {
+  if (isAddress(addressOrEnsName)) {
+    const ensName = await readProvider.lookupAddress(addressOrEnsName)
+    return {
+      address: addressOrEnsName,
+      ensName,
+    }
+  }
+
+  if (addressOrEnsName.endsWith('.eth')) {
+    const address = await readProvider.resolveName(addressOrEnsName)
+    if (!address) return undefined
+    return {
+      address,
+      ensName: addressOrEnsName,
+    }
+  }
+
+  return undefined
+}

--- a/src/pages/account/[addressOrEnsName]/index.page.tsx
+++ b/src/pages/account/[addressOrEnsName]/index.page.tsx
@@ -1,7 +1,6 @@
 import { AccountDashboard } from 'components/AccountDashboard'
 import { AppWrapper, SEO } from 'components/common'
-import { readProvider } from 'constants/readProvider'
-import { isAddress } from 'ethers/lib/utils'
+import { resolveEnsNameAddressPair } from 'lib/ssr/address'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { truncateEthAddress } from 'utils/format/formatAddress'
 
@@ -21,31 +20,20 @@ export const getServerSideProps: GetServerSideProps<
 
   const addressOrEnsName = context.params.addressOrEnsName as string
 
-  if (isAddress(addressOrEnsName)) {
-    const ensName = await readProvider.lookupAddress(addressOrEnsName)
+  const pair = await resolveEnsNameAddressPair(addressOrEnsName)
+  if (!pair) {
     return {
-      props: {
-        address: addressOrEnsName,
-        ensName,
-      },
+      notFound: true,
     }
   }
+  const { address, ensName } = pair
 
-  if (addressOrEnsName.includes('.eth')) {
-    const address = await readProvider.resolveName(addressOrEnsName)
-    if (!address) {
-      return { notFound: true }
-    }
-
-    return {
-      props: {
-        address,
-        ensName: addressOrEnsName,
-      },
-    }
+  return {
+    props: {
+      address,
+      ensName,
+    },
   }
-
-  return { notFound: true }
 }
 
 export default function AccountPage({


### PR DESCRIPTION
## What does this PR do and why?

Redirects the user when attempting to go to an unauthorized edit of a profile.

The previous behaviour was that it would go to the settings page, but it might be editing a profile the user doesnt expect (but still owns)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
