### PR TITLE
[1/n] fix! Default tooltips in create/tokens now doesn't crash app

### DIFF
--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -4,7 +4,7 @@ import { Callout } from 'components/Callout'
 import { CYCLE_EXPLANATION } from 'components/Explanations'
 import ExternalLink from 'components/ExternalLink'
 import Loading from 'components/Loading'
-import { RECONFIG_RULES_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import { RECONFIG_RULES_EXPLANATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { readNetwork } from 'constants/networks'
 import { NetworkName } from 'models/networkName'
 import Link from 'next/link'
@@ -127,7 +127,7 @@ export function Create() {
           <Wizard.Page
             name="reconfigurationRules"
             title={<Trans>Edit Deadline</Trans>}
-            description={RECONFIG_RULES_EXPLAINATION}
+            description={RECONFIG_RULES_EXPLANATION}
           >
             <ReconfigurationRulesPage />
           </Wizard.Page>

--- a/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
+++ b/src/components/Create/components/pages/NftRewards/NftRewardsPage.tsx
@@ -1,5 +1,4 @@
-import { RightOutlined } from '@ant-design/icons'
-import { EyeOutlined } from '@ant-design/icons'
+import { EyeOutlined, RightOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Form, Radio, Space } from 'antd'
 import { CreateButton } from 'components/buttons/CreateButton'
@@ -12,8 +11,8 @@ import { NftPostPayModal } from 'components/NftRewards/NftPostPayModal'
 import { RadioItem } from 'components/RadioItem'
 import TooltipLabel from 'components/TooltipLabel'
 import {
-  PREVENT_OVERSPENDING_EXPLAINATION,
-  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION,
+  PREVENT_OVERSPENDING_EXPLANATION,
+  USE_DATASOURCE_FOR_REDEEM_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { CREATE_FLOW } from 'constants/fathomEvents'
 import { useModal } from 'hooks/Modal'
@@ -272,13 +271,13 @@ export const NftRewardsPage = () => {
                 >
                   <Form.Item
                     name="useDataSourceForRedeem"
-                    extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+                    extra={USE_DATASOURCE_FOR_REDEEM_EXPLANATION}
                   >
                     <JuiceSwitch label={t`Use NFTs for redemptions`} />
                   </Form.Item>
                   <Form.Item
                     name="preventOverspending"
-                    extra={PREVENT_OVERSPENDING_EXPLAINATION}
+                    extra={PREVENT_OVERSPENDING_EXPLANATION}
                   >
                     <JuiceSwitch label={t`Prevent NFT overspending`} />
                   </Form.Item>

--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
@@ -8,7 +8,7 @@ import NumberSlider from 'components/inputs/NumberSlider'
 import { TokenRedemptionRateGraph } from 'components/TokenRedemptionRateGraph'
 import {
   MINT_RATE_EXPLANATION,
-  OWNER_MINTING_EXPLAINATION,
+  OWNER_MINTING_EXPLANATION,
   OWNER_MINTING_RISK,
   PAUSE_TRANSFERS_EXPLANATION,
   REDEMPTION_RATE_EXPLANATION,
@@ -233,7 +233,7 @@ export const CustomTokenSettings = () => {
 
       <div className="flex flex-col gap-y-5">
         <div>
-          <Form.Item extra={OWNER_MINTING_EXPLAINATION} name="tokenMinting">
+          <Form.Item extra={OWNER_MINTING_EXPLANATION} name="tokenMinting">
             <JuiceSwitch label={t`Owner token minting`} />
           </Form.Item>
           {tokenMinting && (

--- a/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/CustomTokenSettings/CustomTokenSettings.tsx
@@ -3,18 +3,9 @@ import { Divider, Form, Space } from 'antd'
 import { Callout } from 'components/Callout'
 import { formatFundingCycleDuration } from 'components/Create/utils/formatFundingCycleDuration'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
-import NumberSlider from 'components/inputs/NumberSlider'
 import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
+import NumberSlider from 'components/inputs/NumberSlider'
 import { TokenRedemptionRateGraph } from 'components/TokenRedemptionRateGraph'
-import { useAppSelector } from 'redux/hooks/AppSelector'
-import useMobile from 'hooks/Mobile'
-import { useEditingDistributionLimit } from 'redux/hooks/EditingDistributionLimit'
-import { inputMustExistRule } from 'utils/antdRules'
-import { formatAmount } from 'utils/format/formatAmount'
-import { MAX_DISTRIBUTION_LIMIT, MAX_MINT_RATE } from 'utils/v2v3/math'
-import * as ProjectTokenForm from '../../hooks/ProjectTokenForm'
-import { ProjectTokensFormProps } from '../../hooks/ProjectTokenForm'
-import { ReservedTokenRateCallout, ReservedTokensList } from './components'
 import {
   MINT_RATE_EXPLANATION,
   OWNER_MINTING_EXPLAINATION,
@@ -22,6 +13,15 @@ import {
   PAUSE_TRANSFERS_EXPLANATION,
   REDEMPTION_RATE_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import useMobile from 'hooks/Mobile'
+import { useAppSelector } from 'redux/hooks/AppSelector'
+import { useEditingDistributionLimit } from 'redux/hooks/EditingDistributionLimit'
+import { inputMustExistRule } from 'utils/antdRules'
+import { formatAmount } from 'utils/format/formatAmount'
+import { MAX_DISTRIBUTION_LIMIT, MAX_MINT_RATE } from 'utils/v2v3/math'
+import * as ProjectTokenForm from '../../hooks/ProjectTokenForm'
+import { ProjectTokensFormProps } from '../../hooks/ProjectTokenForm'
+import { ReservedTokenRateCallout, ReservedTokensList } from './components'
 
 const calculateMintRateAfterDiscount = ({
   mintRate,

--- a/src/components/Create/components/pages/ProjectToken/components/DefaultSettings/DefaultSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/DefaultSettings/DefaultSettings.tsx
@@ -4,9 +4,9 @@ import TooltipLabel from 'components/TooltipLabel'
 import {
   DISCOUNT_RATE_EXPLANATION,
   MINT_RATE_EXPLANATION,
-  OWNER_MINTING_EXPLAINATION,
+  OWNER_MINTING_EXPLANATION,
   REDEMPTION_RATE_EXPLANATION,
-  RESERVED_RATE_EXPLAINATION,
+  RESERVED_RATE_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { ReactNode, useMemo } from 'react'
 import { formatAmount } from 'utils/format/formatAmount'
@@ -24,7 +24,7 @@ export const DefaultSettings: React.FC = () => {
       },
       [t`Reserved rate`]: {
         data: `${ProjectTokenForm.DefaultSettings.reservedTokensPercentage}%`,
-        tooltip: RESERVED_RATE_EXPLAINATION,
+        tooltip: RESERVED_RATE_EXPLANATION,
       },
       [t`Issuance reduction rate`]: {
         data: `${ProjectTokenForm.DefaultSettings.discountRate}%`,
@@ -36,7 +36,7 @@ export const DefaultSettings: React.FC = () => {
       },
       [t`Owner token minting`]: {
         data: formatBoolean(ProjectTokenForm.DefaultSettings.tokenMinting),
-        tooltip: OWNER_MINTING_EXPLAINATION,
+        tooltip: OWNER_MINTING_EXPLANATION,
       },
     }),
     [],

--- a/src/components/Create/components/pages/ProjectToken/components/DefaultSettings/DefaultSettings.tsx
+++ b/src/components/Create/components/pages/ProjectToken/components/DefaultSettings/DefaultSettings.tsx
@@ -20,23 +20,23 @@ export const DefaultSettings: React.FC = () => {
         data: `${formatAmount(
           ProjectTokenForm.DefaultSettings.initialMintRate,
         )} tokens / ETH`,
-        tooltip: { MINT_RATE_EXPLANATION },
+        tooltip: MINT_RATE_EXPLANATION,
       },
       [t`Reserved rate`]: {
         data: `${ProjectTokenForm.DefaultSettings.reservedTokensPercentage}%`,
-        tooltip: { RESERVED_RATE_EXPLAINATION },
+        tooltip: RESERVED_RATE_EXPLAINATION,
       },
       [t`Issuance reduction rate`]: {
         data: `${ProjectTokenForm.DefaultSettings.discountRate}%`,
-        tooltip: { DISCOUNT_RATE_EXPLANATION },
+        tooltip: DISCOUNT_RATE_EXPLANATION,
       },
       [t`Redemption rate`]: {
         data: `${ProjectTokenForm.DefaultSettings.redemptionRate}%`,
-        tooltip: { REDEMPTION_RATE_EXPLANATION },
+        tooltip: REDEMPTION_RATE_EXPLANATION,
       },
       [t`Owner token minting`]: {
         data: formatBoolean(ProjectTokenForm.DefaultSettings.tokenMinting),
-        tooltip: { OWNER_MINTING_EXPLAINATION },
+        tooltip: OWNER_MINTING_EXPLAINATION,
       },
     }),
     [],

--- a/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
+++ b/src/components/Create/components/pages/ReconfigurationRules/ReconfigurationRulesPage.tsx
@@ -6,13 +6,13 @@ import { Selection } from 'components/Create/components/Selection'
 import { useAvailableReconfigurationStrategies } from 'components/Create/hooks/AvailableReconfigurationStrategies'
 import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
 import {
-  CONTROLLER_CONFIG_EXPLAINATION,
-  CONTROLLER_MIGRATION_EXPLAINATION,
-  HOLD_FEES_EXPLAINATION,
+  CONTROLLER_CONFIG_EXPLANATION,
+  CONTROLLER_MIGRATION_EXPLANATION,
+  HOLD_FEES_EXPLANATION,
   PAUSE_PAYMENTS_EXPLANATION,
   RECONFIG_RULES_WARN,
-  TERMINAL_CONFIG_EXPLAINATION,
-  TERMINAL_MIGRATION_EXPLAINATION,
+  TERMINAL_CONFIG_EXPLANATION,
+  TERMINAL_MIGRATION_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { CREATE_FLOW } from 'constants/fathomEvents'
 import { readNetwork } from 'constants/networks'
@@ -77,7 +77,7 @@ export const ReconfigurationRulesPage = () => {
               <JuiceSwitch label={t`Pause payments to this project`} />
             </Form.Item>
 
-            <Form.Item name="holdFees" extra={HOLD_FEES_EXPLAINATION}>
+            <Form.Item name="holdFees" extra={HOLD_FEES_EXPLANATION}>
               <JuiceSwitch label={t`Hold fees`} />
             </Form.Item>
           </CreateCollapse.Panel>
@@ -92,13 +92,13 @@ export const ReconfigurationRulesPage = () => {
             <div className="mb-8">
               <Form.Item
                 name="allowTerminalConfiguration"
-                extra={TERMINAL_CONFIG_EXPLAINATION}
+                extra={TERMINAL_CONFIG_EXPLANATION}
               >
                 <JuiceSwitch label={t`Allow Payment Terminal configuration`} />
               </Form.Item>
               <Form.Item
                 name="allowControllerConfiguration"
-                extra={CONTROLLER_CONFIG_EXPLAINATION}
+                extra={CONTROLLER_CONFIG_EXPLANATION}
               >
                 <JuiceSwitch label={t`Allow Controller configuration`} />
               </Form.Item>
@@ -109,13 +109,13 @@ export const ReconfigurationRulesPage = () => {
             <div className="mb-8">
               <Form.Item
                 name="allowTerminalMigration"
-                extra={TERMINAL_MIGRATION_EXPLAINATION}
+                extra={TERMINAL_MIGRATION_EXPLANATION}
               >
                 <JuiceSwitch label={t`Allow Payment Terminal migration`} />
               </Form.Item>
               <Form.Item
                 name="allowControllerMigration"
-                extra={CONTROLLER_MIGRATION_EXPLAINATION}
+                extra={CONTROLLER_MIGRATION_EXPLANATION}
               >
                 <JuiceSwitch label={t`Allow Controller migration`} />
               </Form.Item>

--- a/src/components/formItems/ProjectReserved.tsx
+++ b/src/components/formItems/ProjectReserved.tsx
@@ -3,8 +3,8 @@ import { Form } from 'antd'
 import FormItemLabel from 'components/FormItemLabel'
 import FormItemWarningText from 'components/FormItemWarningText'
 import {
-  CONTRIBUTOR_RATE_EXPLAINATION,
-  RESERVED_TOKENS_EXPLAINATION,
+  CONTRIBUTOR_RATE_EXPLANATION,
+  RESERVED_TOKENS_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import {
   FUNDING_CYCLE_WARNING_TEXT,
@@ -79,7 +79,7 @@ export default function ProjectReserved({
               <span>
                 <TooltipLabel
                   label={t`Payer issuance rate`}
-                  tip={CONTRIBUTOR_RATE_EXPLAINATION}
+                  tip={CONTRIBUTOR_RATE_EXPLANATION}
                 />
                 :
               </span>
@@ -89,7 +89,7 @@ export default function ProjectReserved({
               <span>
                 <TooltipLabel
                   label={t`Reserved issuance rate`}
-                  tip={RESERVED_TOKENS_EXPLAINATION}
+                  tip={RESERVED_TOKENS_EXPLANATION}
                 />
                 :
               </span>

--- a/src/components/v1/V1Project/modals/PrintPreminedModal.tsx
+++ b/src/components/v1/V1Project/modals/PrintPreminedModal.tsx
@@ -14,9 +14,9 @@ import { RuleObject } from 'antd/lib/form'
 import { StoreValue } from 'antd/lib/form/interface'
 import { Callout } from 'components/Callout'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
+import { OWNER_MINTING_EXPLANATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
 import { isZeroAddress } from 'utils/address'
-import { OWNER_MINTING_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 
 export default function PrintPreminedModal({
   open,
@@ -106,7 +106,7 @@ export default function PrintPreminedModal({
         <Trans>
           Owner token minting can be enabled or disabled by editing your cycle.{' '}
         </Trans>
-        {OWNER_MINTING_EXPLAINATION}
+        {OWNER_MINTING_EXPLANATION}
       </Callout.Info>
 
       <Form layout="vertical" form={form} onFinish={mint}>

--- a/src/components/v1/V1Project/modals/ReconfigureFCModal/RestrictedActionsForm.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal/RestrictedActionsForm.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Button, Form, FormInstance, Space, Switch } from 'antd'
 import FormItemWarningText from 'components/FormItemWarningText'
 import {
-  OWNER_MINTING_EXPLAINATION,
+  OWNER_MINTING_EXPLANATION,
   OWNER_MINTING_RISK,
   PAUSE_PAYMENTS_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
@@ -58,7 +58,7 @@ export default function RestrictedActionsForm({
         <Form.Item
           name="ticketPrintingIsAllowed"
           label={t`Allow owner token minting`}
-          extra={OWNER_MINTING_EXPLAINATION}
+          extra={OWNER_MINTING_EXPLANATION}
           valuePropName="checked"
         >
           <Switch

--- a/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -2,10 +2,25 @@ import { parseEther } from '@ethersproject/units'
 import { Trans } from '@lingui/macro'
 import { Descriptions, Tooltip } from 'antd'
 import CurrencySymbol from 'components/CurrencySymbol'
+import EtherscanLink from 'components/EtherscanLink'
+import FundingCycleDetailWarning from 'components/Project/FundingCycleDetailWarning'
+import TooltipLabel from 'components/TooltipLabel'
+import {
+  CONTRIBUTOR_RATE_EXPLANATION,
+  DISCOUNT_RATE_EXPLANATION,
+  OWNER_MINTING_EXPLANATION,
+  RECONFIG_RULES_EXPLANATION,
+  REDEMPTION_RATE_EXPLANATION,
+  RESERVED_RATE_EXPLANATION,
+} from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
+import { FUNDING_CYCLE_WARNING_TEXT } from 'constants/fundingWarningText'
+import { SECONDS_IN_DAY } from 'constants/numbers'
+import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { V1FundingCycle } from 'models/v1/fundingCycle'
 import { useContext } from 'react'
+import { formatPaused } from 'utils/format/formatBoolean'
 import { formatDate, formatDateToUTC } from 'utils/format/formatDate'
 import {
   formatWad,
@@ -13,6 +28,7 @@ import {
   permilleToPercent,
 } from 'utils/format/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
+import { V1CurrencyName } from 'utils/v1/currency'
 import {
   decodeFundingCycleMetadata,
   getUnsafeV1FundingCycleProperties,
@@ -20,22 +36,6 @@ import {
   isRecurring,
 } from 'utils/v1/fundingCycle'
 import { weightAmountPerbicent } from 'utils/v1/math'
-import { V1CurrencyName } from 'utils/v1/currency'
-import TooltipLabel from 'components/TooltipLabel'
-import EtherscanLink from 'components/EtherscanLink'
-import FundingCycleDetailWarning from 'components/Project/FundingCycleDetailWarning'
-import { FUNDING_CYCLE_WARNING_TEXT } from 'constants/fundingWarningText'
-import { SECONDS_IN_DAY } from 'constants/numbers'
-import { getBallotStrategyByAddress } from 'constants/v1/ballotStrategies/getBallotStrategiesByAddress'
-import { formatPaused } from 'utils/format/formatBoolean'
-import {
-  CONTRIBUTOR_RATE_EXPLAINATION,
-  DISCOUNT_RATE_EXPLANATION,
-  OWNER_MINTING_EXPLAINATION,
-  RECONFIG_RULES_EXPLAINATION,
-  REDEMPTION_RATE_EXPLANATION,
-  RESERVED_RATE_EXPLAINATION,
-} from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 
 export default function FundingCycleDetails({
   fundingCycle,
@@ -200,7 +200,7 @@ export default function FundingCycleDetails({
           label={
             <TooltipLabel
               label={<Trans>Reserved {tokenSymbolPlural}</Trans>}
-              tip={RESERVED_RATE_EXPLAINATION}
+              tip={RESERVED_RATE_EXPLANATION}
             />
           }
         >
@@ -216,7 +216,7 @@ export default function FundingCycleDetails({
           label={
             <TooltipLabel
               label={<Trans>Payer issuance rate</Trans>}
-              tip={CONTRIBUTOR_RATE_EXPLAINATION}
+              tip={CONTRIBUTOR_RATE_EXPLANATION}
             />
           }
           span={2}
@@ -230,7 +230,7 @@ export default function FundingCycleDetails({
           label={
             <TooltipLabel
               label={<Trans>Owner token minting</Trans>}
-              tip={OWNER_MINTING_EXPLAINATION}
+              tip={OWNER_MINTING_EXPLANATION}
             />
           }
         >
@@ -258,7 +258,7 @@ export default function FundingCycleDetails({
         <span className="font-medium text-grey-500 dark:text-grey-300">
           <TooltipLabel
             label={<Trans>Edit deadline</Trans>}
-            tip={RECONFIG_RULES_EXPLAINATION}
+            tip={RECONFIG_RULES_EXPLANATION}
           />
           :
         </span>{' '}

--- a/src/components/v1/shared/FundingCycle/ReservedTokens.tsx
+++ b/src/components/v1/shared/FundingCycle/ReservedTokens.tsx
@@ -1,18 +1,18 @@
 import { Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import TooltipLabel from 'components/TooltipLabel'
+import { RESERVED_RATE_EXPLANATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import useReservedTokensOfProject from 'hooks/v1/contractReader/ReservedTokensOfProject'
-import { TicketMod } from 'models/v1/mods'
 import { V1FundingCycle } from 'models/v1/fundingCycle'
+import { TicketMod } from 'models/v1/mods'
 import { useContext, useState } from 'react'
 import { formatWad, perbicentToPercent } from 'utils/format/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 import { decodeFundingCycleMetadata } from 'utils/v1/fundingCycle'
 import TicketModsList from '../TicketModsList'
 import DistributeTokensModal from './modals/DistributeTokensModal'
-import { RESERVED_RATE_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 
 export default function ReservedTokens({
   fundingCycle,
@@ -51,7 +51,7 @@ export default function ReservedTokens({
               ({perbicentToPercent(metadata?.reservedRate)}%)
             </h4>
           }
-          tip={RESERVED_RATE_EXPLAINATION}
+          tip={RESERVED_RATE_EXPLANATION}
         />
       </div>
 

--- a/src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
+++ b/src/components/v1/shared/ReconfigurationStrategyDrawer.tsx
@@ -5,8 +5,8 @@ import ReconfigurationStrategySelector from 'components/ReconfigurationStrategy/
 import { BallotStrategy } from 'models/ballot'
 import { useEffect, useState } from 'react'
 
+import { RECONFIG_RULES_EXPLANATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import { ballotStrategies } from 'constants/v1/ballotStrategies'
-import { RECONFIG_RULES_EXPLAINATION } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 
 export default function ReconfigurationStrategyDrawer({
   className,
@@ -45,7 +45,7 @@ export default function ReconfigurationStrategyDrawer({
         <Trans>Edit deadline</Trans>
       </h1>
       <p className="text-grey-500 dark:text-grey-300">
-        {RECONFIG_RULES_EXPLAINATION}
+        {RECONFIG_RULES_EXPLANATION}
       </p>
 
       <ReconfigurationStrategySelector

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/index.tsx
@@ -9,12 +9,12 @@ import { useContext } from 'react'
 import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
 import { getUnsafeV2V3FundingCycleProperties } from 'utils/v2v3/fundingCycle'
 import {
-  HOLD_FEES_EXPLAINATION,
-  RECONFIG_RULES_EXPLAINATION,
-  TERMINAL_CONFIG_EXPLAINATION,
-  CONTROLLER_CONFIG_EXPLAINATION,
-  TERMINAL_MIGRATION_EXPLAINATION,
-  CONTROLLER_MIGRATION_EXPLAINATION,
+  CONTROLLER_CONFIG_EXPLANATION,
+  CONTROLLER_MIGRATION_EXPLANATION,
+  HOLD_FEES_EXPLANATION,
+  RECONFIG_RULES_EXPLANATION,
+  TERMINAL_CONFIG_EXPLANATION,
+  TERMINAL_MIGRATION_EXPLANATION,
 } from '../../settingExplanations'
 import { FundingCycleListItem } from '../FundingCycleListItem'
 import { AllowedValue } from './AllowedValue'
@@ -98,7 +98,7 @@ export function RulesListItems({
             />
           ) : undefined
         }
-        helperText={RECONFIG_RULES_EXPLAINATION}
+        helperText={RECONFIG_RULES_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Payments to this project`}
@@ -117,7 +117,7 @@ export function RulesListItems({
             <HoldFeesValue holdFees={oldFundingCycleMetadata.holdFees} />
           ) : undefined
         }
-        helperText={HOLD_FEES_EXPLAINATION}
+        helperText={HOLD_FEES_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Set payment terminals`}
@@ -133,7 +133,7 @@ export function RulesListItems({
             />
           ) : undefined
         }
-        helperText={TERMINAL_CONFIG_EXPLAINATION}
+        helperText={TERMINAL_CONFIG_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Set controller`}
@@ -149,7 +149,7 @@ export function RulesListItems({
             />
           ) : undefined
         }
-        helperText={CONTROLLER_CONFIG_EXPLAINATION}
+        helperText={CONTROLLER_CONFIG_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Migrate payment terminal`}
@@ -163,7 +163,7 @@ export function RulesListItems({
             />
           ) : undefined
         }
-        helperText={TERMINAL_MIGRATION_EXPLAINATION}
+        helperText={TERMINAL_MIGRATION_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Migrate controller`}
@@ -179,7 +179,7 @@ export function RulesListItems({
             />
           ) : undefined
         }
-        helperText={CONTROLLER_MIGRATION_EXPLAINATION}
+        helperText={CONTROLLER_MIGRATION_EXPLANATION}
       />
     </>
   )

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/TokenListItems/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/TokenListItems/index.tsx
@@ -4,14 +4,14 @@ import {
   V2V3FundingCycleMetadata,
 } from 'models/v2v3/fundingCycle'
 import {
-  CONTRIBUTOR_RATE_EXPLAINATION,
+  CONTRIBUTOR_RATE_EXPLANATION,
   DISCOUNT_RATE_EXPLANATION,
   MINT_RATE_EXPLANATION,
-  OWNER_MINTING_EXPLAINATION,
+  OWNER_MINTING_EXPLANATION,
   PAUSE_TRANSFERS_EXPLANATION,
   REDEMPTION_RATE_EXPLANATION,
-  RESERVED_RATE_EXPLAINATION,
-  RESERVED_TOKENS_EXPLAINATION,
+  RESERVED_RATE_EXPLANATION,
+  RESERVED_TOKENS_EXPLANATION,
 } from '../../settingExplanations'
 import { FundingCycleListItem } from '../FundingCycleListItem'
 
@@ -139,7 +139,7 @@ export function TokenListItems({
             />
           ) : undefined
         }
-        helperText={CONTRIBUTOR_RATE_EXPLAINATION}
+        helperText={CONTRIBUTOR_RATE_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Reserved rate`}
@@ -154,7 +154,7 @@ export function TokenListItems({
             <ReservedRateValue value={oldFundingCycleMetadata.reservedRate} />
           ) : undefined
         }
-        helperText={RESERVED_RATE_EXPLAINATION}
+        helperText={RESERVED_RATE_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Reserved issuance rate`}
@@ -172,7 +172,7 @@ export function TokenListItems({
             />
           ) : undefined
         }
-        helperText={RESERVED_TOKENS_EXPLAINATION}
+        helperText={RESERVED_TOKENS_EXPLANATION}
         subItem
       />
       <FundingCycleListItem
@@ -209,7 +209,7 @@ export function TokenListItems({
             />
           ) : undefined
         }
-        helperText={OWNER_MINTING_EXPLAINATION}
+        helperText={OWNER_MINTING_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Token transfers`}

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
@@ -51,27 +51,27 @@ export const MINT_RATE_EXPLANATION = (
   </Trans>
 )
 
-export const CONTRIBUTOR_RATE_EXPLAINATION = (
+export const CONTRIBUTOR_RATE_EXPLANATION = (
   <Trans>
     The number of tokens sent to someone who pays this project 1 ETH.
   </Trans>
 )
 
-export const RESERVED_RATE_EXPLAINATION = (
+export const RESERVED_RATE_EXPLANATION = (
   <Trans>
     A percentage of token issuance which is set aside for addresses and other
     projects chosen by the project owner.
   </Trans>
 )
 
-export const RESERVED_TOKENS_EXPLAINATION = (
+export const RESERVED_TOKENS_EXPLANATION = (
   <Trans>
     The number of tokens set aside for reserved token recipients when someone
     pays this project 1 ETH.
   </Trans>
 )
 
-export const OWNER_MINTING_EXPLAINATION = (
+export const OWNER_MINTING_EXPLANATION = (
   <Trans>
     While enabled, the project owner can mint any amount of project tokens.
   </Trans>
@@ -84,7 +84,7 @@ export const OWNER_MINTING_RISK = (
   </Trans>
 )
 
-export const TERMINAL_CONFIG_EXPLAINATION = (
+export const TERMINAL_CONFIG_EXPLANATION = (
   <Trans>
     While enabled, the project owner can change the project's{' '}
     <ExternalLink href={helpPagePath(`/dev/learn/glossary/payment-terminal/`)}>
@@ -94,7 +94,7 @@ export const TERMINAL_CONFIG_EXPLAINATION = (
   </Trans>
 )
 
-export const CONTROLLER_CONFIG_EXPLAINATION = (
+export const CONTROLLER_CONFIG_EXPLANATION = (
   <Trans>
     While enabled, the project owner can change the project's{' '}
     <ExternalLink
@@ -106,7 +106,7 @@ export const CONTROLLER_CONFIG_EXPLAINATION = (
   </Trans>
 )
 
-export const TERMINAL_MIGRATION_EXPLAINATION = (
+export const TERMINAL_MIGRATION_EXPLANATION = (
   <Trans>
     While enabled, the project owner can migrate the project's current{' '}
     <ExternalLink href={helpPagePath(`/dev/learn/glossary/payment-terminal/`)}>
@@ -116,7 +116,7 @@ export const TERMINAL_MIGRATION_EXPLAINATION = (
   </Trans>
 )
 
-export const CONTROLLER_MIGRATION_EXPLAINATION = (
+export const CONTROLLER_MIGRATION_EXPLANATION = (
   <Trans>
     While enabled, the project owner can migrate the project's current{' '}
     <ExternalLink
@@ -143,7 +143,7 @@ export const PAUSE_PAYMENTS_EXPLANATION = (
   </Trans>
 )
 
-export const RECONFIG_RULES_EXPLAINATION = (
+export const RECONFIG_RULES_EXPLANATION = (
   <Trans>
     <p>
       Edits to this project must be made before this deadline. This gives token
@@ -163,7 +163,7 @@ export const RECONFIG_RULES_WARN = (
   </Trans>
 )
 
-export const HOLD_FEES_EXPLAINATION = (
+export const HOLD_FEES_EXPLANATION = (
   <Trans>
     When enabled, fees are held in the project instead of being processed
     automatically.{' '}
@@ -173,14 +173,14 @@ export const HOLD_FEES_EXPLAINATION = (
   </Trans>
 )
 
-export const USE_DATASOURCE_FOR_REDEEM_EXPLAINATION = (
+export const USE_DATASOURCE_FOR_REDEEM_EXPLANATION = (
   <Trans>
     While enabled, NFTs can be redeemed to reclaim some of the ETH that isn't
     needed for payouts. While enabled, it won't be possible to redeem tokens.
   </Trans>
 )
 
-export const PREVENT_OVERSPENDING_EXPLAINATION = (
+export const PREVENT_OVERSPENDING_EXPLANATION = (
   <Trans>
     When enabled, supporters can only mint NFTs by paying their exact price.
     This ensures that they can reclaim their full payment amount if they redeem

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/RulesForm.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/RulesForm.tsx
@@ -4,24 +4,24 @@ import { Button, Form, Space, Switch } from 'antd'
 import FormItemLabel from 'components/FormItemLabel'
 import ReconfigurationStrategySelector from 'components/ReconfigurationStrategy/ReconfigurationStrategySelector'
 import {
-  CONTROLLER_CONFIG_EXPLAINATION,
-  CONTROLLER_MIGRATION_EXPLAINATION,
-  HOLD_FEES_EXPLAINATION,
+  CONTROLLER_CONFIG_EXPLANATION,
+  CONTROLLER_MIGRATION_EXPLANATION,
+  HOLD_FEES_EXPLANATION,
   PAUSE_PAYMENTS_EXPLANATION,
   PAUSE_TRANSFERS_EXPLANATION,
-  TERMINAL_CONFIG_EXPLAINATION,
-  TERMINAL_MIGRATION_EXPLAINATION,
-  USE_DATASOURCE_FOR_REDEEM_EXPLAINATION,
+  TERMINAL_CONFIG_EXPLANATION,
+  TERMINAL_MIGRATION_EXPLANATION,
+  USE_DATASOURCE_FOR_REDEEM_EXPLANATION,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 import {
   ballotStrategiesFn,
   DEFAULT_BALLOT_STRATEGY,
 } from 'constants/v2v3/ballotStrategies'
-import { useAppDispatch } from 'redux/hooks/AppDispatch'
-import { useAppSelector } from 'redux/hooks/AppSelector'
 import isEqual from 'lodash/isEqual'
 import { BallotStrategy } from 'models/ballot'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAppDispatch } from 'redux/hooks/AppDispatch'
+import { useAppSelector } from 'redux/hooks/AppSelector'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
 import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
 import TokenMintingExtra from './TokenMintingExtra'
@@ -159,7 +159,7 @@ export default function RulesForm({
                 <Trans>Pause payments to this project</Trans>
               </div>
             </Form.Item>
-            <Form.Item name="holdfees" extra={HOLD_FEES_EXPLAINATION}>
+            <Form.Item name="holdfees" extra={HOLD_FEES_EXPLANATION}>
               <div className="flex font-medium text-black dark:text-slate-100">
                 <Switch
                   className="mr-2"
@@ -215,7 +215,7 @@ export default function RulesForm({
             <h4 className="mb-3 font-normal uppercase text-black dark:text-slate-100">
               <Trans>Configuration rules</Trans>
             </h4>
-            <Form.Item extra={TERMINAL_CONFIG_EXPLAINATION}>
+            <Form.Item extra={TERMINAL_CONFIG_EXPLANATION}>
               <div className="flex font-medium text-black dark:text-slate-100">
                 <Switch
                   className="mr-2"
@@ -227,7 +227,7 @@ export default function RulesForm({
                 <Trans>Allow Payment Terminal configuration</Trans>
               </div>
             </Form.Item>
-            <Form.Item extra={CONTROLLER_CONFIG_EXPLAINATION}>
+            <Form.Item extra={CONTROLLER_CONFIG_EXPLANATION}>
               <div className="flex font-medium text-black dark:text-slate-100">
                 <Switch
                   className="mr-2"
@@ -243,7 +243,7 @@ export default function RulesForm({
             <h4 className="mb-3 font-normal uppercase text-black dark:text-slate-100">
               <Trans>Migration rules</Trans>
             </h4>
-            <Form.Item extra={TERMINAL_MIGRATION_EXPLAINATION}>
+            <Form.Item extra={TERMINAL_MIGRATION_EXPLANATION}>
               <div className="flex font-medium text-black dark:text-slate-100">
                 <Switch
                   className="mr-2"
@@ -255,7 +255,7 @@ export default function RulesForm({
                 <Trans>Allow Payment Terminal migration</Trans>
               </div>
             </Form.Item>
-            <Form.Item extra={CONTROLLER_MIGRATION_EXPLAINATION}>
+            <Form.Item extra={CONTROLLER_MIGRATION_EXPLANATION}>
               <div className="flex font-medium text-black dark:text-slate-100">
                 <Switch
                   className="mr-2"
@@ -275,7 +275,7 @@ export default function RulesForm({
             </h3>
             <Form.Item
               name="useDataSourceForRedeem"
-              extra={USE_DATASOURCE_FOR_REDEEM_EXPLAINATION}
+              extra={USE_DATASOURCE_FOR_REDEEM_EXPLANATION}
             >
               <div className="flex font-medium text-black dark:text-slate-100">
                 <Switch

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/TokenMintingExtra.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/TokenMintingExtra.tsx
@@ -1,7 +1,7 @@
 import { Space } from 'antd'
 import FormItemWarningText from 'components/FormItemWarningText'
 import {
-  OWNER_MINTING_EXPLAINATION,
+  OWNER_MINTING_EXPLANATION,
   OWNER_MINTING_RISK,
 } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations'
 
@@ -12,7 +12,7 @@ export default function TokenMintingExtra({
 }) {
   return (
     <Space direction="vertical">
-      {OWNER_MINTING_EXPLAINATION}
+      {OWNER_MINTING_EXPLANATION}
       {showMintingWarning && (
         <FormItemWarningText>{OWNER_MINTING_RISK}</FormItemWarningText>
       )}


### PR DESCRIPTION
## What does this PR do and why?

This bug was caused by the JSX Element being wrapped in an object.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
