### PR TITLE
feat: Add tooltips to social buttons with placement options [3/x] JB-195

### DIFF
--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -173,6 +173,7 @@ export function AccountDashboard({
                 <SocialLinks
                   infoUri={profile?.website ?? undefined}
                   twitter={profile?.twitter ?? undefined}
+                  tooltipPlacement="bottom"
                 />
               </div>
             </div>
@@ -203,7 +204,11 @@ const EtherscanSocialButton = ({ address }: { address: string }) => {
   const isMobile = useMobile()
 
   return (
-    <SocialButton link={etherscanLink('address', address)} name="Etherscan">
+    <SocialButton
+      link={etherscanLink('address', address)}
+      tooltip="Etherscan"
+      tooltipPlacement={'bottom'}
+    >
       <Etherscan size={isMobile ? 16 : 14} />
     </SocialButton>
   )

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -164,6 +164,7 @@ export function ProjectHeader({
               telegram={projectMetadata?.telegram}
               twitter={projectMetadata?.twitter}
               infoUri={projectMetadata?.infoUri}
+              tooltipPlacement="bottom"
             />
             {hasSocialLinks && actions ? (
               <div className="hidden md:block">

--- a/src/components/Project/ProjectHeader/SocialLinks.tsx
+++ b/src/components/Project/ProjectHeader/SocialLinks.tsx
@@ -11,12 +11,14 @@ export default function SocialLinks({
   twitter,
   discord,
   telegram,
+  tooltipPlacement,
 }: {
   className?: string
   infoUri?: string
   twitter?: string
   discord?: string
   telegram?: string
+  tooltipPlacement?: 'top' | 'bottom'
 }) {
   const isMobile = useMobile()
   const iconClasses =
@@ -25,25 +27,38 @@ export default function SocialLinks({
   return (
     <Space className={className} size={12}>
       {infoUri && (
-        <SocialButton link={infoUri} name="Project website">
+        <SocialButton
+          link={infoUri}
+          tooltip="Website"
+          tooltipPlacement={tooltipPlacement}
+        >
           <GlobalOutlined className={iconClasses} />
         </SocialButton>
       )}
       {twitter && (
         <SocialButton
           link={'https://twitter.com/' + twitter}
-          name="Project Twitter"
+          tooltip="Twitter"
+          tooltipPlacement={tooltipPlacement}
         >
           <TwitterOutlined className={iconClasses} />
         </SocialButton>
       )}
       {discord && (
-        <SocialButton link={discord} name="Project Discord">
+        <SocialButton
+          link={discord}
+          tooltip="Discord"
+          tooltipPlacement={tooltipPlacement}
+        >
           <Discord className={iconClasses} size={isMobile ? 16 : 14} />
         </SocialButton>
       )}
       {telegram && (
-        <SocialButton link={telegram} name="Project Telegram">
+        <SocialButton
+          link={telegram}
+          tooltip="Telegram"
+          tooltipPlacement={tooltipPlacement}
+        >
           <Telegram className={iconClasses} size={isMobile ? 16 : 14} />
         </SocialButton>
       )}

--- a/src/components/SocialButton.tsx
+++ b/src/components/SocialButton.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from 'antd'
 import { PropsWithChildren } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { linkUrl } from 'utils/url'
@@ -7,26 +8,30 @@ export const SocialButton = ({
   className,
   children,
   link,
+  tooltip,
+  tooltipPlacement,
   ...props
 }: PropsWithChildren<{
   className?: string
   onClick?: () => void
   link: string
-  name?: string
-  title?: string
+  tooltip?: string
+  tooltipPlacement?: 'top' | 'bottom' | 'left' | 'right'
 }>) => {
   return (
-    <ExternalLink
-      className={twMerge(
-        'border-1 p-30 flex h-10 w-10 items-center justify-center rounded-full',
-        'bg-smoke-100 hover:bg-smoke-200 dark:bg-slate-400 dark:hover:bg-slate-500 md:h-9 md:w-9',
-        'transition-colors duration-300',
-        className,
-      )}
-      href={linkUrl(link)}
-      {...props}
-    >
-      {children}
-    </ExternalLink>
+    <Tooltip title={tooltip} placement={tooltipPlacement}>
+      <ExternalLink
+        className={twMerge(
+          'border-1 p-30 flex h-10 w-10 items-center justify-center rounded-full',
+          'bg-smoke-100 hover:bg-smoke-200 dark:bg-slate-400 dark:hover:bg-slate-500 md:h-9 md:w-9',
+          'transition-colors duration-300',
+          className,
+        )}
+        href={linkUrl(link)}
+        {...props}
+      >
+        {children}
+      </ExternalLink>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

This commit adds tooltips to social buttons and provides a placement option. Users can now hover over social buttons to view a tooltip with the name of the platform, making it easier for users to identify the social media platform associated with the button. Tooltips can also be placed at the top or bottom of the button, giving developers more customization options.


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
