### PR TITLE
Twitter metadata fixes

### DIFF
--- a/src/components/common/SEO/SEO.tsx
+++ b/src/components/common/SEO/SEO.tsx
@@ -52,7 +52,7 @@ export const SEO: FC<SEOProps> = ({
         title={formattedTitle}
         description={description ?? config.description}
         handle={formatTwitterHandle(twitter?.handle ?? config.twitter.handle)}
-        site={formatTwitterHandle(twitter?.site ?? config.twitter.site)}
+        site={config.twitter.site}
         creator={formatTwitterHandle(
           twitter?.creator ?? config.twitter.creator,
         )}

--- a/src/config/seo_meta.json
+++ b/src/config/seo_meta.json
@@ -4,7 +4,7 @@
   "description": "Juicebox is a programmable funding platform for crypto and web3. Fund, operate, and scale your project transparently. Community DAO owned, on Ethereum.",
   "twitter": {
     "handle": "@juiceboxETH",
-    "site": "@juiceboxETH",
+    "site": "https://juicebox.money",
     "creator": "@juiceboxETH",
     "cardType": "summary_large_image",
     "image": "https://juicebox.money/assets/JBM-Unfurl-banner.png"

--- a/src/pages/p/[handle]/index.page.tsx
+++ b/src/pages/p/[handle]/index.page.tsx
@@ -12,6 +12,7 @@ import { ProjectMetadataV7 } from 'models/projectMetadata'
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
+import { cidFromUrl, ipfsPublicGatewayUrl } from 'utils/ipfs'
 import { getV1StaticPaths, getV1StaticProps } from './pageLoaders'
 
 export interface V1StaticProps {
@@ -34,20 +35,21 @@ export default function V1HandlePage({
   // Checks URL to see if user was just directed from project deploy
   return (
     <>
-      {metadata ? (
-        <SEO
-          title={metadata.name}
-          url={`${process.env.NEXT_PUBLIC_BASE_URL}p/${handle}`}
-          description={metadata.description}
-          twitter={{
-            card: 'summary',
-            creator: metadata.twitter,
-            handle: metadata.twitter,
-            image: metadata.logoUri,
-            site: metadata.twitter,
-          }}
-        />
-      ) : null}
+      <SEO
+        // Set known values, leave others undefined to be overridden
+        title={metadata?.name}
+        url={`${process.env.NEXT_PUBLIC_BASE_URL}p/${handle}`}
+        description={metadata?.description ? metadata.description : undefined}
+        twitter={{
+          card: 'summary',
+          creator: metadata?.twitter,
+          handle: metadata?.twitter,
+          // Swap out all gateways with ipfs.io public gateway until we can resolve our meta tag issue.
+          image: metadata?.logoUri
+            ? ipfsPublicGatewayUrl(cidFromUrl(metadata.logoUri))
+            : undefined,
+        }}
+      />
       <AppWrapper>
         {metadata ? (
           <V1UserProvider>

--- a/src/pages/v2/p/[projectId]/index.page.tsx
+++ b/src/pages/v2/p/[projectId]/index.page.tsx
@@ -8,6 +8,7 @@ import {
   ProjectPageProps,
 } from 'utils/server/pages/props'
 import { V2V3Dashboard } from './components/V2V3Dashboard'
+import { cidFromUrl, ipfsPublicGatewayUrl } from 'utils/ipfs'
 
 export const getStaticPaths: GetStaticPaths = async () => {
   if (process.env.BUILD_CACHE_V2_PROJECTS === 'true') {
@@ -48,20 +49,21 @@ export default function V2ProjectPage({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
-      {metadata ? (
-        <SEO
-          title={metadata.name}
-          url={`${process.env.NEXT_PUBLIC_BASE_URL}v2/p/${projectId}`}
-          description={metadata.description}
-          twitter={{
-            card: 'summary',
-            creator: metadata.twitter,
-            handle: metadata.twitter,
-            image: metadata.logoUri,
-            site: metadata.twitter,
-          }}
-        />
-      ) : null}
+      <SEO
+        // Set known values, leave others undefined to be overridden
+        title={metadata?.name}
+        url={`${process.env.NEXT_PUBLIC_BASE_URL}v2/p/${projectId}`}
+        description={metadata?.description}
+        twitter={{
+          card: 'summary',
+          creator: metadata?.twitter,
+          handle: metadata?.twitter,
+          // Swap out all gateways with ipfs.io public gateway until we can resolve our meta tag issue.
+          image: metadata?.logoUri
+            ? ipfsPublicGatewayUrl(cidFromUrl(metadata.logoUri))
+            : undefined,
+        }}
+      />
       <AppWrapper>
         <V2V3ProjectPageProvider projectId={projectId} metadata={metadata}>
           <V2V3Dashboard />

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -82,3 +82,10 @@ export function percentFromUploadProgressEvent(e: UploadProgressEvent) {
   const percent = (e.loaded / e.total) * 100
   return round(percent, 0)
 }
+
+/**
+ * Return a URL to a public IPFS gateway for the given cid
+ */
+export const ipfsPublicGatewayUrl = (cid: string | undefined): string => {
+  return `https://ipfs.io/ipfs/${cid}`
+}


### PR DESCRIPTION
- Fallback to defaults on individual tags (instead of only when project metadata was missing)
- Use [ipfs.io public gateway](https://ipfs.io/ipfs/) project page logo Twitter tags.
- Update site Twitter tag to always be `config.twitter.site`, which is now https://juicebox.money. See https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started

