### PR TITLE
feat: redesign account settings dashboard [3/n]

### DIFF
--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -186,7 +186,7 @@ export function AccountDashboard({
               onClick={onEditProfileClicked}
             >
               <span className="inline-flex gap-3">
-                <Trans>Edit profile</Trans> <Badge variant="info">Beta</Badge>
+                <Trans>Settings</Trans> <Badge variant="info">Beta</Badge>
               </span>
             </Button>
           )}

--- a/src/components/AccountSettingsDashboard/AccountSettingsDashboard.tsx
+++ b/src/components/AccountSettingsDashboard/AccountSettingsDashboard.tsx
@@ -1,73 +1,113 @@
-import { ArrowLeftOutlined } from '@ant-design/icons'
-import { Trans } from '@lingui/macro'
+import { LeftOutlined, UnorderedListOutlined } from '@ant-design/icons'
+import { Tab } from '@headlessui/react'
+import { Trans, t } from '@lingui/macro'
 import { Button } from 'antd'
-import { Badge } from 'components/Badge'
-import { Callout } from 'components/Callout'
-import { Formik } from 'formik'
 import { User } from 'models/database'
-import { AccountSettingsForm } from './components/AccountSettingsForm'
-import { useAccountSettingsDashboard } from './hooks/useAccountSettingsDashboard'
-import { AccountSettingsSchema } from './lib/AccountSettingsSchema'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import { ProfileDetailsTab } from './components/ProfileDetailsTab'
 
 export const AccountSettingsDashboard = ({ user }: { user: User }) => {
-  const {
-    initialValues,
-    lastEmailUpdated,
-    onSubmit,
-    onEmailResendClicked,
-    onBackButtonClicked,
-  } = useAccountSettingsDashboard({ user })
+  const [minimized, setMinimized] = useState(false)
+  const toggleMinimized = () => setMinimized(!minimized)
+  const minimize = () => setMinimized(true)
+
+  const tabs = useMemo(
+    () => [
+      {
+        name: t`Profile details`,
+        component: <ProfileDetailsTab user={user} />,
+      },
+      { name: t`Subscriptions`, component: 'Tab 2 content goes here' },
+    ],
+    [user],
+  )
 
   return (
-    <div className="m-auto flex flex-col items-center ">
-      <div className="flex w-full flex-col gap-y-10 py-8 px-4 md:w-[800px] md:px-16">
-        <div>
-          <h1 className="text-primary text-2xl dark:text-slate-100">
-            <Trans>Profile details</Trans> <Badge variant="info">Beta</Badge>
-          </h1>
-          <div className="text-secondary">
-            <Trans>
-              Customize your public facing profile and add additional management
-              information.
-            </Trans>
-          </div>
-        </div>
-        <Formik
-          initialValues={initialValues}
-          validationSchema={AccountSettingsSchema}
-          onSubmit={onSubmit}
-        >
-          {({ isSubmitting, dirty }) => (
-            <>
-              <AccountSettingsForm address={user.wallet} />
-              <div className="flex h-9 justify-between">
-                <Button onClick={onBackButtonClicked}>
-                  <ArrowLeftOutlined /> Back
-                </Button>
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  form="accountSettings"
-                  disabled={!dirty}
-                  loading={isSubmitting}
-                >
-                  Save
-                </Button>
-              </div>
-            </>
-          )}
-        </Formik>
-        {lastEmailUpdated && (
-          <Callout.Info>
-            <Trans>
-              Please check {lastEmailUpdated} and verify your new email address.
-              <br />
-              Still no email after a couple of minutes?{' '}
-              <a onClick={onEmailResendClicked}>Click here to resend.</a>
-            </Trans>
-          </Callout.Info>
-        )}
+    <div className="mx-auto mt-20 flex max-w-5xl flex-col p-5">
+      <SettingsMenuButton className="md:hidden" onClick={toggleMinimized} />
+
+      <div className="flex">
+        <Tab.Group onChange={minimize}>
+          <Tab.List
+            className={twMerge(
+              'absolute z-[5] flex h-full w-0 flex-col space-y-1 overflow-auto bg-white py-4 transition-all duration-200 ease-in-out dark:bg-slate-800',
+              'md:static md:flex md:w-1/4 md:min-w-[1/4] md:p-4',
+              minimized ? '' : 'w-1/2 px-4',
+            )}
+          >
+            <BackToAccountButton
+              className="text-start"
+              walletAddress={user.wallet}
+            />
+            {tabs.map((tab, index) => (
+              <Tab
+                key={index}
+                className={({ selected }) =>
+                  `text-primary rounded-lg border-0 px-4 py-2 text-left transition-colors duration-200 ${
+                    selected
+                      ? 'bg-smoke-100 font-semibold dark:bg-slate-500'
+                      : 'text-gray-700 cursor-pointer bg-transparent hover:bg-smoke-100 dark:hover:bg-slate-500'
+                  }`
+                }
+              >
+                {tab.name}
+              </Tab>
+            ))}
+          </Tab.List>
+          <Tab.Panels
+            className={twMerge(
+              'w-full',
+              'md:ml-1/4',
+              minimized ? 'md:w-full' : 'md:w-3/4',
+            )}
+          >
+            {tabs.map((tab, index) => (
+              <Tab.Panel key={index} className="p-8">
+                {tab.component}
+              </Tab.Panel>
+            ))}
+          </Tab.Panels>
+        </Tab.Group>
       </div>
     </div>
   )
 }
