### PR TITLE
chore: webp script & package.json reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "supabase:diffdb": "supabase db diff",
     "supabase:generate:local": "supabase gen types typescript --local > src/types/database.types.ts",
     "cy:run": "cypress run",
-    "cy:open": "CYPRESS_REMOTE_DEBUGGING_PORT=9222 cypress open"
+    "cy:open": "CYPRESS_REMOTE_DEBUGGING_PORT=9222 cypress open",
+    "webp": "./scripts/webp.sh"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css}": [

--- a/scripts/webp.sh
+++ b/scripts/webp.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+#
+# To install cwebp on...
+# MacOS: brew install webp
+# Ubuntu: sudo apt install webp
+# Arch: sudo pacman -S libwebp
+
+# Change quality from 0-100 to change compression ratio. See https://developers.google.com/speed/webp/docs/cwebp#options
+QUALITY=85
+
+if ! command -v cwebp > /dev/null 2>&1; then
+  echo "Error: cwebp was not found in your path. See https://developers.google.com/speed/webp/download."
+  echo "\`brew install webp\` or "
+  exit 1
+fi
+
+if [ $(pwd | xargs basename) != "juice-interface" ]; then
+  echo "Error: you must run this script from the root juice-interface directory"
+  exit 1
+fi
+
+IMGS=$(find ./public -type f -name "*.png" -o -name "*.jpg" -o -name "*.jpeg")
+
+for IMG_PATH in $IMGS; do
+ cwebp -quiet "$IMG_PATH" -q $QUALITY -o "${IMG_PATH%.*}.webp"
+ BASE=$(basename $IMG_PATH)
+ REPLACE="${BASE%.*}.webp"
+ grep -rl "$BASE" src | xargs -I {} sed -i "s#$BASE#$REPLACE#g" {} 2>/dev/null
+ rm $IMG_PATH
+done
+
+grep -ri -e "png" -e "jpg" -e "jpeg" src > remaining-references.txt
+echo "Remaining references to old filetypes written to remaining-references.txt"


### PR DESCRIPTION
Some things to know:
- The script searches and replaces based on the file's basename, meaning it will replace `foo.png` with `foo.webp` *everywhere* in src (including comments).
- The script writes any remaining references containing `png` `jpg` or `jpeg` to `remaining-references.txt`.
- By default, the script uses compression quality `85`. To use a different quality, change the first variable in the script (from 0-100).

The script requires `cwebp` to run. To install `cwebp` on...
- MacOS: brew install webp
- Ubuntu: sudo apt install webp
- Arch: sudo pacman -S libwebp
