### PR TITLE
feat: enable CORs for projects API

### DIFF
--- a/src/pages/api/projects/index.page.ts
+++ b/src/pages/api/projects/index.page.ts
@@ -11,6 +11,15 @@ const handler: NextApiHandler = async (req, res) => {
   const { text, tags, page, pageSize, archived, pv, orderDirection, orderBy } =
     req.query
 
+  // https://vercel.com/guides/how-to-enable-cors#enabling-cors-in-a-next.js-app
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET')
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+  )
+
   if (text && typeof text !== 'string') {
     res.status(400).send('Text is not a string')
     return


### PR DESCRIPTION
This PR enables CORs for the `/api/projects` endpoint. This will be very useful for organizations building on top of juicebox that need project search (nance and Project Cards).

source: https://vercel.com/guides/how-to-enable-cors#enabling-cors-in-a-next.js-app