### PR TITLE
Make "About" panel text 16px

### DIFF
--- a/src/components/ProjectDashboard/components/AboutPanel/AboutPanel.tsx
+++ b/src/components/ProjectDashboard/components/AboutPanel/AboutPanel.tsx
@@ -28,7 +28,7 @@ export const AboutPanel = () => {
             <h3 className="mb-0 font-heading text-2xl font-medium">
               <Trans>About {projectName}</Trans>
             </h3>
-            <RichNote className="mt-0" note={description} />
+            <RichNote className="mt-0 text-base" note={description} />
           </>
         ) : (
           <EmptyScreen subtitle={t`This project has no description`} />

--- a/src/components/ProjectDashboard/components/CurrentCycleCard/__snapshots__/CurrentCycleCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CurrentCycleCard/__snapshots__/CurrentCycleCard.test.tsx.snap
@@ -6,12 +6,12 @@ exports[`CurrentCycleCard renders 1`] = `
     class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 min-w-0 cursor-pointer pr-9"
   >
     <div
-      class="truncate whitespace-nowrap font-medium"
+      class="truncate whitespace-nowrap text-base font-medium"
     >
       Current Cycle: #1
     </div>
     <div
-      class="mt-6 flex min-w-0 items-center gap-2"
+      class="mt-4 flex min-w-0 items-center gap-2"
     >
       <div
         aria-label=""
@@ -35,7 +35,7 @@ exports[`CurrentCycleCard renders 1`] = `
     </div>
     <div
       aria-label=""
-      class="truncate mt-3 text-smoke-500 dark:text-slate-200"
+      class="truncate mt-2 text-smoke-500 dark:text-slate-200"
     >
       until Cycle #2
     </div>

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/__snapshots__/CyclesPayoutsPanel.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/__snapshots__/CyclesPayoutsPanel.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CyclesPayoutsPanel renders 1`] = `
     class="mx-auto flex w-full max-w-[596px] flex-col gap-5"
   >
     <div
-      class="flex flex-col justify-between md:flex-row md:items-center"
+      class="flex flex-col justify-between gap-4 md:flex-row md:items-center"
     >
       <h2
         class="mb-0 font-heading text-2xl font-medium"

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`ConfigurationDisplayCard renders 1`] = `
       type="button"
     >
       <div
-        class="flex w-full items-center justify-between text-start"
+        class="mb-8 flex w-full items-center justify-between text-start"
       >
         <div
           class="flex flex-col gap-2 text-sm font-medium text-grey-600 dark:text-slate-200"
         >
           Current
           <div
-            class="font-heading text-2xl font-medium dark:text-slate-50"
+            class="font-heading text-xl font-medium text-grey-900 dark:text-slate-50"
           >
             Configuration
           </div>

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationTable.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationTable.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ConfigurationTable renders 1`] = `
       class="w-full"
     >
       <div
-        class="text-start text-base font-semibold uppercase"
+        class="text-start text-base font-medium uppercase"
       >
         title
       </div>

--- a/src/components/ProjectDashboard/components/PayProjectCard/__snapshots__/PayProjectCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/PayProjectCard/__snapshots__/PayProjectCard.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PayProjectCard renders 1`] = `
     class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 flex flex-col gap-2 pr-9"
   >
     <div
-      class="font-medium"
+      class="text-base font-medium"
     >
       <span>
         Pay Project


### PR DESCRIPTION
Fixes JB-573 (https://linear.app/peel/issue/JB-573/make-about-tab-body-text-16px-desktop-and-mobile)

![Screen Shot 2023-06-28 at 1 50 56 pm](https://github.com/jbx-protocol/juice-interface/assets/96150256/0e98a998-d756-4b62-877e-f2c151d950ff)
