### PR TITLE
Fix create flow token section console errors

### DIFF
--- a/src/components/inputs/NumberSlider.tsx
+++ b/src/components/inputs/NumberSlider.tsx
@@ -57,7 +57,6 @@ export default function NumberSlider({
           {...inputConfig}
           value={_value}
           onChange={(val: number) => updateValue(val)}
-          defaultValue={defaultValue}
           disabled={disabled}
         />
         <Form.Item
@@ -86,7 +85,6 @@ export default function NumberSlider({
                 (typeof val === 'string' ? parseFloat(val) : val) ?? undefined
               updateValue(newVal)
             }}
-            defaultValue={defaultValue}
           />
         </Form.Item>
       </div>


### PR DESCRIPTION
Fixes JB-225 

`defaultValue` unnecessarily being passed to `Slider` and `JuiceInputNumber` when it is already baked in at:
```
const [_value, setValue] = useState<number | undefined>(
    sliderValue ?? defaultValue,
  )
```