### PR TITLE
Replace remaining `querySubgraph` and `querySubgraphExhaustive` instances

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -18,3 +18,6 @@ config:
     enumValues: keep
   scalars:
     BigInt: BigNumber
+  avoidOptionals:
+    field: true
+  skipTypename: true

--- a/src/components/VolumeChart/loadProjectEvents.ts
+++ b/src/components/VolumeChart/loadProjectEvents.ts
@@ -1,9 +1,12 @@
-import { SGWhereArg } from 'models/graph'
 import { PV } from 'models/pv'
-import { Project } from 'models/subgraph-entities/vX/project'
 import { fromWad } from 'utils/format/formatNumber'
-import { querySubgraph } from 'utils/graph'
 
+import {
+  ProjectsTlDocument,
+  ProjectsTlQuery,
+  QueryProjectsArgs,
+} from 'generated/graphql'
+import { client } from 'lib/apollo/client'
 import { BlockRef, EventRef, ShowGraph } from './types'
 
 export const loadProjectEvents = async ({
@@ -22,65 +25,54 @@ export const loadProjectEvents = async ({
 
   if (!blockRefs.length) return
 
-  let queryKeys: (keyof Project)[]
-
-  switch (showGraph) {
-    case 'volume':
-      queryKeys = ['volume']
-      break
-    case 'balance':
-      queryKeys = ['currentBalance']
-      break
-  }
-
   // Query balance of project for interval blocks
   blockRefs.forEach(blockRef => {
-    const whereOpts: SGWhereArg<'project'>[] = []
-    if (projectId) {
-      whereOpts.push({ key: 'projectId', value: projectId })
-    }
-    if (pv) {
-      whereOpts.push({ key: 'pv', value: pv })
-    }
-
     // For block == null, don't specify block param
     const block =
       blockRef.block !== null ? { block: { number: blockRef.block } } : {}
 
     promises.push(
-      querySubgraph({
-        entity: 'project',
-        keys: queryKeys,
-        ...block,
-        where: whereOpts,
-      }).then(projects => {
-        if (!projects.length) return
-
-        let value: number | undefined = undefined
-
-        const project = projects[0]
-
-        if (!project) return
-        projects.forEach(project => {
-          switch (showGraph) {
-            case 'volume':
-              value = parseFloat(parseFloat(fromWad(project.volume)).toFixed(4))
-              break
-            case 'balance':
-              value = parseFloat(
-                parseFloat(fromWad(project.currentBalance)).toFixed(4),
-              )
-              break
-          }
-
-          if (value !== undefined) {
-            newEvents.push({
-              timestamp: blockRef.timestamp,
-              value,
-            })
-          }
+      client
+        .query<ProjectsTlQuery, QueryProjectsArgs>({
+          query: ProjectsTlDocument,
+          variables: {
+            where: {
+              projectId,
+              pv,
+            },
+            ...block,
+          },
         })
-      }),
+        .then(data => {
+          const { projects } = data.data
+
+          let value: number | undefined = undefined
+
+          const project = projects[0]
+
+          if (!project) return
+          projects.forEach(project => {
+            switch (showGraph) {
+              case 'volume':
+                value = parseFloat(
+                  parseFloat(fromWad(project.volume)).toFixed(4),
+                )
+                break
+              case 'balance':
+                value = parseFloat(
+                  parseFloat(fromWad(project.currentBalance)).toFixed(4),
+                )
+                break
+            }
+
+            if (value !== undefined) {
+              newEvents.push({
+                timestamp: blockRef.timestamp,
+                value,
+              })
+            }
+          })
+        }),
     )
   })
 

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftCard.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { NftTierCard } from 'components/NftRewards/NftTierCard'
+import { Jb721DelegateToken } from 'generated/graphql'
 import { IPFSNftRewardTier, NftRewardTier } from 'models/nftRewards'
-import { JB721DelegateToken } from 'models/subgraph-entities/v2/jb-721-delegate-tokens'
 import { UseQueryResult, useQuery } from 'react-query'
 import { cidFromIpfsUri, ipfsGatewayUrl } from 'utils/ipfs'
 
@@ -31,7 +31,7 @@ export function RedeemNftCard({
   onRemove,
   loading,
 }: {
-  nft: Pick<JB721DelegateToken, 'address' | 'tokenId' | 'tokenUri'>
+  nft: Pick<Jb721DelegateToken, 'address' | 'tokenUri'> & { tokenId: string }
   isSelected: boolean
   onClick: VoidFunction
   onRemove: VoidFunction

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -16,11 +16,11 @@ import { JB721DelegateContractsContext } from 'contexts/NftRewards/JB721Delegate
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { BigNumber, constants } from 'ethers'
 import { defaultAbiCoder } from 'ethers/lib/utils.js'
+import { Jb721DelegateToken } from 'generated/graphql'
 import { useNftAccountBalance } from 'hooks/JB721Delegate/useNftAccountBalance'
 import { useETHReceivedFromNftRedeem } from 'hooks/v2v3/contractReader/useETHReceivedFromNftRedeem'
 import { useRedeemTokensTx } from 'hooks/v2v3/transactor/useRedeemTokensTx'
 import { useWallet } from 'hooks/Wallet'
-import { JB721DelegateToken } from 'models/subgraph-entities/v2/jb-721-delegate-tokens'
 import { useContext, useState } from 'react'
 import { emitErrorNotification } from 'utils/notifications'
 import { formatRedemptionRate } from 'utils/v2v3/math'
@@ -90,13 +90,13 @@ export function RedeemNftsModal({
   if (!fundingCycle || !fundingCycleMetadata || balanceLoading) return null
 
   const handleTierSelect = (
-    nft: Pick<JB721DelegateToken, 'address' | 'tokenId' | 'tokenUri'>,
+    nft: Pick<Jb721DelegateToken, 'address' | 'tokenUri'> & { tokenId: string },
   ) => {
     setTokenIdsToRedeem([...(tokenIdsToRedeem ?? []), nft.tokenId])
   }
 
   const handleTierDeselect = (
-    nft: Pick<JB721DelegateToken, 'address' | 'tokenId' | 'tokenUri'>,
+    nft: Pick<Jb721DelegateToken, 'address' | 'tokenUri'> & { tokenId: string },
   ) => {
     const idxToRemove = tokenIdsToRedeem.indexOf(nft.tokenId)
     const newSelectedTierIds = tokenIdsToRedeem
@@ -144,11 +144,11 @@ export function RedeemNftsModal({
     }
   }
 
-  const nfts = data?.jb721DelegateTokens.map(t => ({
+  const jb721DelegateTokens = data?.jb721DelegateTokens.map(t => ({
     ...t,
     tokenId: t.tokenId.toHexString(),
   }))
-  const nftBalanceFormatted = nfts?.length ?? 0
+  const nftBalanceFormatted = jb721DelegateTokens?.length ?? 0
   const hasOverflow = primaryTerminalCurrentOverflow?.gt(0)
   const hasRedemptionRate = fundingCycleMetadata.redemptionRate.gt(0)
   const canRedeem = hasOverflow && hasRedemptionRate
@@ -242,7 +242,7 @@ export function RedeemNftsModal({
           <Form form={form} layout="vertical">
             <Form.Item label={t`Select NFTs to redeem`}>
               <Row gutter={[20, 20]}>
-                {nfts?.map(nft => {
+                {jb721DelegateTokens?.map(nft => {
                   const isSelected = tokenIdsToRedeem.includes(nft.tokenId)
                   return (
                     <Col span={8} key={nft.tokenId}>

--- a/src/graphql/addToBalanceEvents/addToBalanceEventsDownload.graphql
+++ b/src/graphql/addToBalanceEvents/addToBalanceEventsDownload.graphql
@@ -1,0 +1,21 @@
+query AddToBalanceEventsDownload(
+  $where: AddToBalanceEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  addToBalanceEvents(
+    where: $where
+    block: $block
+    first: $first
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    amount
+    amountUSD
+    from
+    txHash
+  }
+}

--- a/src/graphql/distributePayoutsEvents/distributePayoutsEventsDownload.graphql
+++ b/src/graphql/distributePayoutsEvents/distributePayoutsEventsDownload.graphql
@@ -1,0 +1,21 @@
+query DistributePayoutsEventsDownload(
+  $where: DistributePayoutsEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  distributePayoutsEvents(
+    where: $where
+    block: $block
+    first: $first
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    beneficiaryDistributionAmount
+    beneficiaryDistributionAmountUSD
+    beneficiary
+    txHash
+  }
+}

--- a/src/graphql/distributeToPayoutModEvents/distributeToPayoutModEventsDownload.graphql
+++ b/src/graphql/distributeToPayoutModEvents/distributeToPayoutModEventsDownload.graphql
@@ -1,0 +1,22 @@
+query DistributeToPayoutModEventsDownload(
+  $where: DistributeToPayoutModEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  distributeToPayoutModEvents(
+    where: $where
+    block: $block
+    first: $first
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    modCut
+    modCutUSD
+    modProjectId
+    modBeneficiary
+    txHash
+  }
+}

--- a/src/graphql/distributeToPayoutSplitEvents/distributeToPayoutSplitEventsDownload.graphql
+++ b/src/graphql/distributeToPayoutSplitEvents/distributeToPayoutSplitEventsDownload.graphql
@@ -1,0 +1,22 @@
+query DistributeToPayoutSplitEventsDownload(
+  $where: DistributeToPayoutSplitEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  distributeToPayoutSplitEvents(
+    where: $where
+    block: $block
+    first: $first
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    amount
+    amountUSD
+    splitProjectId
+    beneficiary
+    txHash
+  }
+}

--- a/src/graphql/participants/participantsDownload.graphql
+++ b/src/graphql/participants/participantsDownload.graphql
@@ -1,24 +1,25 @@
-query Participants(
+query ParticipantsDownload(
   $where: Participant_filter
   $first: Int
   $skip: Int
-  $orderBy: Participant_orderBy
-  $orderDirection: OrderDirection
+  $block: Block_height
 ) {
   participants(
     where: $where
     first: $first
     skip: $skip
-    orderBy: $orderBy
-    orderDirection: $orderDirection
+    block: $block
+    orderBy: balance
+    orderDirection: desc
   ) {
     wallet {
       id
     }
     volume
-    lastPaidTimestamp
+    volumeUSD
     balance
     stakedBalance
-    id
+    erc20Balance
+    lastPaidTimestamp
   }
 }

--- a/src/graphql/payEvents/payEventsDownload.graphql
+++ b/src/graphql/payEvents/payEventsDownload.graphql
@@ -1,0 +1,22 @@
+query PayEventsDownload(
+  $where: PayEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  payEvents(
+    where: $where
+    block: $block
+    first: $first
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    amount
+    amountUSD
+    from
+    beneficiary
+    txHash
+  }
+}

--- a/src/graphql/projects/projectsTL.graphql
+++ b/src/graphql/projects/projectsTL.graphql
@@ -1,0 +1,11 @@
+query ProjectsTL(
+  $where: Project_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  projects(where: $where, first: $first, skip: $skip, block: $block) {
+    currentBalance
+    volume
+  }
+}

--- a/src/graphql/redeemEvents/redeemEventsDownload.graphql
+++ b/src/graphql/redeemEvents/redeemEventsDownload.graphql
@@ -1,0 +1,23 @@
+query RedeemEventsDownload(
+  $where: RedeemEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  redeemEvents(
+    where: $where
+    block: $block
+    first: $first
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    amount
+    returnAmount
+    returnAmountUSD
+    from
+    beneficiary
+    txHash
+  }
+}

--- a/src/graphql/tapEvents/tapEventsDownload.graphql
+++ b/src/graphql/tapEvents/tapEventsDownload.graphql
@@ -1,0 +1,21 @@
+query TapEventsDownload(
+  $where: TapEvent_filter
+  $first: Int
+  $skip: Int
+  $block: Block_height
+) {
+  tapEvents(
+    where: $where
+    first: $first
+    skip: $skip
+    block: $block
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    timestamp
+    beneficiaryTransferAmount
+    beneficiaryTransferAmountUSD
+    beneficiary
+    txHash
+  }
+}

--- a/src/graphql/tapEvents/tapEventsProjectTL.graphql
+++ b/src/graphql/tapEvents/tapEventsProjectTL.graphql
@@ -1,0 +1,6 @@
+query TapEventsProjectTL($where: TapEvent_filter, $first: Int, $skip: Int) {
+  tapEvents(where: $where, first: $first, skip: $skip) {
+    timestamp
+    netTransferAmount
+  }
+}

--- a/src/lib/apollo/paginateDepleteProjectsQuery.ts
+++ b/src/lib/apollo/paginateDepleteProjectsQuery.ts
@@ -3,6 +3,8 @@ import {
   ProjectsQuery,
   QueryProjectsArgs,
 } from 'generated/graphql'
+
+import { paginateDepleteQuery } from './paginateDepleteQuery'
 import { serverClient } from './serverClient'
 
 /**
@@ -15,25 +17,9 @@ export async function paginateDepleteProjectsQueryCall({
 }: {
   variables: QueryProjectsArgs
 }) {
-  const first = variables.first ?? 1000
-  const skip = variables.skip
-
-  const { data } = await serverClient.query<ProjectsQuery, QueryProjectsArgs>({
-    query: ProjectsDocument,
-    variables: { ...variables, first, skip },
+  return paginateDepleteQuery<ProjectsQuery, QueryProjectsArgs>({
+    client: serverClient,
+    document: ProjectsDocument,
+    variables,
   })
-  let projects = data.projects
-
-  if (projects.length) {
-    const _projects = await paginateDepleteProjectsQueryCall({
-      variables: {
-        ...variables,
-        first,
-        skip: first + (skip ?? 0),
-      },
-    })
-    projects = projects.concat(_projects)
-  }
-
-  return projects
 }

--- a/src/lib/apollo/paginateDepleteQuery.ts
+++ b/src/lib/apollo/paginateDepleteQuery.ts
@@ -1,0 +1,65 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { InputMaybe } from 'generated/graphql'
+import { DocumentNode } from 'graphql'
+
+/**
+ * Loads all pages for the query.
+ * @param client ApolloClient to use for query.
+ * @param document GraphQL docuemnt to define query.
+ * @param variables Variables to apply to query.
+ * @returns
+ */
+export async function paginateDepleteQuery<
+  Query extends { [k: string]: T[] },
+  QueryArgs extends
+    | {
+        first?: InputMaybe<number>
+        skip?: InputMaybe<number>
+      }
+    | undefined = undefined,
+  T = Query[keyof Query] extends Array<infer U> ? U : never,
+>({
+  client,
+  document,
+  variables,
+}: {
+  client: ApolloClient<NormalizedCacheObject>
+  document: DocumentNode
+  variables?: QueryArgs
+}) {
+  const first = variables?.first ?? 1000
+  const skip = variables?.skip ?? 0
+
+  const { data } = await client.query<Query, QueryArgs>({
+    query: document,
+    variables: {
+      ...(variables ?? {}),
+      first,
+      skip,
+    } as QueryArgs,
+  })
+
+  // Parse the property in response that contains the queried entities
+  const key = Object.keys(data).find(k => Array.isArray(data[k]))
+
+  if (!key) return []
+
+  let records = data[key]
+
+  if (data[key].length === first) {
+    // page again if we get back a full list
+    const _records = await paginateDepleteQuery<Query, QueryArgs, T>({
+      client,
+      document,
+      variables: {
+        ...(variables ?? {}),
+        first,
+        skip: first + skip,
+      } as QueryArgs,
+    })
+
+    records = records.concat(_records)
+  }
+
+  return records
+}

--- a/src/pages/activity/Payments.tsx
+++ b/src/pages/activity/Payments.tsx
@@ -7,11 +7,15 @@ import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import { PV_V1 } from 'constants/pv'
 import { usePayEventsQuery } from 'generated/graphql'
 import { client } from 'lib/apollo/client'
-import { Project } from 'models/subgraph-entities/vX/project'
+import { DBProject } from 'models/dbProject'
 import { classNames } from 'utils/classNames'
 import { formatHistoricalDate } from 'utils/format/formatDate'
 
-const ProjectHandle = ({ project }: { project: Partial<Project> }) => {
+const ProjectHandle = ({
+  project,
+}: {
+  project: Pick<DBProject, 'id' | 'projectId' | 'handle' | 'pv'>
+}) => {
   if (!project?.projectId) return null
 
   return (


### PR DESCRIPTION
- Add a bunch of new .graphql queries based on existing file pattern, and replace remaining `querySubgraph` and `querySubgraphExhaustive` instances
- Updates to `paginateDepleteQuery` for apollo queries, which replaces `useSubgraphExhaustive`