### PR TITLE
Peri/subgraph compatibility v6.1.0 / v6.2.0

### DIFF
--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -63,7 +63,7 @@ export function DownloadParticipantsModal({
           'totalPaid',
           'balance',
           'stakedBalance',
-          'unstakedBalance',
+          'erc20Balance',
           'lastPaidTimestamp',
         ],
         orderBy: 'balance',
@@ -94,7 +94,7 @@ export function DownloadParticipantsModal({
           p.wallet ?? '--',
           fromWad(p.balance),
           fromWad(p.stakedBalance),
-          fromWad(p.unstakedBalance),
+          fromWad(p.erc20Balance),
           fromWad(p.totalPaid),
           date,
         ])

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -65,6 +65,14 @@ export default function ProjectActivity() {
         key: 'useAllowanceEvent',
         value: null, // Exclude all useAllowanceEvents, no UI support yet
       },
+      {
+        key: 'distributeToTicketModEvent',
+        value: null, // Exclude all distributeToTicketModEvent, no UI support
+      },
+      {
+        key: 'distributeToPayoutModEvent',
+        value: null, // Exclude all distributeToPayoutModEvent, no UI support
+      },
     ]
 
     if (projectId) {

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/ConfigureEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/ConfigureEventElem.tsx
@@ -27,7 +27,7 @@ export default function ConfigureEventElem({
         | 'discountRate'
         | 'duration'
         | 'mintingAllowed'
-        | 'payPaused'
+        | 'pausePay'
         | 'redeemPaused'
         | 'burnPaused'
         | 'transfersPaused'
@@ -71,7 +71,7 @@ export default function ConfigureEventElem({
     },
     allowControllerMigration: event.controllerMigrationAllowed,
     allowTerminalMigration: event.terminalMigrationAllowed,
-    pausePay: event.payPaused,
+    pausePay: event.pausePay,
     pauseRedeem: event.redeemPaused,
     pauseBurn: event.burnPaused,
     pauseDistributions: event.distributionsPaused,

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
@@ -1,0 +1,39 @@
+import { t } from '@lingui/macro'
+import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
+import CurrencySymbol from 'components/CurrencySymbol'
+import { SetFundAccessConstraintsEvent } from 'models/subgraph-entities/v2/set-fund-access-constraints-event'
+import { formatWad } from 'utils/format/formatNumber'
+import { V2V3CurrencyName } from 'utils/v2v3/currency'
+
+export default function SetFundAccessConstraintsEventElem({
+  event,
+}: {
+  event:
+    | Pick<
+        SetFundAccessConstraintsEvent,
+        | 'id'
+        | 'timestamp'
+        | 'txHash'
+        | 'caller'
+        | 'distributionLimit'
+        | 'distributionLimitCurrency'
+      >
+    | undefined
+}) {
+  if (!event) return null
+
+  return (
+    <ActivityEvent
+      event={event}
+      header={t`Set distribution limit`}
+      subject={
+        <div>
+          <CurrencySymbol
+            currency={V2V3CurrencyName(event.distributionLimitCurrency)}
+          />
+          {formatWad(event.distributionLimit)}
+        </div>
+      }
+    />
+  )
+}

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
@@ -25,7 +25,7 @@ export default function SetFundAccessConstraintsEventElem({
   return (
     <ActivityEvent
       event={event}
-      header={t`Set distribution limit`}
+      header={t`Edited payout`}
       subject={
         <div>
           <CurrencySymbol

--- a/src/components/v2v3/V2V3Project/ProjectActivity/hooks/ProjectActivity.ts
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/hooks/ProjectActivity.ts
@@ -152,6 +152,7 @@ export type EventFilter =
   | 'distributeReservedTokens'
   | 'deployETHERC20ProjectPayer'
   | 'configure'
+  | 'setFundAccessConstraints'
 
 export function useProjectActivity({
   eventFilter,
@@ -238,42 +239,45 @@ export function useProjectActivity({
   }, [projectId, eventFilter])
 
   const keys = useMemo(() => {
-    let _keys = undefined
+    let key = undefined
 
     switch (eventFilter) {
       case 'deployERC20':
-        _keys = [DEPLOYED_ERC20_EVENT_KEY]
+        key = DEPLOYED_ERC20_EVENT_KEY
         break
       case 'pay':
-        _keys = [PAY_EVENT_KEY]
+        key = PAY_EVENT_KEY
         break
       case 'burn':
-        _keys = [BURN_EVENT_KEY]
+        key = BURN_EVENT_KEY
         break
       case 'addToBalance':
-        _keys = [ADD_TO_BALANCE_EVENT_KEY]
+        key = ADD_TO_BALANCE_EVENT_KEY
         break
       case 'projectCreate':
-        _keys = [PROJECT_CREATE_EVENT_KEY]
+        key = PROJECT_CREATE_EVENT_KEY
         break
       case 'redeem':
-        _keys = [REDEEM_EVENT_KEY]
+        key = REDEEM_EVENT_KEY
         break
       case 'distributePayouts':
-        _keys = [DISTRIBUTED_PAYOUTS_EVENT_KEY]
+        key = DISTRIBUTED_PAYOUTS_EVENT_KEY
         break
       case 'distributeTokens':
-        _keys = [DISTRIBUTED_RESERVED_TOKENS_EVENT_KEY]
+        key = DISTRIBUTED_RESERVED_TOKENS_EVENT_KEY
         break
       case 'deployETHERC20ProjectPayer':
-        _keys = [DEPLOYED_PROJECT_PAYER_EVENT_KEY]
+        key = DEPLOYED_PROJECT_PAYER_EVENT_KEY
         break
       case 'configure':
-        _keys = [CONFIGURE_EVENT_KEY, SET_FUND_ACCESS_CONSTRAINTS_EVENT_KEY]
+        key = CONFIGURE_EVENT_KEY
+        break
+      case 'setFundAccessConstraints':
+        key = SET_FUND_ACCESS_CONSTRAINTS_EVENT_KEY
         break
     }
 
-    if (_keys) return _keys
+    if (key) return [key]
 
     // if no filter, fetch all
     return [

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -182,6 +182,9 @@ export default function ProjectActivity() {
             <Select.Option value="configure">
               <Trans>Edited cycle</Trans>
             </Select.Option>
+            <Select.Option value="setFundAccessConstraints">
+              <Trans>Edited payout</Trans>
+            </Select.Option>
             <Select.Option value="addToBalance">
               <Trans>Transferred ETH to project</Trans>
             </Select.Option>

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -16,6 +16,7 @@ import ConfigureEventElem from './eventElems/ConfigureEventElem'
 import DeployETHERC20ProjectPayerEventElem from './eventElems/DeployETHERC20ProjectPayerEventElem'
 import DistributePayoutsElem from './eventElems/DistributePayoutsElem'
 import DistributeReservedTokensEventElem from './eventElems/DistributeReservedTokensElem'
+import SetFundAccessConstraintsEventElem from './eventElems/SetFundAccessConstraintsEventElem'
 import { EventFilter, useProjectActivity } from './hooks/ProjectActivity'
 
 export default function ProjectActivity() {
@@ -80,6 +81,13 @@ export default function ProjectActivity() {
           }
           if (e.configureEvent) {
             elem = <ConfigureEventElem event={e.configureEvent} />
+          }
+          if (e.setFundAccessConstraintsEvent) {
+            elem = (
+              <SetFundAccessConstraintsEventElem
+                event={e.setFundAccessConstraintsEvent}
+              />
+            )
           }
 
           if (!elem) return null

--- a/src/hooks/Projects.ts
+++ b/src/hooks/Projects.ts
@@ -77,7 +77,7 @@ const queryOpts = (
   if (terminalAddress) {
     where.push({
       key: 'terminal',
-      value: terminalAddress,
+      value: terminalAddress.toLowerCase(),
     })
   }
 
@@ -227,7 +227,7 @@ export function useContributedProjectsQuery(wallet: string | undefined) {
     return [
       {
         key: 'wallet',
-        value: wallet,
+        value: wallet.toLowerCase(),
       },
       {
         key: 'totalPaid',
@@ -248,7 +248,7 @@ export function useHoldingsProjectsQuery(wallet: string | undefined) {
     return [
       {
         key: 'wallet',
-        value: wallet,
+        value: wallet.toLowerCase(),
       },
       {
         key: 'balance',

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1199,6 +1199,9 @@ msgstr ""
 msgid "Edited cycle"
 msgstr ""
 
+msgid "Edited payout"
+msgstr ""
+
 msgid "Editing NFTs"
 msgstr ""
 
@@ -2874,9 +2877,6 @@ msgid "Set controller"
 msgstr ""
 
 msgid "Set cycle duration"
-msgstr ""
-
-msgid "Set distribution limit"
 msgstr ""
 
 msgid "Set handle @{handle}"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2876,6 +2876,9 @@ msgstr ""
 msgid "Set cycle duration"
 msgstr ""
 
+msgid "Set distribution limit"
+msgstr ""
+
 msgid "Set handle @{handle}"
 msgstr ""
 

--- a/src/models/graph.ts
+++ b/src/models/graph.ts
@@ -12,6 +12,7 @@ import { DistributeToPayoutSplitEvent } from './subgraph-entities/v2/distribute-
 import { DistributeToReservedTokenSplitEvent } from './subgraph-entities/v2/distribute-to-reserved-token-split-event'
 import { ETHERC20ProjectPayer } from './subgraph-entities/v2/eth-erc20-project-payer'
 import { JB721DelegateToken } from './subgraph-entities/v2/jb-721-delegate-tokens'
+import { SetFundAccessConstraintsEvent } from './subgraph-entities/v2/set-fund-access-constraints-event'
 import { UseAllowanceEvent } from './subgraph-entities/v2/use-allowance-event'
 import { VeNftContract } from './subgraph-entities/v2/venft-contract'
 import { VeNftToken } from './subgraph-entities/v2/venft-token'
@@ -26,36 +27,39 @@ import { ProjectCreateEvent } from './subgraph-entities/vX/project-create-event'
 import { ProjectEvent } from './subgraph-entities/vX/project-event'
 import { ProtocolLog } from './subgraph-entities/vX/protocol-log'
 import { RedeemEvent } from './subgraph-entities/vX/redeem-event'
+import { Wallet } from './subgraph-entities/vX/wallet'
 
 interface SGEntities {
-  protocolLog: ProtocolLog
-  projectEvent: ProjectEvent
-  projectCreateEvent: ProjectCreateEvent
-  deployedERC20Event: DeployedERC20Event
-  project: Project
-  projectSearch: Project
-  payEvent: PayEvent
-  burnEvent: BurnEvent
   addToBalanceEvent: AddToBalanceEvent
-  redeemEvent: RedeemEvent
-  participant: Participant
-  tapEvent: TapEvent
-  distributeToPayoutModEvent: DistributeToPayoutModEvent
-  distributeToTicketModEvent: DistributeToTicketModEvent
-  printReservesEvent: PrintReservesEvent
-  mintTokensEvent: MintTokensEvent
+  burnEvent: BurnEvent
+  configureEvent: ConfigureEvent
+  deployedERC20Event: DeployedERC20Event
+  deployETHERC20ProjectPayerEvent: DeployETHERC20ProjectPayerEvent
   distributePayoutsEvent: DistributePayoutsEvent
   distributeReservedTokensEvent: DistributeReservedTokensEvent
-  distributeToReservedTokenSplitEvent: DistributeToReservedTokenSplitEvent
+  distributeToPayoutModEvent: DistributeToPayoutModEvent
   distributeToPayoutSplitEvent: DistributeToPayoutSplitEvent
-  useAllowanceEvent: UseAllowanceEvent
+  distributeToReservedTokenSplitEvent: DistributeToReservedTokenSplitEvent
+  distributeToTicketModEvent: DistributeToTicketModEvent
   etherc20ProjectPayer: ETHERC20ProjectPayer
-  deployETHERC20ProjectPayerEvent: DeployETHERC20ProjectPayerEvent
-  veNftToken: VeNftToken
-  veNftContract: VeNftContract
-  configureEvent: ConfigureEvent
-  v1ConfigureEvent: V1ConfigureEvent
   jb721DelegateToken: JB721DelegateToken
+  mintTokensEvent: MintTokensEvent
+  payEvent: PayEvent
+  project: Project
+  projectCreateEvent: ProjectCreateEvent
+  projectEvent: ProjectEvent
+  projectSearch: Project
+  protocolLog: ProtocolLog
+  participant: Participant
+  printReservesEvent: PrintReservesEvent
+  redeemEvent: RedeemEvent
+  setFundAccessConstraintsEvent: SetFundAccessConstraintsEvent
+  tapEvent: TapEvent
+  useAllowanceEvent: UseAllowanceEvent
+  v1ConfigureEvent: V1ConfigureEvent
+  veNftContract: VeNftContract
+  veNftToken: VeNftToken
+  wallet: Wallet
 }
 
 export type SGEntityName = keyof SGEntities

--- a/src/models/subgraph-entities/v2/configure.ts
+++ b/src/models/subgraph-entities/v2/configure.ts
@@ -29,7 +29,7 @@ export interface ConfigureEvent extends BaseEventEntity {
   reservedRate: number
   redemptionRate: number
   ballotRedemptionRate: number
-  payPaused: boolean
+  pausePay: boolean
   distributionsPaused: boolean
   redeemPaused: boolean
   burnPaused: boolean

--- a/src/models/subgraph-entities/v2/set-fund-access-constraints-event.ts
+++ b/src/models/subgraph-entities/v2/set-fund-access-constraints-event.ts
@@ -1,0 +1,35 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
+import { parseBigNumberKeyVals } from 'utils/graph'
+
+import { Json, primitives } from '../../json'
+import { BaseEventEntity } from '../base/base-event-entity'
+import {
+  BaseProjectEntity,
+  parseBaseProjectEntityJson,
+} from '../base/base-project-entity'
+
+export interface SetFundAccessConstraintsEvent
+  extends BaseEventEntity,
+    BaseProjectEntity {
+  distributionLimit: BigNumber
+  distributionLimitCurrency: V2V3CurrencyOption
+  overflowAllowance: BigNumber
+  overflowAllowanceCurrency: V2V3CurrencyOption
+  terminal: string
+  token: string
+  fundingCycleConfiguration: BigNumber
+  fundingCycleNumber: number
+}
+
+export const parseSetFundAccessConstraintsEvent = (
+  j: Json<SetFundAccessConstraintsEvent>,
+): SetFundAccessConstraintsEvent => ({
+  ...primitives(j),
+  ...parseBaseProjectEntityJson(j),
+  ...parseBigNumberKeyVals(j, [
+    'distributionLimit',
+    'overflowAllowance',
+    'fundingCycleConfiguration',
+  ]),
+})

--- a/src/models/subgraph-entities/vX/participant.ts
+++ b/src/models/subgraph-entities/vX/participant.ts
@@ -15,7 +15,7 @@ export interface Participant extends BaseProjectEntity {
   totalPaidUSD: BigNumber
   balance: BigNumber
   stakedBalance: BigNumber
-  unstakedBalance: BigNumber
+  erc20Balance: BigNumber
   lastPaidTimestamp: number
 }
 
@@ -27,6 +27,6 @@ export const parseParticipantJson = (j: Json<Participant>): Participant => ({
     'totalPaidUSD',
     'balance',
     'stakedBalance',
-    'unstakedBalance',
+    'erc20Balance',
   ]),
 })

--- a/src/models/subgraph-entities/vX/project-event.ts
+++ b/src/models/subgraph-entities/vX/project-event.ts
@@ -18,6 +18,7 @@ import { DistributePayoutsEvent } from '../v2/distribute-payouts-event'
 import { DistributeReservedTokensEvent } from '../v2/distribute-reserved-tokens-event'
 import { DistributeToPayoutSplitEvent } from '../v2/distribute-to-payout-split-event'
 import { DistributeToReservedTokenSplitEvent } from '../v2/distribute-to-reserved-token-split-event'
+import { SetFundAccessConstraintsEvent } from '../v2/set-fund-access-constraints-event'
 import { UseAllowanceEvent } from '../v2/use-allowance-event'
 import { AddToBalanceEvent } from './add-to-balance-event'
 import { BurnEvent } from './burn-event'
@@ -56,6 +57,7 @@ export interface ProjectEvent extends TerminalEventEntity, BaseProjectEntity {
   useAllowanceEvent: UseAllowanceEvent | null
   deployETHERC20ProjectPayerEvent: DeployETHERC20ProjectPayerEvent | null
   configureEvent: ConfigureEvent | null
+  setFundAccessConstraintsEvent: SetFundAccessConstraintsEvent | null
 }
 
 export const parseProjectEventJson = (j: Json<ProjectEvent>): ProjectEvent => ({
@@ -82,5 +84,6 @@ export const parseProjectEventJson = (j: Json<ProjectEvent>): ProjectEvent => ({
     'deployETHERC20ProjectPayerEvent',
     'configureEvent',
     'v1ConfigureEvent',
+    'setFundAccessConstraintsEvent',
   ]),
 })

--- a/src/models/subgraph-entities/vX/wallet.ts
+++ b/src/models/subgraph-entities/vX/wallet.ts
@@ -5,13 +5,10 @@ import {
 } from 'utils/graph'
 
 import { Json, primitives } from '../../json'
-import {
-  BaseProjectEntity,
-  parseBaseProjectEntityJson,
-} from '../base/base-project-entity'
 import { Participant } from './participant'
 
-export interface Wallet extends BaseProjectEntity {
+export interface Wallet {
+  id: string
   totalPaid: BigNumber
   totalPaidUSD: BigNumber
   lastPaidTimestamp: number
@@ -20,7 +17,6 @@ export interface Wallet extends BaseProjectEntity {
 
 export const parseWalletJson = (j: Json<Wallet>): Wallet => ({
   ...primitives(j),
-  ...parseBaseProjectEntityJson(j),
   ...parseBigNumberKeyVals(j, ['totalPaid', 'totalPaidUSD']),
   ...subgraphEntityJsonArrayToKeyVal(
     j.participants,

--- a/src/models/subgraph-entities/vX/wallet.ts
+++ b/src/models/subgraph-entities/vX/wallet.ts
@@ -1,0 +1,30 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import {
+  parseBigNumberKeyVals,
+  subgraphEntityJsonArrayToKeyVal,
+} from 'utils/graph'
+
+import { Json, primitives } from '../../json'
+import {
+  BaseProjectEntity,
+  parseBaseProjectEntityJson,
+} from '../base/base-project-entity'
+import { Participant } from './participant'
+
+export interface Wallet extends BaseProjectEntity {
+  totalPaid: BigNumber
+  totalPaidUSD: BigNumber
+  lastPaidTimestamp: number
+  participants: Participant[]
+}
+
+export const parseWalletJson = (j: Json<Wallet>): Wallet => ({
+  ...primitives(j),
+  ...parseBaseProjectEntityJson(j),
+  ...parseBigNumberKeyVals(j, ['totalPaid', 'totalPaidUSD']),
+  ...subgraphEntityJsonArrayToKeyVal(
+    j.participants,
+    'participant',
+    'participants',
+  ),
+})

--- a/src/utils/csvDownloadHelpers.ts
+++ b/src/utils/csvDownloadHelpers.ts
@@ -34,7 +34,7 @@ export async function downloadParticipants(
         'totalPaidUSD',
         'balance',
         'stakedBalance',
-        'unstakedBalance',
+        'erc20Balance',
       ],
       orderBy: 'balance',
       orderDirection: 'desc',
@@ -70,7 +70,7 @@ export async function downloadParticipants(
         fromWad(p.totalPaidUSD),
         fromWad(p.balance),
         fromWad(p.stakedBalance),
-        fromWad(p.unstakedBalance),
+        fromWad(p.erc20Balance),
       ])
     })
 

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -25,6 +25,7 @@ import { parseDistributeToPayoutSplitEventJson } from 'models/subgraph-entities/
 import { parseDistributeToReservedTokenSplitEventJson } from 'models/subgraph-entities/v2/distribute-to-reserved-token-split-event'
 import { parseETHERC20ProjectPayer } from 'models/subgraph-entities/v2/eth-erc20-project-payer'
 import { parseJB721DelegateTokenJson } from 'models/subgraph-entities/v2/jb-721-delegate-tokens'
+import { parseSetFundAccessConstraintsEvent } from 'models/subgraph-entities/v2/set-fund-access-constraints-event'
 import { parseUseAllowanceEventJson } from 'models/subgraph-entities/v2/use-allowance-event'
 import { parseVeNftContractJson } from 'models/subgraph-entities/v2/venft-contract'
 import { parseVeNftTokenJson } from 'models/subgraph-entities/v2/venft-token'
@@ -39,6 +40,7 @@ import { parseProjectCreateEventJson } from 'models/subgraph-entities/vX/project
 import { parseProjectEventJson } from 'models/subgraph-entities/vX/project-event'
 import { parseProtocolLogJson } from 'models/subgraph-entities/vX/protocol-log'
 import { parseRedeemEventJson } from 'models/subgraph-entities/vX/redeem-event'
+import { parseWalletJson } from 'models/subgraph-entities/vX/wallet'
 
 const PLURAL_ENTITY_EXCLUSIONS: SGEntityName[] = ['projectSearch']
 
@@ -216,6 +218,9 @@ export function parseSubgraphEntity<
     case 'participant':
       fn = parseParticipantJson
       break
+    case 'setFundAccessConstraintsEvent':
+      fn = parseSetFundAccessConstraintsEvent
+      break
     case 'tapEvent':
       fn = parseTapEventJson
       break
@@ -230,6 +235,9 @@ export function parseSubgraphEntity<
       break
     case 'veNftToken':
       fn = parseVeNftTokenJson
+      break
+    case 'wallet':
+      fn = parseWalletJson
       break
     default:
       throw Error(`parseSubgraphEntity(): Unhandled "${entityName}"`)


### PR DESCRIPTION
## What does this PR do and why?

**6.2.0**
- new support for v3.1 contracts

**6.1.0**
- new Wallet entity
- new SetFundAccessConstraintsEvent entity + ProjectEvent property
- adds SetFundAccessConstraintsEvents to activity filtering
- few renamed properties
- subgraph query arguments that are addresses are now lowercased (apparent subgraph bug. not gonna go into it here)

## Screenshots or screen recordings

New SetFundAccessConstraintsElem

<img width="520" alt="image" src="https://user-images.githubusercontent.com/79433522/225445318-4675f323-2fc0-4a8a-9fbd-f472a9edbe6b.png">

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] I have tested this PR in dark mode and light mode (if applicable).

## Subgraph QA checklist

- [x] V1 project 
   - [x] page renders
   - [x] shows volume
   - [x] shows activity feed
   - [x] can filter activity feed
   - [x] can download activity feed CSV 
- [x] V3 Project on JB 3.0 renders
- [x] V3 Project on JB 3.1 renders
   - [x] page renders
   - [x] shows volume
   - [x] shows activity feed
   - [x] can filter activity feed
   - [x] can download activity feed CSV 
- [x] V3 Project **with a handle** renders
- [x] Homepage 
   - [x] Trending projects renders
   - [x] Homepage activity feed renders
