### PR TITLE
Show "unlimited" payout in Edited Payout events

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
@@ -4,6 +4,7 @@ import CurrencySymbol from 'components/CurrencySymbol'
 import { SetFundAccessConstraintsEvent } from 'models/subgraph-entities/v2/set-fund-access-constraints-event'
 import { formatWad } from 'utils/format/formatNumber'
 import { V2V3CurrencyName } from 'utils/v2v3/currency'
+import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 
 export default function SetFundAccessConstraintsEventElem({
   event,
@@ -28,10 +29,16 @@ export default function SetFundAccessConstraintsEventElem({
       header={t`Edited payout`}
       subject={
         <div>
-          <CurrencySymbol
-            currency={V2V3CurrencyName(event.distributionLimitCurrency)}
-          />
-          {formatWad(event.distributionLimit)}
+          {event.distributionLimit.eq(MAX_DISTRIBUTION_LIMIT) ? (
+            t`Unlimited`
+          ) : (
+            <>
+              <CurrencySymbol
+                currency={V2V3CurrencyName(event.distributionLimitCurrency)}
+              />
+              {formatWad(event.distributionLimit)}
+            </>
+          )}
         </div>
       }
     />


### PR DESCRIPTION
If the new distribution limit in a SetFundAccessConstraintsEvent (Edited Payout event) is the maximum, show "Unlimited" instead of the numerical value.

![image](https://user-images.githubusercontent.com/79433522/225802750-d8f692bd-671a-4bf0-b53a-96003bcd0a83.png)

Other events are unchanged:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/79433522/225802857-d75c7c10-93d4-4be7-b287-d08a0a97c505.png">
