### PR TITLE
Add "Explore" button back to homepage with Fathom

### DIFF
--- a/src/pages/home/TopSection/TopSection.tsx
+++ b/src/pages/home/TopSection/TopSection.tsx
@@ -61,7 +61,19 @@ export function TopSection() {
           </Trans>
         }
       />
-      <div className="mb-16 flex w-full justify-center md:w-auto">
+      <div className="mb-16 flex w-full flex-col-reverse justify-center gap-4 md:w-auto md:flex-row">
+        <Link href="/projects" className="w-full md:w-auto">
+          <XLButton
+            size="large"
+            type="default"
+            className="w-full md:w-auto"
+            onClick={() => {
+              trackFathomGoal(HOMEPAGE.EXPLORE_PROJECTS_CTA)
+            }}
+          >
+            <Trans>Explore projects</Trans>
+          </XLButton>
+        </Link>
         <Link href="/create" className="w-full md:w-auto">
           <XLButton
             size="large"


### PR DESCRIPTION
Closes JB-428

Desktop:
<img width="1416" alt="Screen Shot 2023-06-14 at 5 37 16 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/f4574a62-1e4d-4fe9-92f1-eba6e7f0de65">

Mobile:
<img width="306" alt="Screen Shot 2023-06-14 at 5 37 02 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/7f3a85a6-ef8f-4382-be32-549d19fe3bb3">

