### PR TITLE
DBProjects updates + Owned/Created projects on account page

### DIFF
--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -144,11 +144,11 @@ export function RedeemNftsModal({
     }
   }
 
-  const jb721DelegateTokens = data?.jb721DelegateTokens.map(t => ({
+  const nfts = data?.jb721DelegateTokens.map(t => ({
     ...t,
     tokenId: t.tokenId.toHexString(),
   }))
-  const nftBalanceFormatted = jb721DelegateTokens?.length ?? 0
+  const nftBalanceFormatted = nfts?.length ?? 0
   const hasOverflow = primaryTerminalCurrentOverflow?.gt(0)
   const hasRedemptionRate = fundingCycleMetadata.redemptionRate.gt(0)
   const canRedeem = hasOverflow && hasRedemptionRate
@@ -242,7 +242,7 @@ export function RedeemNftsModal({
           <Form form={form} layout="vertical">
             <Form.Item label={t`Select NFTs to redeem`}>
               <Row gutter={[20, 20]}>
-                {jb721DelegateTokens?.map(nft => {
+                {nfts?.map(nft => {
                   const isSelected = tokenIdsToRedeem.includes(nft.tokenId)
                   return (
                     <Col span={8} key={nft.tokenId}>

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -144,11 +144,11 @@ export function RedeemNftsModal({
     }
   }
 
-  const nfts = data?.jb721DelegateTokens.map(t => ({
+  const jb721DelegateTokens = data?.jb721DelegateTokens.map(t => ({
     ...t,
     tokenId: t.tokenId.toHexString(),
   }))
-  const nftBalanceFormatted = nfts?.length ?? 0
+  const nftBalanceFormatted = jb721DelegateTokens?.length ?? 0
   const hasOverflow = primaryTerminalCurrentOverflow?.gt(0)
   const hasRedemptionRate = fundingCycleMetadata.redemptionRate.gt(0)
   const canRedeem = hasOverflow && hasRedemptionRate
@@ -242,7 +242,7 @@ export function RedeemNftsModal({
           <Form form={form} layout="vertical">
             <Form.Item label={t`Select NFTs to redeem`}>
               <Row gutter={[20, 20]}>
-                {nfts?.map(nft => {
+                {jb721DelegateTokens?.map(nft => {
                   const isSelected = tokenIdsToRedeem.includes(nft.tokenId)
                   return (
                     <Col span={8} key={nft.tokenId}>

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -30,6 +30,7 @@ import {
 } from 'utils/graph'
 import { formatQueryParams } from 'utils/queryParams'
 import { parseDBProjectJson, parseDBProjectsRow } from 'utils/sgDbProjects'
+
 import useSubgraphQuery from './useSubgraphQuery'
 
 interface ProjectsOptions {
@@ -316,28 +317,6 @@ function useProjectsOfParticipants(where: ProjectsOfParticipantsWhereQuery) {
   return {
     ...projectsQuery,
     isLoading: projectsQuery.isLoading || loadingParticipants,
-  }
-}
-
-export function useMyProjectsQuery(wallet: string | undefined) {
-  const projectsQuery = useSubgraphQuery(
-    wallet
-      ? {
-          entity: 'project',
-          keys: DEFAULT_PROJECT_ENTITY_KEYS,
-          where: {
-            key: 'owner',
-            operator: 'in',
-            value: [wallet],
-          },
-          orderBy: 'createdAt',
-          orderDirection: 'desc',
-        }
-      : null,
-  )
-
-  return {
-    ...projectsQuery,
   }
 }
 

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -16,18 +16,14 @@ import { ProjectState } from 'models/projectVisibility'
 import { PV } from 'models/pv'
 import { Project } from 'models/subgraph-entities/vX/project'
 import { V1TerminalVersion } from 'models/v1/terminals'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
   UseInfiniteQueryOptions,
   UseQueryOptions,
   useInfiniteQuery,
   useQuery,
 } from 'react-query'
-import {
-  getSubgraphIdForProject,
-  parseSubgraphEntity,
-  querySubgraphExhaustive,
-} from 'utils/graph'
+import { getSubgraphIdForProject, parseSubgraphEntity } from 'utils/graph'
 import { formatQueryParams } from 'utils/queryParams'
 import { parseDBProjectJson, parseDBProjectsRow } from 'utils/sgDbProjects'
 
@@ -45,10 +41,6 @@ interface ProjectsOptions {
   terminalVersion?: V1TerminalVersion
   pv?: PV[]
 }
-
-type ProjectsOfParticipantsWhereQuery =
-  | SGQueryOpts<'participant', SGEntityKey<'participant'>>['where']
-  | null
 
 const DEFAULT_STALE_TIME = 60 * 1000 // 60 seconds
 export const DEFAULT_PROJECT_ENTITY_KEYS: (keyof Project)[] = [
@@ -228,96 +220,6 @@ export function useTrendingProjects(count: number) {
 
     return projects
   })
-}
-
-// Query all projects that a wallet has previously made payments to
-export function useContributedProjectsQuery(wallet: string | undefined) {
-  const where = useMemo((): ProjectsOfParticipantsWhereQuery => {
-    if (!wallet) return null
-
-    return [
-      {
-        key: 'wallet',
-        value: wallet.toLowerCase(),
-      },
-      {
-        key: 'volume',
-        operator: 'gt',
-        value: 0,
-      },
-    ]
-  }, [wallet])
-
-  return useProjectsOfParticipants(where)
-}
-
-function useProjectsOfParticipants(where: ProjectsOfParticipantsWhereQuery) {
-  const [loadingParticipants, setLoadingParticipants] = useState<boolean>()
-  const [projectIds, setProjectIds] = useState<string[]>()
-
-  useEffect(() => {
-    // Get all participant entities for wallet
-    const loadParticipants = async () => {
-      setLoadingParticipants(true)
-
-      const participants = await querySubgraphExhaustive(
-        where
-          ? {
-              entity: 'participant',
-              orderBy: 'balance',
-              orderDirection: 'desc',
-              keys: [
-                {
-                  entity: 'project',
-                  keys: ['id'],
-                },
-              ],
-              where,
-            }
-          : null,
-      )
-
-      if (!participants) {
-        setProjectIds(undefined)
-        return
-      }
-
-      // Reduce list of paid project ids
-      setProjectIds(
-        participants?.reduce((acc, curr) => {
-          const projectId = curr?.project.id
-
-          return [
-            ...acc,
-            ...(projectId ? (acc.includes(projectId) ? [] : [projectId]) : []),
-          ]
-        }, [] as string[]),
-      )
-
-      setLoadingParticipants(false)
-    }
-
-    loadParticipants()
-  }, [where])
-
-  const projectsQuery = useSubgraphQuery(
-    projectIds
-      ? {
-          entity: 'project',
-          keys: DEFAULT_PROJECT_ENTITY_KEYS,
-          where: {
-            key: 'id',
-            operator: 'in',
-            value: projectIds,
-          },
-        }
-      : null,
-  )
-
-  return {
-    ...projectsQuery,
-    isLoading: projectsQuery.isLoading || loadingParticipants,
-  }
 }
 
 export function useProjectTrendingPercentageIncrease({

--- a/src/lib/api/supabase/projects/api.ts
+++ b/src/lib/api/supabase/projects/api.ts
@@ -57,7 +57,7 @@ export async function queryDBProjects(
   res: NextApiResponse,
   opts: DBProjectQueryOpts,
 ) {
-  const orderBy = opts.orderBy ?? 'total_paid'
+  const orderBy = opts.orderBy ?? 'volume'
   const page = opts.page ?? 0
   const pageSize = opts.pageSize ?? 20
   // Only sort ascending if orderBy is defined and orderDirection is 'asc'
@@ -77,6 +77,8 @@ export async function queryDBProjects(
   if (opts.archived) query = query.is('archived', true)
   else query = query.not('archived', 'is', true)
   if (opts.pv?.length) query = query.in('pv', opts.pv)
+  if (opts.owner) query = query.ilike('owner', opts.owner)
+  if (opts.creator) query = query.ilike('creator', opts.creator)
   if (opts.tags?.length) query = query.overlaps('tags', opts.tags)
   if (searchFilter) query = query.or(searchFilter)
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1631,6 +1631,9 @@ msgstr ""
 msgid "{0} for you"
 msgstr ""
 
+msgid "You don't own any projects."
+msgstr ""
+
 msgid "While enabled, NFTs can be minted when this project receives a payment."
 msgstr ""
 
@@ -2094,6 +2097,9 @@ msgid "Are you sure you want to unwatch all projects? You will no longer be noti
 msgstr ""
 
 msgid "Project token beneficiary address"
+msgstr ""
+
+msgid "This account doesn't own any projects yet."
 msgstr ""
 
 msgid "Leave this blank to make your currently connected wallet the project owner. Fill this out with an Ethereum address to make that address this project's owner."
@@ -3183,6 +3189,9 @@ msgid "All {tokensText} will go to the project owner:"
 msgstr ""
 
 msgid "Customize your public facing profile and other details."
+msgstr ""
+
+msgid "Projects owned"
 msgstr ""
 
 msgid "Transfer {tokenTextShort}"

--- a/src/models/dbProject.ts
+++ b/src/models/dbProject.ts
@@ -43,6 +43,7 @@ export type DBProject = {
   volumeUSD: BigNumber
   redeemVolume: BigNumber
   redeemVolumeUSD: BigNumber
+  trendingVolume: BigNumber
 
   paymentsCount: number
   contributorsCount: number

--- a/src/models/dbProject.ts
+++ b/src/models/dbProject.ts
@@ -46,6 +46,7 @@ export type DBProject = {
   trendingVolume: BigNumber
 
   paymentsCount: number
+  trendingPaymentsCount: number
   contributorsCount: number
   nftsMintedCount: number
   redeemCount: number

--- a/src/models/dbProject.ts
+++ b/src/models/dbProject.ts
@@ -21,7 +21,9 @@ export type DBProjectQueryOpts = {
   tags?: ProjectTagName[]
   archived?: boolean
   pv?: PV[]
-  orderBy?: 'total_paid' | 'created_at' | 'current_balance' | 'payments_count'
+  owner?: string
+  creator?: string
+  orderBy?: 'volume' | 'created_at' | 'current_balance' | 'payments_count'
   orderDirection?: 'asc' | 'desc'
   page?: number
   pageSize?: number
@@ -34,10 +36,21 @@ export type DBProject = {
   pv: PV
   handle: string | null
   metadataUri: string | null
+
   currentBalance: BigNumber
   trendingScore: BigNumber
   volume: BigNumber
+  volumeUSD: BigNumber
+  redeemVolume: BigNumber
+  redeemVolumeUSD: BigNumber
+
   paymentsCount: number
+  contributorsCount: number
+  nftsMintedCount: number
+  redeemCount: number
+
+  owner: string
+  creator: string
   deployer: string | null
   terminal: string | null
 

--- a/src/models/dbProject.ts
+++ b/src/models/dbProject.ts
@@ -50,6 +50,7 @@ export type DBProject = {
   contributorsCount: number
   nftsMintedCount: number
   redeemCount: number
+  createdWithinTrendingWindow: boolean
 
   owner: string
   creator: string

--- a/src/models/subgraph-entities/vX/project.ts
+++ b/src/models/subgraph-entities/vX/project.ts
@@ -24,6 +24,9 @@ export type Project = {
   projectId: number
   pv: PV
   owner: string
+  creator: string
+  contributorsCount: number
+  nftsMintedCount: number
   deployer: string | null
   createdAt: number
   paymentsCount: number

--- a/src/pages/api/projects/index.page.ts
+++ b/src/pages/api/projects/index.page.ts
@@ -8,8 +8,18 @@ import { NextApiHandler } from 'next'
  * @returns Raw SQL query response
  */
 const handler: NextApiHandler = async (req, res) => {
-  const { text, tags, page, pageSize, archived, pv, orderDirection, orderBy } =
-    req.query
+  const {
+    text,
+    tags,
+    page,
+    pageSize,
+    archived,
+    pv,
+    orderDirection,
+    orderBy,
+    owner,
+    creator,
+  } = req.query
 
   // https://vercel.com/guides/how-to-enable-cors#enabling-cors-in-a-next.js-app
   res.setHeader('Access-Control-Allow-Credentials', 'true')
@@ -22,6 +32,16 @@ const handler: NextApiHandler = async (req, res) => {
 
   if (text && typeof text !== 'string') {
     res.status(400).send('Text is not a string')
+    return
+  }
+
+  if (owner && typeof owner !== 'string') {
+    res.status(400).send('Owner is not a string')
+    return
+  }
+
+  if (creator && typeof creator !== 'string') {
+    res.status(400).send('Creator is not a string')
     return
   }
 
@@ -84,6 +104,8 @@ const handler: NextApiHandler = async (req, res) => {
       pv: pv?.split(',') as DBProjectQueryOpts['pv'],
       orderDirection: orderDirection as DBProjectQueryOpts['orderDirection'],
       orderBy: orderBy as DBProjectQueryOpts['orderBy'],
+      owner,
+      creator,
     })
 
     res.status(200).json(results)

--- a/src/pages/projects/ProjectsFilterAndSort.tsx
+++ b/src/pages/projects/ProjectsFilterAndSort.tsx
@@ -191,7 +191,7 @@ interface ProjectFilterOption {
 }
 
 const projectFilterOptions = (): ProjectFilterOption[] => [
-  { label: t`Total raised`, value: 'total_paid' },
+  { label: t`Total raised`, value: 'volume' },
   { label: t`Date created`, value: 'created_at' },
   { label: t`Current balance`, value: 'current_balance' },
   { label: t`Payments`, value: 'payments_count' },

--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -71,7 +71,7 @@ function Projects() {
     setSearchTags(tags)
   }, [userAddress, router.query.tab, search, tags])
 
-  const [orderBy, setOrderBy] = useState<OrderByOption>('total_paid')
+  const [orderBy, setOrderBy] = useState<OrderByOption>('volume')
   const [includeV1, setIncludeV1] = useState<boolean>(true)
   const [includeV2, setIncludeV2] = useState<boolean>(true)
   const [showArchived, setShowArchived] = useState<boolean>(false)

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -126,6 +126,7 @@ export interface Database {
           redeem_voume_usd: string
           tags: string[] | null
           terminal: string | null
+          trending_payments_count: number
           trending_score: string
           trending_volume: string
           volume: string
@@ -157,6 +158,7 @@ export interface Database {
           redeem_voume_usd: string
           tags?: string[] | null
           terminal?: string | null
+          trending_payments_count: number
           trending_score: string
           trending_volume: string
           volume: string
@@ -188,6 +190,7 @@ export interface Database {
           redeem_voume_usd?: string
           tags?: string[] | null
           terminal?: string | null
+          trending_payments_count?: number
           trending_score?: string
           trending_volume?: string
           volume?: string

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -127,6 +127,7 @@ export interface Database {
           tags: string[] | null
           terminal: string | null
           trending_score: string
+          trending_volume: string
           volume: string
           volume_usd: string
         }
@@ -157,6 +158,7 @@ export interface Database {
           tags?: string[] | null
           terminal?: string | null
           trending_score: string
+          trending_volume: string
           volume: string
           volume_usd: string
         }
@@ -187,6 +189,7 @@ export interface Database {
           tags?: string[] | null
           terminal?: string | null
           trending_score?: string
+          trending_volume?: string
           volume?: string
           volume_usd?: string
         }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -107,6 +107,7 @@ export interface Database {
           archived: boolean | null
           contributors_count: number
           created_at: number
+          created_within_trending_window: boolean
           creator: string
           current_balance: string
           deployer: string | null
@@ -139,6 +140,7 @@ export interface Database {
           archived?: boolean | null
           contributors_count: number
           created_at: number
+          created_within_trending_window: boolean
           creator: string
           current_balance: string
           deployer?: string | null
@@ -171,6 +173,7 @@ export interface Database {
           archived?: boolean | null
           contributors_count?: number
           created_at?: number
+          created_within_trending_window?: boolean
           creator?: string
           current_balance?: string
           deployer?: string | null

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -105,7 +105,9 @@ export interface Database {
           _metadata_retries_left: number | null
           _updated_at: number
           archived: boolean | null
+          contributors_count: number
           created_at: number
+          creator: string
           current_balance: string
           deployer: string | null
           description: string | null
@@ -114,20 +116,28 @@ export interface Database {
           logo_uri: string | null
           metadata_uri: string | null
           name: string | null
+          nfts_minted_count: number
+          owner: string
           payments_count: number
           project_id: number
           pv: string
+          redeem_count: number
+          redeem_volume: string
+          redeem_voume_usd: string
           tags: string[] | null
           terminal: string | null
-          total_paid: string
           trending_score: string
+          volume: string
+          volume_usd: string
         }
         Insert: {
           _has_unresolved_metadata?: boolean | null
           _metadata_retries_left?: number | null
           _updated_at: number
           archived?: boolean | null
+          contributors_count: number
           created_at: number
+          creator: string
           current_balance: string
           deployer?: string | null
           description?: string | null
@@ -136,20 +146,28 @@ export interface Database {
           logo_uri?: string | null
           metadata_uri?: string | null
           name?: string | null
+          nfts_minted_count: number
+          owner: string
           payments_count: number
           project_id: number
           pv: string
+          redeem_count: number
+          redeem_volume: string
+          redeem_voume_usd: string
           tags?: string[] | null
           terminal?: string | null
-          total_paid: string
           trending_score: string
+          volume: string
+          volume_usd: string
         }
         Update: {
           _has_unresolved_metadata?: boolean | null
           _metadata_retries_left?: number | null
           _updated_at?: number
           archived?: boolean | null
+          contributors_count?: number
           created_at?: number
+          creator?: string
           current_balance?: string
           deployer?: string | null
           description?: string | null
@@ -158,13 +176,19 @@ export interface Database {
           logo_uri?: string | null
           metadata_uri?: string | null
           name?: string | null
+          nfts_minted_count?: number
+          owner?: string
           payments_count?: number
           project_id?: number
           pv?: string
+          redeem_count?: number
+          redeem_volume?: string
+          redeem_voume_usd?: string
           tags?: string[] | null
           terminal?: string | null
-          total_paid?: string
           trending_score?: string
+          volume?: string
+          volume_usd?: string
         }
       }
       user_subscriptions: {

--- a/src/utils/sgDbProjects.ts
+++ b/src/utils/sgDbProjects.ts
@@ -38,6 +38,7 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
   'terminal',
   'paymentsCount',
   'trendingPaymentsCount',
+  'createdWithinTrendingWindow',
 ]
 
 // Parse DB Project json, converting strings to BigNumbers
@@ -61,6 +62,7 @@ export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
     archived: p.archived,
     contributorsCount: p.contributors_count,
     createdAt: p.created_at,
+    createdWithinTrendingWindow: p.created_within_trending_window,
     creator: p.creator,
     currentBalance: p.current_balance,
     deployer: p.deployer,
@@ -97,6 +99,7 @@ export function formatDBProjectRow(p: Json<DBProject>): DBProjectRow {
     archived: p.archived,
     contributors_count: p.contributorsCount,
     created_at: p.createdAt,
+    created_within_trending_window: p.createdWithinTrendingWindow,
     creator: p.creator,
     current_balance: p.currentBalance,
     deployer: p.deployer,

--- a/src/utils/sgDbProjects.ts
+++ b/src/utils/sgDbProjects.ts
@@ -23,6 +23,14 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
   'metadataUri',
   'currentBalance',
   'volume',
+  'volumeUSD',
+  'redeemVolume',
+  'redeemVolumeUSD',
+  'redeemCount',
+  'creator',
+  'owner',
+  'contributorsCount',
+  'nftsMintedCount',
   'createdAt',
   'trendingScore',
   'deployer',
@@ -34,14 +42,23 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
 export const parseDBProjectJson = (j: Json<DBProject>): DBProject => ({
   ...j,
   tags: j.tags ?? [],
-  ...parseBigNumberKeyVals(j, ['currentBalance', 'volume', 'trendingScore']),
+  ...parseBigNumberKeyVals(j, [
+    'currentBalance',
+    'volume',
+    'volumeUSD',
+    'trendingScore',
+    'redeemVolume',
+    'redeemVolumeUSD',
+  ]),
 })
 
 // Parse DB Project row, converting property names from snake_case to camelCase
 export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
   return {
     archived: p.archived,
+    contributorsCount: p.contributors_count,
     createdAt: p.created_at,
+    creator: p.creator,
     currentBalance: p.current_balance,
     deployer: p.deployer,
     description: p.description,
@@ -50,12 +67,18 @@ export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
     logoUri: p.logo_uri,
     metadataUri: p.metadata_uri,
     name: p.name,
+    nftsMintedCount: p.nfts_minted_count,
+    owner: p.owner,
     paymentsCount: p.payments_count,
     projectId: p.project_id,
     pv: p.pv as PV,
+    redeemCount: p.redeem_count,
+    redeemVolume: p.redeem_volume,
+    redeemVolumeUSD: p.redeem_voume_usd,
     tags: p.tags as ProjectTagName[],
     terminal: p.terminal,
-    volume: p.total_paid,
+    volume: p.volume,
+    volumeUSD: p.volume_usd,
     trendingScore: p.trending_score,
     _hasUnresolvedMetadata: p._has_unresolved_metadata,
     _metadataRetriesLeft: p._metadata_retries_left,
@@ -67,7 +90,9 @@ export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
 export function formatDBProjectRow(p: Json<DBProject>): DBProjectRow {
   return {
     archived: p.archived,
+    contributors_count: p.contributorsCount,
     created_at: p.createdAt,
+    creator: p.creator,
     current_balance: p.currentBalance,
     deployer: p.deployer,
     description: p.description,
@@ -76,13 +101,19 @@ export function formatDBProjectRow(p: Json<DBProject>): DBProjectRow {
     logo_uri: p.logoUri,
     metadata_uri: p.metadataUri,
     name: p.name,
+    nfts_minted_count: p.nftsMintedCount,
+    owner: p.owner,
     payments_count: p.paymentsCount,
     project_id: p.projectId,
     pv: p.pv,
+    redeem_count: p.redeemCount,
+    redeem_volume: p.redeemVolume,
+    redeem_voume_usd: p.redeemVolumeUSD,
     tags: p.tags,
     terminal: p.terminal,
-    total_paid: p.volume,
     trending_score: p.trendingScore,
+    volume: p.volume,
+    volume_usd: p.volumeUSD,
     _has_unresolved_metadata: p._hasUnresolvedMetadata ?? null,
     _metadata_retries_left: p._metadataRetriesLeft ?? null,
     _updated_at: p._updatedAt,
@@ -249,7 +280,7 @@ export async function tryResolveMetadata({
   }
 }
 
-// BigNumber values are stored as strings (sql type: keyword). To sort by these they must have an equal number of digits, so we pad them with leading 0s up to a 32 char length.
+// BigNumber values are stored as strings. To sort by these they must have an equal number of digits, so we pad them with leading 0s up to a 32 char length.
 function padBigNumForSort(bn: string) {
   return bn.padStart(32, '0')
 }
@@ -259,7 +290,10 @@ export function formatSGProjectForDB(p: Json<Pick<Project, SGSBCompareKey>>) {
     ...p,
     // Adjust BigNumber values before we compare them to database values
     currentBalance: padBigNumForSort(p.currentBalance),
-    volume: padBigNumForSort(p.volume),
+    redeemVolume: padBigNumForSort(p.redeemVolume),
+    redeemVolumeUSD: padBigNumForSort(p.redeemVolumeUSD),
     trendingScore: padBigNumForSort(p.trendingScore),
+    volume: padBigNumForSort(p.volume),
+    volumeUSD: padBigNumForSort(p.volumeUSD),
   }
 }

--- a/src/utils/sgDbProjects.ts
+++ b/src/utils/sgDbProjects.ts
@@ -37,6 +37,7 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
   'deployer',
   'terminal',
   'paymentsCount',
+  'trendingPaymentsCount',
 ]
 
 // Parse DB Project json, converting strings to BigNumbers
@@ -81,6 +82,7 @@ export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
     terminal: p.terminal,
     volume: p.volume,
     volumeUSD: p.volume_usd,
+    trendingPaymentsCount: p.trending_payments_count,
     trendingScore: p.trending_score,
     trendingVolume: p.trending_volume,
     _hasUnresolvedMetadata: p._has_unresolved_metadata,
@@ -114,6 +116,7 @@ export function formatDBProjectRow(p: Json<DBProject>): DBProjectRow {
     redeem_voume_usd: p.redeemVolumeUSD,
     tags: p.tags,
     terminal: p.terminal,
+    trending_payments_count: p.trendingPaymentsCount,
     trending_score: p.trendingScore,
     trending_volume: p.trendingVolume,
     volume: p.volume,

--- a/src/utils/sgDbProjects.ts
+++ b/src/utils/sgDbProjects.ts
@@ -33,6 +33,7 @@ export const sgDbCompareKeys: SGSBCompareKey[] = [
   'nftsMintedCount',
   'createdAt',
   'trendingScore',
+  'trendingVolume',
   'deployer',
   'terminal',
   'paymentsCount',
@@ -47,6 +48,7 @@ export const parseDBProjectJson = (j: Json<DBProject>): DBProject => ({
     'volume',
     'volumeUSD',
     'trendingScore',
+    'trendingVolume',
     'redeemVolume',
     'redeemVolumeUSD',
   ]),
@@ -80,6 +82,7 @@ export function parseDBProjectsRow(p: DBProjectRow): Json<DBProject> {
     volume: p.volume,
     volumeUSD: p.volume_usd,
     trendingScore: p.trending_score,
+    trendingVolume: p.trending_volume,
     _hasUnresolvedMetadata: p._has_unresolved_metadata,
     _metadataRetriesLeft: p._metadata_retries_left,
     _updatedAt: p._updated_at,
@@ -112,6 +115,7 @@ export function formatDBProjectRow(p: Json<DBProject>): DBProjectRow {
     tags: p.tags,
     terminal: p.terminal,
     trending_score: p.trendingScore,
+    trending_volume: p.trendingVolume,
     volume: p.volume,
     volume_usd: p.volumeUSD,
     _has_unresolved_metadata: p._hasUnresolvedMetadata ?? null,
@@ -285,7 +289,9 @@ function padBigNumForSort(bn: string) {
   return bn.padStart(32, '0')
 }
 
-export function formatSGProjectForDB(p: Json<Pick<Project, SGSBCompareKey>>) {
+export function formatSGProjectForDB(
+  p: Json<Pick<Project, SGSBCompareKey>>,
+): Json<Pick<Project, SGSBCompareKey>> {
   return {
     ...p,
     // Adjust BigNumber values before we compare them to database values
@@ -293,6 +299,7 @@ export function formatSGProjectForDB(p: Json<Pick<Project, SGSBCompareKey>>) {
     redeemVolume: padBigNumForSort(p.redeemVolume),
     redeemVolumeUSD: padBigNumForSort(p.redeemVolumeUSD),
     trendingScore: padBigNumForSort(p.trendingScore),
+    trendingVolume: padBigNumForSort(p.trendingVolume),
     volume: padBigNumForSort(p.volume),
     volumeUSD: padBigNumForSort(p.volumeUSD),
   }

--- a/supabase/migrations/20230525200130_add_project_columns.sql
+++ b/supabase/migrations/20230525200130_add_project_columns.sql
@@ -10,4 +10,5 @@ add COLUMN "trending_volume" char(32) not null,
 add COLUMN "trending_payments_count" int not null,
 add COLUMN "redeem_volume" char(32) not null,
 add COLUMN "redeem_voume_usd" char(32) not null,
-add COLUMN "nfts_minted_count" bigint not null;
+add COLUMN "nfts_minted_count" bigint not null,
+add COLUMN "created_within_trending_window" boolean not null;

--- a/supabase/migrations/20230525200130_add_project_columns.sql
+++ b/supabase/migrations/20230525200130_add_project_columns.sql
@@ -6,6 +6,7 @@ add COLUMN "redeem_count" int not null,
 drop column "total_paid",
 add column "volume" char(32) not null,
 add COLUMN "volume_usd" char(32) not null,
+add COLUMN "trending_volume" char(32) not null,
 add COLUMN "redeem_volume" char(32) not null,
 add COLUMN "redeem_voume_usd" char(32) not null,
 add COLUMN "nfts_minted_count" bigint not null;

--- a/supabase/migrations/20230525200130_add_project_columns.sql
+++ b/supabase/migrations/20230525200130_add_project_columns.sql
@@ -7,6 +7,7 @@ drop column "total_paid",
 add column "volume" char(32) not null,
 add COLUMN "volume_usd" char(32) not null,
 add COLUMN "trending_volume" char(32) not null,
+add COLUMN "trending_payments_count" int not null,
 add COLUMN "redeem_volume" char(32) not null,
 add COLUMN "redeem_voume_usd" char(32) not null,
 add COLUMN "nfts_minted_count" bigint not null;

--- a/supabase/migrations/20230525200130_add_project_columns.sql
+++ b/supabase/migrations/20230525200130_add_project_columns.sql
@@ -1,0 +1,11 @@
+alter table public.projects 
+add COLUMN "owner" char(42) not null,
+add COLUMN "creator" char(42) not null,
+add COLUMN "contributors_count" int not null,
+add COLUMN "redeem_count" int not null,
+drop column "total_paid",
+add column "volume" char(32) not null,
+add COLUMN "volume_usd" char(32) not null,
+add COLUMN "redeem_volume" char(32) not null,
+add COLUMN "redeem_voume_usd" char(32) not null,
+add COLUMN "nfts_minted_count" bigint not null;


### PR DESCRIPTION
Another PR in a sequence to deprecate all subgraph utils from the UI.

This began as replacing the `useMyProjects()` subgraph query hook with a DB query. However there were still some missing (and some recently added) Project properties that haven't been added to the database, which were required to make this query, so this PR also updates the DBProject model and update routine to store all Project properties that currently exist in the subgraph.

Also includes a very simple update to the account page to show both "Created" and "Owned" projects (until a recent subgraph update, only `Project.owner` was available, but we can now also make use of `Project.creator`)

Note on this pattern update: We can still query projects from the subgraph using the new Apollo queries. However the ProjectCard component uses a data type that requires DBProject properties (resolved metadata properties) which can't be retrieved from the subgraph. This is specifically relevant to this update since the query results are being passed to ProjectCard lists, but I intend to replace all Projects queries with DB queries as a general practice.

<img width="1184" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/c97534e0-584e-4c5b-9af1-6d47cb9d00ca">
<img width="1157" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/249a80d5-c0cf-445b-a891-71de59875d27">
