### PR TITLE
Add new subscription button to project header [3/n] { JB-106, JB-189, JB-190, JB-191 }

### DIFF
--- a/src/components/SubscribeButton/SubscribeButton.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.tsx
@@ -1,0 +1,46 @@
+import { Button, Tooltip } from 'antd'
+import SkeletonButton from 'antd/lib/skeleton/Button'
+import { TooltipPlacement } from 'antd/lib/tooltip'
+import { twMerge } from 'tailwind-merge'
+import { useSubscribeButton } from './hooks/useSubscribeButton'
+import { SubscribeButtonIcon } from './SubscribeButtonIcon'
+
+export const SubscribeButton = ({
+  projectId,
+  className,
+  tooltipPlacement,
+}: {
+  projectId: number
+  className?: string
+  tooltipPlacement?: TooltipPlacement
+}) => {
+  const {
+    loading,
+    isSubscribed,
+    showSubscribeButton,
+    onSubscribeButtonClicked,
+  } = useSubscribeButton({ projectId })
+
+  if (!showSubscribeButton) return null
+
+  if (loading) return <SkeletonButton active size="small" />
+
+  return (
+    <Tooltip
+      placement={tooltipPlacement}
+      title={
+        isSubscribed
+          ? 'You are subscribed to notifications'
+          : 'Subscribe to notifications'
+      }
+    >
+      <Button
+        className={twMerge('p-0', className)}
+        type="text"
+        onClick={onSubscribeButtonClicked}
+      >
+        <SubscribeButtonIcon isSubscribed={isSubscribed} />
+      </Button>
+    </Tooltip>
+  )
+}

--- a/src/components/SubscribeButton/SubscribeButtonIcon.tsx
+++ b/src/components/SubscribeButton/SubscribeButtonIcon.tsx
@@ -1,0 +1,15 @@
+import { BellFilled, BellOutlined } from '@ant-design/icons'
+import { Badge } from 'components/Badge'
+
+export const SubscribeButtonIcon = ({
+  isSubscribed,
+}: {
+  isSubscribed: boolean
+}) => {
+  return (
+    <div className="flex items-center gap-x-2">
+      {isSubscribed ? <BellFilled /> : <BellOutlined />}
+      <Badge variant="info">New</Badge>
+    </div>
+  )
+}

--- a/src/components/SubscribeButton/hooks/useSubscribeButton.ts
+++ b/src/components/SubscribeButton/hooks/useSubscribeButton.ts
@@ -1,0 +1,126 @@
+import { useSession, useSupabaseClient } from '@supabase/auth-helpers-react'
+import { useWallet } from 'hooks/Wallet'
+import { useWalletSignIn } from 'hooks/WalletSignIn'
+import { ProjectNotification } from 'models/notifications/projectNotifications'
+import { useCallback, useEffect, useState } from 'react'
+import { Database } from 'types/database.types'
+import { emitErrorNotification } from 'utils/notifications'
+
+/**
+ * Hook to control the subscribe button.
+ * @param projectId The ID of the project to subscribe to.
+
+ * @returns The loading state, the subscribed state, and the subscribe function.
+ * @example const { loading, isSubscribed, subscribe } = useSubscribeButton({ projectId: 1 })
+ */
+export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
+  const [loading, setLoading] = useState<boolean>(false)
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(false)
+
+  const wallet = useWallet()
+  const signIn = useWalletSignIn()
+  const session = useSession()
+  const supabase = useSupabaseClient<Database>()
+
+  // If the user is not connected to a wallet, or the wallet is on an unsupported chain, don't show the button
+  const showSubscribeButton = wallet.isConnected && !wallet.chainUnsupported
+
+  const getUserNotificationsForProjectId = useCallback(
+    async ({ projectId, userId }: { projectId: number; userId: string }) => {
+      const { data, error } = await supabase
+        .from('user_subscriptions')
+        .select('notification_id')
+        .eq('user_id', userId)
+        .eq('project_id', projectId)
+      if (error) {
+        console.error(error)
+        return
+      }
+      return (
+        data
+          .map(notification => notification.notification_id)
+          // Convert notifications to `ProjectNotification` enum
+          .map(
+            notification =>
+              ProjectNotification[
+                notification as keyof typeof ProjectNotification
+              ],
+          )
+      )
+    },
+    [supabase],
+  )
+
+  // Check if the user is subscribed to the project
+  useEffect(() => {
+    if (!session?.user.id) return
+    setLoading(true)
+    const userId = session.user.id
+    getUserNotificationsForProjectId({ projectId, userId }).then(
+      notifications => {
+        if (!notifications) {
+          setLoading(false)
+          return
+        }
+
+        // TODO: This is temporary, just for MVP. we will fine grain this later
+        if (notifications.length > 0) {
+          setIsSubscribed(true)
+        }
+
+        setLoading(false)
+      },
+    )
+  }, [getUserNotificationsForProjectId, projectId, session?.user.id, supabase])
+
+  const onSubscribeButtonClicked = useCallback(async () => {
+    // If the user is not connected to a wallet, don't do anything
+    if (!wallet.isConnected) return
+
+    try {
+      const session = await signIn()
+      // Set the user as subscribed to the project if they are not already
+      const userId = session.user.id
+      const notifications = await getUserNotificationsForProjectId({
+        projectId,
+        userId,
+      })
+      if (!notifications?.length) {
+        const { error } = await supabase.from('user_subscriptions').insert([
+          {
+            user_id: session.user.id,
+            project_id: projectId,
+            notification_id: ProjectNotification.ProjectPaid,
+          },
+        ])
+        if (error) throw error
+        setIsSubscribed(true)
+      } else {
+        const { error } = await supabase
+          .from('user_subscriptions')
+          .delete()
+          .eq('user_id', userId)
+          .eq('project_id', projectId)
+          .eq('notification_id', ProjectNotification.ProjectPaid)
+        if (error) throw error
+        setIsSubscribed(false)
+      }
+    } catch (e) {
+      console.error('Error occurred while subscribing', e)
+      emitErrorNotification('Error occurred while subscribing')
+    }
+  }, [
+    getUserNotificationsForProjectId,
+    projectId,
+    signIn,
+    supabase,
+    wallet.isConnected,
+  ])
+
+  return {
+    loading,
+    isSubscribed,
+    onSubscribeButtonClicked,
+    showSubscribeButton,
+  }
+}

