### PR TITLE
Snapshot button error handling

### DIFF
--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1796,6 +1796,9 @@ msgstr ""
 msgid "Project rules"
 msgstr ""
 
+msgid "Failed to launch Snapshot. Try again."
+msgstr ""
+
 msgid "Choose how you would like to set up payouts."
 msgstr ""
 


### PR DESCRIPTION
Fixes JB-354 

Had recent woes with this button - there's an error on Snapshots side (see https://discord.com/channels/775859454780244028/864240636277293106/1110895086482497567)

However, we need some error handling on our side. This is the result now:
<img width="964" alt="Screen Shot 2023-05-26 at 3 26 18 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/98d96738-c622-48fb-bee9-73a6c9dd5f8b">

