### PR TITLE
[1/n] fix! Rebuild mobile navigation from ground up

### DIFF
--- a/src/components/Navbar/Mobile/MobileNavigation.tsx
+++ b/src/components/Navbar/Mobile/MobileNavigation.tsx
@@ -1,74 +1,140 @@
-import { MenuOutlined } from '@ant-design/icons'
-import { Collapse, Menu } from 'antd'
-import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
-import { Header } from 'antd/lib/layout/layout'
+import { DownOutlined, MenuOutlined } from '@ant-design/icons'
+import { Menu } from '@headlessui/react'
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+import ExternalLink from 'components/ExternalLink'
 import { useWallet } from 'hooks/Wallet'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 import Logo from '../Logo'
-import { mobileNavItems } from '../navigationItems'
-import { TransactionsList } from '../TransactionList'
-
-const NAV_EXPANDED_KEY = 0
+import NavLanguageSelector from '../NavLanguageSelector'
+import WalletButton from '../WalletButton'
+import ThemePickerMobile from './ThemePickerMobile'
 
 export default function MobileNavigation() {
-  const [activeKey, setActiveKey] = useState<0 | undefined>()
-
   const { isConnected, disconnect } = useWallet()
 
-  const isNavExpanded = activeKey === NAV_EXPANDED_KEY
-
-  const collapseNav = () => setActiveKey(undefined)
-  const expandNav = () => setActiveKey(NAV_EXPANDED_KEY)
-  const toggleNav = () => (isNavExpanded ? collapseNav() : expandNav())
-
-  // Close collapse when clicking anywhere in the window except the collapse items
-  useEffect(() => {
-    function handleClick() {
-      setActiveKey(undefined)
-    }
-    window.addEventListener('click', handleClick)
-    return () => window.removeEventListener('click', handleClick)
-  }, [])
-
   return (
-    <Header
-      // ant override for .top-nav
-      className="top-nav top-nav-mobile fixed z-[1] flex h-16 w-full items-center  justify-between bg-smoke-25 py-4 px-2 leading-[64px] dark:bg-slate-800"
-      onClick={e => {
-        e.stopPropagation()
-      }}
-    >
-      <Collapse className="border-none bg-transparent" activeKey={activeKey}>
-        <CollapsePanel
-          className="border-none"
-          key={0}
-          showArrow={false}
-          header={
-            <div className="flex w-full justify-between">
-              <Link href="/">
-                <a>
-                  <Logo />
+    <>
+      <Menu className="bg-l0 fixed z-10 w-full p-4" as="nav">
+        <div className="flex items-center justify-between">
+          <LogoHomeButton />
+          <HamburgerMenuButton />
+        </div>
+        <Menu.Items className="stroke-tertiary flex flex-col gap-5 border border-x-0 border-t-0 border-solid pt-8 pb-4">
+          {/* Main site links */}
+          <div className="flex flex-col gap-4 px-6">
+            <Menu.Item>
+              <Link href="/projects">
+                <a className="text-primary">
+                  <Trans>Explore</Trans>
                 </a>
               </Link>
-              <div className="flex items-center gap-7">
-                <TransactionsList listClassName="absolute top-12 left-0 right-0 p-3" />
-                <MenuOutlined
-                  className="text-2xl leading-none text-black dark:text-slate-100"
-                  onClick={toggleNav}
-                  role="button"
-                />
-              </div>
-            </div>
-          }
+            </Menu.Item>
+            <Menu.Item>
+              <ExternalLink
+                className="text-primary"
+                href="https://discord.gg/wFTh4QnDzk"
+              >
+                <Trans>Discord</Trans>
+              </ExternalLink>
+            </Menu.Item>
+            <Menu.Item>
+              <ResourcesMenu />
+            </Menu.Item>
+          </div>
+
+          {/* Selectors and toggles */}
+          <div className="flex flex-col gap-4 px-6">
+            <Menu.Item>
+              <NavLanguageSelector />
+            </Menu.Item>
+            <Menu.Item>
+              <ThemePickerMobile />
+            </Menu.Item>
+          </div>
+
+          {/* Wallet interaction */}
+          <div className="flex flex-col gap-2">
+            <Menu.Item>
+              <WalletButton />
+            </Menu.Item>
+            {isConnected && (
+              <Menu.Item>
+                <Button onClick={disconnect} block>
+                  <Trans>Disconnect</Trans>
+                </Button>
+              </Menu.Item>
+            )}
+          </div>
+        </Menu.Items>
+      </Menu>
+    </>
+  )
+}
+
+const LogoHomeButton = () => (
+  <Link href="/">
+    <a>
+      <Logo />
+    </a>
+  </Link>
+)
+
+const HamburgerMenuButton = () => (
+  <Menu.Button as="div">
+    <MenuOutlined
+      className="text-2xl leading-none text-black dark:text-slate-100"
+      role="button"
+    />
+  </Menu.Button>
+)
+
+const ResourcesMenu = () => {
+  return (
+    <Menu>
+      <div>
+        <Menu.Button
+          as="div"
+          className="text-primary flex justify-between font-medium"
         >
-          <Menu
-            mode="inline"
-            items={mobileNavItems({ isConnected, disconnect, collapseNav })}
-            defaultSelectedKeys={['resources']}
-          />
-        </CollapsePanel>
-      </Collapse>
-    </Header>
+          <Trans>Resources</Trans>
+          <DownOutlined />
+        </Menu.Button>
+
+        <Menu.Items className="flex flex-col gap-4 px-6 pt-4">
+          <Menu.Item>
+            <ExternalLink
+              className="text-primary"
+              href="https://docs.juicebox.money/"
+            >
+              <Trans>Docs</Trans>
+            </ExternalLink>
+          </Menu.Item>
+          <Menu.Item>
+            <ExternalLink
+              className="text-primary"
+              href="https://newsletter.juicebox.money/"
+            >
+              <Trans>Newsletter</Trans>
+            </ExternalLink>
+          </Menu.Item>
+          <Menu.Item>
+            <ExternalLink
+              className="text-primary"
+              href="https://podcast.juicebox.money/"
+            >
+              <Trans>Podcast</Trans>
+            </ExternalLink>
+          </Menu.Item>
+          <Menu.Item>
+            <Link href="/contact">
+              <a className="text-primary">
+                <Trans>Contact</Trans>
+              </a>
+            </Link>
+          </Menu.Item>
+        </Menu.Items>
+      </div>
+    </Menu>
   )
 }

