### PR TITLE
JB-587 - Is it possible to get summary to show at leat 1 item on mobile?

### DIFF
--- a/src/components/ProjectDashboard/components/Cart/components/SummaryCollapsedView.tsx
+++ b/src/components/ProjectDashboard/components/Cart/components/SummaryCollapsedView.tsx
@@ -43,7 +43,8 @@ export const SummaryCollapsedView = () => {
       internalSummaryWidth -
       totalToPayWidth -
       summaryGap -
-      (32 + 16) * 2 // Chevron padding
+      (32 + 16) - // Chevron padding
+      4
 
     const maxItemsBasedOnWidthAvailable = Math.max(
       Math.floor(workableWidth / (stackComponentSize - stackComponentOffset)),
@@ -96,7 +97,7 @@ export const SummaryCollapsedView = () => {
 
   return (
     <div
-      className="flex w-full items-center justify-between px-8 py-6"
+      className="flex w-full items-center justify-between gap-1 px-8 py-6"
       ref={containerRef}
     >
       <div


### PR DESCRIPTION
## What does this PR do and why?

Closes https://linear.app/peel/issue/JB-587/is-it-possible-to-get-summary-to-show-at-leat-1-item-on-mobile

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