+
+const SettingsMenuButton = ({
+  className,
+  onClick,
+}: {
+  className?: string
+  onClick: () => void
+}) => (
+  <div
+    className={twMerge(
+      'text-primary cursor-pointer px-4 py-2 text-left text-2xl leading-none',
+      className,
+    )}
+    onClick={onClick}
+  >
+    <UnorderedListOutlined />
+  </div>
+)
+
+const BackToAccountButton = ({
+  className,
+  walletAddress,
+}: {
+  className?: string
+  walletAddress: string
+}) => (
+  <Link href={`/account/${walletAddress}`}>
+    <Button
+      className={className}
+      type="link"
+      icon={<LeftOutlined />}
+      size="small"
+    >
+      <Trans>Back to profile</Trans>
+    </Button>
+  </Link>
+)

--- a/src/components/AccountSettingsDashboard/AccountSettingsDashboard.tsx
+++ b/src/components/AccountSettingsDashboard/AccountSettingsDashboard.tsx
@@ -19,7 +19,7 @@ export const AccountSettingsDashboard = ({ user }: { user: User }) => {
         name: t`Profile details`,
         component: <ProfileDetailsTab user={user} />,
       },
-      { name: t`Subscriptions`, component: 'Tab 2 content goes here' },
+      { name: t`Notifications`, component: 'Tab 2 content goes here' },
     ],
     [user],
   )

