### PR TITLE
Allow NFT min contribution to be 0 in create flow

### DIFF
--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -215,10 +215,7 @@ export const AddEditRewardModal = ({
           label={t`Minimum Contribution`}
           extra={t`Contributors will receive this NFT when they contribute at least this amount.`}
           required
-          rules={[
-            inputMustExistRule({ label: t`Minimum Contribution` }),
-            inputNonZeroRule({ label: t`Minimum Contribution` }),
-          ]}
+          rules={[inputMustExistRule({ label: t`Minimum Contribution` })]}
         >
           <FormattedNumberInput
             className="w-1/2"


### PR DESCRIPTION
Closes JB-148 (https://linear.app/peel/issue/JB-148/cant-make-nft-0-price-in-create-flow)