### PR TITLE
Update DB for new project notifications [1/n]

### DIFF
--- a/src/models/notifications/projectNotifications.ts
+++ b/src/models/notifications/projectNotifications.ts
@@ -1,0 +1,3 @@
+export enum ProjectNotification {
+  ProjectPaid = 'project_paid',
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -76,34 +76,6 @@ export interface Database {
   }
   public: {
     Tables: {
-      notifications: {
-        Row: {
-          id: string
-        }
-        Insert: {
-          id?: string
-        }
-        Update: {
-          id?: string
-        }
-      }
-      project_subscriptions: {
-        Row: {
-          notification_id: string
-          project_id: number
-          user_id: string
-        }
-        Insert: {
-          notification_id: string
-          project_id: number
-          user_id: string
-        }
-        Update: {
-          notification_id?: string
-          project_id?: number
-          user_id?: string
-        }
-      }
       projects: {
         Row: {
           id: number
@@ -113,6 +85,23 @@ export interface Database {
         }
         Update: {
           id?: number
+        }
+      }
+      user_subscriptions: {
+        Row: {
+          notification_id: string
+          project_id: number | null
+          user_id: string
+        }
+        Insert: {
+          notification_id: string
+          project_id?: number | null
+          user_id: string
+        }
+        Update: {
+          notification_id?: string
+          project_id?: number | null
+          user_id?: string
         }
       }
       users: {

--- a/supabase/migrations/20230330212553_project_subscription_impl.sql
+++ b/supabase/migrations/20230330212553_project_subscription_impl.sql
@@ -41,5 +41,7 @@ to public
 using (((auth.jwt() ->> 'sub'::text) = (user_id)::text))
 with check (((auth.jwt() ->> 'sub'::text) = (user_id)::text));
 
+alter table "public"."user_subscriptions" add constraint "user_subscriptions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) not valid;
 
+alter table "public"."user_subscriptions" validate constraint "user_subscriptions_user_id_fkey";
 

--- a/supabase/migrations/20230330212553_project_subscription_impl.sql
+++ b/supabase/migrations/20230330212553_project_subscription_impl.sql
@@ -1,0 +1,45 @@
+drop policy "Can update own user data." on "public"."project_subscriptions";
+
+drop policy "Can view own user data." on "public"."project_subscriptions";
+
+alter table "public"."project_subscriptions" drop constraint "project_subscriptions_notification_id_fkey";
+
+alter table "public"."project_subscriptions" drop constraint "project_subscriptions_project_id_fkey";
+
+alter table "public"."project_subscriptions" drop constraint "project_subscriptions_user_id_fkey";
+
+alter table "public"."notifications" drop constraint "notifications_pkey";
+
+alter table "public"."project_subscriptions" drop constraint "project_subscriptions_pkey";
+
+drop index if exists "public"."notifications_pkey";
+
+drop index if exists "public"."project_subscriptions_pkey";
+
+drop table "public"."notifications";
+
+drop table "public"."project_subscriptions";
+
+create table "public"."user_subscriptions" (
+    "project_id" bigint,
+    "user_id" uuid not null,
+    "notification_id" text not null
+);
+
+
+alter table "public"."user_subscriptions" enable row level security;
+
+CREATE UNIQUE INDEX user_subscriptions_pkey ON public.user_subscriptions USING btree (user_id, notification_id);
+
+alter table "public"."user_subscriptions" add constraint "user_subscriptions_pkey" PRIMARY KEY using index "user_subscriptions_pkey";
+
+create policy "Can perform crud operations."
+on "public"."user_subscriptions"
+as permissive
+for all
+to public
+using (((auth.jwt() ->> 'sub'::text) = (user_id)::text))
+with check (((auth.jwt() ->> 'sub'::text) = (user_id)::text));
+
+
+


### PR DESCRIPTION
## What does this PR do and why?

This PR updates the SQL migration to improve the management of user subscriptions and notifications in the database. It removes the project_subscriptions and notifications tables and introduces a new user_subscriptions table. This change simplifies the data structure and enforces row-level security for CRUD operations, ensuring that users can only perform actions on their own data.

## Screenshots or screen recordings

Not applicable, as this PR only contains SQL migration changes.

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
