### PR TITLE
New project page: NFTs & Rewards Panel UI

### DIFF
--- a/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/AddNftButton.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/AddNftButton.tsx
@@ -1,0 +1,23 @@
+import { PlusIcon } from '@heroicons/react/24/solid'
+import { Trans } from '@lingui/macro'
+import { stopPropagation } from 'react-stop-propagation'
+import { classNames } from 'utils/classNames'
+
+// Button that appears when hovering an NFT reward card
+export function AddNftButton({ onClick }: { onClick: VoidFunction }) {
+  return (
+    <div
+      className={classNames(
+        'absolute bottom-0 h-12 w-full bg-bluebs-500 text-base font-medium text-white',
+        'flex items-center justify-center opacity-0 group-hover:opacity-100',
+        'rounded-b-lg transition-opacity duration-200 ease-in-out',
+      )}
+      onClick={stopPropagation(onClick)}
+    >
+      <PlusIcon className="mr-1 h-6 w-6" />
+      <span>
+        <Trans>Add NFT</Trans>
+      </span>
+    </div>
+  )
+}

--- a/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/NftDetails.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/NftDetails.tsx
@@ -1,0 +1,72 @@
+import { Skeleton } from 'antd'
+import ETHAmount from 'components/currency/ETHAmount'
+import { NftRewardTier } from 'models/nftRewards'
+import { classNames } from 'utils/classNames'
+import { parseWad } from 'utils/format/formatNumber'
+
+export function NftDetails({
+  rewardTier,
+  loading,
+  hideAttributes,
+  remainingSupplyText,
+}: {
+  rewardTier: NftRewardTier | undefined
+  loading: boolean | undefined
+  hideAttributes?: boolean
+  remainingSupplyText: string
+}) {
+  return (
+    <div
+      className={classNames(
+        'flex h-full w-full flex-col justify-between rounded-b-lg bg-white pr-3.5 pl-3 pb-2.5',
+        !loading ? 'pt-3.5' : 'pt-1',
+      )}
+    >
+      <Skeleton
+        loading={loading}
+        active
+        title={false}
+        paragraph={{ rows: 1, width: ['100%'] }}
+      >
+        <span
+          className={classNames(
+            'text-base font-medium',
+            'text-ellipsis',
+            'overflow-hidden',
+            'text-black dark:text-slate-100',
+          )}
+        >
+          {rewardTier?.name}
+        </span>
+      </Skeleton>
+      {!hideAttributes ? (
+        <div className="mt-2 flex items-center justify-between">
+          {rewardTier?.contributionFloor ? (
+            <Skeleton
+              className="mt-1"
+              loading={loading}
+              active
+              title={false}
+              paragraph={{ rows: 1, width: ['50%'] }}
+            >
+              <span className="text-lg font-medium text-grey-900 dark:text-slate-50">
+                <ETHAmount amount={parseWad(rewardTier.contributionFloor)} />
+              </span>
+            </Skeleton>
+          ) : null}
+          <Skeleton
+            className="pt-5 text-right"
+            loading={loading}
+            active
+            title={false}
+            paragraph={{ rows: 1, width: ['50%'] }}
+          >
+            <span className="text-xs text-grey-400 dark:text-slate-200">
+              {remainingSupplyText}
+            </span>
+          </Skeleton>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/NftReward.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/NftReward.tsx
@@ -1,0 +1,89 @@
+import { t } from '@lingui/macro'
+import { NftPreview } from 'components/NftRewards/NftPreview'
+import { PayProjectFormContext } from 'components/Project/PayProjectForm/payProjectFormContext'
+import { DEFAULT_NFT_MAX_SUPPLY } from 'contexts/NftRewards/NftRewards'
+import { NftRewardTier } from 'models/nftRewards'
+import { useContext, useState } from 'react'
+import { classNames } from 'utils/classNames'
+import { ipfsUriToGatewayUrl } from 'utils/ipfs'
+import { AddNftButton } from './AddNftButton'
+import { NftDetails } from './NftDetails'
+import { NftThumbnail } from './NftThumbnail'
+
+type NftRewardProps = {
+  rewardTier?: NftRewardTier
+  loading?: boolean
+  onSelect: (quantity?: number) => void
+  previewDisabled?: boolean
+  hideAttributes?: boolean
+}
+
+export function NftReward({
+  loading,
+  rewardTier,
+  previewDisabled,
+  onSelect,
+  hideAttributes,
+}: NftRewardProps) {
+  const { form: payProjectForm } = useContext(PayProjectFormContext)
+
+  const [previewVisible, setPreviewVisible] = useState<boolean>(false)
+
+  const { payMetadata } = payProjectForm ?? {}
+
+  const quantitySelected =
+    payMetadata?.tierIdsToMint.filter(id => id === rewardTier?.id ?? -1)
+      .length ?? 0
+
+  const fileUrl = rewardTier?.fileUrl
+    ? ipfsUriToGatewayUrl(rewardTier.fileUrl)
+    : rewardTier?.fileUrl
+
+  const isSelected = quantitySelected > 0
+
+  const openPreview = () => {
+    setPreviewVisible(true)
+  }
+  const closePreview = () => {
+    setPreviewVisible(false)
+  }
+
+  const remainingSupply = rewardTier?.remainingSupply
+  const hasRemainingSupply = remainingSupply && remainingSupply > 0
+  const remainingSupplyText = !hasRemainingSupply
+    ? t`SOLD OUT`
+    : rewardTier.maxSupply === DEFAULT_NFT_MAX_SUPPLY
+    ? t`Unlimited`
+    : t`${rewardTier?.remainingSupply} remaining`
+
+  return (
+    <div
+      className={classNames(
+        'group relative flex h-full w-full cursor-pointer select-none flex-col rounded-lg border border-grey-200',
+        isSelected ? 'border-2 border-bluebs-500' : '',
+      )}
+      onClick={openPreview}
+    >
+      <NftThumbnail
+        fileUrl={fileUrl}
+        isSelected={isSelected}
+        rewardTier={rewardTier}
+      />
+      <NftDetails
+        rewardTier={rewardTier}
+        loading={loading}
+        hideAttributes={hideAttributes}
+        remainingSupplyText={remainingSupplyText}
+      />
+      <AddNftButton onClick={() => onSelect(1)} />
+      {rewardTier && !previewDisabled && previewVisible ? (
+        <NftPreview
+          open={previewVisible}
+          rewardTier={rewardTier}
+          onClose={closePreview}
+          fileUrl={fileUrl}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/NftThumbnail.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/NftThumbnail.tsx
@@ -1,0 +1,36 @@
+import { JuiceVideoThumbnailOrImage } from 'components/JuiceVideo/JuiceVideoThumbnailOrImage'
+import { NftRewardTier } from 'models/nftRewards'
+import { classNames } from 'utils/classNames'
+
+const NFT_DISPLAY_HEIGHT_CLASS = 'h-36' // rem height
+
+export function NftThumbnail({
+  fileUrl,
+  isSelected,
+  rewardTier,
+}: {
+  fileUrl: string | undefined
+  isSelected: boolean
+  rewardTier: NftRewardTier | undefined
+}) {
+  return (
+    <div
+      className={classNames(
+        `relative flex w-full items-center justify-center rounded-t-lg ${NFT_DISPLAY_HEIGHT_CLASS}`,
+        isSelected
+          ? 'bg-white dark:bg-slate-800'
+          : 'bg-white dark:bg-slate-600',
+      )}
+      style={{ borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }}
+    >
+      {fileUrl ? (
+        <JuiceVideoThumbnailOrImage
+          src={fileUrl}
+          alt={rewardTier?.name ?? 'Juicebox NFT reward'}
+          className="absolute w-full rounded-t-lg"
+          heightClass={NFT_DISPLAY_HEIGHT_CLASS}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/index.ts
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/NftReward/index.ts
@@ -1,0 +1,1 @@
+export * from './NftReward'

--- a/src/components/ProjectDashboard/components/NftRewardsPanel/NftRewardsPanel.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/NftRewardsPanel.tsx
@@ -1,3 +1,29 @@
+import { Trans } from '@lingui/macro'
+import { NftReward } from './NftReward'
+import { useNftRewards } from './hooks/useNftRewards'
+
 export const NftRewardsPanel = () => {
-  return <>NFTs & Rewards</>
+  const {
+    rewardTiers,
+    handleTierSelect,
+    loading: nftsLoading,
+  } = useNftRewards()
+
+  return (
+    <div className="flex w-full max-w-2xl flex-col gap-5">
+      <h2 className="font-heading text-2xl font-medium">
+        <Trans>NFTs</Trans>
+      </h2>
+      <div className="grid grid-cols-3 gap-4">
+        {rewardTiers?.map((tier, i) => (
+          <NftReward
+            key={i}
+            rewardTier={tier}
+            loading={nftsLoading}
+            onSelect={(quantity = 1) => handleTierSelect(tier.id, quantity)}
+          />
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/src/components/ProjectDashboard/components/NftRewardsPanel/hooks/useNftRewards.ts
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/hooks/useNftRewards.ts
@@ -1,0 +1,114 @@
+import { PayProjectFormContext } from 'components/Project/PayProjectForm/payProjectFormContext'
+import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
+import { NftRewardsContext } from 'contexts/NftRewards/NftRewardsContext'
+import { CurrencyContext } from 'contexts/shared/CurrencyContext'
+import { useCurrencyConverter } from 'hooks/useCurrencyConverter'
+import { useCallback, useContext } from 'react'
+import { fromWad } from 'utils/format/formatNumber'
+import { sumTierFloors } from 'utils/nftRewards'
+
+export const useNftRewards = () => {
+  const {
+    nftRewards: { rewardTiers },
+    loading,
+  } = useContext(NftRewardsContext)
+  const { form: payProjectForm } = useContext(PayProjectFormContext)
+  const {
+    currencies: { ETH },
+  } = useContext(CurrencyContext)
+
+  const converter = useCurrencyConverter()
+
+  const {
+    payAmount,
+    payMetadata,
+    payInCurrency,
+    setPayAmount,
+    setPayInCurrency,
+    setPayMetadata,
+    validatePayAmount,
+  } = payProjectForm ?? {}
+
+  const payAmountETH =
+    payInCurrency === ETH ? payAmount : fromWad(converter.usdToWei(payAmount))
+
+  const handleTierSelect = useCallback(
+    (
+      tierId: number | undefined,
+      quantity: number, // quantity to select
+    ) => {
+      if (!tierId || !rewardTiers) return
+
+      const newSelectedTierIds = (payMetadata?.tierIdsToMint ?? []).concat(
+        Array(quantity).fill(tierId),
+      )
+
+      setPayMetadata?.({
+        tierIdsToMint: newSelectedTierIds,
+        allowOverspending: DEFAULT_ALLOW_OVERSPENDING,
+      })
+
+      setPayInCurrency?.(ETH)
+
+      const sumSelectedTiers = sumTierFloors(rewardTiers, newSelectedTierIds)
+      if (sumSelectedTiers > parseFloat(payAmountETH ?? '0')) {
+        const newPayAmount = sumSelectedTiers.toString()
+        setPayAmount?.(newPayAmount)
+        validatePayAmount?.(newPayAmount)
+      }
+    },
+    [
+      rewardTiers,
+      payMetadata,
+      payAmountETH,
+      ETH,
+      setPayAmount,
+      setPayInCurrency,
+      setPayMetadata,
+      validatePayAmount,
+    ],
+  )
+
+  const handleNftDeselect = useCallback(
+    (
+      tierId: number | undefined,
+      quantity: number, // quantity to deselect. Remove all instances of tierId if quantity=0
+    ) => {
+      if (tierId === undefined || !rewardTiers || !payMetadata) return
+
+      let count = 0
+      const newSelectedTierIds = (payMetadata?.tierIdsToMint ?? []).filter(
+        id => {
+          if (!quantity) {
+            return id !== tierId
+          }
+          if (count < quantity && id === tierId) {
+            count += 1
+            return false
+          }
+          return true
+        },
+      )
+
+      setPayMetadata?.({
+        tierIdsToMint: newSelectedTierIds,
+      })
+
+      const newPayAmount = sumTierFloors(
+        rewardTiers,
+        newSelectedTierIds,
+      ).toString()
+
+      setPayAmount?.(newPayAmount)
+      validatePayAmount?.(newPayAmount)
+    },
+    [rewardTiers, payMetadata, setPayAmount, setPayMetadata, validatePayAmount],
+  )
+
+  return {
+    rewardTiers,
+    loading,
+    handleTierSelect,
+    handleNftDeselect,
+  }
+}


### PR DESCRIPTION
Implements the **NFTs & Rewards Panel UI** outside of the **Summary** section.

Everything is hooked up with a copy of the old NFT code which is contained in this `NftRewards/hooks` dir, guessing this will be scrapped when the checkout logic is complete! I was thinking we just consider the UI in this PR and handle the checkout logic in later.

<img width="1325" alt="Screen Shot 2023-06-05 at 5 20 58 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/cb0399c2-6d5b-4f3d-b588-34d16d90246c">

Hover:
<img width="1050" alt="Screen Shot 2023-06-05 at 5 22 00 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/caa2b721-deb6-417e-aaa0-d0a378c9e51c">
