### PR TITLE
Redeem NFTs section fixes

### DIFF
--- a/src/components/ProjectDashboard/components/NftRewardsPanel/RedeemNftsSection/RedeemNftsSection.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsPanel/RedeemNftsSection/RedeemNftsSection.tsx
@@ -17,11 +17,11 @@ export function RedeemNftsSection() {
   })
   const hasRedeemableNfts = (data?.jb721DelegateTokens?.length ?? 0) > 0
 
-  if (loading || !hasRedeemableNfts) return null
+  if (loading || !hasRedeemableNfts || !userAddress) return null
 
   return (
-    <div className="h-32 w-full rounded-lg bg-smoke-50 p-4">
-      <div className="text-sm font-medium text-grey-600">
+    <div className="h-32 w-full rounded-lg bg-smoke-50 p-5 dark:bg-slate-700">
+      <div className="text-sm font-medium text-grey-600 dark:text-slate-50">
         <Trans>Your NFTs</Trans>
       </div>
 


### PR DESCRIPTION
 - Hide when wallet disconnected (Fixes JB-525 https://linear.app/peel/issue/JB-525/redeem-box-shows-up-when-i-dont-have-any-nfts):

<img width="1253" alt="Screen Shot 2023-06-20 at 4 11 48 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/8db8d202-6a93-4af9-9f83-5551efdc37d4">

 - Dark mode style (Fixes JB-528 https://linear.app/peel/issue/JB-528/redeem-box-dark-mode-cooked):
 - 
<img width="936" alt="Screen Shot 2023-06-20 at 4 11 08 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/a478dcde-7616-4322-a9e8-76abc5770a98">
