### PR TITLE
NFT summary card updates

### DIFF
--- a/src/components/ProjectDashboard/components/NftRewardsCard/HoverPreview.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsCard/HoverPreview.tsx
@@ -1,4 +1,5 @@
 import { Transition } from '@headlessui/react'
+import { useProjectPageQueries } from 'components/ProjectDashboard/hooks/useProjectPageQueries'
 import { NftRewardsContext } from 'contexts/NftRewards/NftRewardsContext'
 import { useHasTouch } from 'hooks/useHasTouch'
 import {
@@ -14,6 +15,7 @@ import {
 import { SmallNftSquare } from './SmallNftSquare'
 
 export const HoverPreview: React.FC<PropsWithChildren> = ({ children }) => {
+  const { setProjectPageTab } = useProjectPageQueries()
   const hasTouch = useHasTouch()
   const [hovering, setHovering] = useState(false)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
@@ -107,11 +109,19 @@ export const HoverPreview: React.FC<PropsWithChildren> = ({ children }) => {
 
   if (!NftComponents.length) return <>{children}</>
 
+  const handleMouseEnter = () => {
+    !hasTouch && setHovering(true)
+  }
+
+  const handleMouseLeave = () => {
+    !hasTouch && setHovering(false)
+  }
+
   return (
     <div className="relative inline-block" ref={wrapperRef}>
       <div
-        onMouseEnter={() => !hasTouch && setHovering(true)}
-        onMouseLeave={() => !hasTouch && setHovering(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         {...handleToggle}
       >
         {children}
@@ -127,8 +137,11 @@ export const HoverPreview: React.FC<PropsWithChildren> = ({ children }) => {
         leaveTo="opacity-0"
       >
         <div
-          className="absolute top-full left-1/2 z-20 -translate-x-1/2 transform"
+          className="top-[calc(100% - 1px)] absolute left-1/2 z-20 -translate-x-1/2 transform cursor-pointer"
           ref={tooltipRef}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          onClick={() => setProjectPageTab('nft_rewards')}
         >
           <div className="z-10 mx-auto h-0 w-0 border-l-[20px] border-b-[24px] border-r-[20px] border-white border-l-transparent border-r-transparent dark:border-slate-950 dark:border-l-transparent dark:border-r-transparent" />
           <div className="grid min-w-max grid-cols-2 gap-4 rounded-lg bg-white p-5 shadow-lg dark:bg-slate-950">

--- a/src/components/ProjectDashboard/components/NftRewardsCard/NftRewardsCard.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsCard/NftRewardsCard.tsx
@@ -25,9 +25,10 @@ export const NftRewardsCard = ({ className }: { className?: string }) => {
         nftReward: nft,
         loading: nftsLoading,
         className: 'h-full w-full',
+        onClick: () => setProjectPageTab('nft_rewards'),
       },
     }))
-  }, [nftsLoading, rewardTiers])
+  }, [nftsLoading, rewardTiers, setProjectPageTab])
   const tooltipText = (
     <Trans>See the NFTs and rewards offered by this project.</Trans>
   )

--- a/src/components/ProjectDashboard/components/NftRewardsCard/SmallNftSquare.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsCard/SmallNftSquare.tsx
@@ -10,11 +10,13 @@ export const SmallNftSquare = ({
   className,
   loading,
   border = false,
+  onClick,
 }: {
   nftReward: Pick<NftRewardTier, 'fileUrl' | 'name'> | undefined
   className?: string
   loading?: boolean
   border?: boolean
+  onClick?: VoidFunction
 }) => {
   const _loading = !nftReward || loading
 
@@ -24,7 +26,7 @@ export const SmallNftSquare = ({
         className={twMerge(
           'rounded-lg bg-smoke-50',
           border &&
-            'border-4 border-solid border-smoke-50 dark:border-slate-900',
+            'border-4 border-solid border-smoke-50 dark:border-slate-700',
           className,
         )}
       />
@@ -36,15 +38,18 @@ export const SmallNftSquare = ({
   )
 
   return (
-    <JuiceVideoThumbnailOrImage
-      src={fileUrl}
-      alt={nftReward.name}
-      playIconPosition="hidden"
-      className={twMerge(
-        'rounded-lg bg-smoke-50',
-        border && 'border-4 border-solid border-smoke-50 dark:border-slate-900',
-        className,
-      )}
-    />
+    <div onClick={onClick} className="cursor-pointer">
+      <JuiceVideoThumbnailOrImage
+        src={fileUrl}
+        alt={nftReward.name}
+        playIconPosition="hidden"
+        className={twMerge(
+          'rounded-lg bg-smoke-50',
+          border &&
+            'border-4 border-solid border-smoke-50 dark:border-slate-700',
+          className,
+        )}
+      />
+    </div>
   )
 }


### PR DESCRIPTION
 - Fix hover NFTs disappearing when they are hovered and make it clickable (links to NFTs tab) -> (Fixes JB-526 https://linear.app/peel/issue/JB-526/nft-preview-box-should-link-to-nfts-not-disappear-on-hover):

https://github.com/jbx-protocol/juice-interface/assets/96150256/ecf0822a-a7cc-4665-9a3f-94117f3821b2

 - Fix dark styles on small cards (Fixes JB-538 https://linear.app/peel/issue/JB-538/give-these-outlines-the-same-colour-as-the-background-and-make-them)
 - 
<img width="300" alt="Screen Shot 2023-06-20 at 4 59 26 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/522c2f12-bc93-4975-821d-945e1e2f65f1">
