### PR TITLE
fix: return 404 if address is undefined

### DIFF
--- a/src/pages/account/[addressOrEnsName]/index.page.tsx
+++ b/src/pages/account/[addressOrEnsName]/index.page.tsx
@@ -37,6 +37,11 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   const { address, name: ensName } = pair
+  if (!address) {
+    return {
+      notFound: true,
+    }
+  }
 
   const supabase = createServerSupabaseClient<Database>(context)
 


### PR DESCRIPTION
Fixes a Sentry + server error when trying to
call toLowerCase on undefined address.