### PR TITLE
JB-558 - Placeholder text still in pay modal

### DIFF
--- a/src/components/ProjectDashboard/components/PayProjectModal/PayProjectModal.tsx
+++ b/src/components/ProjectDashboard/components/PayProjectModal/PayProjectModal.tsx
@@ -21,6 +21,7 @@ export const PayProjectModal: React.FC = () => {
     isTransactionPending,
     isTransactionConfirmed,
     pendingTransactionHash,
+    projectName,
     setOpen,
     onPaySubmit,
   } = usePayProjectModal()
@@ -43,7 +44,7 @@ export const PayProjectModal: React.FC = () => {
           <JuiceModal
             className="w-full max-w-xl"
             buttonPosition="stretch"
-            title={t`Pay PyroDAO`}
+            title={t`Pay ${projectName}`}
             position="top"
             okLoading={props.isSubmitting || isTransactionPending}
             okButtonForm="PayProjectModalForm"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1121,9 +1121,6 @@ msgstr ""
 msgid "Collection Name"
 msgstr ""
 
-msgid "Pay PyroDAO"
-msgstr ""
-
 msgid "No active cycle."
 msgstr ""
 
@@ -4455,6 +4452,9 @@ msgid "Project handle"
 msgstr ""
 
 msgid "Manage your project's NFTs and rewards"
+msgstr ""
+
+msgid "Pay {projectName}"
 msgstr ""
 
 msgid "Advanced options"


### PR DESCRIPTION
## What does this PR do and why?

Closes https://linear.app/peel/issue/JB-558/placeholder-text-still-in-pay-modal

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
