### PR TITLE
Fix connecting wallets from everywhere outside the `Connect` button

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/ReviewDeployPage.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/ReviewDeployPage.tsx
@@ -5,6 +5,7 @@ import { Callout } from 'components/Callout'
 import { useDeployProject } from 'components/Create/hooks/DeployProject'
 import ExternalLink from 'components/ExternalLink'
 import TransactionModal from 'components/TransactionModal'
+import { ConnectKitButton } from 'connectkit'
 import { TERMS_OF_SERVICE_URL } from 'constants/links'
 import useMobile from 'hooks/useMobile'
 import { useModal } from 'hooks/useModal'
@@ -58,7 +59,7 @@ export const ReviewDeployPage = () => {
   useSetCreateFurthestPageReached('reviewDeploy')
   const { goToPage } = useContext(WizardContext)
   const isMobile = useMobile()
-  const { chainUnsupported, changeNetworks, isConnected, connect } = useWallet()
+  const { chainUnsupported, changeNetworks, isConnected } = useWallet()
   const router = useRouter()
   const [form] = Form.useForm<{ termsAccepted: boolean }>()
   const termsAccepted = Form.useWatch('termsAccepted', form)
@@ -88,10 +89,6 @@ export const ReviewDeployPage = () => {
       await changeNetworks()
       return
     }
-    if (!isConnected) {
-      await connect()
-      return
-    }
 
     await deployProject({
       onProjectDeployed: deployedProjectId =>
@@ -99,14 +96,7 @@ export const ReviewDeployPage = () => {
           shallow: true,
         }),
     })
-  }, [
-    chainUnsupported,
-    changeNetworks,
-    connect,
-    deployProject,
-    isConnected,
-    router,
-  ])
+  }, [chainUnsupported, changeNetworks, deployProject, router])
 
   const [activeKey, setActiveKey] = useState<ReviewDeployKey[]>(
     !isMobile ? [ReviewDeployKey.ProjectDetails] : [],
@@ -185,37 +175,47 @@ export const ReviewDeployPage = () => {
           <RulesReview />
         </CreateCollapse.Panel>
       </CreateCollapse>
-      <Form
-        form={form}
-        initialValues={{ termsAccepted: false }}
-        onFinish={onFinish}
-        className="mt-8 flex flex-col"
-      >
-        <Callout.Info noIcon collapsible={false}>
-          <div className="flex gap-4">
-            <Form.Item noStyle name="termsAccepted" valuePropName="checked">
-              <Checkbox />
-            </Form.Item>
-            <div>
-              <Trans>
-                I have read and accept the{' '}
-                <ExternalLink href={TERMS_OF_SERVICE_URL}>
-                  Terms of Service
-                </ExternalLink>{' '}
-                and{' '}
-                <ExternalLink href={helpPagePath(`/dev/learn/risks`)}>
-                  the risks
-                </ExternalLink>
-                .
-              </Trans>
-            </div>
-          </div>
-        </Callout.Info>
-        <Wizard.Page.ButtonControl
-          isNextLoading={isDeploying}
-          isNextEnabled={isNextEnabled}
-        />
-      </Form>
+      <ConnectKitButton.Custom>
+        {({ show }) => {
+          return (
+            <Form
+              form={form}
+              initialValues={{ termsAccepted: false }}
+              onFinish={isConnected ? onFinish : show}
+              className="mt-8 flex flex-col"
+            >
+              <Callout.Info noIcon collapsible={false}>
+                <div className="flex gap-4">
+                  <Form.Item
+                    noStyle
+                    name="termsAccepted"
+                    valuePropName="checked"
+                  >
+                    <Checkbox />
+                  </Form.Item>
+                  <div>
+                    <Trans>
+                      I have read and accept the{' '}
+                      <ExternalLink href={TERMS_OF_SERVICE_URL}>
+                        Terms of Service
+                      </ExternalLink>{' '}
+                      and{' '}
+                      <ExternalLink href={helpPagePath(`/dev/learn/risks`)}>
+                        the risks
+                      </ExternalLink>
+                      .
+                    </Trans>
+                  </div>
+                </div>
+              </Callout.Info>
+              <Wizard.Page.ButtonControl
+                isNextLoading={isDeploying}
+                isNextEnabled={isNextEnabled}
+              />
+            </Form>
+          )
+        }}
+      </ConnectKitButton.Custom>
 
       <div className="flex flex-col gap-4 pt-20 text-grey-400 dark:text-slate-200">
         <div>

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -1,5 +1,6 @@
 import { t, Trans } from '@lingui/macro'
 import { Modal, ModalProps } from 'antd'
+import { ConnectKitButton } from 'connectkit'
 import { readNetwork } from 'constants/networks'
 import { TxHistoryContext } from 'contexts/Transaction/TxHistoryContext'
 import { useWallet } from 'hooks/Wallet'
@@ -89,12 +90,18 @@ export default function TransactionModal(props: TransactionModalProps) {
   }
 
   return (
-    <Modal {...modalProps}>
-      {props.transactionPending ? (
-        <PendingTransactionModalBody />
-      ) : (
-        props.children
-      )}
-    </Modal>
+    <ConnectKitButton.Custom>
+      {({ show }) => {
+        return (
+          <Modal {...modalProps} onOk={isConnected ? props.onOk : show}>
+            {props.transactionPending ? (
+              <PendingTransactionModalBody />
+            ) : (
+              props.children
+            )}
+          </Modal>
+        )
+      }}
+    </ConnectKitButton.Custom>
   )
 }

--- a/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
+++ b/src/components/v1/V1Project/modals/V1ConfirmPayOwnerModal.tsx
@@ -13,6 +13,7 @@ import Paragraph from 'components/Paragraph'
 import { Parenthesis } from 'components/Parenthesis'
 import { StickerSelection } from 'components/Project/StickerSelection'
 import ProjectRiskNotice from 'components/ProjectRiskNotice'
+import { ConnectKitButton } from 'connectkit'
 import { ProjectPreferences } from 'constants/v1/projectPreferences'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V1ProjectContext } from 'contexts/v1/Project/V1ProjectContext'
