### PR TITLE
refactor: Improve ProjectHeader layout responsiveness

### DIFF
--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -8,16 +8,18 @@ import ProjectLogo from 'components/ProjectLogo'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { useGnosisSafe } from 'hooks/safe/GnosisSafe'
 import { useContext } from 'react'
-import { classNames } from 'utils/classNames'
+import { twMerge } from 'tailwind-merge'
 import { ipfsUriToGatewayUrl } from 'utils/ipfs'
 import { EditProjectHandleButton } from './EditProjectHandleButton'
 import SocialLinks from './SocialLinks'
 
 function ProjectSubheading({
+  className,
   handle,
   canEditProjectHandle,
   projectOwnerAddress,
 }: {
+  className?: string
   handle: string | undefined
   projectOwnerAddress: string | undefined
   canEditProjectHandle?: boolean
@@ -28,7 +30,12 @@ function ProjectSubheading({
     useGnosisSafe(projectOwnerAddress)
 
   return (
-    <div className="flex items-center gap-x-4 text-grey-500 dark:text-grey-300">
+    <div
+      className={twMerge(
+        'flex flex-col flex-wrap items-center gap-x-4 text-grey-500 dark:text-grey-300 md:flex-row',
+        className,
+      )}
+    >
       <span className="flex items-center justify-between gap-2 font-medium">
         {handle ? (
           <Tooltip title={t`Project ID: ${projectId}`}>
@@ -45,10 +52,12 @@ function ProjectSubheading({
 
       {projectOwnerAddress && (
         <>
-          <Divider
-            type="vertical"
-            className="m-0 h-6 bg-grey-100 dark:bg-grey-900"
-          />
+          <div className="hidden md:block">
+            <Divider
+              type="vertical"
+              className="m-0 h-6 bg-grey-100 dark:bg-grey-900"
+            />
+          </div>
           <div className="flex items-center font-medium">
             <span className="mr-2 flex gap-2">
               <Trans>
@@ -73,12 +82,12 @@ function ProjectSubheading({
   )
 }
 
-function ProjectHeading() {
+function ProjectHeading({ className }: { className?: string }) {
   const { projectMetadata, isArchived } = useContext(ProjectMetadataContext)
   const projectTitle = projectMetadata?.name || t`Untitled project`
 
   return (
-    <div className="flex max-w-md items-center overflow-hidden">
+    <div className={twMerge('flex items-center overflow-hidden', className)}>
       <h1
         className="mb-0 overflow-hidden text-ellipsis font-heading text-4xl font-medium text-black dark:text-slate-100"
         title={projectTitle}
@@ -119,6 +128,7 @@ export function ProjectHeader({
 
   return (
     <header>
+      {/* Project Cover */}
       {projectMetadata?.coverImageUri && (
         <div className="w-full">
           <img
@@ -130,54 +140,58 @@ export function ProjectHeader({
         </div>
       )}
 
-      <div className="my-0 mx-auto flex w-full max-w-5xl flex-wrap gap-x-7 gap-y-3 p-5">
-        <ProjectLogo
-          className={classNames(
-            'h-32 w-32',
-            hasBanner
-              ? 'mt-[-70px] border-4 border-solid border-smoke-25 dark:border-slate-800'
-              : '',
-          )}
-          uri={projectMetadata?.logoUri}
-          name={projectMetadata?.name}
-          projectId={projectId}
+      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-y-3 p-5 md:grid-cols-6">
+        <div className="mx-auto flex flex-col items-center md:col-span-1 md:row-span-3 md:flex-row">
+          <ProjectLogo
+            className={twMerge(
+              'h-32 w-32',
+              hasBanner
+                ? 'mt-[-70px] border-4 border-solid border-smoke-25 dark:border-slate-800'
+                : '',
+            )}
+            uri={projectMetadata?.logoUri}
+            name={projectMetadata?.name}
+            projectId={projectId}
+          />
+        </div>
+
+        <div className="mx-auto flex flex-col items-center gap-3 md:col-span-5 md:w-full md:flex-row md:justify-between md:text-start">
+          <ProjectHeading className="md:full-w max-w-md" />
+          <div className="flex flex-col items-center gap-4 md:flex-row">
+            <SocialLinks
+              className="mx-auto"
+              discord={projectMetadata?.discord}
+              telegram={projectMetadata?.telegram}
+              twitter={projectMetadata?.twitter}
+              infoUri={projectMetadata?.infoUri}
+            />
+            {hasSocialLinks && actions ? (
+              <div className="hidden md:block">
+                <Divider type="vertical" className="h-8" />
+              </div>
+            ) : null}
+            {actions && (
+              <div className="flex w-full justify-center">{actions}</div>
+            )}
+          </div>
+        </div>
+
+        <ProjectSubheading
+          className="md:col-span-5"
+          handle={handle}
+          canEditProjectHandle={canEditProjectHandle}
+          projectOwnerAddress={projectOwnerAddress}
         />
 
-        <div className="flex min-w-[70%] flex-1 flex-col gap-y-2">
-          <div className="flex flex-wrap items-start justify-between gap-y-3">
-            <div className="flex flex-col flex-wrap gap-y-2">
-              <ProjectHeading />
-              <ProjectSubheading
-                handle={handle}
-                canEditProjectHandle={canEditProjectHandle}
-                projectOwnerAddress={projectOwnerAddress}
-              />
-            </div>
-
-            <div className="flex items-center">
-              <SocialLinks
-                discord={projectMetadata?.discord}
-                twitter={projectMetadata?.twitter}
-                infoUri={projectMetadata?.infoUri}
-                telegram={projectMetadata?.telegram}
-              />
-
-              {hasSocialLinks && actions ? (
-                <Divider type="vertical" className="mx-5 h-9 md:h-8" />
-              ) : null}
-
-              {actions ?? null}
-            </div>
-          </div>
-
-          {projectMetadata?.description && !hideDescription && (
+        {projectMetadata?.description && !hideDescription && (
+          <div className="mx-auto md:col-span-5 md:w-full md:text-start">
             <Paragraph
               className="text-grey-900 dark:text-slate-100"
               description={projectMetadata.description}
               characterLimit={250}
             />
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/src/components/Project/ProjectHeader/SocialLinks.tsx
+++ b/src/components/Project/ProjectHeader/SocialLinks.tsx
@@ -28,11 +28,13 @@ function SocialButton(props: SocialProps) {
 }
 
 export default function SocialLinks({
+  className,
   infoUri,
   twitter,
   discord,
   telegram,
 }: {
+  className?: string
   infoUri?: string
   twitter?: string
   discord?: string
@@ -43,7 +45,7 @@ export default function SocialLinks({
     'flex text-grey-500 dark:text-slate-100 text-xl md:text-base'
 
   return (
-    <Space size={12}>
+    <Space className={className} size={12}>
       {infoUri && (
         <SocialButton link={infoUri} name="Project website">
           <GlobalOutlined className={iconClasses} />


### PR DESCRIPTION
## What does this PR do and why?

This commit improves the ProjectHeader layout's responsiveness. Changes include reorganizing the layout for various screen sizes, updating the position of SocialLinks, and ensuring that the ProjectSubheading and ProjectDescription are correctly aligned on different devices. These improvements enhance the user experience by providing a consistent and visually appealing interface across various screen sizes.


Fixes JB-196

## Screenshots or screen recordings

### Before

![Screen Shot 2023-04-02 at 4.58.20 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/4ec2fbae-366f-48a0-a7fd-1d61100491a9/Screen%20Shot%202023-04-02%20at%204.58.20%20pm.png)


![Screen Shot 2023-04-02 at 4.59.10 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/232fc74a-dfed-4ab2-a52c-13d24b30cd84/Screen%20Shot%202023-04-02%20at%204.59.10%20pm.png)

### After

![Screen Shot 2023-04-02 at 4.55.06 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/36ac87aa-d790-4ecb-9cb8-6b855149e119/Screen%20Shot%202023-04-02%20at%204.55.06%20pm.png)

![Screen Shot 2023-04-02 at 4.55.22 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/885dc87d-1023-44d7-9c0d-0911cd6661cf/Screen%20Shot%202023-04-02%20at%204.55.22%20pm.png)

![Screen Shot 2023-04-02 at 4.55.53 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/17046e64-818c-4cbf-9805-a5b5c94c867c/Screen%20Shot%202023-04-02%20at%204.55.53%20pm.png)

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
