### PR TITLE
fix! MetaMask connection on FireFox JB-199

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,8 +23,10 @@ const SCRIPT_SRC = [
   'https://qwestive-referral-prod.web.app',
   'https://static.hotjar.com',
   'https://script.hotjar.com',
-  `'sha256-kZ9E6/oLrki51Yx03/BugStfFrPlm8hjaFbaokympXo='`, // hotjar
+  // Not working as unsafe-eval is required for metamask
+  // `'sha256-kZ9E6/oLrki51Yx03/BugStfFrPlm8hjaFbaokympXo='`, // hotjar
   `'unsafe-eval'`, // hotjar
+  `'unsafe-inline'`, // MetaMask
 ]
 
 const STYLE_SRC = [


### PR DESCRIPTION
## What does this PR do and why?

This PR addresses a compatibility issue with MetaMask in our Next.js application by modifying the next.config.js file.

The changes include:

1. Commenting out a Hotjar-specific sha256 CSP that was causing issues, as it conflicted with MetaMask's requirement for unsafe-eval.
2. Adding 'unsafe-inline' to the SCRIPT_SRC array, which is required for MetaMask to function correctly.
3. These changes will ensure that MetaMask can be used without conflicts in our Next.js application.

Please review and merge the changes if they look good.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
