### PR TITLE
Subgraph compatibility v7.0.0

### DIFF
--- a/src/components/AboutDashboard/components/OurMissionSection.tsx
+++ b/src/components/AboutDashboard/components/OurMissionSection.tsx
@@ -11,7 +11,7 @@ import illustration from '/public/assets/images/about/illustration1.webp'
 const PROGRESS_MAX_AMOUNT = ONE_BILLION
 
 export const OurMissionSection = () => {
-  const { volumePaidUSD } = useOurMissionSession()
+  const { volumeUSD } = useOurMissionSession()
   return (
     <SectionContainer className="sm:gap-24 md:flex md:items-center md:justify-between md:gap-32">
       <div className="md:w-1/2">
@@ -29,7 +29,7 @@ export const OurMissionSection = () => {
 
         <ProgressBar
           className="my-20 md:mb-0"
-          currentAmount={volumePaidUSD ? Number(fromWad(volumePaidUSD)) : 0}
+          currentAmount={volumeUSD ? Number(fromWad(volumeUSD)) : 0}
           maxAmount={PROGRESS_MAX_AMOUNT}
         />
       </div>

--- a/src/components/AboutDashboard/hooks/useOurMissionSection.ts
+++ b/src/components/AboutDashboard/hooks/useOurMissionSection.ts
@@ -3,13 +3,13 @@ import useSubgraphQuery from 'hooks/SubgraphQuery'
 export const useOurMissionSession = () => {
   const { data: protocolLogs, isLoading } = useSubgraphQuery({
     entity: 'protocolLog',
-    keys: ['volumePaidUSD'],
+    keys: ['volumeUSD'],
   })
 
-  const volumePaidUSD = protocolLogs?.[0]?.volumePaidUSD
+  const volumeUSD = protocolLogs?.[0]?.volumeUSD
 
   return {
-    volumePaidUSD,
+    volumeUSD,
     isLoading,
   }
 }

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -20,7 +20,7 @@ import ETHAmount from './currency/ETHAmount'
 
 export type ProjectCardProject = Pick<
   Project,
-  'id' | 'handle' | 'totalPaid' | 'createdAt' | 'terminal' | 'projectId' | 'pv'
+  'id' | 'handle' | 'volume' | 'createdAt' | 'terminal' | 'projectId' | 'pv'
 > & { tags?: ProjectTagName[] | null; metadataUri: string | null }
 
 function ArchivedBadge() {
@@ -41,7 +41,7 @@ function useProjectCardData(project?: ProjectCardProject | BigNumber) {
             'id',
             'handle',
             'metadataUri',
-            'totalPaid',
+            'volume',
             'createdAt',
             'terminal',
             'projectId',
@@ -81,8 +81,8 @@ export default function ProjectCard({
 
   // If the total paid is greater than 0, but less than 10 ETH, show two decimal places.
   const precision =
-    projectCardData.totalPaid?.gt(0) &&
-    projectCardData.totalPaid.lt(constants.WeiPerEther)
+    projectCardData.volume?.gt(0) &&
+    projectCardData.volume.lt(constants.WeiPerEther)
       ? 2
       : 0
 
@@ -153,7 +153,7 @@ export default function ProjectCard({
             <div>
               <span className="font-medium text-black dark:text-slate-100">
                 <ETHAmount
-                  amount={projectCardData.totalPaid}
+                  amount={projectCardData.volume}
                   precision={precision}
                 />{' '}
               </span>

--- a/src/components/QuickProjectSearch.tsx
+++ b/src/components/QuickProjectSearch.tsx
@@ -224,7 +224,7 @@ export default function QuickProjectSearch({
                     )}
 
                     <div className="text-xs font-medium text-slate-200 dark:text-slate-200">
-                      <ETHAmount amount={p.totalPaid} precision={0} />
+                      <ETHAmount amount={p.volume} precision={0} />
                     </div>
 
                     <ProjectVersionBadge

--- a/src/components/VolumeChart/loadProjectEvents.ts
+++ b/src/components/VolumeChart/loadProjectEvents.ts
@@ -26,7 +26,7 @@ export const loadProjectEvents = async ({
 
   switch (showGraph) {
     case 'volume':
-      queryKeys = ['totalPaid']
+      queryKeys = ['volume']
       break
     case 'balance':
       queryKeys = ['currentBalance']
@@ -64,9 +64,7 @@ export const loadProjectEvents = async ({
         projects.forEach(project => {
           switch (showGraph) {
             case 'volume':
-              value = parseFloat(
-                parseFloat(fromWad(project.totalPaid)).toFixed(4),
-              )
+              value = parseFloat(parseFloat(fromWad(project.volume)).toFixed(4))
               break
             case 'balance':
               value = parseFloat(

--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -5,24 +5,23 @@ import { isEqualAddress } from 'utils/address'
 import { formatHistoricalDate } from 'utils/format/formatDate'
 import { ActivityElementEvent } from './activityElementEvent'
 
-const CallerBeneficiary = ({
-  caller,
+const FromBeneficiary = ({
+  from,
   beneficiary,
 }: {
-  caller?: string
+  from?: string
   beneficiary?: string
 }) => {
-  if (!(beneficiary || caller)) return null
+  if (!(beneficiary || from)) return null
 
-  return beneficiary && caller && !isEqualAddress(beneficiary, caller) ? (
+  return beneficiary && from && !isEqualAddress(beneficiary, from) ? (
     <div className="text-xs">
-      <FormattedAddress address={caller} title="Caller" />{' '}
-      <ArrowRightOutlined />{' '}
+      <FormattedAddress address={from} title="From" /> <ArrowRightOutlined />{' '}
       <FormattedAddress address={beneficiary} title="Beneficiary" />
     </div>
   ) : (
     <div className="text-sm">
-      <FormattedAddress withEnsAvatar address={caller} />
+      <FormattedAddress withEnsAvatar address={from} />
     </div>
   )
 }
@@ -88,7 +87,7 @@ export function ActivityEvent({
 
         <div className="mt-1 flex items-start justify-between">
           <Subject subject={subject} />
-          <CallerBeneficiary {...event} />
+          <FromBeneficiary {...event} />
         </div>
       </div>
 

--- a/src/components/activityEventElems/ActivityElement/activityElementEvent.ts
+++ b/src/components/activityEventElems/ActivityElement/activityElementEvent.ts
@@ -1,7 +1,7 @@
 export interface ActivityElementEvent {
   timestamp: number
   txHash: string
-  caller?: string // TODO should always be defined
+  from: string
   beneficiary?: string
   terminal?: string
 }

--- a/src/components/activityEventElems/AddToBalanceEventElem.tsx
+++ b/src/components/activityEventElems/AddToBalanceEventElem.tsx
@@ -11,13 +11,7 @@ export default function AddToBalanceEventElem({
   event:
     | Pick<
         AddToBalanceEvent,
-        | 'amount'
-        | 'timestamp'
-        | 'caller'
-        | 'note'
-        | 'id'
-        | 'txHash'
-        | 'terminal'
+        'amount' | 'timestamp' | 'from' | 'note' | 'id' | 'txHash' | 'terminal'
       >
     | undefined
 }) {

--- a/src/components/activityEventElems/BurnEventElem.tsx
+++ b/src/components/activityEventElems/BurnEventElem.tsx
@@ -9,7 +9,7 @@ export default function BurnEventElem({
   tokenSymbol,
 }: {
   event:
-    | Pick<BurnEvent, 'amount' | 'timestamp' | 'caller' | 'id' | 'txHash'>
+    | Pick<BurnEvent, 'amount' | 'timestamp' | 'from' | 'id' | 'txHash'>
     | undefined
   tokenSymbol: string | undefined
 }) {

--- a/src/components/activityEventElems/DeployedERC20EventElem.tsx
+++ b/src/components/activityEventElems/DeployedERC20EventElem.tsx
@@ -6,7 +6,10 @@ export default function DeployedERC20EventElem({
   event,
 }: {
   event:
-    | Pick<DeployedERC20Event, 'symbol' | 'id' | 'timestamp' | 'txHash'>
+    | Pick<
+        DeployedERC20Event,
+        'symbol' | 'id' | 'timestamp' | 'txHash' | 'from'
+      >
     | undefined
 }) {
   if (!event) return null
@@ -14,7 +17,7 @@ export default function DeployedERC20EventElem({
     <ActivityEvent
       header={t`Deployed ERC20 token`}
       subject={<div className="text-base">{event.symbol}</div>}
-      event={{ ...event, beneficiary: undefined, caller: undefined }}
+      event={{ ...event, beneficiary: undefined }}
     />
   )
 }

--- a/src/components/activityEventElems/PayEventElem.tsx
+++ b/src/components/activityEventElems/PayEventElem.tsx
@@ -14,7 +14,7 @@ export default function PayEventElem({
         PayEvent,
         | 'amount'
         | 'timestamp'
-        | 'caller'
+        | 'from'
         | 'beneficiary'
         | 'note'
         | 'id'

--- a/src/components/activityEventElems/ProjectCreateEventElem.tsx
+++ b/src/components/activityEventElems/ProjectCreateEventElem.tsx
@@ -6,7 +6,7 @@ import { ActivityEvent } from './ActivityElement'
 export default function ProjectCreateEventElem({
   event,
 }: {
-  event: Pick<ProjectCreateEvent, 'id' | 'caller' | 'timestamp' | 'txHash'>
+  event: Pick<ProjectCreateEvent, 'id' | 'from' | 'timestamp' | 'txHash'>
 }) {
   return (
     <ActivityEvent

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -17,7 +17,7 @@ export default function RedeemEventElem({
         | 'id'
         | 'amount'
         | 'beneficiary'
-        | 'caller'
+        | 'from'
         | 'txHash'
         | 'timestamp'
         | 'returnAmount'

--- a/src/components/modals/DownloadParticipantsModal.tsx
+++ b/src/components/modals/DownloadParticipantsModal.tsx
@@ -60,7 +60,7 @@ export function DownloadParticipantsModal({
         entity: 'participant',
         keys: [
           'wallet { id }',
-          'totalPaid',
+          'volume',
           'balance',
           'stakedBalance',
           'erc20Balance',
@@ -95,7 +95,7 @@ export function DownloadParticipantsModal({
           fromWad(p.balance),
           fromWad(p.stakedBalance),
           fromWad(p.erc20Balance),
-          fromWad(p.totalPaid),
+          fromWad(p.volume),
           date,
         ])
       })

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -44,7 +44,7 @@ export default function ParticipantsModal({
     Pick<
       Participant,
       | 'wallet'
-      | 'totalPaid'
+      | 'volume'
       | 'lastPaidTimestamp'
       | 'balance'
       | 'stakedBalance'
@@ -76,7 +76,7 @@ export default function ParticipantsModal({
       entity: 'participant',
       keys: [
         'wallet { id }',
-        'totalPaid',
+        'volume',
         'lastPaidTimestamp',
         'balance',
         'stakedBalance',
@@ -144,7 +144,7 @@ export default function ParticipantsModal({
                 balance
               </Trans>
             </Select.Option>
-            <Select.Option value="totalPaid">
+            <Select.Option value="volume">
               <Trans>Total paid</Trans>
             </Select.Option>
             <Select.Option value="lastPaidTimestamp">
@@ -186,7 +186,7 @@ export default function ParticipantsModal({
                 </div>
                 <div className="text-xs text-grey-400 dark:text-slate-200">
                   <Trans>
-                    <ETHAmount amount={p.totalPaid} /> contributed
+                    <ETHAmount amount={p.volume} /> contributed
                   </Trans>
                 </div>
               </div>

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
@@ -17,7 +17,7 @@ export default function ReservesEventElem({
         | 'id'
         | 'timestamp'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'beneficiary'
         | 'beneficiaryTicketAmount'
         | 'count'

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
@@ -19,7 +19,7 @@ export default function TapEventElem({
         | 'id'
         | 'timestamp'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'beneficiary'
         | 'beneficiaryTransferAmount'
         | 'netTransferAmount'

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/V1ConfigureEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/V1ConfigureEventElem.tsx
@@ -25,7 +25,7 @@ export default function V1ConfigureEventElem({
         | 'id'
         | 'timestamp'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'ballot'
         | 'discountRate'
         | 'duration'

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -146,11 +146,11 @@ export default function ProjectActivity() {
       },
       {
         entity: 'burnEvent',
-        keys: ['id', 'timestamp', 'txHash', 'caller', 'holder', 'amount'],
+        keys: ['id', 'timestamp', 'txHash', 'from', 'holder', 'amount'],
       },
       {
         entity: 'addToBalanceEvent',
-        keys: ['amount', 'timestamp', 'caller', 'id', 'txHash'],
+        keys: ['amount', 'timestamp', 'from', 'id', 'txHash'],
       },
       {
         entity: 'deployedERC20Event',
@@ -162,7 +162,7 @@ export default function ProjectActivity() {
           'id',
           'timestamp',
           'txHash',
-          'caller',
+          'from',
           'beneficiary',
           'beneficiaryTransferAmount',
           'netTransferAmount',
@@ -174,7 +174,7 @@ export default function ProjectActivity() {
           'id',
           'timestamp',
           'txHash',
-          'caller',
+          'from',
           'beneficiary',
           'beneficiaryTicketAmount',
           'count',
@@ -194,7 +194,7 @@ export default function ProjectActivity() {
       },
       {
         entity: 'projectCreateEvent',
-        keys: ['id', 'txHash', 'timestamp', 'caller'],
+        keys: ['id', 'txHash', 'timestamp', 'from'],
       },
       {
         entity: 'v1ConfigureEvent',
@@ -202,7 +202,7 @@ export default function ProjectActivity() {
           'id',
           'timestamp',
           'txHash',
-          'caller',
+          'from',
           'ballot',
           'discountRate',
           'duration',

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/ConfigureEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/ConfigureEventElem.tsx
@@ -21,7 +21,7 @@ export default function ConfigureEventElem({
         | 'timestamp'
         | 'mustStartAtOrAfter'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'ballot'
         | 'dataSource'
         | 'discountRate'

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
@@ -10,7 +10,7 @@ export default function DeployETHERC20ProjectPayerEventElem({
   event:
     | Pick<
         DeployETHERC20ProjectPayerEvent,
-        'id' | 'timestamp' | 'txHash' | 'caller' | 'address' | 'memo'
+        'id' | 'timestamp' | 'txHash' | 'from' | 'address' | 'memo'
       >
     | undefined
 }) {
@@ -22,7 +22,7 @@ export default function DeployETHERC20ProjectPayerEventElem({
       header={t`Deployed a project payer address`}
       subject={
         <Trans>
-          called by <FormattedAddress address={event.caller} />
+          called by <FormattedAddress address={event.from} />
         </Trans>
       }
       extra={

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
@@ -22,7 +22,7 @@ export default function DeployETHERC20ProjectPayerEventElem({
       header={t`Deployed a project payer address`}
       subject={
         <Trans>
-          called by <FormattedAddress address={event.from} />
+          from <FormattedAddress address={event.from} />
         </Trans>
       }
       extra={

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
@@ -15,7 +15,7 @@ export default function DistributePayoutsElem({
         | 'id'
         | 'timestamp'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'beneficiary'
         | 'beneficiaryDistributionAmount'
         | 'distributedAmount'

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
@@ -17,7 +17,7 @@ export default function DistributeReservedTokensEventElem({
         | 'id'
         | 'timestamp'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'beneficiary'
         | 'beneficiaryTokenCount'
         | 'tokenCount'

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/SetFundAccessConstraintsEventElem.tsx
@@ -14,7 +14,7 @@ export default function SetFundAccessConstraintsEventElem({
         | 'id'
         | 'timestamp'
         | 'txHash'
-        | 'caller'
+        | 'from'
         | 'distributionLimit'
         | 'distributionLimitCurrency'
       >

--- a/src/components/v2v3/V2V3Project/ProjectActivity/hooks/ProjectActivity.ts
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/hooks/ProjectActivity.ts
@@ -17,7 +17,7 @@ const PAY_EVENT_KEY: ActivityQueryKey<'payEvent'> = {
   keys: [
     'amount',
     'timestamp',
-    'caller',
+    'from',
     'beneficiary',
     'note',
     'id',
@@ -33,7 +33,7 @@ const CONFIGURE_EVENT_KEY: ActivityQueryKey<'configureEvent'> = {
     'id',
     'timestamp',
     'txHash',
-    'caller',
+    'from',
     'ballot',
     'dataSource',
     'discountRate',
@@ -57,24 +57,24 @@ const CONFIGURE_EVENT_KEY: ActivityQueryKey<'configureEvent'> = {
 
 const BURN_EVENT_KEY: ActivityQueryKey<'burnEvent'> = {
   entity: 'burnEvent',
-  keys: ['id', 'timestamp', 'txHash', 'caller', 'holder', 'amount'],
+  keys: ['id', 'timestamp', 'txHash', 'from', 'holder', 'amount'],
 }
 
 const ADD_TO_BALANCE_EVENT_KEY: ActivityQueryKey<'addToBalanceEvent'> = {
   entity: 'addToBalanceEvent',
-  keys: ['amount', 'timestamp', 'caller', 'note', 'id', 'txHash', 'terminal'],
+  keys: ['amount', 'timestamp', 'from', 'note', 'id', 'txHash', 'terminal'],
 }
 
 const DEPLOYED_ERC20_EVENT_KEY: ActivityQueryKey<'deployedERC20Event'> = {
   entity: 'deployedERC20Event',
-  keys: ['symbol', 'txHash', 'timestamp', 'id', 'caller'],
+  keys: ['symbol', 'txHash', 'timestamp', 'id', 'from'],
 }
 
 const REDEEM_EVENT_KEY: ActivityQueryKey<'redeemEvent'> = {
   entity: 'redeemEvent',
   keys: [
     'id',
-    'caller',
+    'from',
     'amount',
     'beneficiary',
     'txHash',
@@ -88,7 +88,7 @@ const REDEEM_EVENT_KEY: ActivityQueryKey<'redeemEvent'> = {
 
 const PROJECT_CREATE_EVENT_KEY: ActivityQueryKey<'projectCreateEvent'> = {
   entity: 'projectCreateEvent',
-  keys: ['id', 'txHash', 'timestamp', 'caller'],
+  keys: ['id', 'txHash', 'timestamp', 'from'],
 }
 
 const DISTRIBUTED_PAYOUTS_EVENT_KEY: ActivityQueryKey<'distributePayoutsEvent'> =
@@ -98,7 +98,7 @@ const DISTRIBUTED_PAYOUTS_EVENT_KEY: ActivityQueryKey<'distributePayoutsEvent'> 
       'id',
       'timestamp',
       'txHash',
-      'caller',
+      'from',
       'beneficiary',
       'beneficiaryDistributionAmount',
       'distributedAmount',
@@ -114,7 +114,7 @@ const DISTRIBUTED_RESERVED_TOKENS_EVENT_KEY: ActivityQueryKey<'distributeReserve
       'id',
       'timestamp',
       'txHash',
-      'caller',
+      'from',
       'beneficiary',
       'beneficiaryTokenCount',
       'tokenCount',
@@ -124,7 +124,7 @@ const DISTRIBUTED_RESERVED_TOKENS_EVENT_KEY: ActivityQueryKey<'distributeReserve
 const DEPLOYED_PROJECT_PAYER_EVENT_KEY: ActivityQueryKey<'deployETHERC20ProjectPayerEvent'> =
   {
     entity: 'deployETHERC20ProjectPayerEvent',
-    keys: ['id', 'timestamp', 'txHash', 'caller', 'address', 'memo'],
+    keys: ['id', 'timestamp', 'txHash', 'from', 'address', 'memo'],
   }
 
 const SET_FUND_ACCESS_CONSTRAINTS_EVENT_KEY: ActivityQueryKey<'setFundAccessConstraintsEvent'> =
@@ -134,7 +134,7 @@ const SET_FUND_ACCESS_CONSTRAINTS_EVENT_KEY: ActivityQueryKey<'setFundAccessCons
       'id',
       'timestamp',
       'txHash',
-      'caller',
+      'from',
       'distributionLimit',
       'distributionLimitCurrency',
     ],

--- a/src/contexts/v1/Project/V1ProjectState.ts
+++ b/src/contexts/v1/Project/V1ProjectState.ts
@@ -67,11 +67,11 @@ export function useV1ProjectState({
 
   const { data: projects } = useProjectsQuery({
     projectId: projectId,
-    keys: ['createdAt', 'totalPaid'],
+    keys: ['createdAt', 'volume'],
   })
 
   const createdAt = projects?.[0]?.createdAt
-  const earned = projects?.[0]?.totalPaid
+  const earned = projects?.[0]?.volume
 
   const project = useMemo<V1ProjectContextType>((): V1ProjectContextType => {
     const projectType = 'standard'

--- a/src/contexts/v2v3/Project/V2V3ProjectState.ts
+++ b/src/contexts/v2v3/Project/V2V3ProjectState.ts
@@ -86,11 +86,11 @@ export function useV2V3ProjectState({ projectId }: { projectId: number }) {
    */
   const { data: projects } = useProjectsQuery({
     projectId,
-    keys: ['createdAt', 'totalPaid'],
+    keys: ['createdAt', 'volume'],
     pv: [PV_V2],
   })
   const createdAt = first(projects)?.createdAt
-  const totalVolume = first(projects)?.totalPaid
+  const totalVolume = first(projects)?.volume
 
   /**
    * Load funding cycle data

--- a/src/graphql/documents/query.graphql
+++ b/src/graphql/documents/query.graphql
@@ -13,7 +13,7 @@ query TrendingProjects($where: Project_filter, $first: Int, $skip: Int, $orderBy
     handle
     createdAt
     metadataUri
-    totalPaid
+    volume
     pv
     trendingScore
     paymentsCount

--- a/src/hooks/Projects.ts
+++ b/src/hooks/Projects.ts
@@ -36,7 +36,7 @@ interface ProjectsOptions {
   pageNumber?: number
   projectId?: number
   projectIds?: number[]
-  orderBy?: 'createdAt' | 'currentBalance' | 'totalPaid' | 'paymentsCount'
+  orderBy?: 'createdAt' | 'currentBalance' | 'volume' | 'paymentsCount'
   orderDirection?: 'asc' | 'desc'
   pageSize?: number
   state?: ProjectState
@@ -56,7 +56,7 @@ export const DEFAULT_PROJECT_ENTITY_KEYS: (keyof Project)[] = [
   'handle',
   'createdAt',
   'metadataUri',
-  'totalPaid',
+  'volume',
   'pv',
 ]
 const V1_ARCHIVED_SUBGRAPH_IDS = V1ArchivedProjectIds.map(projectId =>
@@ -117,7 +117,7 @@ const buildProjectQueryOpts = (
     entity: 'project',
     keys: opts.keys ?? DEFAULT_PROJECT_ENTITY_KEYS,
     orderDirection: opts.orderDirection ?? 'desc',
-    orderBy: opts.orderBy ?? 'totalPaid',
+    orderBy: opts.orderBy ?? 'volume',
     pageSize: opts.pageSize,
     where,
   }
@@ -240,7 +240,7 @@ export function useContributedProjectsQuery(wallet: string | undefined) {
         value: wallet.toLowerCase(),
       },
       {
-        key: 'totalPaid',
+        key: 'volume',
         operator: 'gt',
         value: 0,
       },
@@ -342,14 +342,14 @@ export function useMyProjectsQuery(wallet: string | undefined) {
 }
 
 export function useProjectTrendingPercentageIncrease({
-  totalPaid,
+  volume,
   trendingVolume,
 }: {
-  totalPaid: BigNumber
+  volume: BigNumber
   trendingVolume: BigNumber
 }): number {
   const percentageGain = useMemo(() => {
-    const preTrendingVolume = totalPaid?.sub(trendingVolume)
+    const preTrendingVolume = volume?.sub(trendingVolume)
 
     if (!preTrendingVolume?.gt(0)) return Infinity
 
@@ -372,7 +372,7 @@ export function useProjectTrendingPercentageIncrease({
     }
 
     return percentRounded
-  }, [totalPaid, trendingVolume])
+  }, [volume, trendingVolume])
 
   return percentageGain
 }

--- a/src/hooks/Projects.ts
+++ b/src/hooks/Projects.ts
@@ -342,14 +342,14 @@ export function useMyProjectsQuery(wallet: string | undefined) {
 }
 
 export function useProjectTrendingPercentageIncrease({
-  volume,
+  totalVolume,
   trendingVolume,
 }: {
-  volume: BigNumber
+  totalVolume: BigNumber
   trendingVolume: BigNumber
 }): number {
   const percentageGain = useMemo(() => {
-    const preTrendingVolume = volume?.sub(trendingVolume)
+    const preTrendingVolume = totalVolume?.sub(trendingVolume)
 
     if (!preTrendingVolume?.gt(0)) return Infinity
 
@@ -372,7 +372,7 @@ export function useProjectTrendingPercentageIncrease({
     }
 
     return percentRounded
-  }, [volume, trendingVolume])
+  }, [totalVolume, trendingVolume])
 
   return percentageGain
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1445,6 +1445,9 @@ msgstr ""
 msgid "Free to launch, just pay gas."
 msgstr ""
 
+msgid "From"
+msgstr ""
+
 msgid "Fun"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -623,9 +623,6 @@ msgstr ""
 msgid "CYCLE #{cycleNumber}"
 msgstr ""
 
-msgid "Caller"
-msgstr ""
-
 msgid "Cancel"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1580,6 +1580,9 @@ msgstr ""
 msgid "How do I use this website?"
 msgstr ""
 
+msgid "How does it work?"
+msgstr ""
+
 msgid "How long one cycle will last. Your project's rules are locked during each cycle. Edits you make to your project's rules during a cycle will only take effect at the start of the next cycle."
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -4115,10 +4115,10 @@ msgstr ""
 msgid "allocation"
 msgstr ""
 
-msgid "called by <0/>"
+msgid "days"
 msgstr ""
 
-msgid "days"
+msgid "from <0/>"
 msgstr ""
 
 msgid "handle"

--- a/src/models/dbProject.ts
+++ b/src/models/dbProject.ts
@@ -36,7 +36,7 @@ export type DBProject = {
   metadataUri: string | null
   currentBalance: BigNumber
   trendingScore: BigNumber
-  totalPaid: BigNumber
+  volume: BigNumber
   paymentsCount: number
   deployer: string | null
   terminal: string | null

--- a/src/models/subgraph-entities/base/base-event-entity.ts
+++ b/src/models/subgraph-entities/base/base-event-entity.ts
@@ -6,4 +6,5 @@ export interface BaseEventEntity {
   timestamp: number
   txHash: string
   caller: string
+  from: string
 }

--- a/src/models/subgraph-entities/vX/add-to-balance-event.ts
+++ b/src/models/subgraph-entities/vX/add-to-balance-event.ts
@@ -16,7 +16,6 @@ export interface AddToBalanceEvent
     TerminalEventEntity {
   pv: PV
   fundingCycleId: BigNumber
-  caller: string
   amount: BigNumber
   amountUSD: BigNumber
   note: string

--- a/src/models/subgraph-entities/vX/participant.ts
+++ b/src/models/subgraph-entities/vX/participant.ts
@@ -15,8 +15,8 @@ import { Wallet } from './wallet'
 export interface Participant extends BaseProjectEntity {
   pv: PV
   wallet: Wallet
-  totalPaid: BigNumber
-  totalPaidUSD: BigNumber
+  volume: BigNumber
+  volumeUSD: BigNumber
   balance: BigNumber
   stakedBalance: BigNumber
   erc20Balance: BigNumber
@@ -28,8 +28,8 @@ export const parseParticipantJson = (j: Json<Participant>): Participant => ({
   ...parseBaseProjectEntityJson(j),
   ...parseSubgraphEntitiesFromJson(j, ['wallet']),
   ...parseBigNumberKeyVals(j, [
-    'totalPaid',
-    'totalPaidUSD',
+    'volume',
+    'volumeUSD',
     'balance',
     'stakedBalance',
     'erc20Balance',

--- a/src/models/subgraph-entities/vX/project.ts
+++ b/src/models/subgraph-entities/vX/project.ts
@@ -34,8 +34,8 @@ export type Project = {
   createdWithinTrendingWindow: boolean
   volume: BigNumber
   volumeUSD: BigNumber
-  totalRedeemed: BigNumber
-  totalRedeemedUSD: BigNumber
+  redeemVolume: BigNumber
+  redeemVolumeUSD: BigNumber
   currentBalance: BigNumber
   participants: Participant[]
   payEvents: PayEvent[]
@@ -61,8 +61,8 @@ export const parseProjectJson = (j: Json<Project>): Project => ({
     'currentBalance',
     'volume',
     'volumeUSD',
-    'totalRedeemed',
-    'totalRedeemedUSD',
+    'redeemVolume',
+    'redeemVolumeUSD',
     'trendingScore',
     'trendingVolume',
     'metadataDomain',

--- a/src/models/subgraph-entities/vX/project.ts
+++ b/src/models/subgraph-entities/vX/project.ts
@@ -32,8 +32,8 @@ export type Project = {
   trendingScore: BigNumber
   trendingVolume: BigNumber
   createdWithinTrendingWindow: boolean
-  totalPaid: BigNumber
-  totalPaidUSD: BigNumber
+  volume: BigNumber
+  volumeUSD: BigNumber
   totalRedeemed: BigNumber
   totalRedeemedUSD: BigNumber
   currentBalance: BigNumber
@@ -59,8 +59,8 @@ export const parseProjectJson = (j: Json<Project>): Project => ({
   ...primitives(j),
   ...parseBigNumberKeyVals(j, [
     'currentBalance',
-    'totalPaid',
-    'totalPaidUSD',
+    'volume',
+    'volumeUSD',
     'totalRedeemed',
     'totalRedeemedUSD',
     'trendingScore',

--- a/src/models/subgraph-entities/vX/protocol-log.ts
+++ b/src/models/subgraph-entities/vX/protocol-log.ts
@@ -6,8 +6,8 @@ import { Json } from '../../json'
 export type ProtocolLog = {
   id: '1' // Only one entity exists
   projectsCount: number
-  volumePaid: BigNumber
-  volumePaidUSD: BigNumber
+  volume: BigNumber
+  volumeUSD: BigNumber
   volumeRedeemed: BigNumber
   volumeRedeemedUSD: BigNumber
   paymentsCount: number
@@ -24,9 +24,9 @@ export const parseProtocolLogJson = (j: Json<ProtocolLog>): ProtocolLog => ({
   ...j,
   id: '1',
   ...parseBigNumberKeyVals(j, [
-    'volumePaid',
+    'volume',
     'volumeRedeemed',
-    'volumePaidUSD',
+    'volumeUSD',
     'volumeRedeemedUSD',
   ]),
   ...subgraphEntityJsonToKeyVal(j.v1, 'protocolLog', 'v1'),

--- a/src/models/subgraph-entities/vX/redeem-event.ts
+++ b/src/models/subgraph-entities/vX/redeem-event.ts
@@ -20,7 +20,6 @@ export interface RedeemEvent
   amount: BigNumber
   returnAmount: BigNumber
   returnAmountUSD: BigNumber
-  caller: string
   memo: string
   metadata: string | undefined
 }

--- a/src/models/subgraph-entities/vX/wallet.ts
+++ b/src/models/subgraph-entities/vX/wallet.ts
@@ -9,15 +9,15 @@ import { Participant } from './participant'
 
 export interface Wallet {
   id: string
-  totalPaid: BigNumber
-  totalPaidUSD: BigNumber
+  volume: BigNumber
+  volumeUSD: BigNumber
   lastPaidTimestamp: number
   participants: Participant[]
 }
 
 export const parseWalletJson = (j: Json<Wallet>): Wallet => ({
   ...primitives(j),
-  ...parseBigNumberKeyVals(j, ['totalPaid', 'totalPaidUSD']),
+  ...parseBigNumberKeyVals(j, ['volume', 'volumeUSD']),
   ...subgraphEntityJsonArrayToKeyVal(
     j.participants,
     'participant',

--- a/src/pages/api/events/on-pay.page.ts
+++ b/src/pages/api/events/on-pay.page.ts
@@ -51,7 +51,7 @@ const Schema = Yup.object().shape({
   ).required(),
   memo: Yup.string(),
   metadata: Yup.string().required(),
-  caller: Yup.string().required(),
+  from: Yup.string().required(),
   blockHash: Yup.string().required(),
   blockNumber: Yup.number(),
 })

--- a/src/pages/home/HomepageProjectCard.tsx
+++ b/src/pages/home/HomepageProjectCard.tsx
@@ -44,7 +44,7 @@ export function HomepageProjectCard({
     Project,
     | 'terminal'
     | 'metadataUri'
-    | 'totalPaid'
+    | 'volume'
     | 'paymentsCount'
     | 'handle'
     | 'pv'
@@ -84,7 +84,7 @@ export function HomepageProjectCard({
         <div className="flex gap-8">
           <Statistic
             name={<Trans>Volume</Trans>}
-            value={<ETHAmount amount={project.totalPaid} precision={2} />}
+            value={<ETHAmount amount={project.volume} precision={2} />}
           />
           <Statistic
             name={<Trans>Payments</Trans>}

--- a/src/pages/home/JuicyPicksSection/SpotlightProjectCard.tsx
+++ b/src/pages/home/JuicyPicksSection/SpotlightProjectCard.tsx
@@ -37,7 +37,7 @@ export function SpotlightProjectCard({ project }: { project: Project }) {
 
   const percentageGain = useProjectTrendingPercentageIncrease({
     trendingVolume: project.trendingVolume,
-    volume: project.volume,
+    totalVolume: project.volume,
   })
   const percentGainText = project.createdWithinTrendingWindow
     ? t`New`

--- a/src/pages/home/JuicyPicksSection/SpotlightProjectCard.tsx
+++ b/src/pages/home/JuicyPicksSection/SpotlightProjectCard.tsx
@@ -37,7 +37,7 @@ export function SpotlightProjectCard({ project }: { project: Project }) {
 
   const percentageGain = useProjectTrendingPercentageIncrease({
     trendingVolume: project.trendingVolume,
-    totalPaid: project.totalPaid,
+    volume: project.volume,
   })
   const percentGainText = project.createdWithinTrendingWindow
     ? t`New`
@@ -71,7 +71,7 @@ export function SpotlightProjectCard({ project }: { project: Project }) {
         <div className="mb-5 flex gap-8">
           <Statistic
             name={<Trans>Volume</Trans>}
-            value={<ETHAmount amount={project.totalPaid} precision={2} />}
+            value={<ETHAmount amount={project.volume} precision={2} />}
           />
           <Statistic
             name={<Trans>Payments</Trans>}

--- a/src/pages/home/OldHomePage/TopProjectsSection.tsx
+++ b/src/pages/home/OldHomePage/TopProjectsSection.tsx
@@ -1,0 +1,183 @@
+import { RightCircleOutlined } from '@ant-design/icons'
+import { Trans } from '@lingui/macro'
+import { Button, Skeleton } from 'antd'
+import ETHAmount from 'components/currency/ETHAmount'
+import Loading from 'components/Loading'
+import { ProjectCardProject } from 'components/ProjectCard'
+import ProjectLogo from 'components/ProjectLogo'
+import { PV_V1, PV_V2 } from 'constants/pv'
+import useMobile from 'hooks/Mobile'
+import { useProjectMetadata } from 'hooks/ProjectMetadata'
+import { useProjectsQuery } from 'hooks/Projects'
+import Link from 'next/link'
+import { v2v3ProjectRoute } from 'utils/routes'
+
+import { OldSectionHeading } from './OldSectionHeading'
+import {
+  TopProjectsHeading,
+  TopProjectsSubheadingOne,
+  TopProjectsSubheadingTwo,
+} from './strings'
+
+const SmallProjectCardMobile = ({
+  project,
+}: {
+  project: ProjectCardProject
+}) => {
+  const { data: metadata } = useProjectMetadata(project?.metadataUri)
+
+  return (
+    <Link
+      key={`${project.id}_${project.pv}`}
+      href={
+        project.pv === PV_V2
+          ? v2v3ProjectRoute(project)
+          : `/p/${project?.handle}`
+      }
+      prefetch={project.pv === PV_V1}
+    >
+      <a className="flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-lg border border-smoke-300 bg-white py-2 px-4 text-center transition-colors hover:border-smoke-500 dark:border-slate-300 dark:bg-slate-700 dark:hover:border-slate-100">
+        <div className="flex justify-center">
+          <ProjectLogo
+            className="h-16 w-16"
+            uri={metadata?.logoUri}
+            name={metadata?.name}
+            projectId={project.projectId}
+          />
+        </div>
+
+        <div className="w-full font-normal">
+          {metadata ? (
+            <span className="m-0 overflow-hidden text-ellipsis text-black dark:text-slate-100">
+              {metadata.name}
+            </span>
+          ) : (
+            <Skeleton paragraph={false} title={{ width: 120 }} active />
+          )}
+
+          <div className="font-medium text-black dark:text-slate-100">
+            <ETHAmount amount={project?.volume} precision={0} /> raised
+          </div>
+        </div>
+      </a>
+    </Link>
+  )
+}
+
+const SmallProjectCard = ({ project }: { project: ProjectCardProject }) => {
+  const { data: metadata } = useProjectMetadata(project?.metadataUri)
+
+  return (
+    <Link
+      key={`${project.id}_${project.pv}`}
+      href={
+        project.pv === PV_V2
+          ? v2v3ProjectRoute(project)
+          : `/p/${project?.handle}`
+      }
+    >
+      <a>
+        <div className="w-44 cursor-pointer overflow-hidden rounded-lg border border-smoke-300 bg-white p-4 text-center transition-colors hover:border-smoke-500 dark:border-slate-300  dark:bg-slate-700 dark:hover:border-slate-100">
+          <div className="mb-2 flex justify-center">
+            <ProjectLogo
+              className="h-24 w-24"
+              uri={metadata?.logoUri}
+              name={metadata?.name}
+              projectId={project.projectId}
+            />
+          </div>
+
+          <div className="min-w-0 flex-1 font-normal">
+            {metadata ? (
+              <span
+                className="m-0 block overflow-hidden text-ellipsis whitespace-nowrap text-black dark:text-slate-100"
+                title={metadata.name}
+              >
+                {metadata.name}
+              </span>
+            ) : (
+              <Skeleton paragraph={false} title={{ width: 120 }} active />
+            )}
+
+            <div>
+              <span className="text-base font-medium text-black dark:text-slate-100">
+                <ETHAmount amount={project?.volume} precision={0} /> raised
+              </span>
+            </div>
+          </div>
+        </div>
+      </a>
+    </Link>
+  )
+}
+
+export function TopProjectsSection() {
+  const isMobile = useMobile()
+
+  const { data: previewProjects } = useProjectsQuery({
+    pageSize: 4,
+  })
+
+  return (
+    <section className="bg-smoke-50 p-8 dark:bg-slate-600">
+      <div className="my-10 mx-auto max-w-5xl">
+        <div className="flex w-full flex-col items-center gap-6">
+          <div>
+            <OldSectionHeading className="mx-auto max-w-[900px] leading-tight">
+              <TopProjectsHeading />
+            </OldSectionHeading>
+
+            <p className="mb-1 text-center text-base text-black dark:text-slate-100">
+              <TopProjectsSubheadingOne />
+            </p>
+            <p className="mb-3 text-center text-base">
+              <TopProjectsSubheadingTwo />
+            </p>
+          </div>
+
+          <div className="mb-3">
+            {previewProjects ? (
+              <div className="my-0 flex flex-wrap justify-between gap-2 md:w-full md:px-0">
+                {previewProjects.map(p =>
+                  isMobile ? (
+                    <SmallProjectCardMobile key={p.metadataUri} project={p} />
+                  ) : (
+                    <SmallProjectCard key={p.metadataUri} project={p} />
+                  ),
+                )}
+              </div>
+            ) : (
+              <Loading />
+            )}
+          </div>
+
+          <div className="text-center">
+            <div className="flex w-full flex-col gap-6">
+              <Link href="/create">
+                <a className="flex">
+                  <Button size="large" type="primary" block={isMobile}>
+                    <Trans>Create a project</Trans>
+                  </Button>
+                </a>
+              </Link>
+              <Link href="#how-it-works">
+                <a
+                  className="flex cursor-pointer items-center justify-center gap-2 text-sm font-normal text-grey-500 hover:underline dark:text-grey-300"
+                  role="button"
+                  onClick={() => {
+                    document
+                      .getElementById('how-it-works')
+                      ?.scrollIntoView({ behavior: 'smooth' })
+                  }}
+                >
+                  <Trans>How does it work?</Trans>
+                  <RightCircleOutlined />
+                </a>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/home/StatsSection.tsx
+++ b/src/pages/home/StatsSection.tsx
@@ -33,8 +33,8 @@ export function StatsSection() {
       'erc20Count',
       'paymentsCount',
       'projectsCount',
-      'volumePaid',
-      'volumePaidUSD',
+      'volume',
+      'volumeUSD',
     ],
   })
 
@@ -53,11 +53,11 @@ export function StatsSection() {
             <Link href="/activity">
               <a className="text-current">
                 <USDAmount
-                  amount={stats?.volumePaidUSD}
+                  amount={stats?.volumeUSD}
                   precision={0}
                   symbol="$"
                   tooltipContent={
-                    <ETHAmount amount={stats?.volumePaid} hideTooltip />
+                    <ETHAmount amount={stats?.volume} hideTooltip />
                   }
                   className="gradient-animation bg-gradient-to-r from-bluebs-500 via-grape-400 to-juice-500 bg-clip-text font-display transition-colors hover:text-transparent"
                 />

--- a/src/pages/home/SuccessStoriesSection/SuccessStoriesCard.tsx
+++ b/src/pages/home/SuccessStoriesSection/SuccessStoriesCard.tsx
@@ -96,7 +96,7 @@ export function SuccessStoriesCard({
 
           <div className="mt-2">
             <span className="text-4xl font-medium text-black dark:text-slate-100">
-              <ETHAmount amount={project?.totalPaid} precision={0} />
+              <ETHAmount amount={project?.volume} precision={0} />
             </span>
           </div>
         </div>

--- a/src/pages/projects/TrendingProjectCard.tsx
+++ b/src/pages/projects/TrendingProjectCard.tsx
@@ -21,7 +21,7 @@ export default function TrendingProjectCard({
     | 'terminal'
     | 'trendingVolume'
     | 'metadataUri'
-    | 'totalPaid'
+    | 'volume'
     | 'trendingPaymentsCount'
     | 'createdWithinTrendingWindow'
     | 'handle'
@@ -35,7 +35,7 @@ export default function TrendingProjectCard({
 
   const percentageGain = useProjectTrendingPercentageIncrease({
     trendingVolume: project.trendingVolume,
-    totalPaid: project.totalPaid,
+    volume: project.volume,
   })
   const percentGainText = project.createdWithinTrendingWindow
     ? t`New`

--- a/src/pages/projects/TrendingProjectCard.tsx
+++ b/src/pages/projects/TrendingProjectCard.tsx
@@ -35,7 +35,7 @@ export default function TrendingProjectCard({
 
   const percentageGain = useProjectTrendingPercentageIncrease({
     trendingVolume: project.trendingVolume,
-    volume: project.volume,
+    totalVolume: project.volume,
   })
   const percentGainText = project.createdWithinTrendingWindow
     ? t`New`

--- a/src/utils/csvDownloadHelpers.ts
+++ b/src/utils/csvDownloadHelpers.ts
@@ -472,7 +472,7 @@ export async function downloadAdditionsToBalance(
       t`Date`,
       t`ETH transferred`,
       t`USD value of ETH transferred`,
-      t`Caller`,
+      t`From`,
       t`Transaction hash`,
     ], // CSV header row
   ]

--- a/src/utils/csvDownloadHelpers.ts
+++ b/src/utils/csvDownloadHelpers.ts
@@ -30,8 +30,8 @@ export async function downloadParticipants(
       keys: [
         'lastPaidTimestamp',
         'wallet { id }',
-        'totalPaid',
-        'totalPaidUSD',
+        'volume',
+        'volumeUSD',
         'balance',
         'stakedBalance',
         'erc20Balance',
@@ -66,8 +66,8 @@ export async function downloadParticipants(
       rows.push([
         date,
         p.wallet.id,
-        fromWad(p.totalPaid),
-        fromWad(p.totalPaidUSD),
+        fromWad(p.volume),
+        fromWad(p.volumeUSD),
         fromWad(p.balance),
         fromWad(p.stakedBalance),
         fromWad(p.erc20Balance),
@@ -333,7 +333,7 @@ export async function downloadPayments(
         'timestamp',
         'amount',
         'amountUSD',
-        'caller',
+        'from',
         'beneficiary',
         'txHash',
       ],
@@ -368,7 +368,7 @@ export async function downloadPayments(
         date,
         fromWad(p.amount),
         fromWad(p.amountUSD),
-        p.caller,
+        p.from,
         p.beneficiary,
         p.txHash,
       ])
@@ -408,7 +408,7 @@ export async function downloadRedemptions(
         'amount',
         'returnAmount',
         'returnAmountUSD',
-        'caller',
+        'from',
         'beneficiary',
         'txHash',
       ],
@@ -444,7 +444,7 @@ export async function downloadRedemptions(
         fromWad(r.amount),
         fromWad(r.returnAmount),
         fromWad(r.returnAmountUSD),
-        r.caller,
+        r.from,
         r.beneficiary,
         r.txHash,
       ])
@@ -480,7 +480,7 @@ export async function downloadAdditionsToBalance(
   try {
     const additions = await querySubgraphExhaustive({
       entity: 'addToBalanceEvent',
-      keys: ['timestamp', 'amount', 'amountUSD', 'caller', 'txHash'],
+      keys: ['timestamp', 'amount', 'amountUSD', 'from', 'txHash'],
       orderBy: 'timestamp',
       orderDirection: 'desc',
       block: {
@@ -512,7 +512,7 @@ export async function downloadAdditionsToBalance(
         date,
         fromWad(a.amount),
         fromWad(a.amountUSD),
-        a.caller,
+        a.from,
         a.txHash,
       ])
     })

--- a/src/utils/csvDownloadHelpers.ts
+++ b/src/utils/csvDownloadHelpers.ts
@@ -394,7 +394,7 @@ export async function downloadRedemptions(
       t`Tokens redeemed`,
       t`ETH received`,
       t`USD value of ETH received`,
-      t`Caller`,
+      t`From`,
       t`Beneficiary`,
       t`Transaction hash`,
     ], // CSV header row

--- a/src/utils/sgDbProjects.ts
+++ b/src/utils/sgDbProjects.ts
@@ -22,7 +22,7 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
   'handle',
   'metadataUri',
   'currentBalance',
-  'totalPaid',
+  'volume',
   'createdAt',
   'trendingScore',
   'deployer',
@@ -34,7 +34,7 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
 export const parseDBProjectJson = (j: Json<DBProject>): DBProject => ({
   ...j,
   tags: j.tags ?? [],
-  ...parseBigNumberKeyVals(j, ['currentBalance', 'totalPaid', 'trendingScore']),
+  ...parseBigNumberKeyVals(j, ['currentBalance', 'volume', 'trendingScore']),
 })
 
 // Parse DB Project row, converting property names from snake_case to camelCase
@@ -55,7 +55,7 @@ export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
     pv: p.pv as PV,
     tags: p.tags as ProjectTagName[],
     terminal: p.terminal,
-    totalPaid: p.total_paid,
+    volume: p.total_paid,
     trendingScore: p.trending_score,
     _hasUnresolvedMetadata: p._has_unresolved_metadata,
     _metadataRetriesLeft: p._metadata_retries_left,
@@ -81,7 +81,7 @@ export function formatDBProjectRow(p: Json<DBProject>): DBProjectRow {
     pv: p.pv,
     tags: p.tags,
     terminal: p.terminal,
-    total_paid: p.totalPaid,
+    total_paid: p.volume,
     trending_score: p.trendingScore,
     _has_unresolved_metadata: p._hasUnresolvedMetadata ?? null,
     _metadata_retries_left: p._metadataRetriesLeft ?? null,
@@ -259,7 +259,7 @@ export function formatSGProjectForDB(p: Json<Pick<Project, SGSBCompareKey>>) {
     ...p,
     // Adjust BigNumber values before we compare them to database values
     currentBalance: padBigNumForSort(p.currentBalance),
-    totalPaid: padBigNumForSort(p.totalPaid),
+    volume: padBigNumForSort(p.volume),
     trendingScore: padBigNumForSort(p.trendingScore),
   }
 }


### PR DESCRIPTION
- Rename `totalPaid`, `totalPaidUSD` -> `volume`, `volumeUSD`
- Rename `totalRedeemed`, `totalRedeemedUSD` -> `redeemVolume`, `redeemVolumeUSD`
- Use `from` in place of `caller`