### PR TITLE
JB-483 - Increase tiny nfts images in NFTs & Rewards card to 56px as per design

### DIFF
--- a/src/components/ProjectDashboard/components/NftRewardsCard/NftRewardsCard.tsx
+++ b/src/components/ProjectDashboard/components/NftRewardsCard/NftRewardsCard.tsx
@@ -50,7 +50,7 @@ export const NftRewardsCard = ({ className }: { className?: string }) => {
       </div>
       <div className="flex items-center gap-3">
         <HoverPreview>
-          <StackedComponents components={NftComponents} size="56px" />
+          <StackedComponents components={NftComponents} size="60px" />
         </HoverPreview>
         <div>
           <button className="flex items-center gap-1 whitespace-nowrap rounded-2xl bg-smoke-100 py-1 pl-3 pr-2.5 text-sm text-smoke-700 dark:bg-slate-500 dark:text-slate-100">


### PR DESCRIPTION
## What does this PR do and why?

Closes JB-483

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
