### PR TITLE
Show tag counts in tag filter

### DIFF
--- a/src/hooks/TagCounts.ts
+++ b/src/hooks/TagCounts.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+import { ProjectTag } from 'models/project-tags'
+import { useQuery } from 'react-query'
+
+export function useTagCounts() {
+  return useQuery<
+    Partial<Record<ProjectTag, number>>,
+    Error,
+    Partial<Record<ProjectTag, number>>,
+    [string]
+  >(
+    ['tag-counts'],
+    () =>
+      axios
+        .get<Partial<Record<ProjectTag, number>>>('/api/projects/tag-counts')
+        .then(res => res.data),
+    {
+      staleTime: 5 * 60 * 1000,
+    },
+  )
+}

--- a/src/pages/api/projects/tag-counts.page.ts
+++ b/src/pages/api/projects/tag-counts.page.ts
@@ -1,0 +1,32 @@
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { ProjectTag, projectTagOptions } from 'models/project-tags'
+import { NextApiHandler } from 'next'
+import { Database } from 'types/database.types'
+
+/**
+ * Returns the number of projects that are using each tag.
+ *
+ * @returns An object containing project counts for all tag options.
+ */
+const handler: NextApiHandler = async (req, res) => {
+  const counts: Partial<Record<ProjectTag, number>> = {}
+
+  try {
+    for (const tag of projectTagOptions) {
+      const { count } = await createServerSupabaseClient<Database>({ req, res })
+        .from('projects')
+        .select('*', { count: 'exact', head: true })
+        .not('archived', 'is', true)
+        .overlaps('tags', [tag])
+
+      counts[tag] = count ?? 0
+    }
+
+    res.status(200).json(counts)
+    return
+  } catch (e) {
+    res.status(500).send(e)
+  }
+}
+
+export default handler

--- a/src/pages/projects/ProjectsFilterAndSort.tsx
+++ b/src/pages/projects/ProjectsFilterAndSort.tsx
@@ -2,6 +2,7 @@ import { FilterOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Collapse, Select } from 'antd'
 import CollapsePanel from 'antd/lib/collapse/CollapsePanel'
+import { useTagCounts } from 'hooks/TagCounts'
 import { DBProjectQueryOpts } from 'models/dbProject'
 import { ProjectTag, projectTagOptions } from 'models/project-tags'
 import { useEffect, useState } from 'react'
@@ -52,6 +53,8 @@ export default function ProjectsFilterAndSort({
     return () => window.removeEventListener('click', handleClick)
   }, [])
 
+  const { data: tagCounts } = useTagCounts()
+
   return (
     <div className="flex max-w-[100vw] flex-wrap items-center whitespace-pre">
       <Collapse
@@ -96,7 +99,9 @@ export default function ProjectsFilterAndSort({
             {projectTagOptions.map(t => (
               <FilterCheckboxItem
                 key={t}
-                label={t}
+                label={`${t}${
+                  tagCounts && tagCounts[t] ? ` (${tagCounts[t]})` : ''
+                }`}
                 checked={searchTags.includes(t)}
                 onChange={() =>
                   setSearchTags(


### PR DESCRIPTION
Shows number of projects matching each tag in the tag filter dropdown on the Explore page.

This should maybe use a new database view instead of putting this logic in the api endpoint. If so we can consider this a temporary solution.

<img width="354" alt="image" src="https://user-images.githubusercontent.com/79433522/231302159-635680a4-3c9e-4eb8-9529-f487b7f370c7.png">
