### PR TITLE
Add error boundaries to project page

### DIFF
--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -41,22 +41,15 @@ export const Callout: React.FC<CalloutProps> & CalloutTypes = ({
       role={collapsible ? 'button' : undefined}
     >
       {iconComponent !== null && (
-        <span>{iconComponent ?? <InfoCircleOutlined />}</span>
+        <span className="flex">{iconComponent ?? <InfoCircleOutlined />}</span>
       )}
       <div
-        // Unsure why grid works, but this stops it from being
-        className="grid min-w-0 flex-shrink flex-grow"
+        className={classNames(
+          'inline-block overflow-hidden overflow-ellipsis',
+          collapsible && !expanded ? 'whitespace-nowrap' : 'whitespace-normal',
+        )}
       >
-        <div
-          className={classNames(
-            'inline-block overflow-hidden overflow-ellipsis',
-            collapsible && !expanded
-              ? 'whitespace-nowrap'
-              : 'whitespace-normal',
-          )}
-        >
-          {children}
-        </div>
+        {children}
       </div>
       {collapsible && (
         <DownOutlined className="text-base" rotate={expanded ? 180 : 0} />

--- a/src/components/Callout/WarningCallout.tsx
+++ b/src/components/Callout/WarningCallout.tsx
@@ -1,13 +1,13 @@
 import { WarningOutlined } from '@ant-design/icons'
 import useMobile from 'hooks/Mobile'
-import { twMerge } from 'tailwind-merge'
+import { twJoin, twMerge } from 'tailwind-merge'
 import { Callout } from './Callout'
 
 export const WarningCallout: React.FC<{
   className?: string
   collapsible?: boolean
   iconSize?: 'small' | 'large'
-}> = ({ className, collapsible, children }) => {
+}> = ({ className, collapsible, children, iconSize }) => {
   const isMobile = useMobile()
   const collapse = collapsible ?? isMobile
   return (
@@ -16,7 +16,14 @@ export const WarningCallout: React.FC<{
         'rounded-lg border border-solid border-warning-200 bg-warning-50 text-warning-800 dark:border-warning-500 dark:bg-warning-950 dark:text-warning-100',
         className,
       )}
-      iconComponent={<WarningOutlined className="text-2xl text-warning-500" />}
+      iconComponent={
+        <WarningOutlined
+          className={twJoin(
+            'flex text-warning-500',
+            iconSize === 'small' ? 'text-lg' : 'text-2xl',
+          )}
+        />
+      }
       collapsible={collapse}
     >
       {children}

--- a/src/components/ErrorBoundaryCallout.tsx
+++ b/src/components/ErrorBoundaryCallout.tsx
@@ -1,0 +1,16 @@
+import { ErrorBoundary } from '@sentry/nextjs'
+import { PropsWithChildren } from 'react'
+import { Callout } from './Callout'
+
+export function ErrorBoundaryCallout({
+  children,
+  message,
+}: PropsWithChildren<{ message: string | JSX.Element }>) {
+  return (
+    <ErrorBoundary
+      fallback={<Callout.Warning iconSize="small">{message}</Callout.Warning>}
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -59,7 +59,7 @@ function ProjectSubheading({
             />
           </div>
           <div className="flex items-center font-medium">
-            <span className="mr-2 flex gap-2">
+            <span className="mr-1 flex gap-1">
               <Trans>
                 <span>Owned by</span>
                 <FormattedAddress
@@ -140,8 +140,8 @@ export function ProjectHeader({
         </div>
       )}
 
-      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-y-3 p-5 md:grid-cols-6">
-        <div className="mx-auto flex flex-col items-center md:col-span-1 md:row-span-3 md:flex-row">
+      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-y-3 py-5 px-5 md:grid-cols-6 md:px-0">
+        <div className="mx-auto flex flex-col md:col-span-1 md:row-span-3 md:flex-row">
           <ProjectLogo
             className={twMerge(
               'h-32 w-32',

--- a/src/components/SocialButton.tsx
+++ b/src/components/SocialButton.tsx
@@ -24,7 +24,7 @@ export const SocialButton = ({
         className={twMerge(
           'border-1 p-30 flex h-10 w-10 items-center justify-center rounded-full',
           'bg-smoke-100 hover:bg-smoke-200 dark:bg-slate-400 dark:hover:bg-slate-500 md:h-9 md:w-9',
-          'transition-colors duration-300',
+          'transition-colors duration-100',
           className,
         )}
         href={linkUrl(link)}

--- a/src/components/v2v3/V2V3Project/ProjectPageMobile.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectPageMobile.tsx
@@ -1,3 +1,5 @@
+import { Trans } from '@lingui/macro'
+import { ErrorBoundaryCallout } from 'components/ErrorBoundaryCallout'
 import { NftRewardsSection } from 'components/NftRewards/NftRewardsSection'
 import { useNftRewardsEnabledForPay } from 'hooks/JB721Delegate/NftRewardsEnabledForPay'
 import ProjectActivity from './ProjectActivity'
@@ -14,12 +16,30 @@ export function ProjectPageMobile() {
       </section>
       {nftRewardsEnabled ? (
         <div className="mt-5">
-          <NftRewardsSection />
+          <ErrorBoundaryCallout
+            message={
+              <div>
+                <Trans>NFTs failed to load.</Trans>
+              </div>
+            }
+          >
+            <NftRewardsSection />
+          </ErrorBoundaryCallout>
         </div>
       ) : null}
-      <ProjectPageTabs />
+
+      <ErrorBoundaryCallout
+        message={<Trans>Project details failed to load.</Trans>}
+      >
+        <ProjectPageTabs />
+      </ErrorBoundaryCallout>
+
       <section className="mt-10">
-        <ProjectActivity />
+        <ErrorBoundaryCallout
+          message={<Trans>Project activity failed to load.</Trans>}
+        >
+          <ProjectActivity />
+        </ErrorBoundaryCallout>
       </section>
     </>
   )

--- a/src/components/v2v3/V2V3Project/ProjectPageRightCol.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectPageRightCol.tsx
@@ -1,6 +1,8 @@
 import { Col } from 'antd'
 import { NftRewardsSection } from 'components/NftRewards/NftRewardsSection'
 
+import { Trans } from '@lingui/macro'
+import { ErrorBoundaryCallout } from 'components/ErrorBoundaryCallout'
 import { useNftRewardsEnabledForPay } from 'hooks/JB721Delegate/NftRewardsEnabledForPay'
 import ProjectActivity from './ProjectActivity'
 import { V2V3PayProjectForm } from './V2V3PayProjectForm'
@@ -18,11 +20,17 @@ export function ProjectPageRightCol() {
       <div className="flex flex-col">
         {nftRewardsEnabled ? (
           <div className="mt-6">
-            <NftRewardsSection />
+            <ErrorBoundaryCallout message={<Trans>NFTs failed to load.</Trans>}>
+              <NftRewardsSection />
+            </ErrorBoundaryCallout>
           </div>
         ) : null}
         <section className="mt-6">
-          <ProjectActivity />
+          <ErrorBoundaryCallout
+            message={<Trans>Project activity failed to load.</Trans>}
+          >
+            <ProjectActivity />
+          </ErrorBoundaryCallout>
         </section>
       </div>
     </Col>

--- a/src/components/v2v3/V2V3Project/V2V3Project.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3Project.tsx
@@ -1,19 +1,21 @@
+import { Trans } from '@lingui/macro'
 import { Row, Space } from 'antd'
+import { ErrorBoundaryCallout } from 'components/ErrorBoundaryCallout'
+import { ProjectHeader } from 'components/Project/ProjectHeader'
 import ScrollToTopButton from 'components/buttons/ScrollToTopButton'
 import { useModalFromUrlQuery } from 'components/modals/hooks/ModalFromUrlQuery'
-import { ProjectHeader } from 'components/Project/ProjectHeader'
 import { V2V3PayProjectFormProvider } from 'components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3PayProjectFormProvider'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useIsUserAddress } from 'hooks/IsUserAddress'
 import useMobile from 'hooks/Mobile'
 import { useContext } from 'react'
-import { ProjectBanners } from './banners/ProjectBanners'
-import NewDeployModal, { NEW_DEPLOY_QUERY_PARAM } from './modals/NewDeployModal'
 import { ProjectPageMobile } from './ProjectPageMobile'
 import { ProjectPageRightCol } from './ProjectPageRightCol'
 import { ProjectPageTabs } from './ProjectPageTabs'
 import { V2V3ProjectHeaderActions } from './V2V3ProjectHeaderActions/V2V3ProjectHeaderActions'
+import { ProjectBanners } from './banners/ProjectBanners'
+import NewDeployModal, { NEW_DEPLOY_QUERY_PARAM } from './modals/NewDeployModal'
 
 export const GUTTER_PX = 24
 export const COL_SIZE_MD = 12
@@ -49,7 +51,11 @@ export function V2V3Project() {
             <ProjectPageMobile />
           ) : (
             <Row gutter={48} className="gap-y-10">
-              <ProjectPageTabs />
+              <ErrorBoundaryCallout
+                message={<Trans>Project details failed to load.</Trans>}
+              >
+                <ProjectPageTabs />
+              </ErrorBoundaryCallout>
               <ProjectPageRightCol />
             </Row>
           )}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1811,6 +1811,9 @@ msgstr ""
 msgid "NFTs detached from project."
 msgstr ""
 
+msgid "NFTs failed to load."
+msgstr ""
+
 msgid "NFTs for you"
 msgstr ""
 
@@ -2240,6 +2243,9 @@ msgstr ""
 msgid "Project Token"
 msgstr ""
 
+msgid "Project activity failed to load."
+msgstr ""
+
 msgid "Project balance"
 msgstr ""
 
@@ -2253,6 +2259,9 @@ msgid "Project created 🎉"
 msgstr ""
 
 msgid "Project description"
+msgstr ""
+
+msgid "Project details failed to load."
 msgstr ""
 
 msgid "Project handle"

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -92,7 +92,7 @@ button {
 
 body,
 div {
-  transition: background-color, border 250ms linear;
+  transition: background-color, border 100ms linear;
 }
 
 


### PR DESCRIPTION
Fixes https://linear.app/peel/issue/JB-54/add-error-boundaries-to-project-page

Example: if there was an unhandled exception in NFTs section, the whole site wouldn't crash.

<img width="1153" alt="Screenshot 2023-04-05 at 11 19 34 AM" src="https://user-images.githubusercontent.com/12551741/229960866-bd97dc2a-b8e2-4094-8c34-760ff8f5611e.png">
