### PR TITLE
Cached api route for project id

### DIFF
--- a/src/middleware.page.ts
+++ b/src/middleware.page.ts
@@ -1,5 +1,3 @@
-import { PV_V2 } from 'constants/pv'
-import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
 import { NextRequest, NextResponse } from 'next/server'
 
 // get the handle name from a URL path
@@ -21,13 +19,13 @@ export async function middleware(request: NextRequest) {
     handle: handleDecoded,
   })
 
-  let projects
+  let projectId
   try {
-    projects = await paginateDepleteProjectsQueryCall({
-      variables: {
-        where: { pv: PV_V2, handle: handleDecoded },
-      },
-    })
+    projectId = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/juicebox/project/${handleDecoded}`,
+    )
+      .then(r => r.json())
+      .then(r => r.projectId)
   } catch (e) {
     console.error('Failed to query projects', e)
     throw e
@@ -35,7 +33,7 @@ export async function middleware(request: NextRequest) {
 
   const url = request.nextUrl
 
-  if (!projects.length) {
+  if (!projectId) {
     console.info('Page not found', {
       originalPathname: request.nextUrl.pathname,
       newPathname: '/404',
@@ -45,7 +43,6 @@ export async function middleware(request: NextRequest) {
     return NextResponse.rewrite(url)
   }
 
-  const projectId = projects[0].projectId
   url.pathname = `/v2/p/${projectId}${trailingPath ? `/${trailingPath}` : ''}`
 
   console.info('Rewriting to project route', {

--- a/src/pages/api/juicebox/project/[projectHandle].page.ts
+++ b/src/pages/api/juicebox/project/[projectHandle].page.ts
@@ -1,0 +1,33 @@
+import { PV_V2 } from 'constants/pv'
+import { paginateDepleteProjectsQueryCall } from 'lib/apollo'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+/**
+ * Get project data from project handle
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { projectHandle } = req.query
+  if (!projectHandle)
+    return res.status(400).json({ error: 'projectHandle is required' })
+
+  const handleDecoded = decodeURI(projectHandle as string)
+
+  const projects = await paginateDepleteProjectsQueryCall({
+    variables: {
+      where: { pv: PV_V2, handle: handleDecoded },
+    },
+  })
+
+  if (!projects.length) {
+    return res.status(404).json({ error: 'project not found' })
+  }
+
+  const projectId = projects[0].projectId
+
+  // cache for a day
+  res.setHeader('Cache-Control', 's-maxage=86400, stale-while-revalidate')
+  return res.status(200).json({ projectId })
+}


### PR DESCRIPTION
- Move the "get project ID from handle" code to an API route
- cache successful resolutions (if theres a project ID found at that given handle)
- Use it in middleware

The goal is to speed up middleware.