### PR TITLE
refactor: extract SocialButton component for modularity [1/x]

### DIFF
--- a/src/components/Project/ProjectHeader/SocialLinks.tsx
+++ b/src/components/Project/ProjectHeader/SocialLinks.tsx
@@ -1,31 +1,9 @@
 import { GlobalOutlined, TwitterOutlined } from '@ant-design/icons'
 import { Space } from 'antd'
-import ExternalLink from 'components/ExternalLink'
 import Discord from 'components/icons/Discord'
 import Telegram from 'components/icons/Telegram'
+import { SocialButton } from 'components/SocialButton'
 import useMobile from 'hooks/Mobile'
-import { linkUrl } from 'utils/url'
-
-type SocialProps = {
-  children: React.ReactNode
-  link: string
-  name: string
-}
-
-function SocialButton(props: SocialProps) {
-  const { children, link, name } = props
-
-  return (
-    <ExternalLink
-      className="border-1 p-30 flex h-10 w-10 items-center justify-center rounded-full bg-smoke-100 hover:bg-smoke-200  dark:bg-slate-400 dark:hover:bg-slate-500 md:h-9 md:w-9"
-      href={linkUrl(link)}
-      name={name}
-      title={name}
-    >
-      {children}
-    </ExternalLink>
-  )
-}
 
 export default function SocialLinks({
   infoUri,

--- a/src/components/SocialButton.tsx
+++ b/src/components/SocialButton.tsx
@@ -1,0 +1,32 @@
+import { PropsWithChildren } from 'react'
+import { twMerge } from 'tailwind-merge'
+import { linkUrl } from 'utils/url'
+import ExternalLink from './ExternalLink'
+
+export const SocialButton = ({
+  className,
+  children,
+  link,
+  ...props
+}: PropsWithChildren<{
+  className?: string
+  onClick?: () => void
+  link: string
+  name?: string
+  title?: string
+}>) => {
+  return (
+    <ExternalLink
+      className={twMerge(
+        'border-1 p-30 flex h-10 w-10 items-center justify-center rounded-full',
+        'bg-smoke-100 hover:bg-smoke-200 dark:bg-slate-400 dark:hover:bg-slate-500 md:h-9 md:w-9',
+        'transition-colors duration-300',
+        className,
+      )}
+      href={linkUrl(link)}
+      {...props}
+    >
+      {children}
+    </ExternalLink>
+  )
+}


### PR DESCRIPTION
## What does this PR do and why?

This PR refactors the `SocialButton` component by moving its logic from `src/components/Project/ProjectHeader/SocialLinks.tsx` to a new file `src/components/SocialButton.tsx`. The purpose of this change is to make the `SocialButton` component reusable and more modular.

### Changes:

1. Removed the `SocialButton` function and its related `SocialProps` type from `src/components/Project/ProjectHeader/SocialLinks.tsx`.
2. Created a new file `src/components/SocialButton.tsx` containing the `SocialButton` component logic, making it a reusable component.
3. Imported the `SocialButton` component in `src/components/Project/ProjectHeader/SocialLinks.tsx`.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
