### PR TITLE
Fix mobile trending cards on `/projects`

### DIFF
--- a/src/pages/projects/TrendingProjectCard.tsx
+++ b/src/pages/projects/TrendingProjectCard.tsx
@@ -74,7 +74,7 @@ export default function TrendingProjectCard({
 
   const projectLogo = (
     <ProjectLogo
-      className={size === 'sm' ? 'h-20 w-20' : 'h-28 w-28'}
+      className={size === 'sm' ? 'h-20 w-20' : 'h-20 w-20 md:h-28 md:w-28'}
       uri={metadata?.logoUri}
       name={metadata?.name}
       projectId={project.projectId}


### PR DESCRIPTION
## What does this PR do and why?

BEFORE:

<img width="570" alt="Screen Shot 2023-03-15 at 11 51 15 pm" src="https://user-images.githubusercontent.com/96150256/225329491-7548e9c6-bbcd-4e56-a15f-70cbd3fa62cf.png">

AFTER:

<img width="573" alt="Screen Shot 2023-03-15 at 11 50 50 pm" src="https://user-images.githubusercontent.com/96150256/225329446-f4d9b088-82f7-4c57-a374-2806a50ca9e2.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).
