### PR TITLE
Wallet activity on Account page

### DIFF
--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -44,11 +44,11 @@ function ProjectsList({ projects }: { projects: ProjectCardProject[] }) {
 function ContributedList({ address }: { address: string }) {
   const orderByOpts = (): { label: string; value: Participant_OrderBy }[] => [
     {
-      label: 'Highest paid',
+      label: t`Highest paid`,
       value: Participant_OrderBy.volume,
     },
     {
-      label: 'Recent',
+      label: t`Recent`,
       value: Participant_OrderBy.lastPaidTimestamp,
     },
   ]

--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -1,10 +1,11 @@
 import { SettingOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
-import { Button, Select, Tabs } from 'antd'
+import { Button, Tabs } from 'antd'
 import ActivityList from 'components/ActivityList'
 import EthereumAddress from 'components/EthereumAddress'
 import Grid from 'components/Grid'
 import { Etherscan } from 'components/icons/Etherscan'
+import { JuiceListbox } from 'components/inputs/JuiceListbox'
 import Loading from 'components/Loading'
 import Paragraph from 'components/Paragraph'
 import SocialLinks from 'components/Project/ProjectHeader/SocialLinks'
@@ -41,8 +42,19 @@ function ProjectsList({ projects }: { projects: ProjectCardProject[] }) {
 }
 
 function ContributedList({ address }: { address: string }) {
+  const orderByOpts = (): { label: string; value: Participant_OrderBy }[] => [
+    {
+      label: 'Highest paid',
+      value: Participant_OrderBy.volume,
+    },
+    {
+      label: 'Recent',
+      value: Participant_OrderBy.lastPaidTimestamp,
+    },
+  ]
+
   const [orderBy, setOrderBy] = useState<Participant_OrderBy>(
-    Participant_OrderBy.volume,
+    orderByOpts()[0].value,
   )
 
   const { data, loading: contributionsLoading } = useWalletContributionsQuery({
@@ -86,14 +98,12 @@ function ContributedList({ address }: { address: string }) {
 
   return (
     <div>
-      <Select className="mb-6 w-44" value={orderBy} onChange={setOrderBy}>
-        <Select.Option value={Participant_OrderBy.volume}>
-          <Trans>Highest paid</Trans>
-        </Select.Option>
-        <Select.Option value={Participant_OrderBy.lastPaidTimestamp}>
-          <Trans>Recent</Trans>
-        </Select.Option>
-      </Select>
+      <JuiceListbox
+        className="mb-6 w-[240px]"
+        options={orderByOpts()}
+        value={orderByOpts().find(o => o.value === orderBy)}
+        onChange={v => setOrderBy(v.value)}
+      />
 
       <Grid>
         {contributions?.map(c => (

--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -1,6 +1,7 @@
 import { SettingOutlined } from '@ant-design/icons'
 import { t, Trans } from '@lingui/macro'
 import { Button, Select, Tabs } from 'antd'
+import ActivityList from 'components/ActivityList'
 import EthereumAddress from 'components/EthereumAddress'
 import Grid from 'components/Grid'
 import { Etherscan } from 'components/icons/Etherscan'
@@ -168,6 +169,11 @@ export function AccountDashboard({
   }, [router, signIn, wallet.userAddress])
 
   const items = [
+    {
+      label: t`Activity`,
+      key: 'activity',
+      children: <ActivityList from={address} />,
+    },
     {
       label: t`Contributions`,
       key: 'holding',

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -1,0 +1,227 @@
+import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
+import { Trans, t } from '@lingui/macro'
+import { Button, Divider } from 'antd'
+import Loading from 'components/Loading'
+import { JuiceListbox } from 'components/inputs/JuiceListbox'
+import { PV_V1, PV_V2 } from 'constants/pv'
+import {
+  ProjectEventFilter,
+  ProjectEventsQueryArgs,
+  useProjectEvents,
+} from 'hooks/useProjectEvents'
+import { useMemo, useState } from 'react'
+import { AnyProjectEvent } from './activityEventElems/AnyProjectEvent'
+
+interface ActivityOption {
+  label: string
+  value: ProjectEventFilter
+}
+
+const ALL_OPT: ActivityOption = { label: t`All activity`, value: 'all' }
+
+const PV1_OPTS: ActivityOption[] = [
+  ALL_OPT,
+  { label: t`Paid`, value: 'payEvent' },
+  { label: t`Redeemed`, value: 'redeemEvent' },
+  { label: t`Burned`, value: 'burnEvent' },
+  { label: t`Sent payouts`, value: 'tapEvent' },
+  { label: t`Sent reserved tokens`, value: 'printReservesEvent' },
+  { label: t`Edited cycle`, value: 'v1ConfigureEvent' },
+  { label: t`Deployed ERC20`, value: 'deployedERC20Event' },
+  { label: t`Transferred ETH to project`, value: 'addToBalanceEvent' },
+  { label: t`Created project`, value: 'projectCreateEvent' },
+]
+
+const PV2_OPTS: ActivityOption[] = [
+  ALL_OPT,
+  { label: t`Paid`, value: 'payEvent' },
+  { label: t`Redeemed`, value: 'redeemEvent' },
+  { label: t`Burned`, value: 'burnEvent' },
+  { label: t`Sent payouts`, value: 'distributePayoutsEvent' },
+  {
+    label: t`Sent reserved tokens`,
+    value: 'distributeReservedTokensEvent',
+  },
+  { label: t`Edited cycle`, value: 'configureEvent' },
+  { label: t`Edited payout`, value: 'setFundAccessConstraintsEvent' },
+  { label: t`Transferred ETH to project`, value: 'addToBalanceEvent' },
+  { label: t`Deployed ERC20`, value: 'deployedERC20Event' },
+  {
+    label: t`Created a project payer address`,
+    value: 'deployETHERC20ProjectPayerEvent',
+  },
+  { label: t`Created project`, value: 'projectCreateEvent' },
+]
+
+const SHARED_OPTS: ActivityOption[] = [
+  ALL_OPT,
+  { label: t`Paid`, value: 'payEvent' },
+  { label: t`Redeemed`, value: 'redeemEvent' },
+  { label: t`Burned`, value: 'burnEvent' },
+  { label: t`Sent payouts`, value: 'distributePayoutsEvent' },
+  { label: t`Sent payouts (v1)`, value: 'tapEvent' },
+  {
+    label: t`Sent reserved tokens`,
+    value: 'distributeReservedTokensEvent',
+  },
+  {
+    label: t`Sent reserved tokens (v1)`,
+    value: 'printReservesEvent',
+  },
+  { label: t`Edited cycle`, value: 'configureEvent' },
+  { label: t`Edited cycle (v1)`, value: 'v1ConfigureEvent' },
+  { label: t`Edited payout`, value: 'setFundAccessConstraintsEvent' },
+  { label: t`Transferred ETH to project`, value: 'addToBalanceEvent' },
+  { label: t`Deployed ERC20`, value: 'deployedERC20Event' },
+  {
+    label: t`Created a project payer address`,
+    value: 'deployETHERC20ProjectPayerEvent',
+  },
+  { label: t`Created project`, value: 'projectCreateEvent' },
+]
+
+export default function ActivityList({
+  projectId,
+  pv,
+  from,
+  pageSize,
+  tokenSymbol,
+  header,
+  setDownloadModalVisible,
+  downloadComponent,
+}: Pick<ProjectEventsQueryArgs, 'projectId' | 'pv' | 'from'> & {
+  pageSize?: number
+  tokenSymbol?: string
+  header?: JSX.Element | null
+  setDownloadModalVisible?: (visible: boolean) => void
+  downloadComponent?: JSX.Element | null
+}) {
+  const [eventFilter, setEventFilter] = useState<ProjectEventFilter>('all')
+
+  const activityOptions = useMemo((): ActivityOption[] => {
+    switch (pv) {
+      case PV_V1:
+        return PV1_OPTS
+      case PV_V2:
+        return PV2_OPTS
+      default:
+        return SHARED_OPTS
+    }
+  }, [pv])
+
+  const [isFetchingMore, setIsFetchingMore] = useState<boolean>()
+
+  const _pageSize = pageSize ?? 10
+
+  const { data, fetchMore, loading } = useProjectEvents({
+    filter: eventFilter,
+    projectId,
+    pv,
+    from,
+    first: _pageSize,
+  })
+
+  const isLoading = loading || isFetchingMore
+
+  const projectEvents = data?.projectEvents
+
+  const activityOption = activityOptions.find(o => o.value === eventFilter)
+
+  const count = projectEvents?.length || 0
+
+  const list = useMemo(
+    () =>
+      projectEvents?.map(e => (
+        <div
+          className="mb-5 border-b border-smoke-200 pb-5 dark:border-grey-600"
+          key={e.id}
+        >
+          <AnyProjectEvent
+            event={e}
+            tokenSymbol={tokenSymbol}
+            withProjectLink={!projectId}
+          />
+        </div>
+      )),
+    [projectEvents, tokenSymbol, projectId],
+  )
+
+  const listStatus = useMemo(() => {
+    if (isLoading) {
+      return (
+        <div>
+          <Loading />
+        </div>
+      )
+    }
+
+    if (count === 0 && !isLoading) {
+      return (
+        <>
+          <Divider />
+          <div className="my-5 pb-5 text-grey-500 dark:text-grey-300">
+            <Trans>No activity yet</Trans>
+          </div>
+        </>
+      )
+    }
+
+    if (count % _pageSize === 0) {
+      return (
+        <div className="text-center">
+          <Button
+            onClick={() => {
+              setIsFetchingMore(true)
+              fetchMore({
+                variables: {
+                  skip: count,
+                },
+              }).finally(() => setIsFetchingMore(false))
+            }}
+            type="link"
+            className="px-0"
+          >
+            <Trans>Load more</Trans>
+          </Button>
+        </div>
+      )
+    }
+
+    return (
+      <div className="p-2 text-center text-grey-500 dark:text-grey-300">
+        <Trans>{count} total</Trans>
+      </div>
+    )
+  }, [isLoading, fetchMore, count, _pageSize])
+
+  return (
+    <div>
+      <div className="mb-5 flex items-baseline justify-between">
+        {header}
+
+        <div className="flex gap-2">
+          {count > 0 && downloadComponent && setDownloadModalVisible && (
+            <Button
+              type="text"
+              icon={<ArrowDownTrayIcon className="inline h-5 w-5" />}
+              onClick={() => setDownloadModalVisible(true)}
+            />
+          )}
+
+          <JuiceListbox
+            className="w-[200px]"
+            options={activityOptions}
+            value={activityOption}
+            onChange={v => setEventFilter(v.value)}
+          />
+        </div>
+      </div>
+
+      {list}
+
+      {listStatus}
+
+      {downloadComponent}
+    </div>
+  )
+}

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -74,7 +74,7 @@ const SHARED_OPTS = (): ActivityOption[] => [
   { label: t`Transferred ETH to project`, value: 'addToBalanceEvent' },
   { label: t`Deployed ERC20`, value: 'deployedERC20Event' },
   {
-    label: t`Created a project payer address`,
+    label: t`Deployed project payer`,
     value: 'deployETHERC20ProjectPayerEvent',
   },
   { label: t`Created project`, value: 'projectCreateEvent' },
@@ -128,6 +128,8 @@ export default function ActivityList({
   const activityOption = activityOptions.find(o => o.value === eventFilter)
 
   const count = projectEvents?.length || 0
+
+  const hasDownload = count > 0 && downloadComponent && setDownloadModalVisible
 
   const list = useMemo(
     () =>
@@ -200,7 +202,7 @@ export default function ActivityList({
         {header}
 
         <div className="flex gap-2">
-          {count > 0 && downloadComponent && setDownloadModalVisible && (
+          {hasDownload && (
             <Button
               type="text"
               icon={<ArrowDownTrayIcon className="inline h-5 w-5" />}
@@ -209,7 +211,7 @@ export default function ActivityList({
           )}
 
           <JuiceListbox
-            className="w-[200px]"
+            className={hasDownload ? 'w-[200px]' : 'w-[240px]'}
             options={activityOptions}
             value={activityOption}
             onChange={v => setEventFilter(v.value)}

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -17,10 +17,10 @@ interface ActivityOption {
   value: ProjectEventFilter
 }
 
-const ALL_OPT: ActivityOption = { label: t`All activity`, value: 'all' }
+const ALL_OPT = (): ActivityOption => ({ label: t`All activity`, value: 'all' })
 
-const PV1_OPTS: ActivityOption[] = [
-  ALL_OPT,
+const PV1_OPTS = (): ActivityOption[] => [
+  ALL_OPT(),
   { label: t`Paid`, value: 'payEvent' },
   { label: t`Redeemed`, value: 'redeemEvent' },
   { label: t`Burned`, value: 'burnEvent' },
@@ -32,8 +32,8 @@ const PV1_OPTS: ActivityOption[] = [
   { label: t`Created project`, value: 'projectCreateEvent' },
 ]
 
-const PV2_OPTS: ActivityOption[] = [
-  ALL_OPT,
+const PV2_OPTS = (): ActivityOption[] => [
+  ALL_OPT(),
   { label: t`Paid`, value: 'payEvent' },
   { label: t`Redeemed`, value: 'redeemEvent' },
   { label: t`Burned`, value: 'burnEvent' },
@@ -53,8 +53,8 @@ const PV2_OPTS: ActivityOption[] = [
   { label: t`Created project`, value: 'projectCreateEvent' },
 ]
 
-const SHARED_OPTS: ActivityOption[] = [
-  ALL_OPT,
+const SHARED_OPTS = (): ActivityOption[] => [
+  ALL_OPT(),
   { label: t`Paid`, value: 'payEvent' },
   { label: t`Redeemed`, value: 'redeemEvent' },
   { label: t`Burned`, value: 'burnEvent' },
@@ -101,11 +101,11 @@ export default function ActivityList({
   const activityOptions = useMemo((): ActivityOption[] => {
     switch (pv) {
       case PV_V1:
-        return PV1_OPTS
+        return PV1_OPTS()
       case PV_V2:
-        return PV2_OPTS
+        return PV2_OPTS()
       default:
-        return SHARED_OPTS
+        return SHARED_OPTS()
     }
   }, [pv])
 

--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -2,8 +2,13 @@ import { ArrowRightOutlined } from '@ant-design/icons'
 import EthereumAddress from 'components/EthereumAddress'
 import EtherscanLink from 'components/EtherscanLink'
 import { JuiceboxAccountLink } from 'components/JuiceboxAccountLink'
+import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
+import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
+import { PV_V2 } from 'constants/pv'
+import { PV } from 'models/pv'
 import { isEqualAddress } from 'utils/address'
 import { formatHistoricalDate } from 'utils/format/formatDate'
+
 import { ActivityElementEvent } from './activityElementEvent'
 
 const FromBeneficiary = ({
@@ -33,10 +38,38 @@ const ExtraContainer: React.FC<React.PropsWithChildren<unknown>> = ({
   return <div className="mt-2">{children}</div>
 }
 
-function Header({ header }: { header: string | JSX.Element }) {
+function Header({
+  header,
+  projectId,
+  handle,
+  pv,
+}: {
+  header: string | JSX.Element
+  projectId?: number
+  handle?: string | null
+  pv?: PV
+}) {
+  const withProjectLink = projectId && pv
+
   return (
     <div className="text-xs capitalize text-grey-500 dark:text-grey-300">
       {header}
+      {withProjectLink && (
+        <span className="ml-1">
+          {pv === PV_V2 ? (
+            <V2V3ProjectHandleLink
+              projectId={projectId}
+              className="text-grey-500 dark:text-grey-300"
+            />
+          ) : (
+            <V1ProjectHandle
+              projectId={projectId}
+              handle={handle}
+              className="text-grey-500 dark:text-grey-300"
+            />
+          )}
+        </span>
+      )}
     </div>
   )
 }
@@ -74,11 +107,15 @@ export function ActivityEvent({
   subject,
   extra,
   event,
+  withProjectLink,
+  pv,
 }: {
   header: string | JSX.Element
   subject: string | JSX.Element | null
   event: ActivityElementEvent | null | undefined
   extra?: string | JSX.Element | null
+  withProjectLink?: boolean
+  pv?: PV
 }) {
   if (!event) return null
 
@@ -86,7 +123,12 @@ export function ActivityEvent({
     <>
       <div>
         <div className="flex items-center justify-between">
-          <Header header={header} />
+          <Header
+            header={header}
+            projectId={withProjectLink ? event.projectId : undefined}
+            pv={withProjectLink ? event.pv || pv : undefined}
+            handle={withProjectLink ? event.project?.handle : undefined}
+          />
           <TimestampVersion {...event} />
         </div>
 

--- a/src/components/activityEventElems/ActivityElement/activityElementEvent.ts
+++ b/src/components/activityEventElems/ActivityElement/activityElementEvent.ts
@@ -1,7 +1,14 @@
+import { PV } from 'models/pv'
+
 export interface ActivityElementEvent {
   timestamp: number
   txHash: string
   from: string
   beneficiary?: string
   terminal?: string
+  projectId?: number
+  project?: {
+    handle?: string | null
+  }
+  pv?: PV
 }

--- a/src/components/activityEventElems/AddToBalanceEventElem.tsx
+++ b/src/components/activityEventElems/AddToBalanceEventElem.tsx
@@ -7,14 +7,17 @@ import { ActivityEvent } from './ActivityElement'
 
 export default function AddToBalanceEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['addToBalanceEvent']
+  withProjectLink?: boolean
 }) {
   if (!event) return null
 
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
       header={t`Transferred ETH to project`}
       subject={
         <span className="text-base font-medium">

--- a/src/components/activityEventElems/AnyProjectEvent.tsx
+++ b/src/components/activityEventElems/AnyProjectEvent.tsx
@@ -18,68 +18,123 @@ import SetFundAccessConstraintsEventElem from './v2v3/SetFundAccessConstraintsEv
 /**
  * Returns a formatted element for any project event
  * @param event Project event object
- * @param tokenSymbol Must be defined for projectEvents with a `burnEvent`
+ * @param tokenSymbol Should be defined for projectEvents with a `burnEvent`, otherwise default "tokens" text will be used.
  */
 export function AnyProjectEvent({
   event,
   tokenSymbol,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][number]
-  tokenSymbol: string | undefined
+  tokenSymbol?: string
+  withProjectLink?: boolean
 }) {
   if (event.addToBalanceEvent) {
-    return <AddToBalanceEventElem event={event.addToBalanceEvent} />
+    return (
+      <AddToBalanceEventElem
+        event={event.addToBalanceEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.burnEvent) {
-    return <BurnEventElem event={event.burnEvent} tokenSymbol={tokenSymbol} />
+    return (
+      <BurnEventElem
+        event={event.burnEvent}
+        tokenSymbol={tokenSymbol}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.configureEvent) {
-    return <ConfigureEventElem event={event.configureEvent} />
+    return (
+      <ConfigureEventElem
+        event={event.configureEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.deployedERC20Event) {
-    return <DeployedERC20EventElem event={event.deployedERC20Event} />
+    return (
+      <DeployedERC20EventElem
+        event={event.deployedERC20Event}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.deployETHERC20ProjectPayerEvent) {
     return (
       <DeployETHERC20ProjectPayerEventElem
         event={event.deployETHERC20ProjectPayerEvent}
+        withProjectLink={withProjectLink}
       />
     )
   }
   if (event.distributePayoutsEvent) {
-    return <DistributePayoutsElem event={event.distributePayoutsEvent} />
+    return (
+      <DistributePayoutsElem
+        event={event.distributePayoutsEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.distributeReservedTokensEvent) {
     return (
       <DistributeReservedTokensEventElem
         event={event.distributeReservedTokensEvent}
+        withProjectLink={withProjectLink}
       />
     )
   }
   if (event.payEvent) {
-    return <PayEventElem event={event.payEvent} />
+    return (
+      <PayEventElem event={event.payEvent} withProjectLink={withProjectLink} />
+    )
   }
   if (event.printReservesEvent) {
-    return <ReservesEventElem event={event.printReservesEvent} />
+    return (
+      <ReservesEventElem
+        event={event.printReservesEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.projectCreateEvent) {
-    return <ProjectCreateEventElem event={event.projectCreateEvent} />
+    return (
+      <ProjectCreateEventElem
+        event={event.projectCreateEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.redeemEvent) {
-    return <RedeemEventElem event={event.redeemEvent} />
+    return (
+      <RedeemEventElem
+        event={event.redeemEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
   if (event.setFundAccessConstraintsEvent) {
     return (
       <SetFundAccessConstraintsEventElem
         event={event.setFundAccessConstraintsEvent}
+        withProjectLink={withProjectLink}
       />
     )
   }
   if (event.tapEvent) {
-    return <TapEventElem event={event.tapEvent} />
+    return (
+      <TapEventElem event={event.tapEvent} withProjectLink={withProjectLink} />
+    )
   }
   if (event.v1ConfigureEvent) {
-    return <V1ConfigureEventElem event={event.v1ConfigureEvent} />
+    return (
+      <V1ConfigureEventElem
+        event={event.v1ConfigureEvent}
+        withProjectLink={withProjectLink}
+      />
+    )
   }
 
   console.error('Unhandled project event element', event)

--- a/src/components/activityEventElems/AnyProjectEvent.tsx
+++ b/src/components/activityEventElems/AnyProjectEvent.tsx
@@ -41,7 +41,10 @@ export function AnyProjectEvent({
     return (
       <BurnEventElem
         event={event.burnEvent}
-        tokenSymbol={tokenSymbol}
+        tokenSymbol={
+          // TODO tokenSymbol is currently obtained via Context. However the context will vary depending on project version, and will not be present if rendering BurnEventElem outside a project dashboard. We should find another option for cacheing tokenSymbols so the component can do a lookup itself without needing an on-chain call. This will avoid parent components needing to pass down tokenSymbol to this component just to properly render BurnEventElems
+          tokenSymbol
+        }
         withProjectLink={withProjectLink}
       />
     )
@@ -137,7 +140,7 @@ export function AnyProjectEvent({
     )
   }
 
-  console.error('Unhandled project event element', event)
+  console.error('AnyProjectEvent: Unhandled project event', event)
 
   return null
 }

--- a/src/components/activityEventElems/BurnEventElem.tsx
+++ b/src/components/activityEventElems/BurnEventElem.tsx
@@ -7,15 +7,18 @@ import { ActivityEvent } from './ActivityElement'
 export default function BurnEventElem({
   event,
   tokenSymbol,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['burnEvent']
   tokenSymbol: string | undefined
+  withProjectLink?: boolean
 }) {
   if (!event) return null
 
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
       header={t`Burned`}
       subject={
         <span className="text-base font-medium">

--- a/src/components/activityEventElems/DeployedERC20EventElem.tsx
+++ b/src/components/activityEventElems/DeployedERC20EventElem.tsx
@@ -4,13 +4,16 @@ import { ActivityEvent } from './ActivityElement/ActivityElement'
 
 export default function DeployedERC20EventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['deployedERC20Event']
+  withProjectLink?: boolean
 }) {
   if (!event) return null
   return (
     <ActivityEvent
       header={t`Deployed ERC20 token`}
+      withProjectLink={withProjectLink}
       subject={<div className="text-base">{event.symbol}</div>}
       event={{ ...event, beneficiary: undefined }}
     />

--- a/src/components/activityEventElems/PayEventElem.tsx
+++ b/src/components/activityEventElems/PayEventElem.tsx
@@ -8,14 +8,17 @@ import { ActivityEvent } from './ActivityElement'
 
 export default function PayEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['payEvent']
+  withProjectLink?: boolean
 }) {
   if (!event) return null
 
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
       header={t`Paid`}
       subject={
         <span className="text-base font-medium">

--- a/src/components/activityEventElems/ProjectCreateEventElem.tsx
+++ b/src/components/activityEventElems/ProjectCreateEventElem.tsx
@@ -5,12 +5,15 @@ import { ActivityEvent } from './ActivityElement'
 
 export default function ProjectCreateEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['projectCreateEvent']
+  withProjectLink?: boolean
 }) {
   return (
     <ActivityEvent
       header={t`Created`}
+      withProjectLink={withProjectLink}
       subject={<Trans>Project created 🎉</Trans>}
       event={event}
     />

--- a/src/components/activityEventElems/RedeemEventElem.tsx
+++ b/src/components/activityEventElems/RedeemEventElem.tsx
@@ -26,8 +26,10 @@ function decodeJB721DelegateRedeemMetadata(
 
 export default function RedeemEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['redeemEvent']
+  withProjectLink?: boolean
 }) {
   const { tokenSymbol } = useContext(V1ProjectContext)
 
@@ -45,6 +47,7 @@ export default function RedeemEventElem({
     <ActivityEvent
       event={event}
       header={t`Redeemed`}
+      withProjectLink={withProjectLink}
       subject={
         <div className="text-base font-medium">
           {redeemedTokenIds && redeemedTokenIds.length > 0 ? (

--- a/src/components/activityEventElems/v1/ReservesEventElem.tsx
+++ b/src/components/activityEventElems/v1/ReservesEventElem.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import EthereumAddress from 'components/EthereumAddress'
+import { PV_V1 } from 'constants/pv'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
 import { ProjectEventsQuery } from 'generated/graphql'
 import useSubgraphQuery from 'hooks/useSubgraphQuery'
@@ -10,8 +11,10 @@ import { ActivityEvent } from '../ActivityElement'
 
 export default function ReservesEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['printReservesEvent']
+  withProjectLink?: boolean
 }) {
   const { tokenSymbol } = useContext(V1ProjectContext)
 
@@ -36,6 +39,8 @@ export default function ReservesEventElem({
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
+      pv={PV_V1}
       header={
         <Trans>
           Sent reserved{' '}

--- a/src/components/activityEventElems/v1/TapEventElem.tsx
+++ b/src/components/activityEventElems/v1/TapEventElem.tsx
@@ -9,12 +9,15 @@ import { ProjectEventsQuery } from 'generated/graphql'
 import useSubgraphQuery from 'hooks/useSubgraphQuery'
 import { isEqualAddress } from 'utils/address'
 
+import { PV_V1 } from 'constants/pv'
 import { ActivityEvent } from '../ActivityElement'
 
 export default function TapEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['tapEvent']
+  withProjectLink?: boolean
 }) {
   // Load individual DistributeToPayoutMod events, emitted by internal transactions of the Tap transaction
   const { data: payoutEvents } = useSubgraphQuery(
@@ -55,6 +58,8 @@ export default function TapEventElem({
           <ETHAmount amount={event.netTransferAmount} />
         </span>
       }
+      withProjectLink={withProjectLink}
+      pv={PV_V1}
       extra={
         <div>
           {payoutEvents?.map(e => (

--- a/src/components/activityEventElems/v1/V1ConfigureEventElem.tsx
+++ b/src/components/activityEventElems/v1/V1ConfigureEventElem.tsx
@@ -15,12 +15,15 @@ import {
 import { detailedTimeString } from 'utils/format/formatTime'
 import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
 
+import { PV_V1 } from 'constants/pv'
 import { ActivityEvent } from '../ActivityElement'
 
 export default function V1ConfigureEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['v1ConfigureEvent']
+  withProjectLink?: boolean
 }) {
   const { terminal } = useContext(V1ProjectContext)
 
@@ -35,6 +38,8 @@ export default function V1ConfigureEventElem({
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
+      pv={PV_V1}
       header={t`Edited cycle`}
       subject={null}
       extra={

--- a/src/components/activityEventElems/v2v3/ConfigureEventElem.tsx
+++ b/src/components/activityEventElems/v2v3/ConfigureEventElem.tsx
@@ -8,6 +8,7 @@ import {
 } from 'models/v2v3/fundingCycle'
 
 import FundingCycleDetails from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails'
+import { PV_V2 } from 'constants/pv'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { ProjectEventsQuery } from 'generated/graphql'
 import useProjectDistributionLimit from 'hooks/v2v3/contractReader/useProjectDistributionLimit'
@@ -16,8 +17,10 @@ import { ActivityEvent } from '../ActivityElement'
 
 export default function ConfigureEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['configureEvent']
+  withProjectLink?: boolean
 }) {
   if (!event) return null
 
@@ -65,6 +68,8 @@ export default function ConfigureEventElem({
     <ActivityEvent
       event={event}
       header={t`Edited cycle`}
+      withProjectLink={withProjectLink}
+      pv={PV_V2}
       subject={
         <MinimalCollapse
           header={

--- a/src/components/activityEventElems/v2v3/DeployETHERC20ProjectPayerEventElem.tsx
+++ b/src/components/activityEventElems/v2v3/DeployETHERC20ProjectPayerEventElem.tsx
@@ -3,13 +3,16 @@ import EthereumAddress from 'components/EthereumAddress'
 import RichNote from 'components/RichNote'
 import { ProjectEventsQuery } from 'generated/graphql'
 
+import { PV_V2 } from 'constants/pv'
 import { ActivityEvent } from '../ActivityElement'
 
 export default function DeployETHERC20ProjectPayerEventElem({
   event,
+  withProjectLink,
 }: {
   event:
     | ProjectEventsQuery['projectEvents'][0]['deployETHERC20ProjectPayerEvent']
+  withProjectLink?: boolean
 }) {
   if (!event) return null
 
@@ -17,6 +20,8 @@ export default function DeployETHERC20ProjectPayerEventElem({
     <ActivityEvent
       event={event}
       header={t`Deployed a project payer address`}
+      withProjectLink={withProjectLink}
+      pv={PV_V2}
       subject={
         <Trans>
           from <EthereumAddress address={event.from} />

--- a/src/components/activityEventElems/v2v3/DistributePayoutsElem.tsx
+++ b/src/components/activityEventElems/v2v3/DistributePayoutsElem.tsx
@@ -5,12 +5,16 @@ import ETHAmount from 'components/currency/ETHAmount'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import { ProjectEventsQuery } from 'generated/graphql'
 import useSubgraphQuery from 'hooks/useSubgraphQuery'
+
+import { PV_V2 } from 'constants/pv'
 import { ActivityEvent } from '../ActivityElement'
 
 export default function DistributePayoutsElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['distributePayoutsEvent']
+  withProjectLink?: boolean
 }) {
   // Load individual DistributeToPayoutSplit events, emitted by internal transactions of the DistributeReservedPayouts transaction
   const { data: distributePayoutsEvents } = useSubgraphQuery({
@@ -39,6 +43,8 @@ export default function DistributePayoutsElem({
     <ActivityEvent
       event={event}
       header={t`Sent payouts`}
+      withProjectLink={withProjectLink}
+      pv={PV_V2}
       subject={
         distributePayoutsEvents?.length ? (
           <span className="text-base font-medium">

--- a/src/components/activityEventElems/v2v3/DistributeReservedTokensElem.tsx
+++ b/src/components/activityEventElems/v2v3/DistributeReservedTokensElem.tsx
@@ -7,12 +7,15 @@ import { useContext } from 'react'
 import { formatWad, fromWad } from 'utils/format/formatNumber'
 import { tokenSymbolText } from 'utils/tokenSymbolText'
 
+import { PV_V2 } from 'constants/pv'
 import { ActivityEvent } from '../ActivityElement'
 
 export default function DistributeReservedTokensEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['distributeReservedTokensEvent']
+  withProjectLink?: boolean
 }) {
   const { tokenSymbol } = useContext(V1ProjectContext)
 
@@ -45,6 +48,8 @@ export default function DistributeReservedTokensEventElem({
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
+      pv={PV_V2}
       header={
         <Trans>
           Sent reserved{' '}

--- a/src/components/activityEventElems/v2v3/SetFundAccessConstraintsEventElem.tsx
+++ b/src/components/activityEventElems/v2v3/SetFundAccessConstraintsEventElem.tsx
@@ -5,18 +5,23 @@ import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { V2V3CurrencyName } from 'utils/v2v3/currency'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 
+import { PV_V2 } from 'constants/pv'
 import { ActivityEvent } from '../ActivityElement'
 
 export default function SetFundAccessConstraintsEventElem({
   event,
+  withProjectLink,
 }: {
   event: ProjectEventsQuery['projectEvents'][0]['setFundAccessConstraintsEvent']
+  withProjectLink?: boolean
 }) {
   if (!event) return null
 
   return (
     <ActivityEvent
       event={event}
+      withProjectLink={withProjectLink}
+      pv={PV_V2}
       header={t`Edited payout`}
       subject={
         <div>

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -15,18 +15,18 @@ export function V1ProjectActivity() {
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
 
   return (
-    <ActivityList
-      projectId={projectId}
-      pv={PV_V1}
-      header={<SectionHeader className="m-0" text={t`Activity`} />}
-      tokenSymbol={tokenSymbol}
-      setDownloadModalVisible={setDownloadModalVisible}
-      downloadComponent={
-        <V1DownloadActivityModal
-          open={downloadModalVisible}
-          onCancel={() => setDownloadModalVisible(false)}
-        />
-      }
-    />
+    <>
+      <ActivityList
+        projectId={projectId}
+        pv={PV_V1}
+        header={<SectionHeader className="m-0" text={t`Activity`} />}
+        tokenSymbol={tokenSymbol}
+        onClickDownload={() => setDownloadModalVisible(true)}
+      />
+      <V1DownloadActivityModal
+        open={downloadModalVisible}
+        onCancel={() => setDownloadModalVisible(false)}
+      />
+    </>
   )
 }

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -63,7 +63,7 @@ export function V1ProjectActivity() {
       )
     }
 
-    if (count === 0 && !isLoading) {
+    if (count === 0 && !loading) {
       return (
         <div className="border-t border-smoke-200 pt-5 text-grey-500 dark:border-grey-600 dark:text-grey-300">
           <Trans>No activity yet</Trans>

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -63,7 +63,7 @@ export function V1ProjectActivity() {
       )
     }
 
-    if (count === 0 && !loading) {
+    if (count === 0 && !isLoading) {
       return (
         <div className="border-t border-smoke-200 pt-5 text-grey-500 dark:border-grey-600 dark:text-grey-300">
           <Trans>No activity yet</Trans>

--- a/src/components/v1/V1Project/ProjectActivity/index.tsx
+++ b/src/components/v1/V1Project/ProjectActivity/index.tsx
@@ -1,149 +1,32 @@
-import { DownloadOutlined } from '@ant-design/icons'
-import { t, Trans } from '@lingui/macro'
-import { Button, Space } from 'antd'
-import { AnyProjectEvent } from 'components/activityEventElems'
-import { JuiceListbox } from 'components/inputs/JuiceListbox'
-import Loading from 'components/Loading'
+import { t } from '@lingui/macro'
 import SectionHeader from 'components/SectionHeader'
 import { PV_V1 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
-import { ProjectEventFilter, useProjectEvents } from 'hooks/useProjectEvents'
-import { useContext, useMemo, useState } from 'react'
+import { useContext, useState } from 'react'
 
+import ActivityList from 'components/ActivityList'
 import { V1DownloadActivityModal } from './V1DownloadActivityModal'
-
-const PAGE_SIZE = 10
 
 export function V1ProjectActivity() {
   const { projectId } = useContext(ProjectMetadataContext)
   const { tokenSymbol } = useContext(V1ProjectContext)
-  const [isFetchingMore, setIsFetchingMore] = useState<boolean>()
 
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
-  const [eventFilter, setEventFilter] = useState<ProjectEventFilter>('all')
-
-  const eventFilterOption = useMemo(
-    () => activityOptions().find(o => o.value === eventFilter),
-    [eventFilter],
-  )
-
-  const { data, fetchMore, loading } = useProjectEvents({
-    pv: PV_V1,
-    projectId,
-    filter: eventFilter,
-    first: PAGE_SIZE,
-  })
-
-  const isLoading = loading || isFetchingMore
-
-  const projectEvents = data?.projectEvents
-
-  const count = projectEvents?.length || 0
-
-  const list = useMemo(
-    () =>
-      projectEvents?.map(e => (
-        <div
-          className="mb-5 border-b border-smoke-200 pb-5 dark:border-grey-600"
-          key={e.id}
-        >
-          <AnyProjectEvent event={e} tokenSymbol={tokenSymbol} />
-        </div>
-      )),
-    [projectEvents, tokenSymbol],
-  )
-
-  const listStatus = useMemo(() => {
-    if (isLoading) {
-      return (
-        <div>
-          <Loading />
-        </div>
-      )
-    }
-
-    if (count === 0 && !isLoading) {
-      return (
-        <div className="border-t border-smoke-200 pt-5 text-grey-500 dark:border-grey-600 dark:text-grey-300">
-          <Trans>No activity yet</Trans>
-        </div>
-      )
-    }
-
-    if (count % PAGE_SIZE === 0) {
-      return (
-        <div
-          className="cursor-pointer text-center text-grey-500 dark:text-grey-300"
-          onClick={() => {
-            setIsFetchingMore(true)
-            fetchMore({
-              variables: {
-                skip: count,
-              },
-            }).finally(() => setIsFetchingMore(false))
-          }}
-        >
-          <Trans>Load more</Trans>
-        </div>
-      )
-    }
-
-    return (
-      <div className="p-2 text-center text-grey-500 dark:text-grey-300">
-        <Trans>{count} total</Trans>
-      </div>
-    )
-  }, [isLoading, fetchMore, count])
 
   return (
-    <div>
-      <div className="mb-5 flex items-center justify-between">
-        <SectionHeader className="m-0" text={t`Activity`} />
-        <Space direction="horizontal" align="center" size="small">
-          {count > 0 && (
-            <Button
-              type="text"
-              icon={<DownloadOutlined />}
-              onClick={() => setDownloadModalVisible(true)}
-            />
-          )}
-
-          <JuiceListbox
-            className="w-48"
-            options={activityOptions()}
-            value={eventFilterOption}
-            onChange={v => setEventFilter(v.value)}
-          />
-        </Space>
-      </div>
-
-      {list}
-
-      {listStatus}
-
-      <V1DownloadActivityModal
-        open={downloadModalVisible}
-        onCancel={() => setDownloadModalVisible(false)}
-      />
-    </div>
+    <ActivityList
+      projectId={projectId}
+      pv={PV_V1}
+      header={<SectionHeader className="m-0" text={t`Activity`} />}
+      tokenSymbol={tokenSymbol}
+      setDownloadModalVisible={setDownloadModalVisible}
+      downloadComponent={
+        <V1DownloadActivityModal
+          open={downloadModalVisible}
+          onCancel={() => setDownloadModalVisible(false)}
+        />
+      }
+    />
   )
 }
-
-interface ActivityOption {
-  label: string
-  value: ProjectEventFilter
-}
-
-const activityOptions = (): ActivityOption[] => [
-  { label: t`All events`, value: 'all' },
-  { label: t`Paid`, value: 'payEvent' },
-  { label: t`Redeemed`, value: 'redeemEvent' },
-  { label: t`Burned`, value: 'burnEvent' },
-  { label: t`Sent payouts`, value: 'tapEvent' },
-  { label: t`Sent reserved tokens`, value: 'printReservesEvent' },
-  { label: t`Edited cycle`, value: 'v1ConfigureEvent' },
-  { label: t`Deployed ERC20`, value: 'deployedERC20Event' },
-  { label: t`Created project`, value: 'projectCreateEvent' },
-  { label: t`Transferred ETH to project`, value: 'addToBalanceEvent' },
-]

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -61,7 +61,7 @@ export function V2V3ProjectActivity() {
       )
     }
 
-    if (count === 0 && !loading) {
+    if (count === 0 && !isLoading) {
       return (
         <>
           <Divider />

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -15,18 +15,18 @@ export function V2V3ProjectActivity() {
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
 
   return (
-    <ActivityList
-      projectId={projectId}
-      pv={PV_V2}
-      header={<SectionHeader className="m-0" text={t`Activity`} />}
-      tokenSymbol={tokenSymbol}
-      setDownloadModalVisible={setDownloadModalVisible}
-      downloadComponent={
-        <V2V3DownloadActivityModal
-          open={downloadModalVisible}
-          onCancel={() => setDownloadModalVisible(false)}
-        />
-      }
-    />
+    <>
+      <ActivityList
+        projectId={projectId}
+        pv={PV_V2}
+        header={<SectionHeader className="m-0" text={t`Activity`} />}
+        tokenSymbol={tokenSymbol}
+        onClickDownload={() => setDownloadModalVisible(true)}
+      />
+      <V2V3DownloadActivityModal
+        open={downloadModalVisible}
+        onCancel={() => setDownloadModalVisible(false)}
+      />
+    </>
   )
 }

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -1,159 +1,32 @@
-import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
-import { t, Trans } from '@lingui/macro'
-import { Button, Divider } from 'antd'
-import { AnyProjectEvent } from 'components/activityEventElems'
-import { JuiceListbox } from 'components/inputs/JuiceListbox'
-import Loading from 'components/Loading'
+import { t } from '@lingui/macro'
+import ActivityList from 'components/ActivityList'
 import SectionHeader from 'components/SectionHeader'
 import { PV_V2 } from 'constants/pv'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
-import { ProjectEventFilter, useProjectEvents } from 'hooks/useProjectEvents'
-import { useContext, useMemo, useState } from 'react'
+import { useContext, useState } from 'react'
 
 import V2V3DownloadActivityModal from '../modals/V2V3DownloadActivityModal'
-
-const PAGE_SIZE = 10
 
 export function V2V3ProjectActivity() {
   const { projectId } = useContext(ProjectMetadataContext)
   const { tokenSymbol } = useContext(V2V3ProjectContext)
-  const [isFetchingMore, setIsFetchingMore] = useState<boolean>()
 
   const [downloadModalVisible, setDownloadModalVisible] = useState<boolean>()
-  const [eventFilter, setEventFilter] = useState<ProjectEventFilter>('all')
-
-  const { data, fetchMore, loading } = useProjectEvents({
-    pv: PV_V2,
-    projectId,
-    filter: eventFilter,
-    first: PAGE_SIZE,
-    skip: 0,
-  })
-
-  const isLoading = loading || isFetchingMore
-
-  const projectEvents = data?.projectEvents
-
-  const activityOption = activityOptions().find(o => o.value === eventFilter)
-
-  const count = projectEvents?.length || 0
-
-  const list = useMemo(
-    () =>
-      projectEvents?.map(e => (
-        <div
-          className="mb-5 border-b border-smoke-200 pb-5 dark:border-grey-600"
-          key={e.id}
-        >
-          <AnyProjectEvent event={e} tokenSymbol={tokenSymbol} />
-        </div>
-      )),
-    [projectEvents, tokenSymbol],
-  )
-
-  const listStatus = useMemo(() => {
-    if (isLoading) {
-      return (
-        <div>
-          <Loading />
-        </div>
-      )
-    }
-
-    if (count === 0 && !isLoading) {
-      return (
-        <>
-          <Divider />
-          <div className="my-5 pb-5 text-grey-500 dark:text-grey-300">
-            <Trans>No activity yet</Trans>
-          </div>
-        </>
-      )
-    }
-
-    if (count % PAGE_SIZE === 0) {
-      return (
-        <div className="text-center">
-          <Button
-            onClick={() => {
-              setIsFetchingMore(true)
-              fetchMore({
-                variables: {
-                  skip: count,
-                },
-              }).finally(() => setIsFetchingMore(false))
-            }}
-            type="link"
-            className="px-0"
-          >
-            <Trans>Load more</Trans>
-          </Button>
-        </div>
-      )
-    }
-
-    return (
-      <div className="p-2 text-center text-grey-500 dark:text-grey-300">
-        <Trans>{count} total</Trans>
-      </div>
-    )
-  }, [isLoading, fetchMore, count])
 
   return (
-    <div>
-      <div className="mb-5 flex items-start justify-between">
-        <SectionHeader className="m-0" text={t`Activity`} />
-
-        <div className="flex gap-2">
-          {count > 0 && (
-            <Button
-              type="text"
-              icon={<ArrowDownTrayIcon className="inline h-5 w-5" />}
-              onClick={() => setDownloadModalVisible(true)}
-            />
-          )}
-
-          <JuiceListbox
-            className="w-[200px]"
-            options={activityOptions()}
-            value={activityOption}
-            onChange={v => setEventFilter(v.value)}
-          />
-        </div>
-      </div>
-
-      {list}
-
-      {listStatus}
-
-      <V2V3DownloadActivityModal
-        open={downloadModalVisible}
-        onCancel={() => setDownloadModalVisible(false)}
-      />
-    </div>
+    <ActivityList
+      projectId={projectId}
+      pv={PV_V2}
+      header={<SectionHeader className="m-0" text={t`Activity`} />}
+      tokenSymbol={tokenSymbol}
+      setDownloadModalVisible={setDownloadModalVisible}
+      downloadComponent={
+        <V2V3DownloadActivityModal
+          open={downloadModalVisible}
+          onCancel={() => setDownloadModalVisible(false)}
+        />
+      }
+    />
   )
 }
-
-interface ActivityOption {
-  label: string
-  value: ProjectEventFilter
-}
-
-const activityOptions = (): ActivityOption[] => [
-  { label: t`All events`, value: 'all' },
-  { label: t`Paid`, value: 'payEvent' },
-  { label: t`Redeemed`, value: 'redeemEvent' },
-  { label: t`Burned`, value: 'burnEvent' },
-  { label: t`Sent payouts`, value: 'distributePayoutsEvent' },
-  { label: t`Sent reserved tokens`, value: 'distributeReservedTokensEvent' },
-  { label: t`Edited cycle`, value: 'configureEvent' },
-  { label: t`Edited payout`, value: 'setFundAccessConstraintsEvent' },
-  { label: t`Transferred ETH to project`, value: 'addToBalanceEvent' },
-  { label: t`Deployed ERC20`, value: 'deployedERC20Event' },
-  {
-    label: t`Created a project payer address`,
-    value: 'deployETHERC20ProjectPayerEvent',
-  },
-  { label: t`Created project`, value: 'projectCreateEvent' },
-]

--- a/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectActivity/index.tsx
@@ -61,7 +61,7 @@ export function V2V3ProjectActivity() {
       )
     }
 
-    if (count === 0 && !isLoading) {
+    if (count === 0 && !loading) {
       return (
         <>
           <Divider />

--- a/src/graphql/documents/projectEvents.graphql
+++ b/src/graphql/documents/projectEvents.graphql
@@ -21,6 +21,11 @@ query ProjectEvents(
       amount
       note
       terminal
+      projectId
+      pv
+      project {
+        handle
+      }
     }
     burnEvent {
       id
@@ -29,6 +34,11 @@ query ProjectEvents(
       from
       holder
       amount
+      projectId
+      pv
+      project {
+        handle
+      }
     }
     configureEvent {
       id
@@ -60,6 +70,10 @@ query ProjectEvents(
       burnPaused
       distributionsPaused
       useTotalOverflowForRedemptions
+      projectId
+      project {
+        handle
+      }
     }
     deployedERC20Event {
       id
@@ -67,6 +81,11 @@ query ProjectEvents(
       txHash
       from
       symbol
+      projectId
+      pv
+      project {
+        handle
+      }
     }
     deployETHERC20ProjectPayerEvent {
       id
@@ -75,6 +94,10 @@ query ProjectEvents(
       from
       address
       memo
+      projectId
+      project {
+        handle
+      }
     }
     distributePayoutsEvent {
       id
@@ -86,6 +109,10 @@ query ProjectEvents(
       distributedAmount
       memo
       terminal
+      projectId
+      project {
+        handle
+      }
     }
     distributeReservedTokensEvent {
       id
@@ -95,6 +122,10 @@ query ProjectEvents(
       beneficiary
       beneficiaryTokenCount
       tokenCount
+      projectId
+      project {
+        handle
+      }
     }
     payEvent {
       id
@@ -106,6 +137,11 @@ query ProjectEvents(
       note
       feeFromV2Project
       terminal
+      projectId
+      pv
+      project {
+        handle
+      }
     }
     printReservesEvent {
       id
@@ -115,12 +151,21 @@ query ProjectEvents(
       beneficiary
       beneficiaryTicketAmount
       count
+      projectId
+      project {
+        handle
+      }
     }
     projectCreateEvent {
       id
       timestamp
       txHash
       from
+      projectId
+      pv
+      project {
+        handle
+      }
     }
     redeemEvent {
       id
@@ -133,6 +178,11 @@ query ProjectEvents(
       terminal
       metadata
       memo
+      projectId
+      pv
+      project {
+        handle
+      }
     }
     setFundAccessConstraintsEvent {
       id
@@ -141,6 +191,10 @@ query ProjectEvents(
       from
       distributionLimit
       distributionLimitCurrency
+      projectId
+      project {
+        handle
+      }
     }
     tapEvent {
       id
@@ -150,6 +204,10 @@ query ProjectEvents(
       beneficiary
       beneficiaryTransferAmount
       netTransferAmount
+      projectId
+      project {
+        handle
+      }
     }
     v1ConfigureEvent {
       id
@@ -165,6 +223,10 @@ query ProjectEvents(
       currency
       ticketPrintingIsAllowed
       payIsPaused
+      projectId
+      project {
+        handle
+      }
     }
   }
 }

--- a/src/hooks/useProjectEvents.ts
+++ b/src/hooks/useProjectEvents.ts
@@ -27,10 +27,10 @@ export type ProjectEventFilter =
       | 'v1ConfigureEvent'
     >
 
-type ProjectEventsQueryArgs = {
+export type ProjectEventsQueryArgs = {
   filter?: ProjectEventFilter
   pv?: PV
-  wallet?: string
+  from?: string
   projectId?: number
   skip?: number
   first?: number
@@ -40,7 +40,7 @@ export function useProjectEvents({
   filter,
   pv,
   projectId,
-  wallet,
+  from,
   first,
   skip,
 }: ProjectEventsQueryArgs) {
@@ -57,7 +57,12 @@ export function useProjectEvents({
       where: {
         ...(pv ? { pv } : {}),
         ...(projectId ? { projectId } : {}),
-        ...(wallet ? { wallet } : {}),
+        ...(from
+          ? {
+              // subgraph needs addresses to be lowercased
+              from: from.toLowerCase(),
+            }
+          : {}),
 
         // Always filter out projectEvents where these properties are not null. We have no cases for showing them in the UI and don't want them to pollute the query result
         mintTokensEvent: null,

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1427,6 +1427,9 @@ msgstr ""
 msgid "<0/> unclaimed"
 msgstr ""
 
+msgid "Sent payouts (v1)"
+msgstr ""
+
 msgid "Edit tracked assets"
 msgstr ""
 
@@ -1779,6 +1782,9 @@ msgid "Available after fee:"
 msgstr ""
 
 msgid "Recipient address is required."
+msgstr ""
+
+msgid "Edited cycle (v1)"
 msgstr ""
 
 msgid "Project #{projectId}"
@@ -2825,6 +2831,9 @@ msgstr ""
 msgid "Get help planning or setting up my project."
 msgstr ""
 
+msgid "All activity"
+msgstr ""
+
 msgid "Community"
 msgstr ""
 
@@ -3668,9 +3677,6 @@ msgstr ""
 msgid "MoonDAO has built an enthusiastic community of over 10,000 members, successfully sent their first astronaut to space, and is currently coordinating the spaceflight for their second astronaut. Their ambitious long-term roadmap goals include building a settlement on the Moon by 2030. In collaboration with StudioDAO, a decentralized movie studio running on Juicebox, MoonDAO has donated $100,000 to help fund the production of Ticket To Space, the first DAO documentary. The film will cover the story of Yan, a MoonDAO member from China, who will be sent to space on an upcoming Blue Origin flight after minting a free NFT."
 msgstr ""
 
-msgid "All events"
-msgstr ""
-
 msgid "This will give your <0/> or <1/> project's token holders the ability to migrate their tokens to <2/>."
 msgstr ""
 
@@ -4059,6 +4065,9 @@ msgid "Build and launch your NFT project right here on Juicebox with built-in re
 msgstr ""
 
 msgid "No reserved tokens configured."
+msgstr ""
+
+msgid "Sent reserved tokens (v1)"
 msgstr ""
 
 msgid "Spaces are not allowed"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -986,6 +986,9 @@ msgstr ""
 msgid "This cycle's rules may lead to unexpected behavior or other risks."
 msgstr ""
 
+msgid "Deployed project payer"
+msgstr ""
+
 msgid "Recent"
 msgstr ""
 


### PR DESCRIPTION
- Add new wallet activity tab on Account page, showing all projectEvents from that wallet
- new ActivityList component that consolidates all duplicate code relevant for showing a list of project activity. used on:
  - v1 dashboard
  - v2v3 dashboard
  - AccountDashboard
- new `withProjectLink` pattern on ActivityEvent components _(90% of changed files in this PR)_. optionally renders a ProjectLink component on the activity element. This is necessary for activity on the account page, where projectEvents can be for different projects
- update the dropdown on AccountDashboards contributions to match style with the dropdown on activity

<img width="1184" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/f1a8667b-8228-46a1-8a80-08c5aa497b61">