@@ -66,13 +67,8 @@ export default function V1ConfirmPayOwnerModal({
 
   const stickerUrls = useWatch('stickerUrls', form)
 
-  const {
-    userAddress,
-    chainUnsupported,
-    isConnected,
-    changeNetworks,
-    connect,
-  } = useWallet()
+  const { userAddress, chainUnsupported, isConnected, changeNetworks } =
+    useWallet()
   const converter = useCurrencyConverter()
   const payProjectTx = usePayV1ProjectTx()
 
@@ -95,10 +91,6 @@ export default function V1ConfirmPayOwnerModal({
     // Prompt wallet connect if no wallet connected
     if (chainUnsupported) {
       await changeNetworks()
-      return
-    }
-    if (!isConnected) {
-      await connect()
       return
     }
     setLoading(true)
@@ -177,144 +169,154 @@ export default function V1ConfirmPayOwnerModal({
   }
 
   return (
-    <Modal
-      title={t`Pay ${projectMetadata.name}`}
-      open={open}
-      onOk={pay}
-      okText={userAddress ? payButtonText : t`Connect wallet to pay`}
-      onCancel={onCancel}
-      confirmLoading={loading}
-      width={640}
-      centered={true}
-      zIndex={1}
-    >
-      <Space direction="vertical" size="large" className="w-full">
-        <p>
-          <Trans>
-            Paying <span className="font-medium">{projectMetadata.name}</span>{' '}
-            is not an investment — it's a way to support the project. Any value
-            or utility of the tokens you receive is determined by{' '}
-            {projectMetadata.name}.
-          </Trans>
-        </p>
-
-        {projectMetadata.payDisclosure && (
-          <div>
-            <h4>
-              <Trans>Notice from {projectMetadata.name}</Trans>
-            </h4>
-            <Paragraph description={projectMetadata.payDisclosure} />
-          </div>
-        )}
-        {renderRiskNotice()}
-        <Descriptions column={1} bordered>
-          <Descriptions.Item label={t`Pay amount`} className="content-right">
-            <USDAmount amount={usdAmount} />{' '}
-            <Parenthesis>
-              <ETHAmount amount={weiAmount} />
-            </Parenthesis>
-          </Descriptions.Item>
-          <Descriptions.Item
-            label={t`${tokenSymbolText({
-              tokenSymbol,
-              capitalize: true,
-              plural: true,
-            })} for you`}
-            className="content-right"
+    <ConnectKitButton.Custom>
+      {({ show }) => {
+        return (
+          <Modal
+            title={t`Pay ${projectMetadata.name}`}
+            open={open}
+            onOk={isConnected ? pay : show}
+            okText={userAddress ? payButtonText : t`Connect wallet to pay`}
+            onCancel={onCancel}
+            confirmLoading={loading}
+            width={640}
+            centered={true}
+            zIndex={1}
           >
-            <div>{formatWad(receivedTickets, { precision: 0 })}</div>
-            <div>
-              {userAddress ? (
+            <Space direction="vertical" size="large" className="w-full">
+              <p>
                 <Trans>
-                  To: <EthereumAddress address={userAddress} />
+                  Paying{' '}
+                  <span className="font-medium">{projectMetadata.name}</span> is
+                  not an investment — it's a way to support the project. Any
+                  value or utility of the tokens you receive is determined by{' '}
+                  {projectMetadata.name}.
                 </Trans>
-              ) : null}
-            </div>
-          </Descriptions.Item>
-          <Descriptions.Item
-            label={t`${tokenSymbolText({
-              tokenSymbol,
-              capitalize: true,
-              plural: true,
-            })} reserved`}
-            className="content-right"
-          >
-            {formatWad(ownerTickets, { precision: 0 })}
-          </Descriptions.Item>
-        </Descriptions>
-        <Form form={form} layout="vertical">
-          <div className="relative">
-            <Form.Item
-              name="memo"
-              label={t`Memo (optional)`}
-              className="antd-no-number-handler mb-0"
-              extra={t`Add an on-chain memo to this payment.`}
-            >
-              <Input.TextArea
-                placeholder={t`WAGMI!`}
-                maxLength={256}
-                onPressEnter={e => e.preventDefault()} // prevent new lines in memo
-                showCount
-                autoSize
+              </p>
+
+              {projectMetadata.payDisclosure && (
+                <div>
+                  <h4>
+                    <Trans>Notice from {projectMetadata.name}</Trans>
+                  </h4>
+                  <Paragraph description={projectMetadata.payDisclosure} />
+                </div>
+              )}
+              {renderRiskNotice()}
+              <Descriptions column={1} bordered>
+                <Descriptions.Item
+                  label={t`Pay amount`}
+                  className="content-right"
+                >
+                  <USDAmount amount={usdAmount} />{' '}
+                  <Parenthesis>
+                    <ETHAmount amount={weiAmount} />
+                  </Parenthesis>
+                </Descriptions.Item>
+                <Descriptions.Item
+                  label={t`${tokenSymbolText({
+                    tokenSymbol,
+                    capitalize: true,
+                    plural: true,
+                  })} for you`}
+                  className="content-right"
+                >
+                  <div>{formatWad(receivedTickets, { precision: 0 })}</div>
+                  <div>
+                    {userAddress ? (
+                      <Trans>
+                        To: <EthereumAddress address={userAddress} />
+                      </Trans>
+                    ) : null}
+                  </div>
+                </Descriptions.Item>
+                <Descriptions.Item
+                  label={t`${tokenSymbolText({
+                    tokenSymbol,
+                    capitalize: true,
+                    plural: true,
+                  })} reserved`}
+                  className="content-right"
+                >
+                  {formatWad(ownerTickets, { precision: 0 })}
+                </Descriptions.Item>
+              </Descriptions>
+              <Form form={form} layout="vertical">
+                <div className="relative">
+                  <Form.Item
+                    name="memo"
+                    label={t`Memo (optional)`}
+                    className="antd-no-number-handler mb-0"
+                    extra={t`Add an on-chain memo to this payment.`}
+                  >
+                    <Input.TextArea
+                      placeholder={t`WAGMI!`}
+                      maxLength={256}
+                      onPressEnter={e => e.preventDefault()} // prevent new lines in memo
+                      showCount
+                      autoSize
+                    />
+                  </Form.Item>
+                  {/* Sticker select icon (right side of memo input) */}
+                  <div className="absolute right-2 top-9 text-sm">
+                    {
+                      <Sticker
+                        className={classNames(
+                          'text-grey-500 dark:text-grey-300',
+                          canAddMoreStickers
+                            ? 'cursor-pointer'
+                            : 'cursor-not-allowed',
+                        )}
+                        size={20}
+                        onClick={() => {
+                          canAddMoreStickers
+                            ? setAttachStickerModalVisible(true)
+                            : undefined
+                        }}
+                      />
+                    }
+                  </div>
+                </div>
+                <Form.Item name="stickerUrls">
+                  <StickerSelection />
+                </Form.Item>
+
+                <Form.Item name="uploadedImage">
+                  <FormImageUploader text={t`Add image`} />
+                </Form.Item>
+                {hasIssuedTokens && (
+                  <Form.Item
+                    name="preferUnstaked"
+                    valuePropName="checked"
+                    extra={
+                      <Trans>
+                        Check this to mint {tokenSymbol} ERC-20 to your wallet.
+                        Leave unchecked to have the Juicebox protocol internally
+                        track your token balance, saving gas on this
+                        transaction. You can claim your ERC-20 tokens later.
+                      </Trans>
+                    }
+                  >
+                    <Checkbox>
+                      <Trans>Receive ERC-20</Trans>
+                    </Checkbox>
+                  </Form.Item>
+                )}
+              </Form>
+              <AttachStickerModal
+                open={attachStickerModalVisible}
+                onClose={() => setAttachStickerModalVisible(false)}
+                onSelect={sticker => {
+                  if (typeof window === 'undefined') {
+                    return
+                  }
+                  handleStickerSelect(sticker)
+                }}
               />
-            </Form.Item>
-            {/* Sticker select icon (right side of memo input) */}
-            <div className="absolute right-2 top-9 text-sm">
-              {
-                <Sticker
-                  className={classNames(
-                    'text-grey-500 dark:text-grey-300',
-                    canAddMoreStickers
-                      ? 'cursor-pointer'
-                      : 'cursor-not-allowed',
-                  )}
-                  size={20}
-                  onClick={() => {
-                    canAddMoreStickers
-                      ? setAttachStickerModalVisible(true)
-                      : undefined
-                  }}
-                />
-              }
-            </div>
-          </div>
-          <Form.Item name="stickerUrls">
-            <StickerSelection />
-          </Form.Item>
-
-          <Form.Item name="uploadedImage">
-            <FormImageUploader text={t`Add image`} />
-          </Form.Item>
-          {hasIssuedTokens && (
-            <Form.Item
-              name="preferUnstaked"
-              valuePropName="checked"
-              extra={
-                <Trans>
-                  Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave
-                  unchecked to have the Juicebox protocol internally track your
-                  token balance, saving gas on this transaction. You can claim
-                  your ERC-20 tokens later.
-                </Trans>
-              }
-            >
-              <Checkbox>
-                <Trans>Receive ERC-20</Trans>
-              </Checkbox>
-            </Form.Item>
-          )}
-        </Form>
-        <AttachStickerModal
-          open={attachStickerModalVisible}
-          onClose={() => setAttachStickerModalVisible(false)}
-          onSelect={sticker => {
-            if (typeof window === 'undefined') {
-              return
-            }
-            handleStickerSelect(sticker)
-          }}
-        />
-      </Space>
-    </Modal>
+            </Space>
+          </Modal>
+        )
+      }}
+    </ConnectKitButton.Custom>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3PayButton/V2V3ConfirmPayModal/V2V3ConfirmPayModal.tsx
@@ -34,13 +34,7 @@ export function V2V3ConfirmPayModal({
   const [form] = useForm<V2V3PayFormType>()
 
   const router = useRouter()
-  const {
-    userAddress,
-    chainUnsupported,
-    isConnected,
-    changeNetworks,
-    connect,
-  } = useWallet()
+  const { userAddress, chainUnsupported, changeNetworks } = useWallet()
   const delegateMetadata = useDelegateMetadata()
   const nftRewardTiers = useNftRewardTiersToMint()
   const payProjectTx = usePayETHPaymentTerminalTx()
@@ -56,10 +50,6 @@ export function V2V3ConfirmPayModal({
     // Prompt wallet connect if no wallet connected
     if (chainUnsupported) {
       await changeNetworks()
-      return
-    }
-    if (!isConnected) {
-      await connect()
       return
     }
 

--- a/src/hooks/Wallet/useWallet.ts
+++ b/src/hooks/Wallet/useWallet.ts
@@ -1,5 +1,3 @@
-import { readNetwork } from 'constants/networks'
-import { useConnect } from 'wagmi'
 import {
   useChain,
   useChainUnsupported,
@@ -10,8 +8,6 @@ import {
   useUserAddress,
 } from './hooks'
 
-const chainId = readNetwork.chainId
-
 export function useWallet() {
   const { data: signer } = useSigner()
   const userAddress = useUserAddress()
@@ -19,9 +15,6 @@ export function useWallet() {
   const chain = useChain()
   const chainUnsupported = useChainUnsupported()
 
-  const { connect } = useConnect({
-    chainId,
-  })
   const disconnect = useDisconnect()
   const changeNetworks = useChangeNetworks()
 
@@ -31,7 +24,6 @@ export function useWallet() {
     isConnected,
     chain,
     chainUnsupported,
-    connect,
     disconnect,
     changeNetworks,
   }

--- a/src/hooks/useTransactor.ts
+++ b/src/hooks/useTransactor.ts
@@ -78,7 +78,7 @@ export function useTransactor(): Transactor | undefined {
   const { addTransaction } = useContext(TxHistoryContext)
 
   const { chain, signer, userAddress } = useWallet()
-  const { chainUnsupported, isConnected, changeNetworks, connect } = useWallet()
+  const { chainUnsupported, changeNetworks } = useWallet()
   const arcx = useArcx()
 
   return useCallback(
@@ -90,11 +90,6 @@ export function useTransactor(): Transactor | undefined {
     ) => {
       if (chainUnsupported) {
         await changeNetworks()
-        options?.onDone?.()
-        return false
-      }
-      if (!isConnected) {
-        await connect()
         options?.onDone?.()
         return false
       }
@@ -178,11 +173,9 @@ export function useTransactor(): Transactor | undefined {
     [
       arcx,
       chainUnsupported,
-      isConnected,
       signer,
       chain,
       changeNetworks,
-      connect,
       addTransaction,
       userAddress,
     ],


### PR DESCRIPTION
Fixes JB-343

- Now bakes `ConnectKitButton` connect logic into `TransactionModal` so could remove some code in a bunch of other places. 
- Implements `ConnectKitButton` in two other places not using `TransactionModal`:
      - Create flow launch button
      - V1 Pay modal