### PR TITLE
Refactor email notification handling in on-pay event [5/n]

### DIFF
--- a/src/components/SubscribeButton/SubscribeButton.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.tsx
@@ -1,0 +1,46 @@
+import { Button, Tooltip } from 'antd'
+import SkeletonButton from 'antd/lib/skeleton/Button'
+import { TooltipPlacement } from 'antd/lib/tooltip'
+import { twMerge } from 'tailwind-merge'
+import { useSubscribeButton } from './hooks/useSubscribeButton'
+import { SubscribeButtonIcon } from './SubscribeButtonIcon'
+
+export const SubscribeButton = ({
+  projectId,
+  className,
+  tooltipPlacement,
+}: {
+  projectId: number
+  className?: string
+  tooltipPlacement?: TooltipPlacement
+}) => {
+  const {
+    loading,
+    isSubscribed,
+    showSubscribeButton,
+    onSubscribeButtonClicked,
+  } = useSubscribeButton({ projectId })
+
+  if (!showSubscribeButton) return null
+
+  if (loading) return <SkeletonButton active size="small" />
+
+  return (
+    <Tooltip
+      placement={tooltipPlacement}
+      title={
+        isSubscribed
+          ? 'You are subscribed to notifications'
+          : 'Subscribe to notifications'
+      }
+    >
+      <Button
+        className={twMerge('p-0', className)}
+        type="text"
+        onClick={onSubscribeButtonClicked}
+      >
+        <SubscribeButtonIcon isSubscribed={isSubscribed} />
+      </Button>
+    </Tooltip>
+  )
+}

--- a/src/components/SubscribeButton/SubscribeButton.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.tsx
@@ -1,19 +1,23 @@
 import { Button, Tooltip } from 'antd'
 import SkeletonButton from 'antd/lib/skeleton/Button'
 import { TooltipPlacement } from 'antd/lib/tooltip'
+import { ModalProvider } from 'contexts/Modal'
 import { twMerge } from 'tailwind-merge'
 import { useSubscribeButton } from './hooks/useSubscribeButton'
 import { SubscribeButtonIcon } from './SubscribeButtonIcon'
+import { SubscribeModal } from './SubscribeModal'
 
