### PR TITLE
feat: link some addresses to JB account page

### DIFF
--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -1,8 +1,7 @@
 import { SettingOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Tabs } from 'antd'
-import EtherscanLink from 'components/EtherscanLink'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import Grid from 'components/Grid'
 import { Etherscan } from 'components/icons/Etherscan'
 import Loading from 'components/Loading'
@@ -159,13 +158,12 @@ export function AccountDashboard({
             />
             <div className="flex flex-col gap-2">
               <h1 className="mb-0 font-heading text-4xl font-medium text-black dark:text-slate-100">
-                {ensName ?? <FormattedAddress address={address} />}
+                {ensName ?? <EthereumAddress address={address} />}
               </h1>
               {ensName && (
-                <EtherscanLink
-                  truncated
-                  type="address"
-                  value={address}
+                <EthereumAddress
+                  ensDisabled
+                  address={address}
                   className="text-grey-500 dark:text-slate-100"
                 />
               )}

--- a/src/components/Create/components/PayoutsMigrationModal/PayoutsMigrationModal.tsx
+++ b/src/components/Create/components/PayoutsMigrationModal/PayoutsMigrationModal.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { Trans } from '@lingui/macro'
 import { Button, Form, Modal } from 'antd'
 import { Callout } from 'components/Callout'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
 import { AllocationSplit } from 'components/v2v3/shared/Allocation'
@@ -73,7 +73,7 @@ const V1MigrationCard = ({
     >
       <div className="mb-4 flex items-center gap-2 text-lg font-medium">
         <span>Beneficiary:</span>
-        <FormattedAddress address={beneficiary} />
+        <EthereumAddress address={beneficiary} />
       </div>
       <Form.List name="projectIds">
         {(fields, { remove }) => (

--- a/src/components/Create/components/RewardsList/RewardItem.tsx
+++ b/src/components/Create/components/RewardsList/RewardItem.tsx
@@ -1,7 +1,7 @@
 import { DeleteOutlined, EditOutlined, LinkOutlined } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
+import EthereumAddress from 'components/EthereumAddress'
 import ExternalLink from 'components/ExternalLink'
-import FormattedAddress from 'components/FormattedAddress'
 import { JuiceVideoThumbnail } from 'components/NftRewards/NftVideo/JuiceVideoThumbnail'
 import TooltipLabel from 'components/TooltipLabel'
 import { useContentType } from 'hooks/ContentType'
@@ -119,7 +119,7 @@ export const RewardItem = ({
                     tip={t`The wallet address that reserved NFTs will be sent to`}
                   />
                 }
-                stat={<FormattedAddress address={beneficiary} />}
+                stat={<EthereumAddress address={beneficiary} />}
               />
             )}
             {!!votingWeight && (

--- a/src/components/Create/components/pages/PayoutsPage/components/ConvertAmountsModal.tsx
+++ b/src/components/Create/components/pages/PayoutsPage/components/ConvertAmountsModal.tsx
@@ -1,7 +1,7 @@
 import { t, Trans } from '@lingui/macro'
 import { Divider, Modal } from 'antd'
 import CurrencySwitch from 'components/CurrencySwitch'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import { Parenthesis } from 'components/Parenthesis'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
@@ -142,7 +142,7 @@ export const ConvertAmountsModal = ({
                       projectId={parseInt(allocation.projectId)}
                     />
                   ) : (
-                    <FormattedAddress address={allocation.beneficiary} />
+                    <EthereumAddress address={allocation.beneficiary} />
                   )}
                 </>
               }

--- a/src/components/Create/components/pages/ReconfigurationRules/components/RuleCard.tsx
+++ b/src/components/Create/components/pages/ReconfigurationRules/components/RuleCard.tsx
@@ -1,15 +1,13 @@
 import { CreateBadge } from 'components/Create/components/CreateBadge'
 import { Selection } from 'components/Create/components/Selection'
 import { AvailableReconfigurationStrategy } from 'components/Create/hooks/AvailableReconfigurationStrategies'
-import FormattedAddress from 'components/FormattedAddress'
-import useMobile from 'hooks/Mobile'
+import EthereumAddress from 'components/EthereumAddress'
 
 export const RuleCard = ({
   strategy,
 }: {
   strategy: AvailableReconfigurationStrategy
 }) => {
-  const isMobile = useMobile()
   return (
     <Selection.Card
       key={strategy.id}
@@ -31,8 +29,7 @@ export const RuleCard = ({
           {strategy.description}
           <div className="overflow-hidden text-grey-400 dark:text-slate-200">
             Contract address:{' '}
-            <FormattedAddress
-              truncateTo={isMobile ? 8 : 16}
+            <EthereumAddress
               address={strategy.address}
               onClick={e => e.stopPropagation()}
             />

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import ProjectLogo from 'components/ProjectLogo'
 import { ProjectTagsList } from 'components/ProjectTags/ProjectTagsList'
 import { useAppSelector } from 'redux/hooks/AppSelector'
@@ -116,7 +116,7 @@ export const ProjectDetailsReview = () => {
       {/* END: Bottom */}
       <ReviewDescription
         title={t`Project owner`}
-        desc={<FormattedAddress address={inputProjectOwner} />}
+        desc={<EthereumAddress address={inputProjectOwner} />}
       />
     </div>
   )

--- a/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/RulesReview/RulesReview.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { ReviewDescription } from '../ReviewDescription'
 import { useRulesReview } from './hooks/RulesReview'
 
@@ -24,7 +24,7 @@ export const RulesReview = () => {
             {strategy ? (
               strategy
             ) : customAddress ? (
-              <FormattedAddress address={customAddress} />
+              <EthereumAddress address={customAddress} />
             ) : (
               '??'
             )}

--- a/src/components/EthereumAddress.tsx
+++ b/src/components/EthereumAddress.tsx
@@ -2,60 +2,58 @@ import { Tooltip } from 'antd'
 import CopyTextButton from 'components/buttons/CopyTextButton'
 import EtherscanLink from 'components/EtherscanLink'
 import { useEnsName } from 'hooks/ensName'
+import Link from 'next/link'
 import { MouseEventHandler, useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { ensAvatarUrlForAddress } from 'utils/ens'
 import { truncateEthAddress } from 'utils/format/formatAddress'
 
-interface FormattedAddressProps {
+interface EthereumAddressProps {
   className?: string
   address: string | undefined
-  title?: string
   label?: string
   tooltipDisabled?: boolean
   linkDisabled?: boolean
-  showEns?: boolean
-  truncateTo?: number
+  ensDisabled?: boolean
   onClick?: MouseEventHandler
   withEnsAvatar?: boolean
+  href?: string
 }
 
-export default function FormattedAddress({
+export default function EthereumAddress({
   className,
   address,
-  title,
   label,
+  href,
+  onClick,
   tooltipDisabled = false,
   linkDisabled = false,
-  showEns = true,
-  truncateTo,
-  onClick,
-  withEnsAvatar,
-}: FormattedAddressProps) {
-  const { data: ensName } = useEnsName(address)
-
-  if (!address) return null
+  ensDisabled = false,
+  withEnsAvatar = false,
+}: EthereumAddressProps) {
+  const { data: ensName } = useEnsName(address, { enabled: !ensDisabled })
 
   const formattedAddress = useMemo(() => {
-    if (showEns && ensName) return ensName
-
     if (label) return label
+    if (!ensDisabled && ensName) return ensName
+    if (!address) return null
 
-    return truncateEthAddress({ address, truncateTo })
-  }, [address, ensName, label, showEns, truncateTo])
+    return truncateEthAddress({ address })
+  }, [address, ensName, label, ensDisabled])
+
+  if (!formattedAddress) return null
 
   return (
     <Tooltip
       title={
         <span>
-          {title ? <div>{title}</div> : null}
           {address} <CopyTextButton value={address} />
         </span>
       }
       open={tooltipDisabled ? false : undefined}
     >
       <span className="inline-flex items-center">
-        {withEnsAvatar && ensName && (
+        {withEnsAvatar && ensName && address && (
           <img
             src={ensAvatarUrlForAddress(address, { size: 40 })}
             className="mr-1.5 h-5 w-5 rounded-full"
@@ -67,15 +65,24 @@ export default function FormattedAddress({
           <span className={twMerge('select-all leading-[22px]', className)}>
             {formattedAddress}
           </span>
+        ) : href ? (
+          <Link href={href}>
+            <a
+              className={twMerge(
+                'select-all leading-[22px] text-current hover:text-bluebs-500 hover:underline',
+                className,
+              )}
+            >
+              {formattedAddress}
+            </a>
+          </Link>
         ) : (
           <EtherscanLink
             className={twMerge('select-all leading-[22px]', className)}
             onClick={onClick}
             type="address"
-            value={address}
-          >
-            {formattedAddress}
-          </EtherscanLink>
+            value={formattedAddress}
+          />
         )}
       </span>
     </Tooltip>

--- a/src/components/JuiceboxAccountLink.tsx
+++ b/src/components/JuiceboxAccountLink.tsx
@@ -1,0 +1,18 @@
+import EthereumAddress from './EthereumAddress'
+
+export function JuiceboxAccountLink({
+  address,
+  className,
+}: {
+  address: string | undefined
+  className?: string
+}) {
+  return (
+    <EthereumAddress
+      withEnsAvatar
+      href={`/account/${address}`}
+      address={address}
+      className={className}
+    />
+  )
+}

--- a/src/components/Navbar/components/Wallet/WalletMenu.tsx
+++ b/src/components/Navbar/components/Wallet/WalletMenu.tsx
@@ -5,7 +5,7 @@ import {
   UserIcon,
 } from '@heroicons/react/24/outline'
 import { t } from '@lingui/macro'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { useWallet } from 'hooks/Wallet'
 import { ReactNode, useCallback, useState } from 'react'
 import { stopPropagation } from 'react-stop-propagation'
@@ -44,12 +44,11 @@ export default function WalletMenu({ userAddress }: { userAddress: string }) {
             copied ? (
               t`Copied!`
             ) : (
-              <FormattedAddress
+              <EthereumAddress
                 tooltipDisabled
                 linkDisabled
-                showEns={false}
+                ensDisabled
                 address={userAddress}
-                truncateTo={4}
               />
             )
           }
@@ -90,7 +89,7 @@ export default function WalletMenu({ userAddress }: { userAddress: string }) {
       hideArrow
       heading={
         <div className="flex w-full cursor-pointer select-none items-center justify-center rounded-lg bg-bluebs-50 px-4 py-2.5 dark:bg-bluebs-900">
-          <FormattedAddress
+          <EthereumAddress
             address={userAddress}
             tooltipDisabled
             linkDisabled

--- a/src/components/Project/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/Project/ProjectHeader/ProjectHeader.tsx
@@ -1,7 +1,7 @@
 import { t, Trans } from '@lingui/macro'
 import { Divider, Tooltip } from 'antd'
 import { Badge } from 'components/Badge'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import Paragraph from 'components/Paragraph'
 import { GnosisSafeBadge } from 'components/Project/ProjectHeader/GnosisSafeBadge'
 import ProjectLogo from 'components/ProjectLogo'
@@ -66,7 +66,7 @@ function ProjectSubheading({
             <span className="mr-1 flex gap-1">
               <Trans>
                 <span>Owned by</span>
-                <FormattedAddress
+                <EthereumAddress
                   address={projectOwnerAddress}
                   className="inline-flex text-grey-500 dark:text-grey-300"
                 />

--- a/src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
+++ b/src/components/Project/ProjectToolsDrawer/TransferOwnershipForm.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro'
 import { Button, Form, Statistic } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import { TransactorInstance } from 'hooks/Transactor'
 import { useState } from 'react'
@@ -49,7 +49,7 @@ export function TransferOwnershipForm({
           title={<Trans>Current owner</Trans>}
           valueRender={() => (
             <span>
-              <FormattedAddress address={ownerAddress} />
+              <EthereumAddress address={ownerAddress} />
             </span>
           )}
         />

--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightOutlined } from '@ant-design/icons'
+import EthereumAddress from 'components/EthereumAddress'
 import EtherscanLink from 'components/EtherscanLink'
-import FormattedAddress from 'components/FormattedAddress'
+import { JuiceboxAccountLink } from 'components/JuiceboxAccountLink'
 import { isEqualAddress } from 'utils/address'
 import { formatHistoricalDate } from 'utils/format/formatDate'
 import { ActivityElementEvent } from './activityElementEvent'
@@ -16,12 +17,12 @@ const FromBeneficiary = ({
 
   return beneficiary && from && !isEqualAddress(beneficiary, from) ? (
     <div className="text-xs">
-      <FormattedAddress address={from} title="From" /> <ArrowRightOutlined />{' '}
-      <FormattedAddress address={beneficiary} title="Beneficiary" />
+      <EthereumAddress address={from} /> <ArrowRightOutlined />{' '}
+      <EthereumAddress address={beneficiary} />
     </div>
   ) : (
     <div className="text-sm">
-      <FormattedAddress withEnsAvatar address={from} />
+      <JuiceboxAccountLink address={from} />
     </div>
   )
 }

--- a/src/components/modals/ParticipantsModal.tsx
+++ b/src/components/modals/ParticipantsModal.tsx
@@ -8,7 +8,7 @@ import * as constants from '@ethersproject/constants'
 import { t, Trans } from '@lingui/macro'
 import { Button, Modal, Select } from 'antd'
 import ETHAmount from 'components/currency/ETHAmount'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import Loading from 'components/Loading'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { SGOrderDir, SGQueryOpts } from 'models/graph'
@@ -182,7 +182,7 @@ export default function ParticipantsModal({
             <div className="flex content-between justify-between">
               <div>
                 <div className="mr-2 leading-6">
-                  <FormattedAddress address={p.wallet.id} />
+                  <EthereumAddress address={p.wallet.id} />
                 </div>
                 <div className="text-xs text-grey-400 dark:text-slate-200">
                   <Trans>
@@ -241,7 +241,7 @@ export default function ParticipantsModal({
           {tokenAddress && !isZeroAddress(tokenAddress) && (
             <div className="mb-5">
               <Trans>
-                Token address: <FormattedAddress address={tokenAddress} />
+                Token address: <EthereumAddress address={tokenAddress} />
               </Trans>
             </div>
           )}

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/ReservesEventElem.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { PrintReservesEvent } from 'models/subgraph-entities/v1/print-reserves-event'
@@ -80,7 +80,7 @@ export default function ReservesEventElem({
               className="text-sm"
             >
               <div>
-                <FormattedAddress
+                <EthereumAddress
                   className="text-grey-900 dark:text-slate-100"
                   address={e.modBeneficiary}
                 />
@@ -107,7 +107,7 @@ export default function ReservesEventElem({
               className="text-sm"
             >
               <div>
-                <FormattedAddress
+                <EthereumAddress
                   className="text-grey-900 dark:text-slate-100"
                   address={event.beneficiary}
                 />

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/TapEventElem.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
 import ETHAmount from 'components/currency/ETHAmount'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
 import V2V3ProjectLink from 'components/v2v3/shared/V2V3ProjectLink'
 import { V1_V3_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
@@ -85,7 +85,7 @@ export default function TapEventElem({
                     )}
                   </span>
                 ) : (
-                  <FormattedAddress address={e.modBeneficiary} />
+                  <EthereumAddress address={e.modBeneficiary} />
                 )}
                 :
               </div>
@@ -106,7 +106,7 @@ export default function TapEventElem({
               className="text-sm"
             >
               <div className="font-medium">
-                <FormattedAddress address={event.beneficiary} />:
+                <EthereumAddress address={event.beneficiary} />:
               </div>
               <div>
                 <ETHAmount amount={event.beneficiaryTransferAmount} />

--- a/src/components/v1/V1Project/ProjectActivity/eventElems/V1ConfigureEventElem.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/eventElems/V1ConfigureEventElem.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
 import CurrencySymbol from 'components/CurrencySymbol'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import MinimalTable from 'components/MinimalTable'
 import { SECONDS_IN_DAY } from 'constants/numbers'
 import { V1_CURRENCY_ETH } from 'constants/v1/currency'
@@ -44,7 +44,7 @@ export default function V1ConfigureEventElem({
 
   function BallotStrategyElem(ballot: string) {
     const strategy = getBallotStrategyByAddress(ballot)
-    if (strategy.unknown) return <FormattedAddress address={ballot} />
+    if (strategy.unknown) return <EthereumAddress address={ballot} />
     else return strategy.name
   }
 

--- a/src/components/v1/V1Project/TokensSection.tsx
+++ b/src/components/v1/V1Project/TokensSection.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
 import { Button, Descriptions, Space, Statistic } from 'antd'
 import { IssueErc20TokenButton } from 'components/buttons/IssueErc20TokenButton'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import ManageTokensModal from 'components/ManageTokensModal'
 import ParticipantsModal from 'components/modals/ParticipantsModal'
 import SectionHeader from 'components/SectionHeader'
@@ -107,7 +107,7 @@ export function TokensSection() {
               {ticketsIssued && (
                 <Descriptions.Item label={t`Address`} labelStyle={labelStyle}>
                   <div className="w-full">
-                    <FormattedAddress address={tokenAddress} />
+                    <EthereumAddress address={tokenAddress} />
                   </div>
                 </Descriptions.Item>
               )}

--- a/src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
+++ b/src/components/v1/V1Project/modals/ConfirmUnstakeTokensModal.tsx
@@ -1,7 +1,7 @@
 import { t, Trans } from '@lingui/macro'
 import { Form, Modal, Space } from 'antd'
 import InputAccessoryButton from 'components/buttons/InputAccessoryButton'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import { TokenAmount } from 'components/TokenAmount'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
@@ -122,7 +122,7 @@ export default function ConfirmUnstakeTokensModal({
             <div>
               <Trans>
                 <label>{tokenSymbol} ERC-20 address:</label>{' '}
-                <FormattedAddress address={tokenAddress} />
+                <EthereumAddress address={tokenAddress} />
               </Trans>
             </div>
           )}

--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
@@ -6,7 +6,7 @@ import { useForm, useWatch } from 'antd/lib/form/Form'
 import { Callout } from 'components/Callout'
 import ETHAmount from 'components/currency/ETHAmount'
 import USDAmount from 'components/currency/USDAmount'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import Sticker from 'components/icons/Sticker'
 import { FormImageUploader } from 'components/inputs/FormImageUploader'
 import { AttachStickerModal } from 'components/modals/AttachStickerModal'
@@ -225,7 +225,7 @@ export default function V1ConfirmPayOwnerModal({
             <div>
               {userAddress ? (
                 <Trans>
-                  To: <FormattedAddress address={userAddress} />
+                  To: <EthereumAddress address={userAddress} />
                 </Trans>
               ) : null}
             </div>

--- a/src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
+++ b/src/components/v1/shared/FundingCycle/modals/DistributeTokensModal.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro'
 import { Modal, Space } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { TokenAmount } from 'components/TokenAmount'
 import TicketModsList from 'components/v1/shared/TicketModsList'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
@@ -89,7 +89,7 @@ export default function DistributeTokensModal({
         ) : (
           <p>
             <Trans>All {tokensText} will go to the project owner:</Trans>{' '}
-            <FormattedAddress address={owner} />
+            <EthereumAddress address={owner} />
           </p>
         )}
       </Space>

--- a/src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
+++ b/src/components/v1/shared/FundingCycle/modals/WithdrawModal.tsx
@@ -1,9 +1,9 @@
 import { t, Trans } from '@lingui/macro'
 import { Space } from 'antd'
+import InputAccessoryButton from 'components/buttons/InputAccessoryButton'
 import ETHAmount from 'components/currency/ETHAmount'
 import CurrencySymbol from 'components/CurrencySymbol'
-import FormattedAddress from 'components/FormattedAddress'
-import InputAccessoryButton from 'components/buttons/InputAccessoryButton'
+import EthereumAddress from 'components/EthereumAddress'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import TransactionModal from 'components/TransactionModal'
 import PayoutModsList from 'components/v1/shared/PayoutModsList'
@@ -208,7 +208,7 @@ export default function WithdrawModal({
           <p>
             <Trans>
               <ETHAmount amount={convertedAmountSubFee} /> will go to the
-              project owner: <FormattedAddress address={owner} />
+              project owner: <EthereumAddress address={owner} />
             </Trans>
           </p>
         )}

--- a/src/components/v1/shared/Mod.tsx
+++ b/src/components/v1/shared/Mod.tsx
@@ -1,8 +1,8 @@
 import { CrownFilled, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
-import { t, Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { Space, Tooltip } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import TooltipLabel from 'components/TooltipLabel'
 import V2V3ProjectLink from 'components/v2v3/shared/V2V3ProjectLink'
 import {
@@ -61,7 +61,7 @@ export default function Mod({
                     label={t`Tokens` + ':'}
                     tip={t`This address will receive any tokens minted when the recipient project gets paid.`}
                   />{' '}
-                  <FormattedAddress address={mod.beneficiary} />{' '}
+                  <EthereumAddress address={mod.beneficiary} />{' '}
                   {owner === mod.beneficiary && (
                     <Tooltip title={t`Project owner`}>
                       <CrownFilled />
@@ -72,7 +72,7 @@ export default function Mod({
             </div>
           ) : (
             <div className="flex items-baseline font-medium">
-              <FormattedAddress address={mod.beneficiary} />
+              <EthereumAddress address={mod.beneficiary} />
               {owner === mod.beneficiary && (
                 <span className="ml-1">
                   <Tooltip title={t`Project owner`}>

--- a/src/components/v1/shared/ProjectPayMods/ProjectModInput.tsx
+++ b/src/components/v1/shared/ProjectPayMods/ProjectModInput.tsx
@@ -2,7 +2,7 @@ import { CloseCircleOutlined, LockOutlined } from '@ant-design/icons'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Button, Col, Row, Space } from 'antd'
 import CurrencySymbol from 'components/CurrencySymbol'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { AllocatorBadge } from 'components/v2v3/shared/FundingCycleConfigurationDrawers/AllocatorBadge'
 import {
   NULL_ALLOCATOR_ADDRESS,
@@ -131,12 +131,12 @@ export function ProjectModInput({
           </FormattedRow>
         ) : (
           <FormattedRow label={'Address'}>
-            <FormattedAddress address={mod.beneficiary} />
+            <EthereumAddress address={mod.beneficiary} />
           </FormattedRow>
         )}
         {mod.projectId?.gt(0) && mod.allocator === NULL_ALLOCATOR_ADDRESS && (
           <FormattedRow label="Beneficiary">
-            <FormattedAddress address={mod.beneficiary} />
+            <EthereumAddress address={mod.beneficiary} />
           </FormattedRow>
         )}
         <FormattedRow label="Percentage">

--- a/src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
+++ b/src/components/v1/shared/ProjectPayMods/ProjectPayoutMods.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Button, Form, Space } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { FormItemExt } from 'components/formItems/formItemExt'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { useContext, useState } from 'react'
@@ -106,7 +106,7 @@ export default function ProjectPayoutMods({
             {owner ? (
               <Trans>
                 {(100 - total).toFixed(2)}% to{' '}
-                <FormattedAddress address={owner} />
+                <EthereumAddress address={owner} />
               </Trans>
             ) : null}
           </div>

--- a/src/components/v1/shared/ProjectTicketMods.tsx
+++ b/src/components/v1/shared/ProjectTicketMods.tsx
@@ -6,7 +6,7 @@ import {
 import { Trans, t } from '@lingui/macro'
 import { Button, Col, Form, Row, Space, Tooltip } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import {
   validateEthAddress,
   validatePercentage,
@@ -93,7 +93,7 @@ export default function ProjectTicketMods({
               <Col span={17}>
                 <div className="flex items-center justify-between">
                   <span className="cursor-pointer">
-                    <FormattedAddress address={mod.beneficiary} />
+                    <EthereumAddress address={mod.beneficiary} />
                   </span>
                 </div>
               </Col>
@@ -246,11 +246,7 @@ export default function ProjectTicketMods({
             <div>
               <Trans>
                 {(100 - total).toFixed(2)}% to{' '}
-                {owner ? (
-                  <FormattedAddress address={owner} />
-                ) : (
-                  t`project owner`
-                )}
+                {owner ? <EthereumAddress address={owner} /> : t`project owner`}
               </Trans>
             </div>
           ) : null}

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DeployETHERC20ProjectPayerEventElem.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import RichNote from 'components/RichNote'
 import { DeployETHERC20ProjectPayerEvent } from 'models/subgraph-entities/v2/deploy-eth-erc20-project-payer-event'
 
@@ -22,13 +22,13 @@ export default function DeployETHERC20ProjectPayerEventElem({
       header={t`Deployed a project payer address`}
       subject={
         <Trans>
-          from <FormattedAddress address={event.from} />
+          from <EthereumAddress address={event.from} />
         </Trans>
       }
       extra={
         <div>
           <Trans>
-            Address: <FormattedAddress address={event.address} />
+            Address: <EthereumAddress address={event.address} />
           </Trans>
           <div className="mt-2">
             <RichNote note={event.memo} />

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributePayoutsElem.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
 import ETHAmount from 'components/currency/ETHAmount'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { DistributePayoutsEvent } from 'models/subgraph-entities/v2/distribute-payouts-event'
@@ -72,7 +72,7 @@ export default function DistributePayoutsElem({
                     projectId={e.splitProjectId}
                   />
                 ) : (
-                  <FormattedAddress
+                  <EthereumAddress
                     className="text-grey-900 dark:text-slate-100"
                     address={e.beneficiary}
                   />
@@ -89,7 +89,7 @@ export default function DistributePayoutsElem({
           {event.beneficiaryDistributionAmount?.gt(0) && (
             <div className="flex items-baseline justify-between">
               <div>
-                <FormattedAddress
+                <EthereumAddress
                   className="text-grey-900 dark:text-slate-100"
                   address={event.beneficiary}
                 />

--- a/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/eventElems/DistributeReservedTokensElem.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { ActivityEvent } from 'components/activityEventElems/ActivityElement'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import useSubgraphQuery from 'hooks/SubgraphQuery'
 import { DistributeReservedTokensEvent } from 'models/subgraph-entities/v2/distribute-reserved-tokens-event'
@@ -80,7 +80,7 @@ export default function DistributeReservedTokensEventElem({
           {distributeEvents?.map(e => (
             <div key={e.id} className="flex items-baseline justify-between">
               <div>
-                <FormattedAddress
+                <EthereumAddress
                   className="text-grey-900 dark:text-slate-100"
                   address={e.beneficiary}
                 />
@@ -101,7 +101,7 @@ export default function DistributeReservedTokensEventElem({
           {event.beneficiaryTokenCount?.gt(0) && (
             <div className="flex items-baseline justify-between">
               <div>
-                <FormattedAddress
+                <EthereumAddress
                   className="text-grey-900 dark:text-slate-100"
                   address={event.beneficiary}
                 />

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/DataSourceListItems/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/DataSourceListItems/index.tsx
@@ -1,8 +1,8 @@
 import { CheckCircleOutlined, WarningOutlined } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { Tooltip } from 'antd'
+import EthereumAddress from 'components/EthereumAddress'
 import ExternalLink from 'components/ExternalLink'
-import FormattedAddress from 'components/FormattedAddress'
 import { JB721DelegateContractsContext } from 'contexts/NftRewards/JB721DelegateContracts/JB721DelegateContractsContext'
 import { V2V3FundingCycleMetadata } from 'models/v2v3/fundingCycle'
 import { useContext } from 'react'
@@ -23,7 +23,7 @@ function DataSourceAddressValue({ address }: { address: string | undefined }) {
 
   return (
     <span>
-      <FormattedAddress address={address} />{' '}
+      <EthereumAddress address={address} />{' '}
       {version ? (
         <Tooltip
           title={

--- a/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/AccountBalanceDescription/V2V3ClaimTokensModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/AccountBalanceDescription/V2V3ClaimTokensModal.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { t, Trans } from '@lingui/macro'
 import { Descriptions, Form } from 'antd'
 import InputAccessoryButton from 'components/buttons/InputAccessoryButton'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import { TokenAmount } from 'components/TokenAmount'
 import TransactionModal from 'components/TransactionModal'
@@ -149,7 +149,7 @@ export function V2V3ClaimTokensModal({
             <Descriptions.Item
               label={<Trans>{tokenSymbol} ERC-20 address</Trans>}
             >
-              <FormattedAddress address={tokenAddress} />
+              <EthereumAddress address={tokenAddress} />
             </Descriptions.Item>
           )}
         </Descriptions>

--- a/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/ProjectTokenDescription/ProjectTokenDescription.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ManageTokensSection/ProjectTokenDescription/ProjectTokenDescription.tsx
@@ -1,4 +1,4 @@
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useContext } from 'react'
 import AddERC20ToWalletButton from './AddERC20ToWalletButton'
@@ -9,7 +9,7 @@ export function ProjectTokenDescription() {
   return (
     <div>
       {tokenSymbol} (
-      <FormattedAddress address={tokenAddress} />)
+      <EthereumAddress address={tokenAddress} />)
       <AddERC20ToWalletButton />
     </div>
   )

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3PayForm.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3PayForm.tsx
@@ -6,7 +6,7 @@ import { FormInstance, FormProps, useWatch } from 'antd/lib/form/Form'
 import { Callout } from 'components/Callout'
 import ETHAmount from 'components/currency/ETHAmount'
 import USDAmount from 'components/currency/USDAmount'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import Sticker from 'components/icons/Sticker'
 import { EthAddressInput } from 'components/inputs/EthAddressInput'
 import { FormImageUploader } from 'components/inputs/FormImageUploader'
@@ -130,7 +130,7 @@ export const V2V3PayForm = ({
                   </Form.Item>
 
                   {beneficiary && !customBeneficiaryEnabled && (
-                    <FormattedAddress address={beneficiary} />
+                    <EthereumAddress address={beneficiary} />
                   )}
 
                   {customBeneficiaryEnabled ? (

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/V1V2TokenMigrationSettingsPage/TokenMigrationSetupSection/TokenMigrationSetupModal/GrantChangeTokenPermissionSection.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/V1V2TokenMigrationSettingsPage/TokenMigrationSetupSection/TokenMigrationSetupModal/GrantChangeTokenPermissionSection.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro'
 import { Button } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { MinimalCollapse } from 'components/MinimalCollapse'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
@@ -63,7 +63,7 @@ export function GrantChangeTokenPermissionSection({
     >
       <p>
         Grant the Token Deployer contract (
-        <FormattedAddress address={deployer?.address} />) permission to change
+        <EthereumAddress address={deployer?.address} />) permission to change
         your project's token.
       </p>
       <MinimalCollapse

--- a/src/components/v2v3/V2V3Project/modals/PaymentAddressesModal.tsx
+++ b/src/components/v2v3/V2V3Project/modals/PaymentAddressesModal.tsx
@@ -3,8 +3,8 @@ import { plural, t, Trans } from '@lingui/macro'
 import { Modal, Tooltip } from 'antd'
 import CopyTextButton from 'components/buttons/CopyTextButton'
 import { Callout } from 'components/Callout'
+import EthereumAddress from 'components/EthereumAddress'
 import EtherscanLink from 'components/EtherscanLink'
-import FormattedAddress from 'components/FormattedAddress'
 import TooltipLabel from 'components/TooltipLabel'
 import useMobile from 'hooks/Mobile'
 import { ETHERC20ProjectPayer } from 'models/subgraph-entities/v2/eth-erc20-project-payer'
@@ -78,9 +78,8 @@ export function PaymentAddressesModal({
                           </Trans>
                         }
                         label={
-                          <FormattedAddress
+                          <EthereumAddress
                             address={p.beneficiary}
-                            truncateTo={3}
                             className="font-medium"
                           />
                         }

--- a/src/components/v2v3/shared/Allocation/components/AllocationItemTitle.tsx
+++ b/src/components/v2v3/shared/Allocation/components/AllocationItemTitle.tsx
@@ -1,7 +1,7 @@
 import { LockFilled } from '@ant-design/icons'
 import { t } from '@lingui/macro'
 import { Tooltip } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import { formatDate } from 'utils/format/formatDate'
 import { isProjectSplit } from 'utils/splits'
@@ -17,7 +17,7 @@ export function AllocationItemTitle({
       {isProjectSplit(allocation) && allocation.projectId ? (
         <V2V3ProjectHandleLink projectId={parseInt(allocation.projectId)} />
       ) : (
-        <FormattedAddress address={allocation.beneficiary} />
+        <EthereumAddress address={allocation.beneficiary} />
       )}
       {!!allocation.lockedUntil && (
         <Tooltip

--- a/src/components/v2v3/shared/DiffedSplits/DiffedSplitFields/DiffedJBProjectBeneficiary.tsx
+++ b/src/components/v2v3/shared/DiffedSplits/DiffedSplitFields/DiffedJBProjectBeneficiary.tsx
@@ -1,4 +1,4 @@
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { Split } from 'models/splits'
 import { DiffedItem } from '../../DiffedItem'
 import { JuiceboxProjectBeneficiary } from '../../SplitItem/JuiceboxProjectBeneficiary'
@@ -22,11 +22,11 @@ export function DiffedJBProjectBeneficiary({
         hasDiff ? (
           <div className="flex">
             <DiffedItem
-              value={<FormattedAddress address={oldSplit.beneficiary} />}
+              value={<EthereumAddress address={oldSplit.beneficiary} />}
               diffStatus="old"
             />
             <DiffedItem
-              value={<FormattedAddress address={split.beneficiary} />}
+              value={<EthereumAddress address={split.beneficiary} />}
               diffStatus="new"
             />
           </div>

--- a/src/components/v2v3/shared/PayoutCard/PayoutCard.tsx
+++ b/src/components/v2v3/shared/PayoutCard/PayoutCard.tsx
@@ -1,6 +1,6 @@
 import { DeleteOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { DeleteConfirmationModal } from 'components/modals/DeleteConfirmationModal'
 import { Allocation, AllocationSplit } from 'components/v2v3/shared/Allocation'
 import { AllocationItemTitle } from 'components/v2v3/shared/Allocation/components/AllocationItemTitle'
@@ -57,7 +57,7 @@ export const PayoutCard = ({
         body={
           <Trans>
             This will delete the payout for{' '}
-            <FormattedAddress address={allocation.beneficiary} />.
+            <EthereumAddress address={allocation.beneficiary} />.
           </Trans>
         }
       />

--- a/src/components/v2v3/shared/SplitItem/EthAddressBeneficiary.tsx
+++ b/src/components/v2v3/shared/SplitItem/EthAddressBeneficiary.tsx
@@ -1,7 +1,7 @@
 import { CrownFilled } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import { JuiceboxAccountLink } from 'components/JuiceboxAccountLink'
 import { isEqualAddress } from 'utils/address'
 
 export function ETHAddressBeneficiary({
@@ -16,7 +16,7 @@ export function ETHAddressBeneficiary({
   return (
     <div className="flex items-center justify-center gap-1 font-medium">
       {beneficaryAddress ? (
-        <FormattedAddress address={beneficaryAddress} />
+        <JuiceboxAccountLink address={beneficaryAddress} />
       ) : null}
       {!beneficaryAddress && isProjectOwner ? (
         <Trans>Project owner (you)</Trans>

--- a/src/components/v2v3/shared/SplitItem/JuiceboxProjectBeneficiary.tsx
+++ b/src/components/v2v3/shared/SplitItem/JuiceboxProjectBeneficiary.tsx
@@ -1,7 +1,7 @@
 import { CrownFilled } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
-import FormattedAddress from 'components/FormattedAddress'
+import EthereumAddress from 'components/EthereumAddress'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
 import { Split } from 'models/splits'
 import { isEqualAddress } from 'utils/address'
@@ -40,7 +40,7 @@ export function JuiceboxProjectBeneficiary({
               <Trans>Tokens:</Trans>
             </span>
           </Tooltip>
-          {value ?? <FormattedAddress address={split.beneficiary} />}{' '}
+          {value ?? <EthereumAddress address={split.beneficiary} />}{' '}
           {isProjectOwner && (
             <Tooltip title={<Trans>Project owner</Trans>}>
               <CrownFilled />

--- a/src/hooks/ensName.ts
+++ b/src/hooks/ensName.ts
@@ -5,12 +5,21 @@ import { useQuery } from 'react-query'
 /**
  * Try to resolve an address to an ENS name.
  */
-export function useEnsName(address: string | undefined) {
-  return useQuery(['ensName', address], async () => {
-    if (!address || !isAddress(address)) return
+export function useEnsName(
+  address: string | undefined,
+  { enabled }: { enabled?: boolean } = {},
+) {
+  return useQuery(
+    ['ensName', address],
+    async () => {
+      if (!address || !isAddress(address)) return
 
-    const data = await resolveAddress(address)
+      const data = await resolveAddress(address)
 
-    return data.name
-  })
+      return data.name
+    },
+    {
+      enabled,
+    },
+  )
 }

--- a/src/pages/activity/Payments.tsx
+++ b/src/pages/activity/Payments.tsx
@@ -1,5 +1,5 @@
 import ETHAmount from 'components/currency/ETHAmount'
-import FormattedAddress from 'components/FormattedAddress'
+import { JuiceboxAccountLink } from 'components/JuiceboxAccountLink'
 import Loading from 'components/Loading'
 import RichNote from 'components/RichNote'
 import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
@@ -73,7 +73,7 @@ export function PaymentsFeed() {
                   <ETHAmount amount={e.amount} precision={2} />
                 </span>
                 <span>
-                  <FormattedAddress address={e.beneficiary} withEnsAvatar />
+                  <JuiceboxAccountLink address={e.beneficiary} />
                 </span>
               </div>
               <div>

--- a/src/utils/format/formatAddress.ts
+++ b/src/utils/format/formatAddress.ts
@@ -16,7 +16,6 @@ export function truncateEthAddress({
   truncateTo?: number
 }) {
   const frontTruncate = truncateTo + 2 // account for 0x
-
   return (
     address.substring(0, frontTruncate) +
     '...' +


### PR DESCRIPTION
- rename FormattedAddress component to EthereumAddress
- Add JuiceboxAccountProfile component
- Show avatars on payouts
- remove/rename EthereumAddress props