### PR TITLE
Fix redemption rate graph when value is 0

### DIFF
--- a/src/components/TokenRedemptionRateGraph/TokenRedemptionRateGraph.tsx
+++ b/src/components/TokenRedemptionRateGraph/TokenRedemptionRateGraph.tsx
@@ -34,9 +34,13 @@ export const TokenRedemptionRateGraph = ({
 
     const dataPoints = []
     for (let i = 0; i <= supply; i++) {
+      const y =
+        _value > 0
+          ? overflow * (i / supply) * (normValue + (i - i * normValue) / supply)
+          : 0
       dataPoints.push({
         x: i,
-        y: overflow * (i / supply) * (normValue + (i - i * normValue) / supply),
+        y,
       })
     }
     return dataPoints


### PR DESCRIPTION
Closes JB-151 (https://linear.app/peel/issue/JB-151/redemption-rate-graph-wrong-when-rate=0)

https://user-images.githubusercontent.com/96150256/227230413-fb7bc347-4af8-4708-a0c0-33835e601bb3.mp4

