### PR TITLE
JB-570 - [Mobile & Desktop] Auto scroll to 'about' tab on-click of 'read more'

### DIFF
--- a/src/components/ProjectDashboard/components/ProjectTabs/ProjectTabs.tsx
+++ b/src/components/ProjectDashboard/components/ProjectTabs/ProjectTabs.tsx
@@ -2,7 +2,8 @@ import { Tab } from '@headlessui/react'
 import { t } from '@lingui/macro'
 import { useProjectPageQueries } from 'components/ProjectDashboard/hooks/useProjectPageQueries'
 import { useHasNftRewards } from 'hooks/JB721Delegate/useHasNftRewards'
-import { Fragment, useMemo } from 'react'
+import { useOnScreen } from 'hooks/useOnScreen'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { AboutPanel } from '../AboutPanel'
 import { ActivityPanel } from '../ActivityPanel'
@@ -15,6 +16,29 @@ export const ProjectTabs = ({ className }: { className?: string }) => {
   const { projectPageTab, setProjectPageTab } = useProjectPageQueries()
 
   const { value: showNftRewards } = useHasNftRewards()
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const isPanelVisible = useOnScreen(panelRef)
+  const [firstRender, setFirstRender] = useState(true)
+
+  useEffect(() => {
+    if (firstRender) {
+      setFirstRender(false)
+      return
+    }
+    if (
+      containerRef.current &&
+      !isPanelVisible &&
+      projectPageTab !== undefined
+    ) {
+      containerRef.current.scrollIntoView(true)
+    }
+
+    // Intentionally only set - isPanelVisible updates should not cause a
+    // re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectPageTab])
 
   const tabs = useMemo(
     () => [
@@ -42,7 +66,10 @@ export const ProjectTabs = ({ className }: { className?: string }) => {
   }, [projectPageTab, tabs])
 
   return (
-    <div className={twMerge('flex flex-col items-center gap-12', className)}>
+    <div
+      ref={containerRef}
+      className={twMerge('flex flex-col items-center gap-12', className)}
+    >
       <Tab.Group
         as={Fragment}
         selectedIndex={selectedTabIndex}
@@ -60,7 +87,7 @@ export const ProjectTabs = ({ className }: { className?: string }) => {
             ))}
           </Tab.List>
         </div>
-        <div className="flex w-full justify-center px-4 md:px-0">
+        <div ref={panelRef} className="flex w-full justify-center px-4 md:px-0">
           <Tab.Panels as={Fragment}>
             {tabs.map(tab => (
               <Tab.Panel as={Fragment} key={tab.id}>

--- a/src/components/ProjectDashboard/hooks/useProjectPageQueries.ts
+++ b/src/components/ProjectDashboard/hooks/useProjectPageQueries.ts
@@ -26,7 +26,7 @@ export type ProjectPayReceipt = {
 export const useProjectPageQueries = () => {
   const router = useRouter()
 
-  const projectPageTab = (router.query.tabid as ProjectPageTab) || 'activity'
+  const projectPageTab = router.query.tabid as ProjectPageTab | undefined
   const projectPayReceiptString = router.query.payReceipt as string | undefined
 
   const projectPayReceipt = useMemo(() => {

--- a/src/hooks/useOnScreen.ts
+++ b/src/hooks/useOnScreen.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export const useOnScreen = (
+  ref: React.RefObject<HTMLElement>,
+  rootMargin = '0px',
+) => {
+  const [isIntersecting, setIntersecting] = useState(false)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => setIntersecting(entry.isIntersecting),
+      { rootMargin },
+    )
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+  }, [ref, rootMargin])
+
+  return isIntersecting
+}


### PR DESCRIPTION
## What does this PR do and why?

Closes https://linear.app/peel/issue/JB-570/[mobile-and-desktop]-auto-scroll-to-about-tab-on-click-of-read-more

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
