### PR TITLE
Improve `/projects` page loading state

### DIFF
--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -164,7 +164,7 @@ function Projects() {
             </div>
           </div>
 
-          <div>
+          <div className="md:min-h-[50vh]">
             <ArchivedProjectsMessage
               hidden={!showArchived || selectedTab !== 'all'}
             />


### PR DESCRIPTION
Closes JB-330. Stops the footer from jumping up during the loading state.

Before:
<img width="1418" alt="Screen Shot 2023-06-15 at 11 12 53 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/40d7a10c-cb2d-4806-a649-5c1ab0271033">

After:
<img width="1419" alt="Screen Shot 2023-06-15 at 11 11 26 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/cc8144c5-210a-413a-9af0-c6c5509819b0">
