### PR TITLE
feat: data source (& tooltip) copy improvements

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/DataSourceListItems/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/DataSourceListItems/index.tsx
@@ -69,8 +69,8 @@ export function DataSourceListItems({
         value={formatBoolean(fundingCycleMetadata.useDataSourceForPay)}
         helperText={
           version
-            ? USE_DATASOURCE_FOR_PAY_EXPLANATION
-            : USE_NFT_DATASOURCE_FOR_PAY_EXPLANATION
+            ? USE_NFT_DATASOURCE_FOR_PAY_EXPLANATION
+            : USE_DATASOURCE_FOR_PAY_EXPLANATION
         }
       />
       <FundingCycleListItem
@@ -78,8 +78,8 @@ export function DataSourceListItems({
         value={formatBoolean(fundingCycleMetadata.useDataSourceForRedeem)}
         helperText={
           version
-            ? USE_DATASOURCE_FOR_REDEEM_EXPLANATION
-            : USE_NFT_DATASOURCE_FOR_REDEEM_EXPLANATION
+            ? USE_NFT_DATASOURCE_FOR_REDEEM_EXPLANATION
+            : USE_DATASOURCE_FOR_REDEEM_EXPLANATION
         }
       />
     </>

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/DataSourceListItems/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/DataSourceListItems/index.tsx
@@ -8,6 +8,14 @@ import { V2V3FundingCycleMetadata } from 'models/v2v3/fundingCycle'
 import { useContext } from 'react'
 import { formatBoolean } from 'utils/format/formatBoolean'
 import { helpPagePath } from 'utils/routes'
+import {
+  DATASOURCE_EXPLANATION,
+  NFT_DATASOURCE_EXPLANATION,
+  USE_DATASOURCE_FOR_PAY_EXPLANATION,
+  USE_DATASOURCE_FOR_REDEEM_EXPLANATION,
+  USE_NFT_DATASOURCE_FOR_PAY_EXPLANATION,
+  USE_NFT_DATASOURCE_FOR_REDEEM_EXPLANATION,
+} from '../../settingExplanations'
 import { FundingCycleListItem } from '../FundingCycleListItem'
 
 function DataSourceAddressValue({ address }: { address: string | undefined }) {
@@ -31,7 +39,7 @@ function DataSourceAddressValue({ address }: { address: string | undefined }) {
           <CheckCircleOutlined />
         </Tooltip>
       ) : (
-        <Tooltip title={<Trans>Unknown datasource</Trans>}>
+        <Tooltip title={<Trans>Unknown extension</Trans>}>
           <WarningOutlined className="text-warning-600 dark:text-warning-300" />
         </Tooltip>
       )}
@@ -44,6 +52,7 @@ export function DataSourceListItems({
 }: {
   fundingCycleMetadata: V2V3FundingCycleMetadata
 }) {
+  const { version } = useContext(JB721DelegateContractsContext)
   return (
     <>
       <FundingCycleListItem
@@ -51,14 +60,27 @@ export function DataSourceListItems({
         value={
           <DataSourceAddressValue address={fundingCycleMetadata.dataSource} />
         }
+        helperText={
+          version ? NFT_DATASOURCE_EXPLANATION : DATASOURCE_EXPLANATION
+        }
       />
       <FundingCycleListItem
         name={t`Use for payments`}
         value={formatBoolean(fundingCycleMetadata.useDataSourceForPay)}
+        helperText={
+          version
+            ? USE_DATASOURCE_FOR_PAY_EXPLANATION
+            : USE_NFT_DATASOURCE_FOR_PAY_EXPLANATION
+        }
       />
       <FundingCycleListItem
         name={t`Use for redemptions`}
         value={formatBoolean(fundingCycleMetadata.useDataSourceForRedeem)}
+        helperText={
+          version
+            ? USE_DATASOURCE_FOR_REDEEM_EXPLANATION
+            : USE_NFT_DATASOURCE_FOR_REDEEM_EXPLANATION
+        }
       />
     </>
   )

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/index.tsx
@@ -63,7 +63,7 @@ export default function FundingCycleDetails({
       />
       {!isZeroAddress(fundingCycleMetadata.dataSource) ? (
         <FundingCycleDetailsRow
-          header={t`Data source`}
+          header={t`Extension`}
           items={
             <DataSourceListItems fundingCycleMetadata={fundingCycleMetadata} />
           }

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/settingExplanations.tsx
@@ -173,13 +173,6 @@ export const HOLD_FEES_EXPLANATION = (
   </Trans>
 )
 
-export const USE_DATASOURCE_FOR_REDEEM_EXPLANATION = (
-  <Trans>
-    While enabled, NFTs can be redeemed to reclaim some of the ETH that isn't
-    needed for payouts. While enabled, it won't be possible to redeem tokens.
-  </Trans>
-)
-
 export const PREVENT_OVERSPENDING_EXPLANATION = (
   <Trans>
     When enabled, supporters can only mint NFTs by paying their exact price.
@@ -196,5 +189,49 @@ export const FEES_EXPLANATION = (
       Learn more
     </ExternalLink>
     .
+  </Trans>
+)
+
+export const DATASOURCE_EXPLANATION = (
+  <Trans>
+    A contract which defines custom behavior which can be used when somebody
+    pays this project or redeems from it.{' '}
+    <ExternalLink href={helpPagePath(`/dev/learn/glossary/data-source/`)}>
+      Learn more
+    </ExternalLink>
+  </Trans>
+)
+
+export const USE_DATASOURCE_FOR_PAY_EXPLANATION = (
+  <Trans>
+    While enabled, this project will use the custom behavior defined in the
+    contract above when somebody pays this project. Exercise caution.
+  </Trans>
+)
+
+export const USE_DATASOURCE_FOR_REDEEM_EXPLANATION = (
+  <Trans>
+    While enabled, this project will use the custom behavior defined in the
+    contract above when somebody redeems from this project. Exercise caution.
+  </Trans>
+)
+
+export const NFT_DATASOURCE_EXPLANATION = (
+  <Trans>
+    This contract manages NFT minting and redeeming for this project.
+  </Trans>
+)
+
+export const USE_NFT_DATASOURCE_FOR_REDEEM_EXPLANATION = (
+  <Trans>
+    While enabled, NFTs can be redeemed to reclaim some of the ETH that isn't
+    needed for payouts, but it won't be possible to redeem this project's
+    tokens.
+  </Trans>
+)
+
+export const USE_NFT_DATASOURCE_FOR_PAY_EXPLANATION = (
+  <Trans>
+    While enabled, NFTs can be minted when this project receives a payment.
   </Trans>
 )

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -233,6 +233,9 @@ msgstr ""
 msgid "A collection's symbol is typically a 3-4 letter acronym or abbreviation of its name. The symbol is used on NFT marketplaces (like <0>OpenSea</0>)."
 msgstr ""
 
+msgid "A contract which defines custom behavior which can be used when somebody pays this project or redeems from it. <0>Learn more</0>"
+msgstr ""
+
 msgid "A fixed amount of ETH can be paid out from your project each cycle. You can send specific ETH amounts (or ETH amounts based on USD values) to one or more recipients. Any remaining ETH will stay in your project for token redemptions or use in future cycles."
 msgstr ""
 
@@ -959,9 +962,6 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-msgid "Data source"
-msgstr ""
-
 msgid "Date"
 msgstr ""
 
@@ -1323,6 +1323,9 @@ msgid "Export this cycle's payouts to CSV."
 msgstr ""
 
 msgid "Extensible"
+msgstr ""
+
+msgid "Extension"
 msgstr ""
 
 msgid "External link"
@@ -3224,6 +3227,9 @@ msgstr ""
 msgid "This address will receive any tokens minted when this project is paid."
 msgstr ""
 
+msgid "This contract manages NFT minting and redeeming for this project."
+msgstr ""
+
 msgid "This custom deadline contract"
 msgstr ""
 
@@ -3524,7 +3530,7 @@ msgstr ""
 msgid "Unix timestamp in seconds. Leave blank to start immediately."
 msgstr ""
 
-msgid "Unknown datasource"
+msgid "Unknown extension"
 msgstr ""
 
 msgid "Unless payments to this project are paused in your cycle's rules, your project can still receive payments directly through the Juicebox protocol contracts."
@@ -3719,7 +3725,10 @@ msgstr ""
 msgid "Whether you’re building a boutique crypto law firm or the next mega-fundraiser, Juicebox is customizable to match your needs."
 msgstr ""
 
-msgid "While enabled, NFTs can be redeemed to reclaim some of the ETH that isn't needed for payouts. While enabled, it won't be possible to redeem tokens."
+msgid "While enabled, NFTs can be minted when this project receives a payment."
+msgstr ""
+
+msgid "While enabled, NFTs can be redeemed to reclaim some of the ETH that isn't needed for payouts, but it won't be possible to redeem this project's tokens."
 msgstr ""
 
 msgid "While enabled, the project owner can change the project's <0>controller</0> at any time."
@@ -3735,6 +3744,12 @@ msgid "While enabled, the project owner can migrate the project's current <0>pay
 msgstr ""
 
 msgid "While enabled, the project owner can mint any amount of project tokens."
+msgstr ""
+
+msgid "While enabled, this project will use the custom behavior defined in the contract above when somebody pays this project. Exercise caution."
+msgstr ""
+
+msgid "While enabled, this project will use the custom behavior defined in the contract above when somebody redeems from this project. Exercise caution."
 msgstr ""
 
 msgid "While payments to this project are paused, your project will not be able to receive payments. Transferring ETH to this project will still work."


### PR DESCRIPTION
Within Cycle tab on project page:

- Tooltips for data source section
- Clearer language (data source -> extension)
- Different, simpler tooltips if the contract is a JB721Delegate