### PR TITLE
refactor: change button to get updates and use loading animation [JB-211] [JB-212]

### DIFF
--- a/src/components/SubscribeButton/SubscribeButton.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.tsx
@@ -1,11 +1,9 @@
-import { BellFilled, BellOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
-import SkeletonButton from 'antd/lib/skeleton/Button'
 import { TooltipPlacement } from 'antd/lib/tooltip'
-import { Badge } from 'components/Badge'
 import { ModalProvider } from 'contexts/Modal'
 import { twMerge } from 'tailwind-merge'
+import { SubscribeButtonIcon } from './SubscribeButtonIcon'
 import { SubscribeModal } from './SubscribeModal'
 import { useSubscribeButton } from './hooks/useSubscribeButton'
 
@@ -20,19 +18,11 @@ const _SubscribeButton = ({
   className,
   tooltipPlacement,
 }: SubscribeButtonProps) => {
-  const {
-    loading,
-    isSubscribed,
-    showSubscribeButton,
-    onSubscribeButtonClicked,
-  } = useSubscribeButton({ projectId })
-
-  if (!showSubscribeButton) return null
-
-  if (loading) return <SkeletonButton active size="small" />
+  const { loading, isSubscribed, onSubscribeButtonClicked } =
+    useSubscribeButton({ projectId })
 
   return (
-    <div className="flex flex-nowrap items-center">
+    <>
       <Tooltip
         placement={tooltipPlacement}
         title={
@@ -42,19 +32,23 @@ const _SubscribeButton = ({
         }
       >
         <Button
-          className={twMerge('p-0', className)}
+          className={twMerge(
+            'flex items-center justify-center gap-3 p-0',
+            className,
+          )}
           type="text"
           onClick={onSubscribeButtonClicked}
-          icon={isSubscribed ? <BellFilled /> : <BellOutlined />}
-        />
+          loading={loading}
+          icon={<SubscribeButtonIcon isSubscribed={isSubscribed} />}
+        >
+          <span className="font-base text-sm">
+            <Trans>Get Updates</Trans>
+          </span>
+        </Button>
       </Tooltip>
-      <span>
-        <Badge variant="info">
-          <Trans>New</Trans>
-        </Badge>
-      </span>
+
       <SubscribeModal />
-    </div>
+    </>
   )
 }
 

--- a/src/components/SubscribeButton/SubscribeButton.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.tsx
@@ -33,7 +33,7 @@ const _SubscribeButton = ({
       >
         <Button
           className={twMerge(
-            'flex items-center justify-center gap-3 p-0',
+            'flex items-center justify-center gap-3',
             className,
           )}
           type="text"

--- a/src/components/SubscribeButton/SubscribeButtonIcon.tsx
+++ b/src/components/SubscribeButton/SubscribeButtonIcon.tsx
@@ -1,0 +1,13 @@
+import { BellFilled, BellOutlined } from '@ant-design/icons'
+
+export const SubscribeButtonIcon = ({
+  isSubscribed,
+}: {
+  isSubscribed: boolean
+}) => {
+  return (
+    <div className="flex items-center gap-x-2">
+      {isSubscribed ? <BellFilled /> : <BellOutlined />}
+    </div>
+  )
+}

--- a/src/components/SubscribeButton/hooks/useSubscribeButton.ts
+++ b/src/components/SubscribeButton/hooks/useSubscribeButton.ts
@@ -28,9 +28,6 @@ export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
   const session = useSession()
   const supabase = useSupabaseClient<Database>()
 
-  // If the user is not connected to a wallet, or the wallet is on an unsupported chain, don't show the button
-  const showSubscribeButton = wallet.isConnected && !wallet.chainUnsupported
-
   const getUserNotificationsForProjectId = useCallback(
     async ({ projectId, userId }: { projectId: number; userId: string }) => {
       const { data, error } = await supabase
@@ -130,6 +127,7 @@ export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
   const onSubscribeButtonClicked = useCallback(async () => {
     // If the user is not connected to a wallet, don't do anything
     if (!wallet.isConnected) return
+    setLoading(true)
 
     try {
       const session = await signIn()
@@ -144,6 +142,7 @@ export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
       }
       if (!data?.email) {
         subscribeModal.openModal()
+        setLoading(false)
         return
       }
 
@@ -151,6 +150,8 @@ export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
     } catch (e) {
       console.error('Error occurred while subscribing', e)
       emitErrorNotification('Error occurred while subscribing')
+    } finally {
+      setLoading(false)
     }
   }, [signIn, subscribeModal, supabase, toggleSubscription, wallet.isConnected])
 
@@ -158,6 +159,5 @@ export const useSubscribeButton = ({ projectId }: { projectId: number }) => {
     loading,
     isSubscribed,
     onSubscribeButtonClicked,
-    showSubscribeButton,
   }
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
@@ -1,6 +1,6 @@
 import { SettingOutlined, ToolOutlined } from '@ant-design/icons'
 import { Trans, t } from '@lingui/macro'
-import { Button, Tooltip } from 'antd'
+import { Button, Divider, Tooltip } from 'antd'
 import { SubscribeButton } from 'components/SubscribeButton'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
@@ -30,6 +30,7 @@ export function V2V3ProjectHeaderActions() {
         <div className="flex items-center gap-x-4">
           <SubscribeButton projectId={projectId} tooltipPlacement={'bottom'} />
           <ContractVersionSelect />
+          <Divider className="h-8" type="vertical" />
           <Tooltip title={t`Project tools`} placement="bottom">
             <Button
               onClick={() => setToolDrawerVisible(true)}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectHeaderActions/V2V3ProjectHeaderActions.tsx
@@ -5,6 +5,7 @@ import { SubscribeButton } from 'components/SubscribeButton'
 import { V2V3ProjectToolsDrawer } from 'components/v2v3/V2V3Project/V2V3ProjectToolsDrawer'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
+import { useWallet } from 'hooks/Wallet'
 import { useV2ConnectedWalletHasPermission } from 'hooks/v2v3/contractReader/V2ConnectedWalletHasPermission'
 import { V2V3OperatorPermission } from 'models/v2v3/permissions'
 import Link from 'next/link'
@@ -13,6 +14,7 @@ import { settingsPagePath } from 'utils/routes'
 import { ContractVersionSelect } from './ContractVersionSelect'
 
 export function V2V3ProjectHeaderActions() {
+  const wallet = useWallet()
   const { handle } = useContext(V2V3ProjectContext)
 
   const [toolDrawerVisible, setToolDrawerVisible] = useState<boolean>(false)
@@ -22,15 +24,25 @@ export function V2V3ProjectHeaderActions() {
 
   const { projectId } = useContext(ProjectMetadataContext)
 
+  // If the user is not connected to a wallet, or the wallet is on an unsupported chain, don't show the button
+  const showSubscribeButton = wallet.isConnected && !wallet.chainUnsupported
+
   if (projectId === undefined) return null
 
   return (
     <>
       <div className="flex items-center">
         <div className="flex items-center gap-x-4">
-          <SubscribeButton projectId={projectId} tooltipPlacement={'bottom'} />
+          {showSubscribeButton && (
+            <>
+              <SubscribeButton
+                projectId={projectId}
+                tooltipPlacement={'bottom'}
+              />
+              <Divider className="h-8" type="vertical" />
+            </>
+          )}
           <ContractVersionSelect />
-          <Divider className="h-8" type="vertical" />
           <Tooltip title={t`Project tools`} placement="bottom">
             <Button
               onClick={() => setToolDrawerVisible(true)}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1424,6 +1424,9 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+msgid "Get Updates"
+msgstr ""
+
 msgid "Get help planning or setting up my project."
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

Closes https://linear.app/peel/issue/JB-212/add-loading-animation-for-subscribe-button

Closes https://linear.app/peel/issue/JB-211/add-subscribe-text-to-subscribe-button

## Screenshots or screen recordings


[Screen Recording 2023-04-04 at 2.57.55 pm.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/9e4b3bdf-611c-4bf5-ba22-4b2c3b290c61/Screen%20Recording%202023-04-04%20at%202.57.55%20pm.mov)

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
