### PR TITLE
Fix avatar/ens to top of activity feed elements

### DIFF
--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -108,7 +108,7 @@ export function ActivityEvent({
           <TimestampVersion {...event} />
         </div>
 
-        <div className="mt-1 flex items-center justify-between">
+        <div className="mt-1 flex items-start justify-between">
           <Subject subject={subject} />
           <CallerBeneficiary {...event} />
         </div>


### PR DESCRIPTION
Closes JB-134 (https://linear.app/peel/issue/JB-134/avatar-in-activity-event-incorrectly-positioned-with-large-content)

<img width="544" alt="Screen Shot 2023-03-20 at 6 43 40 pm" src="https://user-images.githubusercontent.com/96150256/226423927-ea4d75e8-8918-4416-91b9-f41120e4ebf5.png">
