### PR TITLE
Fix settings drawers appearing in front of modals

### DIFF
--- a/src/styles/antd-overrides/modal.scss
+++ b/src/styles/antd-overrides/modal.scss
@@ -29,7 +29,7 @@
 
 .ant-modal-wrap,
 .ant-modal-mask {
-  z-index: 19 !important;
+  z-index: 20 !important;
 }
 
 .ant-modal-footer {

--- a/src/styles/web3-onboard-overrides/onboard/connect.scss
+++ b/src/styles/web3-onboard-overrides/onboard/connect.scss
@@ -1,5 +1,5 @@
 :root {
-  --onboard-modal-z-index: 20;
+  --onboard-modal-z-index: 100; // Ensure greater than other modal indices of 20 
 
   --onboard-connect-sidebar-background: theme(colors.smoke.100);
   --onboard-connect-sidebar-color: theme(colors.black);


### PR DESCRIPTION
- This was caused by reducing the z-index of all modals (#3831)  -> now appears behind drawers which had the same z-index
- The PR reverts yesterday's change^ , and instead just increases the index of the wallet connect modal

<img width="1391" alt="Screen Shot 2023-06-29 at 11 08 52 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/b49395b8-7e18-4bcf-a098-8322fd08511f">

https://github.com/jbx-protocol/juice-interface/assets/96150256/965f89de-51e6-4591-9635-0f1d3ac06ffa