--- a/src/components/AccountSettingsDashboard/components/AccountSettingsForm.tsx
+++ b/src/components/AccountSettingsDashboard/components/AccountSettingsForm.tsx
@@ -13,7 +13,7 @@ const InputPrefix = (
 ) => {
   if (props.prefix) {
     return (
-      <span className="stroke-secondary relative box-border inline-flex w-full min-w-0 list-none gap-0.5 text-ellipsis border border-solid bg-smoke-50 py-1 px-3 outline-0 focus-within:shadow-inputLight  dark:bg-slate-600  dark:focus-within:shadow-inputDark">
+      <span className="stroke-secondary relative box-border inline-flex w-full min-w-0 list-none gap-0.5 text-ellipsis rounded-lg border border-solid bg-smoke-50 py-1 px-3 outline-0 focus-within:shadow-inputLight  dark:bg-slate-600  dark:focus-within:shadow-inputDark">
         <span className="text-secondary">{props.prefix}</span>
         <input
           className="relative m-0 inline-block w-full border-0 bg-transparent p-0 outline-0 placeholder:text-grey-400 dark:placeholder:text-slate-300"
@@ -35,7 +35,7 @@ export const AccountSettingsForm = ({ address }: { address: string }) => (
   <Form
     id="accountSettings"
     name="accountSettings"
-    className="flex w-1/2 flex-col gap-4"
+    className="flex flex-col gap-4 md:w-1/2"
   >
     <TooltipLabel
       label={

--- a/src/components/AccountSettingsDashboard/components/ProfileDetailsTab.tsx
+++ b/src/components/AccountSettingsDashboard/components/ProfileDetailsTab.tsx
@@ -1,0 +1,61 @@
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+import { Badge } from 'components/Badge'
+import { Callout } from 'components/Callout'
+import { Formik } from 'formik'
+import { User } from 'models/database'
+import { useProfileDetailsTab } from '../hooks/useProfileDetailsTab'
+import { AccountSettingsSchema } from '../lib/AccountSettingsSchema'
+import { AccountSettingsForm } from './AccountSettingsForm'
+
+export const ProfileDetailsTab = ({ user }: { user: User }) => {
+  const { initialValues, lastEmailUpdated, onEmailResendClicked, onSubmit } =
+    useProfileDetailsTab({ user })
+  return (
+    <div className="flex flex-col gap-y-10">
+      <div>
+        <h1 className="text-primary text-2xl dark:text-slate-100">
+          <Trans>Profile details</Trans> <Badge variant="info">Beta</Badge>
+        </h1>
+        <div className="text-secondary">
+          <Trans>
+            Customize your public facing profile and add additional management
+            information.
+          </Trans>
+        </div>
+      </div>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={AccountSettingsSchema}
+        onSubmit={onSubmit}
+      >
+        {({ isSubmitting, dirty }) => (
+          <>
+            <AccountSettingsForm address={user.wallet} />
+            <div className="flex h-9">
+              <Button
+                type="primary"
+                htmlType="submit"
+                form="accountSettings"
+                disabled={!dirty}
+                loading={isSubmitting}
+              >
+                <Trans>Save profile details</Trans>
+              </Button>
+            </div>
+          </>
+        )}
+      </Formik>
+      {lastEmailUpdated && (
+        <Callout.Info>
+          <Trans>
+            Please check {lastEmailUpdated} and verify your new email address.
+            <br />
+            Still no email after a couple of minutes?{' '}
+            <a onClick={onEmailResendClicked}>Click here to resend.</a>
+          </Trans>
+        </Callout.Info>
+      )}
+    </div>
+  )
+}

--- a/src/components/AccountSettingsDashboard/components/ProfileDetailsTab.tsx
+++ b/src/components/AccountSettingsDashboard/components/ProfileDetailsTab.tsx
@@ -18,10 +18,7 @@ export const ProfileDetailsTab = ({ user }: { user: User }) => {
           <Trans>Profile details</Trans> <Badge variant="info">Beta</Badge>
         </h1>
         <div className="text-secondary">
-          <Trans>
-            Customize your public facing profile and add additional management
-            information.
-          </Trans>
+          <Trans>Customize your public facing profile and other details.</Trans>
         </div>
       </div>
       <Formik

--- a/src/components/AccountSettingsDashboard/hooks/useProfileDetailsTab.ts
+++ b/src/components/AccountSettingsDashboard/hooks/useProfileDetailsTab.ts
@@ -2,26 +2,23 @@ import { t } from '@lingui/macro'
 import axios from 'axios'
 import { FormikHelpers } from 'formik'
 import { User } from 'models/database'
-import { useRouter } from 'next/router'
 import { useCallback, useMemo, useState } from 'react'
 import {
   emitErrorNotification,
   emitInfoNotification,
 } from 'utils/notifications'
 
-export type AccountSettingsFormType = {
+export type ProfileDetailsFormType = {
   bio?: string | null | undefined
   email?: string | null | undefined
   website?: string | null | undefined
   twitter?: string | null | undefined
 }
 
-export const useAccountSettingsDashboard = ({ user }: { user: User }) => {
+export const useProfileDetailsTab = ({ user }: { user: User }) => {
   const [lastEmailUpdated, setLastEmailUpdated] = useState<string>()
 
-  const router = useRouter()
-
-  const initialValues: AccountSettingsFormType = useMemo(
+  const initialValues: ProfileDetailsFormType = useMemo(
     () => ({
       bio: user.bio ?? '',
       email: user.email_verified ? user.email : '',
@@ -33,8 +30,8 @@ export const useAccountSettingsDashboard = ({ user }: { user: User }) => {
 
   const onSubmit = useCallback(
     async (
-      values: AccountSettingsFormType,
-      helpers: FormikHelpers<AccountSettingsFormType>,
+      values: ProfileDetailsFormType,
+      helpers: FormikHelpers<ProfileDetailsFormType>,
     ) => {
       const touched = determinedTouched(values, initialValues)
       const formWasTouched = Object.values(touched).reduce(
@@ -91,30 +88,25 @@ export const useAccountSettingsDashboard = ({ user }: { user: User }) => {
     )
   }, [lastEmailUpdated])
 
-  const onBackButtonClicked = useCallback(() => {
-    router.push(`/account/${user.wallet}`)
-  }, [router, user.wallet])
-
   return {
     initialValues,
     lastEmailUpdated,
     onSubmit,
     onEmailResendClicked,
-    onBackButtonClicked,
   }
 }
 
 const determinedTouched = (
-  values: AccountSettingsFormType,
-  initialValues: AccountSettingsFormType,
-): Record<keyof AccountSettingsFormType, boolean> => {
-  const touched: Record<keyof AccountSettingsFormType, boolean> = {} as Record<
-    keyof AccountSettingsFormType,
+  values: ProfileDetailsFormType,
+  initialValues: ProfileDetailsFormType,
+): Record<keyof ProfileDetailsFormType, boolean> => {
+  const touched: Record<keyof ProfileDetailsFormType, boolean> = {} as Record<
+    keyof ProfileDetailsFormType,
     boolean
   >
 
   for (const k in values) {
-    const key = k as keyof AccountSettingsFormType
+    const key = k as keyof ProfileDetailsFormType
     touched[key] = values[key] !== initialValues[key]
   }
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1136,9 +1136,6 @@ msgstr ""
 msgid "Edit payouts"
 msgstr ""
 
-msgid "Edit profile"
-msgstr ""
-
 msgid "Edit project"
 msgstr ""
 
@@ -1974,6 +1971,9 @@ msgid "Not set"
 msgstr ""
 
 msgid "Notice from {0}"
+msgstr ""
+
+msgid "Notifications"
 msgstr ""
 
 msgid "On-chain Governance"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -884,7 +884,7 @@ msgstr ""
 msgid "Customize your project's \"pay\" button. Leave blank to use the default."
 msgstr ""
 
-msgid "Customize your public facing profile and add additional management information."
+msgid "Customize your public facing profile and other details."
 msgstr ""
 
 msgid "Cycle"
@@ -2892,9 +2892,6 @@ msgid "Subscribe to Juicenews to get the latest updates from the Juicebox ecosys
 msgstr ""
 
 msgid "Subscribe to project activity"
-msgstr ""
-
-msgid "Subscriptions"
 msgstr ""
 
 msgid "Successfully subscribed to Juicenews!"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -509,6 +509,9 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+msgid "Back to profile"
+msgstr ""
+
 msgid "Back to project"
 msgstr ""
 
@@ -2633,6 +2636,9 @@ msgstr ""
 msgid "Save payouts"
 msgstr ""
 
+msgid "Save profile details"
+msgstr ""
+
 msgid "Save project details"
 msgstr ""
 
@@ -2886,6 +2892,9 @@ msgid "Subscribe to Juicenews to get the latest updates from the Juicebox ecosys
 msgstr ""
 
 msgid "Subscribe to project activity"
+msgstr ""
+
+msgid "Subscriptions"
 msgstr ""
 
 msgid "Successfully subscribed to Juicenews!"


### PR DESCRIPTION
## What does this PR do and why?

This PR redesigns the account settings dashboard, adds tab navigation, and improves the overall layout for better user experience.

## Screenshots or screen recordings

![Screen Shot 2023-04-03 at 2.36.12 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/02c7b82d-e2db-416e-a033-9dba5369d6c3/Screen%20Shot%202023-04-03%20at%202.36.12%20pm.png)

[Screen Recording 2023-04-03 at 2.36.35 pm.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/4554eac3-bd98-44fc-9646-b685f0dab041/Screen%20Recording%202023-04-03%20at%202.36.35%20pm.mov)

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
