### PR TITLE
Fix loading pay button not full width

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3PayButton.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3PayButton.tsx
@@ -54,7 +54,10 @@ export function V2V3PayButton({ disabled, wrapperClassName }: PayButtonProps) {
         className="block"
       >
         <Button
-          className="w-full"
+          // Need inline style here because AntD Button overrides className when disabled
+          style={{
+            width: '100%',
+          }}
           type="primary"
           size="large"
           onClick={() => {


### PR DESCRIPTION
Fixes JB-332

Problem was that AntD overrides the given `w-full` className when button is disabled. Quick and easy fix is just using inline style in this case. 

https://github.com/jbx-protocol/juice-interface/assets/96150256/df4d85c3-706c-4c95-afe8-07430549926d

