### PR TITLE
JB-480 - Give ETH/USD switcher button 4px corners instead of 8px

### DIFF
--- a/src/components/ProjectDashboard/components/PayProjectCard/components/PayInput.tsx
+++ b/src/components/ProjectDashboard/components/PayProjectCard/components/PayInput.tsx
@@ -55,7 +55,7 @@ export const PayInput = ({
         role="button"
         data-testid="pay-input-currency-button"
         className={twMerge(
-          'flex select-none items-center gap-0.5 rounded-lg py-1.5 pl-2 pr-3 text-xs font-medium transition-colors',
+          'flex select-none items-center gap-0.5 rounded py-1.5 pl-2 pr-3 text-xs font-medium transition-colors',
           currency === V2V3_CURRENCY_ETH
             ? 'bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950'
             : 'bg-melon-50 text-melon-600 dark:bg-melon-500 dark:text-melon-950',

--- a/src/components/ProjectDashboard/components/PayProjectCard/components/__snapshots__/PayInput.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/PayProjectCard/components/__snapshots__/PayInput.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`PayInput renders 1`] = `
       value=""
     />
     <div
-      class="flex select-none items-center gap-0.5 rounded-lg py-1.5 pl-2 pr-3 text-xs font-medium transition-colors bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950"
+      class="flex select-none items-center gap-0.5 rounded py-1.5 pl-2 pr-3 text-xs font-medium transition-colors bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950"
       data-testid="pay-input-currency-button"
       role="button"
     >
@@ -88,7 +88,7 @@ exports[`PayInput renders with placeholder 1`] = `
       value=""
     />
     <div
-      class="flex select-none items-center gap-0.5 rounded-lg py-1.5 pl-2 pr-3 text-xs font-medium transition-colors bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950"
+      class="flex select-none items-center gap-0.5 rounded py-1.5 pl-2 pr-3 text-xs font-medium transition-colors bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950"
       data-testid="pay-input-currency-button"
       role="button"
     >
@@ -144,7 +144,7 @@ exports[`PayInput renders with value 1`] = `
       value="1"
     />
     <div
-      class="flex select-none items-center gap-0.5 rounded-lg py-1.5 pl-2 pr-3 text-xs font-medium transition-colors bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950"
+      class="flex select-none items-center gap-0.5 rounded py-1.5 pl-2 pr-3 text-xs font-medium transition-colors bg-bluebs-50 text-bluebs-600 dark:bg-bluebs-500 dark:text-bluebs-950"
       data-testid="pay-input-currency-button"
       role="button"
     >


### PR DESCRIPTION
## What does this PR do and why?

Closes JB-480

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
