### PR TITLE
Fix token holders modal style

### DIFF
--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -240,7 +240,7 @@ export default function ParticipantsModal({
             {tokenSymbolText({ tokenSymbol, capitalize: true })} holders
           </Trans>
         </h4>
-        <Space direction="vertical">
+        <Space direction="vertical" className="w-full">
           {tokenAddress && !isZeroAddress(tokenAddress) && (
             <div className="mb-5">
               <Trans>


### PR DESCRIPTION
Closes JB-178 (https://linear.app/peel/issue/JB-178/holders-modal-at-half-width)

<img width="756" alt="Screen Shot 2023-03-23 at 3 29 24 pm" src="https://user-images.githubusercontent.com/96150256/227235798-1ea9d534-abb2-44fa-9103-147c8b5ff06f.png">