--- a/src/components/Navbar/navigationItems.tsx
+++ b/src/components/Navbar/navigationItems.tsx
@@ -1,23 +1,15 @@
 import { DownOutlined, UpOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Button, Dropdown, MenuProps } from 'antd'
+import { Dropdown, MenuProps } from 'antd'
 import { TOP_NAV } from 'constants/fathomEvents'
 import { trackFathomGoal } from 'lib/fathom'
 import Link from 'next/link'
 import { CSSProperties } from 'react'
 import Logo from './Logo'
-import ThemePickerMobile from './Mobile/ThemePickerMobile'
-import NavLanguageSelector from './NavLanguageSelector'
-import WalletButton from './WalletButton'
 
 type ResourceItem = {
   label: JSX.Element
   key: string
-}
-
-const externalMenuLinkProps = {
-  target: '_blank',
-  rel: 'noopener noreferrer',
 }
 
 const DesktopDropDown = ({
@@ -158,66 +150,5 @@ export const desktopMenuItems = ({
         >{t`Create a project`}</a>
       </Link>
     ),
-  },
-]
-
-export const mobileNavItems = ({
-  isConnected,
-  disconnect,
-  collapseNav,
-}: {
-  isConnected: boolean
-  disconnect: () => void
-  collapseNav: () => void
-}) => [
-  {
-    key: 'projects',
-    label: (
-      <Link href="/projects">
-        <a
-          className="flex cursor-pointer items-center font-medium text-black hover:opacity-70 dark:text-slate-100"
-          onClick={() => trackFathomGoal(TOP_NAV.EXPLORE_CTA)}
-          {...{ ...collapseNav }}
-        >{t`Explore`}</a>
-      </Link>
-    ),
-  },
-  {
-    key: 'discord',
-    label: (
-      <Link href="https://discord.gg/wFTh4QnDzk">
-        <a
-          className="flex cursor-pointer items-center font-medium text-black hover:opacity-70 dark:text-slate-100"
-          onClick={() => trackFathomGoal(TOP_NAV.DISCORD_CTA)}
-          {...{ ...externalMenuLinkProps, ...collapseNav }}
-        >{t`Discord`}</a>
-      </Link>
-    ),
-  },
-  {
-    key: 'resources',
-    label: (
-      <Link href="">
-        <a className="flex cursor-pointer items-center font-medium text-black hover:opacity-70 dark:text-slate-100">
-          {t`Resources`}
-        </a>
-      </Link>
-    ),
-    children: [...resourcesMenuItems()],
-  },
-
-  { key: 'language-picker', label: <NavLanguageSelector /> },
-  { key: 'theme-picker', label: <ThemePickerMobile /> },
-  {
-    key: 'wallet',
-    label: <WalletButton />,
-  },
-  {
-    key: 'disconnect',
-    label: isConnected ? (
-      <Button className="mt-2" onClick={disconnect} block>
-        <Trans>Disconnect</Trans>
-      </Button>
-    ) : null,
   },
 ]

--- a/src/styles/antd-overrides/collapse.scss
+++ b/src/styles/antd-overrides/collapse.scss
@@ -122,7 +122,6 @@
   }
 }
 
-
 .ant-collapse-content-hidden {
   display: none !important;
 }


### PR DESCRIPTION
## What does this PR do and why?

There was some formatting fudging, as well as just ant design behaving irregularly, so I rebuilt in pure css and used headless ui.

This work was required to fix the update branding on mobile

## Screenshots or screen recordings

### Before

![Screen Shot 2023-03-15 at 12 21 17 pm](https://user-images.githubusercontent.com/104132113/225179837-7dc3dec1-1f35-4964-9212-abea61d4bea3.png)

### After

![Screen Shot 2023-03-15 at 12 22 03 pm](https://user-images.githubusercontent.com/104132113/225179870-cd096730-d241-4780-9811-1e2861d2bd23.png)



## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
