### PR TITLE
Fix narrow NFT section, "Create a Project" title

### DIFF
--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -40,7 +40,7 @@ export function Create() {
 
   return (
     <div className="mt-10">
-      <h1 className="mb-0 text-center text-base font-medium uppercase text-black dark:text-slate-100">
+      <h1 className="mb-0 text-center font-heading text-base font-medium uppercase text-black dark:text-slate-100">
         {!isMigration ? (
           <Trans>Create a project</Trans>
         ) : (
@@ -113,11 +113,9 @@ export function Create() {
           <Wizard.Page
             name="nftRewards"
             title={
-              <div className="inline-flex items-center gap-3">
+              <div className="flex items-center gap-3">
                 <Trans>NFTs</Trans>
-                <div>
-                  <CreateBadge.Optional />
-                </div>
+                <CreateBadge.Optional />
               </div>
             }
             description={

--- a/src/components/Create/components/Wizard/Page.tsx
+++ b/src/components/Create/components/Wizard/Page.tsx
@@ -50,7 +50,7 @@ export const Page: React.FC<PageProps> & {
       }}
     >
       <Space
-        className={twMerge('max-w-full md:max-w-[600px]', className)}
+        className={twMerge('w-full max-w-full md:max-w-[600px]', className)}
         direction="vertical"
         size="large"
       >


### PR DESCRIPTION
Fixes JB-120 (https://linear.app/peel/issue/JB-120/create-project-title-wrong-font)
Fixes JB-119 (https://linear.app/peel/issue/JB-119/rebrand-bug-nft-create-section-too-narrow)

<img width="1388" alt="Screen Shot 2023-03-16 at 1 01 38 pm" src="https://user-images.githubusercontent.com/96150256/225500350-1d59316d-aa56-402b-8617-d28f19696540.png">