--- a/src/components/SubscribeButton/index.ts
+++ b/src/components/SubscribeButton/index.ts
@@ -1,0 +1,1 @@
+export * from './SubscribeButton'

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
@@ -1,5 +1,5 @@
 import { SettingOutlined, ToolOutlined } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
 import { SubscribeButton } from 'components/SubscribeButton'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer'
@@ -29,16 +29,14 @@ export function V2V3ProjectHeaderActions() {
       <div className="flex items-center">
         <div className="flex items-center gap-x-4">
           <SubscribeButton projectId={projectId} tooltipPlacement={'bottom'} />
-          <>
-            <ContractVersionSelect />
-            <Tooltip title={t`Project tools`} placement="bottom">
-              <Button
-                onClick={() => setToolDrawerVisible(true)}
-                icon={<ToolOutlined />}
-                type="text"
-              />
-            </Tooltip>
-          </>
+          <ContractVersionSelect />
+          <Tooltip title={t`Project tools`} placement="bottom">
+            <Button
+              onClick={() => setToolDrawerVisible(true)}
+              icon={<ToolOutlined />}
+              type="text"
+            />
+          </Tooltip>
           {canReconfigure && (
             <div>
               <Link href={settingsPagePath('general', { handle, projectId })}>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
@@ -1,6 +1,7 @@
 import { SettingOutlined, ToolOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
+import { SubscribeButton } from 'components/SubscribeButton'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
@@ -21,11 +22,14 @@ export function V2V3ProjectHeaderActions() {
 
   const { projectId } = useContext(ProjectMetadataContext)
 
+  if (projectId === undefined) return null
+
   return (
     <>
       <div className="flex items-center">
         <div className="flex items-center gap-x-4">
-          <div>
+          <SubscribeButton projectId={projectId} tooltipPlacement={'bottom'} />
+          <>
             <ContractVersionSelect />
             <Tooltip title={t`Project tools`} placement="bottom">
               <Button
@@ -34,7 +38,7 @@ export function V2V3ProjectHeaderActions() {
                 type="text"
               />
             </Tooltip>
-          </div>
+          </>
           {canReconfigure && (
             <div>
               <Link href={settingsPagePath('general', { handle, projectId })}>

--- a/src/hooks/WalletSignIn.ts
+++ b/src/hooks/WalletSignIn.ts
@@ -24,7 +24,9 @@ export const useWalletSignIn = () => {
     }
 
     const getSessionResult = await supabase.auth.getSession()
-    if (getSessionResult.data) return
+    if (getSessionResult.data.session) {
+      return getSessionResult.data.session
+    }
 
     const challengeMessage = await AuthAPI.getChallengeMessage({
       wallet: wallet.userAddress,
@@ -35,7 +37,7 @@ export const useWalletSignIn = () => {
       signature,
       message: challengeMessage,
     })
-    const { error } = await supabase.auth.setSession({
+    const { error, data } = await supabase.auth.setSession({
       access_token: accessToken,
       refresh_token: v4(), // Set to garbage token, no long lived refresh tokens
     })
@@ -43,5 +45,10 @@ export const useWalletSignIn = () => {
       console.error(error)
       throw new Error(error.message)
     }
+    if (!data.session) {
+      console.error('No session returned')
+      throw new Error('No session returned')
+    }
+    return data.session
   }, [supabase.auth, wallet])
 }


### PR DESCRIPTION
## What does this PR do and why?

This PR introduces the following changes:

- Centered the SocialLinks in the ProjectHeader component.
- Added a new SubscribeButton component that displays a tooltip with the subscription status and a button to toggle the subscription.
- The SubscribeButton component makes use of a new hook called useSubscribeButton, which fetches the subscription status and updates it when the button is clicked.
- Integrated the SubscribeButton component into the V2V3ProjectHeaderActions component, allowing users to subscribe or unsubscribe from project notifications.
- The SubscribeButton will only be displayed if the user is connected to a wallet and the wallet is on a supported chain.

With these changes, users will now have the ability to subscribe or unsubscribe from project notifications, enhancing their user experience on the platform.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
