### PR TITLE
Make all links on new project page font-medium

### DIFF
--- a/src/components/EthereumAddress.tsx
+++ b/src/components/EthereumAddress.tsx
@@ -62,7 +62,7 @@ export default function EthereumAddress({
     >
       <span
         className={twMerge(
-          'inline-flex items-center',
+          'inline-flex items-center font-medium',
           showEnsLoading && isLoading ? 'animate-pulse' : null,
         )}
       >

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ConfigurationDisplayCard renders 1`] = `
       type="button"
     >
       <div
-        class="mb-8 flex w-full items-center justify-between text-start"
+        class="flex w-full items-center justify-between text-start"
       >
         <div
           class="flex flex-col gap-2 text-sm font-medium text-grey-600 dark:text-slate-200"

--- a/src/components/ProjectDashboard/components/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/ProjectDashboard/components/ProjectHeader/ProjectHeader.tsx
@@ -70,7 +70,7 @@ export const ProjectHeader = ({ className }: { className?: string }) => {
             <div className="text-grey-500 dark:text-slate-200">
               {projectId ? (
                 <V2V3ProjectHandleLink
-                  className="font-normal text-grey-500 dark:text-slate-200"
+                  className="text-grey-500 dark:text-slate-200"
                   handle={handle}
                   projectId={projectId}
                 />


### PR DESCRIPTION
Fixes JB-571 (https://linear.app/peel/issue/JB-571/all-text-links-should-be-font-weight-medium)

These were the only instances I could find: 

![Screen Shot 2023-06-28 at 1 47 28 pm](https://github.com/jbx-protocol/juice-interface/assets/96150256/ccfb1bdc-0f48-4e0f-ab74-dcbf15cc26a5)

![Screen Shot 2023-06-28 at 1 47 23 pm](https://github.com/jbx-protocol/juice-interface/assets/96150256/e161f95d-319d-4bf5-93e9-2e1983d81eac)
