### PR TITLE
[Project Tags 1/4] ProjectMetadataV8

### DIFF
--- a/src/contexts/shared/ProjectMetadataContext.ts
+++ b/src/contexts/shared/ProjectMetadataContext.ts
@@ -1,9 +1,9 @@
-import { ProjectMetadataV7 } from 'models/projectMetadata'
+import { ProjectMetadata } from 'models/projectMetadata'
 import { PV } from 'models/pv'
 import { createContext } from 'react'
 
 interface ProjectMetadataContextType {
-  projectMetadata: ProjectMetadataV7 | undefined
+  projectMetadata: ProjectMetadata | undefined
   isArchived: boolean | undefined
   projectId: number | undefined
   pv: PV | undefined

--- a/src/contexts/v1/V1ProjectMetadataProvider.tsx
+++ b/src/contexts/v1/V1ProjectMetadataProvider.tsx
@@ -2,7 +2,7 @@ import { PV_V1 } from 'constants/pv'
 import { V1ArchivedProjectIds } from 'constants/v1/archivedProjects'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import useProjectIdForHandle from 'hooks/v1/contractReader/ProjectIdForHandle'
-import { ProjectMetadataV7 } from 'models/projectMetadata'
+import { ProjectMetadata } from 'models/projectMetadata'
 import { PropsWithChildren } from 'react'
 
 export function V1ProjectMetadataProvider({
@@ -11,7 +11,7 @@ export function V1ProjectMetadataProvider({
   children,
 }: PropsWithChildren<{
   handle: string
-  metadata: ProjectMetadataV7 | undefined
+  metadata: ProjectMetadata | undefined
 }>) {
   const { data: projectId } = useProjectIdForHandle(handle)
 

--- a/src/contexts/v2v3/V2V3ProjectMetadataProvider.tsx
+++ b/src/contexts/v2v3/V2V3ProjectMetadataProvider.tsx
@@ -3,7 +3,7 @@ import { V2ArchivedProjectIds } from 'constants/v2v3/archivedProjects'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { useProjectMetadata } from 'hooks/ProjectMetadata'
 import useProjectMetadataContent from 'hooks/v2v3/contractReader/ProjectMetadataContent'
-import { ProjectMetadataV7 } from 'models/projectMetadata'
+import { ProjectMetadata } from 'models/projectMetadata'
 import { PropsWithChildren } from 'react'
 
 export default function V2V3ProjectMetadataProvider({
@@ -11,7 +11,7 @@ export default function V2V3ProjectMetadataProvider({
   metadata,
   children,
 }: PropsWithChildren<{
-  metadata: ProjectMetadataV7 | undefined
+  metadata: ProjectMetadata | undefined
   projectId: number
 }>) {
   const hasMetadata = Boolean(metadata)

--- a/src/lib/api/ipfs.ts
+++ b/src/lib/api/ipfs.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { InfuraPinResponse } from 'lib/infura/ipfs'
-import { consolidateMetadata, ProjectMetadataV7 } from 'models/projectMetadata'
+import { consolidateMetadata, ProjectMetadata } from 'models/projectMetadata'
 import { ipfsGatewayUrl } from 'utils/ipfs'
 
 import { UploadProgressEvent } from 'rc-upload/lib/interface'
@@ -76,7 +76,7 @@ export const pinJson = async (data: unknown) => {
 }
 
 export const uploadProjectMetadata = async (
-  metadata: Omit<ProjectMetadataV7, 'version'>,
+  metadata: Omit<ProjectMetadata, 'version'>,
 ) => {
   return await pinJson(consolidateMetadata(metadata))
 }

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -3,7 +3,11 @@ import axios from 'axios'
 import { juiceboxEmojiImageUri } from 'constants/images'
 import { readNetwork } from 'constants/networks'
 import { WAD_DECIMALS } from 'constants/numbers'
-import { AnyProjectMetadata, ProjectMetadataV7 } from 'models/projectMetadata'
+import {
+  AnyProjectMetadata,
+  consolidateMetadata,
+  ProjectMetadata,
+} from 'models/projectMetadata'
 import { pinJson } from './api/ipfs'
 
 /**
@@ -24,7 +28,7 @@ const generateSnapshotSpaceSettings = ({
   handle: string
   tokenSymbol: string
   projectId: number
-  projectMetadata: AnyProjectMetadata
+  projectMetadata: ProjectMetadata
   projectOwnerAddress: string
   JBTokenStoreAddress: string
 }) => {
@@ -84,10 +88,10 @@ const generateSnapshotSpaceSettings = ({
     network: `${readNetwork.chainId}`,
     children: [],
     private: false,
-    name: projectMetadata?.name,
+    name: projectMetadata.name,
     about: '',
     website: `https://juicebox.money/@${handle}`,
-    twitter: (projectMetadata as ProjectMetadataV7)?.twitter,
+    twitter: projectMetadata.twitter,
     symbol: tokenSymbol,
     avatar,
   }
@@ -108,7 +112,7 @@ export async function uploadSnapshotSettingsToIPFS({
   handle: string
   tokenSymbol: string
   projectId: number
-  projectMetadata: ProjectMetadataV7
+  projectMetadata: AnyProjectMetadata
   projectOwnerAddress: string
   JBTokenStoreAddress: string
 }): Promise<string> {
@@ -116,7 +120,7 @@ export async function uploadSnapshotSettingsToIPFS({
     handle,
     tokenSymbol,
     projectId,
-    projectMetadata,
+    projectMetadata: consolidateMetadata(projectMetadata),
     projectOwnerAddress,
     JBTokenStoreAddress,
   })

--- a/src/models/project-tags.ts
+++ b/src/models/project-tags.ts
@@ -1,0 +1,21 @@
+export const projectTagOptions = [
+  'art',
+  'business',
+  'charity',
+  'dao',
+  'defi',
+  'education',
+  'events',
+  'fundraising',
+  'games',
+  'music',
+  'social',
+] as const
+
+export type ProjectTag = typeof projectTagOptions extends Readonly<
+  Array<infer T>
+>
+  ? T
+  : never
+
+export const MAX_PROJECT_TAGS = 3

--- a/src/models/projectMetadata.ts
+++ b/src/models/projectMetadata.ts
@@ -1,7 +1,8 @@
 import { NftPostPayModalConfig } from './nftRewards'
+import { ProjectTag } from './project-tags'
 import { TokenRef } from './tokenRef'
 
-export const LATEST_METADATA_VERSION = 7
+export const LATEST_METADATA_VERSION = 8
 
 type ProjectMetadataV1 = Partial<{
   name: string
@@ -48,7 +49,7 @@ type ProjectMetadataV5 = Partial<
 >
 
 // add `telegram`
-export type ProjectMetadataV6 = Partial<
+type ProjectMetadataV6 = Partial<
   Omit<ProjectMetadataV5, 'version'> & {
     version: 6
     telegram: string
@@ -56,10 +57,18 @@ export type ProjectMetadataV6 = Partial<
 >
 
 // add `coverImageUri`
-export type ProjectMetadataV7 = Partial<
+type ProjectMetadataV7 = Partial<
   Omit<ProjectMetadataV6, 'version'> & {
     version: typeof LATEST_METADATA_VERSION
     coverImageUri: string
+  }
+>
+
+// add `tags`
+type ProjectMetadataV8 = Partial<
+  Omit<ProjectMetadataV7, 'version'> & {
+    version: typeof LATEST_METADATA_VERSION
+    tags: ProjectTag[]
   }
 >
 
@@ -71,11 +80,15 @@ export type AnyProjectMetadata =
   | ProjectMetadataV5
   | ProjectMetadataV6
   | ProjectMetadataV7
+  | ProjectMetadataV8
+
+// Current version
+export type ProjectMetadata = ProjectMetadataV8
 
 // Converts metadata of any version to latest version
 export const consolidateMetadata = (
   metadata: AnyProjectMetadata,
-): ProjectMetadataV7 => {
+): ProjectMetadata => {
   return {
     ...metadata,
     payButton:

--- a/src/models/projectMetadata.ts
+++ b/src/models/projectMetadata.ts
@@ -2,8 +2,6 @@ import { NftPostPayModalConfig } from './nftRewards'
 import { ProjectTag } from './project-tags'
 import { TokenRef } from './tokenRef'
 
-export const LATEST_METADATA_VERSION = 8
-
 type ProjectMetadataV1 = Partial<{
   name: string
   description: string
@@ -59,7 +57,7 @@ type ProjectMetadataV6 = Partial<
 // add `coverImageUri`
 type ProjectMetadataV7 = Partial<
   Omit<ProjectMetadataV6, 'version'> & {
-    version: typeof LATEST_METADATA_VERSION
+    version: 7
     coverImageUri: string
   }
 >
@@ -67,7 +65,7 @@ type ProjectMetadataV7 = Partial<
 // add `tags`
 type ProjectMetadataV8 = Partial<
   Omit<ProjectMetadataV7, 'version'> & {
-    version: typeof LATEST_METADATA_VERSION
+    version: 8
     tags: ProjectTag[]
   }
 >
@@ -84,6 +82,7 @@ export type AnyProjectMetadata =
 
 // Current version
 export type ProjectMetadata = ProjectMetadataV8
+export const LATEST_METADATA_VERSION = 8
 
 // Converts metadata of any version to latest version
 export const consolidateMetadata = (

--- a/src/pages/p/[handle]/index.page.tsx
+++ b/src/pages/p/[handle]/index.page.tsx
@@ -8,7 +8,7 @@ import { V1ProjectProvider } from 'contexts/v1/Project/V1ProjectProvider'
 import { V1UserProvider } from 'contexts/v1/User/V1UserProvider'
 import { V1CurrencyProvider } from 'contexts/v1/V1CurrencyProvider'
 import { V1ProjectMetadataProvider } from 'contexts/v1/V1ProjectMetadataProvider'
-import { ProjectMetadataV7 } from 'models/projectMetadata'
+import { ProjectMetadata } from 'models/projectMetadata'
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
@@ -16,7 +16,7 @@ import { cidFromUrl, ipfsPublicGatewayUrl } from 'utils/ipfs'
 import { getV1StaticPaths, getV1StaticProps } from './pageLoaders'
 
 export interface V1StaticProps {
-  metadata: ProjectMetadataV7
+  metadata: ProjectMetadata
   handle: string
 }
 

--- a/src/redux/slices/editingProject.ts
+++ b/src/redux/slices/editingProject.ts
@@ -3,7 +3,7 @@ import * as constants from '@ethersproject/constants'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
   LATEST_METADATA_VERSION,
-  ProjectMetadataV7,
+  ProjectMetadata,
 } from 'models/projectMetadata'
 import { V1CurrencyOption } from 'models/v1/currencyOption'
 import { PayoutMod, TicketMod } from 'models/v1/mods'
@@ -22,7 +22,7 @@ import {
 import { V1_CURRENCY_USD } from 'constants/v1/currency'
 
 interface EditingProjectInfo {
-  metadata: ProjectMetadataV7
+  metadata: ProjectMetadata
   handle: string
 }
 

--- a/src/redux/slices/editingV2Project/defaultState.ts
+++ b/src/redux/slices/editingV2Project/defaultState.ts
@@ -8,7 +8,7 @@ import {
 import { JB721GovernanceType, JBTiered721Flags } from 'models/nftRewards'
 import {
   LATEST_METADATA_VERSION,
-  ProjectMetadataV7,
+  ProjectMetadata,
 } from 'models/projectMetadata'
 import { issuanceRateFrom, redemptionRateFrom } from 'utils/v2v3/math'
 import {
@@ -80,7 +80,7 @@ export const DEFAULT_NFT_FLAGS: JBTiered721Flags = {
   preventOverspending: false,
 }
 
-const DEFAULT_PROJECT_METADATA_STATE: ProjectMetadataV7 = {
+const DEFAULT_PROJECT_METADATA_STATE: ProjectMetadata = {
   name: '',
   infoUri: '',
   logoUri: '',
@@ -90,6 +90,7 @@ const DEFAULT_PROJECT_METADATA_STATE: ProjectMetadataV7 = {
   discord: '',
   telegram: '',
   tokens: [],
+  tags: [],
   nftPaymentSuccessModal: undefined,
   version: LATEST_METADATA_VERSION,
 }

--- a/src/redux/slices/editingV2Project/types.ts
+++ b/src/redux/slices/editingV2Project/types.ts
@@ -8,7 +8,7 @@ import {
   NftRewardTier,
 } from 'models/nftRewards'
 import { PayoutsSelection } from 'models/payoutsSelection'
-import { ProjectMetadataV7 } from 'models/projectMetadata'
+import { ProjectMetadata } from 'models/projectMetadata'
 import { ProjectTokensSelection } from 'models/projectTokenSelection'
 import { ReconfigurationStrategy } from 'models/reconfigurationStrategy'
 import {
@@ -43,7 +43,7 @@ export interface CreateState {
 }
 
 export interface ProjectState {
-  projectMetadata: ProjectMetadataV7
+  projectMetadata: ProjectMetadata
   fundingCycleData: SerializedV2V3FundingCycleData
   fundingCycleMetadata: SerializedV2V3FundingCycleMetadata
   fundAccessConstraints: SerializedV2V3FundAccessConstraint[]

--- a/src/utils/server/ipfs/findProjectMetadata.ts
+++ b/src/utils/server/ipfs/findProjectMetadata.ts
@@ -3,7 +3,7 @@ import { ipfsGet } from 'lib/api/ipfs'
 import {
   AnyProjectMetadata,
   consolidateMetadata,
-  ProjectMetadataV7,
+  ProjectMetadata,
 } from 'models/projectMetadata'
 
 import { GlobalInfuraScheduler } from './infuraScheduler'
@@ -14,7 +14,7 @@ export const findProjectMetadata = async ({
 }: {
   metadataCid: string
   limiter?: Bottleneck
-}): Promise<ProjectMetadataV7> => {
+}): Promise<ProjectMetadata> => {
   limiter = limiter ?? GlobalInfuraScheduler
   /*
    * Safe to do so, as the static timeout will catch this and retry later.

--- a/src/utils/server/pages/props.ts
+++ b/src/utils/server/pages/props.ts
@@ -1,9 +1,9 @@
-import { ProjectMetadataV7 } from 'models/projectMetadata'
+import { ProjectMetadata } from 'models/projectMetadata'
 import { GetStaticPropsResult } from 'next'
 import { getProjectMetadata } from '../metadata'
 
 export interface ProjectPageProps {
-  metadata?: ProjectMetadataV7
+  metadata?: ProjectMetadata
   projectId: number
 }
 


### PR DESCRIPTION
- Adds new ProjectMetadataV8 with `tags`
- Updates to ProjectMetadata pattern:
    - `ProjectMetadata` is now latest metadata version
    - No more dependencies on specific `ProjectMetadataVX` types, which are no longer exported