### PR TITLE
fix: Fix i18n linter error on crowdin PRs

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -70,7 +70,7 @@ jobs:
           files: '**/*.po'
 
       - name: Check for modified translation source files
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
         run: |
           echo "🍎 PRs should not change .po files. Only changes to the messages.pot are allowed."
           exit 1

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           upload_translations: false
           download_translations: true
-          create_pull_request: true
+          create_pull_request: false
           project_id: '492549'
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           source: 'src/locales/messages.pot'


### PR DESCRIPTION
Crowdin PRs fail because they add .po files.

This commit updates CI so:
- only runs the i18n linter on PRs
- Lets crowdin commit directly to main, instead of creating PR

Fixes JB-110