-export const SubscribeButton = ({
-  projectId,
-  className,
-  tooltipPlacement,
-}: {
+interface SubscribeButtonProps {
   projectId: number
   className?: string
   tooltipPlacement?: TooltipPlacement
-}) => {
+}
+
+const _SubscribeButton = ({
+  projectId,
+  className,
+  tooltipPlacement,
+}: SubscribeButtonProps) => {
   const {
     loading,
     isSubscribed,
@@ -26,21 +30,31 @@ export const SubscribeButton = ({
   if (loading) return <SkeletonButton active size="small" />
 
   return (
-    <Tooltip
-      placement={tooltipPlacement}
-      title={
-        isSubscribed
-          ? 'You are subscribed to notifications'
-          : 'Subscribe to notifications'
-      }
-    >
-      <Button
-        className={twMerge('p-0', className)}
-        type="text"
-        onClick={onSubscribeButtonClicked}
+    <>
+      <Tooltip
+        placement={tooltipPlacement}
+        title={
+          isSubscribed
+            ? 'You are subscribed to notifications'
+            : 'Subscribe to notifications'
+        }
       >
-        <SubscribeButtonIcon isSubscribed={isSubscribed} />
-      </Button>
-    </Tooltip>
+        <Button
+          className={twMerge('p-0', className)}
+          type="text"
+          onClick={onSubscribeButtonClicked}
+        >
+          <SubscribeButtonIcon isSubscribed={isSubscribed} />
+        </Button>
+      </Tooltip>
+
+      <SubscribeModal />
+    </>
   )
 }
+
+export const SubscribeButton = (props: SubscribeButtonProps) => (
+  <ModalProvider>
+    <_SubscribeButton {...props} />
+  </ModalProvider>
+)

--- a/src/components/SubscribeButton/SubscribeButtonIcon.tsx
+++ b/src/components/SubscribeButton/SubscribeButtonIcon.tsx
@@ -1,0 +1,15 @@
+import { BellFilled, BellOutlined } from '@ant-design/icons'
+import { Badge } from 'components/Badge'
+
+export const SubscribeButtonIcon = ({
+  isSubscribed,
+}: {
+  isSubscribed: boolean
+}) => {
+  return (
+    <div className="flex items-center gap-x-2">
+      {isSubscribed ? <BellFilled /> : <BellOutlined />}
+      <Badge variant="info">New</Badge>
+    </div>
+  )
+}

--- a/src/components/SubscribeButton/SubscribeModal.tsx
+++ b/src/components/SubscribeButton/SubscribeModal.tsx
@@ -1,0 +1,43 @@
+import { t } from '@lingui/macro'
+import { Modal } from 'antd'
+import { JuiceInput } from 'components/inputs/JuiceTextInput'
+import { ErrorMessage, Field, Form, Formik } from 'formik'
+import { useSubscribeModal } from './hooks/useSubscribeModal'
+
+const FORM_NAME = 'SubscribeModal'
+
+export const SubscribeModal = () => {
+  const { open, schema, initialValues, closeModal, onSubmit } =
+    useSubscribeModal()
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={schema}
+      onSubmit={onSubmit}
+    >
+      {({ isSubmitting }) => (
+        <Modal
+          open={open}
+          title={t`Subscribe for updates!`}
+          okButtonProps={{ form: FORM_NAME, htmlType: 'submit' }}
+          confirmLoading={isSubmitting}
+          onCancel={closeModal}
+        >
+          <Form id={FORM_NAME}>
+            <Field
+              name="email"
+              type="email"
+              placeholder="Email"
+              as={JuiceInput}
+            />
+            <ErrorMessage
+              className="text-error pt-2"
+              name="email"
+              component="div"
+            />
+          </Form>
+        </Modal>
+      )}
+    </Formik>
+  )
+}

--- a/src/components/SubscribeButton/SubscribeModal.tsx
+++ b/src/components/SubscribeButton/SubscribeModal.tsx
@@ -1,7 +1,9 @@
+import { CheckCircleOutlined } from '@ant-design/icons'
 import { t } from '@lingui/macro'
 import { Modal } from 'antd'
 import { JuiceInput } from 'components/inputs/JuiceTextInput'
 import { ErrorMessage, Field, Form, Formik } from 'formik'
+import { ReactNode } from 'react'
 import { useSubscribeModal } from './hooks/useSubscribeModal'
 
 const FORM_NAME = 'SubscribeModal'
@@ -18,26 +20,41 @@ export const SubscribeModal = () => {
       {({ isSubmitting }) => (
         <Modal
           open={open}
-          title={t`Subscribe for updates!`}
+          title={t`Subscribe to project activity`}
           okButtonProps={{ form: FORM_NAME, htmlType: 'submit' }}
           confirmLoading={isSubmitting}
           onCancel={closeModal}
         >
-          <Form id={FORM_NAME}>
-            <Field
-              name="email"
-              type="email"
-              placeholder="Email"
-              as={JuiceInput}
-            />
-            <ErrorMessage
-              className="text-error pt-2"
-              name="email"
-              component="div"
-            />
-          </Form>
+          <div className="flex flex-col gap-y-6">
+            <div className="flex flex-col gap-y-2">
+              <CheckBullet
+                text={t`Get notified when a contributor supports this project`}
+              />
+              <CheckBullet text={t`More updates coming soon`} />
+            </div>
+            <Form id={FORM_NAME}>
+              <Field
+                name="email"
+                type="email"
+                placeholder="Email"
+                as={JuiceInput}
+              />
+              <ErrorMessage
+                className="text-error pt-2"
+                name="email"
+                component="div"
+              />
+            </Form>
+          </div>
         </Modal>
       )}
     </Formik>
   )
 }
+
+const CheckBullet = ({ text }: { text: ReactNode }) => (
+  <div className="flex items-center gap-x-2">
+    <CheckCircleOutlined className="text-action-primary" />
+    {text}
+  </div>
+)

--- a/src/components/SubscribeButton/hooks/useSubscribeButton.ts
+++ b/src/components/SubscribeButton/hooks/useSubscribeButton.ts
@@ -1,0 +1,126 @@
+import { useSession, useSupabaseClient } from '@supabase/auth-helpers-react'
+import { useWallet } from 'hooks/Wallet'
+import { useWalletSignIn } from 'hooks/WalletSignIn'
+import { ProjectNotification } from 'models/notifications/projectNotifications'
+import { useCallback, useEffect, useState } from 'react'
+import { Database } from 'types/database.types'
+import { emitErrorNotification } from 'utils/notifications'
+
+/**
+ * Hook to control the subscribe button.
+ * @param projectId The ID of the project to subscribe to.
+
+ * @returns The loading state, the subscribed state, and the subscribe function.
+ * @example const { loading, isSubscribed, subscribe } = useSubscribeButton({ projectId: 1 })
+ */
+export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
+  const [loading, setLoading] = useState<boolean>(false)
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(false)
+
+  const wallet = useWallet()
+  const signIn = useWalletSignIn()
+  const session = useSession()
+  const supabase = useSupabaseClient<Database>()
+
+  // If the user is not connected to a wallet, or the wallet is on an unsupported chain, don't show the button
+  const showSubscribeButton = wallet.isConnected && !wallet.chainUnsupported
+
+  const getUserNotificationsForProjectId = useCallback(
+    async ({ projectId, userId }: { projectId: number; userId: string }) => {
+      const { data, error } = await supabase
+        .from('user_subscriptions')
+        .select('notification_id')
+        .eq('user_id', userId)
+        .eq('project_id', projectId)
+      if (error) {
+        console.error(error)
+        return
+      }
+      return (
+        data
+          .map(notification => notification.notification_id)
+          // Convert notifications to `ProjectNotification` enum
+          .map(
+            notification =>
+              ProjectNotification[
+                notification as keyof typeof ProjectNotification
+              ],
+          )
+      )
+    },
+    [supabase],
+  )
+
+  // Check if the user is subscribed to the project
+  useEffect(() => {
+    if (!session?.user.id) return
+    setLoading(true)
+    const userId = session.user.id
+    getUserNotificationsForProjectId({ projectId, userId }).then(
+      notifications => {
+        if (!notifications) {
+          setLoading(false)
+          return
+        }
+
+        // TODO: This is temporary, just for MVP. we will fine grain this later
+        if (notifications.length > 0) {
+          setIsSubscribed(true)
+        }
+
+        setLoading(false)
+      },
+    )
+  }, [getUserNotificationsForProjectId, projectId, session?.user.id, supabase])
+
+  const onSubscribeButtonClicked = useCallback(async () => {
+    // If the user is not connected to a wallet, don't do anything
+    if (!wallet.isConnected) return
+
+    try {
+      const session = await signIn()
+      // Set the user as subscribed to the project if they are not already
+      const userId = session.user.id
+      const notifications = await getUserNotificationsForProjectId({
+        projectId,
+        userId,
+      })
+      if (!notifications?.length) {
+        const { error } = await supabase.from('user_subscriptions').insert([
+          {
+            user_id: session.user.id,
+            project_id: projectId,
+            notification_id: ProjectNotification.ProjectPaid,
+          },
+        ])
+        if (error) throw error
+        setIsSubscribed(true)
+      } else {
+        const { error } = await supabase
+          .from('user_subscriptions')
+          .delete()
+          .eq('user_id', userId)
+          .eq('project_id', projectId)
+          .eq('notification_id', ProjectNotification.ProjectPaid)
+        if (error) throw error
+        setIsSubscribed(false)
+      }
+    } catch (e) {
+      console.error('Error occurred while subscribing', e)
+      emitErrorNotification('Error occurred while subscribing')
+    }
+  }, [
+    getUserNotificationsForProjectId,
+    projectId,
+    signIn,
+    supabase,
+    wallet.isConnected,
+  ])
+
+  return {
+    loading,
+    isSubscribed,
+    onSubscribeButtonClicked,
+    showSubscribeButton,
+  }
+}

--- a/src/components/SubscribeButton/hooks/useSubscribeModal.ts
+++ b/src/components/SubscribeButton/hooks/useSubscribeModal.ts
@@ -1,0 +1,46 @@
+import { t } from '@lingui/macro'
+import axios from 'axios'
+import { ModalContext } from 'contexts/Modal'
+import { FormikHelpers } from 'formik'
+import { useCallback, useContext } from 'react'
+import {
+  emitErrorNotification,
+  emitInfoNotification,
+} from 'utils/notifications'
+import * as Yup from 'yup'
+
+const Schema = Yup.object().shape({
+  email: Yup.string()
+    .email('Invalid email')
+    .required('Required')
+    .max(320, 'Invalid email'),
+})
+
+// Determine Values based on the schema
+type Values = Yup.InferType<typeof Schema>
+
+export const useSubscribeModal = () => {
+  const modal = useContext(ModalContext)
+  const initialValues: Values = { email: '' }
+
+  const onSubmit = useCallback(
+    async (values: Values, { setSubmitting }: FormikHelpers<Values>) => {
+      try {
+        await axios.post('/api/account/update-details', values)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (e: any) {
+        console.error(e)
+        emitErrorNotification(e?.response?.data?.message ?? 'Unknown error')
+      }
+      setSubmitting(false)
+
+      modal.closeModal()
+      emitInfoNotification(
+        t`Check your email for a confirmation link and retry subscribing.`,
+      )
+    },
+    [modal],
+  )
+
+  return { schema: Schema, initialValues, onSubmit, ...modal }
+}

--- a/src/components/SubscribeButton/index.ts
+++ b/src/components/SubscribeButton/index.ts
@@ -1,0 +1,1 @@
+export * from './SubscribeButton'

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
@@ -1,5 +1,5 @@
 import { SettingOutlined, ToolOutlined } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
 import { SubscribeButton } from 'components/SubscribeButton'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer'
@@ -29,16 +29,14 @@ export function V2V3ProjectHeaderActions() {
       <div className="flex items-center">
         <div className="flex items-center gap-x-4">
           <SubscribeButton projectId={projectId} tooltipPlacement={'bottom'} />
-          <>
-            <ContractVersionSelect />
-            <Tooltip title={t`Project tools`} placement="bottom">
-              <Button
-                onClick={() => setToolDrawerVisible(true)}
-                icon={<ToolOutlined />}
-                type="text"
-              />
-            </Tooltip>
-          </>
+          <ContractVersionSelect />
+          <Tooltip title={t`Project tools`} placement="bottom">
+            <Button
+              onClick={() => setToolDrawerVisible(true)}
+              icon={<ToolOutlined />}
+              type="text"
+            />
+          </Tooltip>
           {canReconfigure && (
             <div>
               <Link href={settingsPagePath('general', { handle, projectId })}>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
@@ -1,6 +1,7 @@
 import { SettingOutlined, ToolOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
+import { SubscribeButton } from 'components/SubscribeButton'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
@@ -21,11 +22,14 @@ export function V2V3ProjectHeaderActions() {
 
   const { projectId } = useContext(ProjectMetadataContext)
 
+  if (projectId === undefined) return null
+
   return (
     <>
       <div className="flex items-center">
         <div className="flex items-center gap-x-4">
-          <div>
+          <SubscribeButton projectId={projectId} tooltipPlacement={'bottom'} />
+          <>
             <ContractVersionSelect />
             <Tooltip title={t`Project tools`} placement="bottom">
               <Button
@@ -34,7 +38,7 @@ export function V2V3ProjectHeaderActions() {
                 type="text"
               />
             </Tooltip>
-          </div>
+          </>
           {canReconfigure && (
             <div>
               <Link href={settingsPagePath('general', { handle, projectId })}>

--- a/src/contexts/Modal/ModalContext.ts
+++ b/src/contexts/Modal/ModalContext.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react'
+
+type ModalContextType = {
+  openModal: () => void
+  closeModal: () => void
+  open: boolean
+}
+
+export const ModalContext = createContext<ModalContextType>({
+  openModal: () => {
+    console.error('ModalContext.openModal called but no provider set')
+  },
+  closeModal: () => {
+    console.error('ModalContext.closeModal called but no provider set')
+  },
+  open: false,
+})

--- a/src/contexts/Modal/ModalProvider.tsx
+++ b/src/contexts/Modal/ModalProvider.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import { ModalContext } from './ModalContext'
+
+export const ModalProvider: React.FC = ({ children }) => {
+  const [open, setOpen] = useState<boolean>(false)
+
+  const openModal = () => {
+    setOpen(true)
+  }
+
+  const closeModal = () => {
+    setOpen(false)
+  }
+
+  return (
+    <ModalContext.Provider
+      value={{
+        open,
+        openModal,
+        closeModal,
+      }}
+    >
+      {children}
+    </ModalContext.Provider>
+  )
+}

--- a/src/contexts/Modal/index.ts
+++ b/src/contexts/Modal/index.ts
@@ -1,0 +1,2 @@
+export * from './ModalContext'
+export * from './ModalProvider'

--- a/src/hooks/WalletSignIn.ts
+++ b/src/hooks/WalletSignIn.ts
@@ -24,7 +24,9 @@ export const useWalletSignIn = () => {
     }
 
     const getSessionResult = await supabase.auth.getSession()
-    if (getSessionResult.data) return
+    if (getSessionResult.data.session) {
+      return getSessionResult.data.session
+    }
 
     const challengeMessage = await AuthAPI.getChallengeMessage({
       wallet: wallet.userAddress,
@@ -35,7 +37,7 @@ export const useWalletSignIn = () => {
       signature,
       message: challengeMessage,
     })
-    const { error } = await supabase.auth.setSession({
+    const { error, data } = await supabase.auth.setSession({
       access_token: accessToken,
       refresh_token: v4(), // Set to garbage token, no long lived refresh tokens
     })
@@ -43,5 +45,10 @@ export const useWalletSignIn = () => {
       console.error(error)
       throw new Error(error.message)
     }
+    if (!data.session) {
+      console.error('No session returned')
+      throw new Error('No session returned')
+    }
+    return data.session
   }, [supabase.auth, wallet])
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -599,6 +599,9 @@ msgstr ""
 msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked to have the Juicebox protocol internally track your token balance, saving gas on this transaction. You can claim your ERC-20 tokens later."
 msgstr ""
 
+msgid "Check your email for a confirmation link and retry subscribing."
+msgstr ""
+
 msgid "Check {0} and verify your new email address."
 msgstr ""
 
@@ -2838,6 +2841,9 @@ msgid "Subject"
 msgstr ""
 
 msgid "Subscribe"
+msgstr ""
+
+msgid "Subscribe for updates!"
 msgstr ""
 
 msgid "Subscribe to Juicenews to get the latest updates from the Juicebox ecosystem."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1346,6 +1346,9 @@ msgstr ""
 msgid "Get help planning or setting up my project."
 msgstr ""
 
+msgid "Get notified when a contributor supports this project"
+msgstr ""
+
 msgid "GitHub"
 msgstr ""
 
@@ -1761,6 +1764,9 @@ msgid "Minutes"
 msgstr ""
 
 msgid "More trending projects"
+msgstr ""
+
+msgid "More updates coming soon"
 msgstr ""
 
 msgid "Move ETH"
@@ -2847,6 +2853,9 @@ msgid "Subscribe for updates!"
 msgstr ""
 
 msgid "Subscribe to Juicenews to get the latest updates from the Juicebox ecosystem."
+msgstr ""
+
+msgid "Subscribe to project activity"
 msgstr ""
 
 msgid "Successfully subscribed to Juicenews!"


### PR DESCRIPTION
## What does this PR do and why?

## Description

This PR optimizes the email notification handling in the `on-pay` event to enhance performance and simplify the code. The main changes include:

1. Remove the use of the GraphQL `ParticipantsDocument` query and the associated `client.query()` call. Instead, we directly fetch user data with the necessary subscription information from the `users` table in the Supabase database.
2. Update the `usersResult` query to include `user_subscriptions` with `project_id` and `notification_id` in the `select` statement. The filtering for relevant users and their subscriptions is now done post-query.
3. The `orQuery` has been removed and replaced with a filter operation applied after the query execution. The filter operation includes users who are either subscribed to the project or are the payer.
4. Map the filtered users to the appropriate email event type based on their wallet.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
