### PR TITLE
JB-605 - If no project cover photo, hide component

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -122,7 +122,7 @@ export function Footer() {
   const gitCommit = process.env.NEXT_PUBLIC_VERSION
 
   return (
-    <footer className="bg-slate-900 px-12 pt-12 text-sm text-slate-100">
+    <footer className="bg-slate-900 px-5 pt-12 text-sm text-slate-100 md:px-12">
       <div className="m-auto max-w-6xl">
         <div className="flex flex-col gap-y-10 md:grid md:grid-cols-6 md:items-start md:gap-x-10">
           <div className="flex flex-col gap-y-5 text-slate-200 md:col-span-2 md:items-start">

--- a/src/components/ProjectDashboard/components/CoverPhoto/CoverPhoto.tsx
+++ b/src/components/ProjectDashboard/components/CoverPhoto/CoverPhoto.tsx
@@ -1,14 +1,24 @@
 import { useCoverPhoto } from 'components/ProjectDashboard/hooks'
+import { twMerge } from 'tailwind-merge'
 
 export const CoverPhoto = () => {
   const { coverImageUrl, coverImageAltText } = useCoverPhoto()
+  const hasCoverImage = !!coverImageUrl
 
   return (
-    <div className="relative h-70 w-full bg-split-200 dark:bg-slate-600">
+    <div
+      className={twMerge(
+        'relative w-full',
+        hasCoverImage ? 'h-70 bg-split-200 dark:bg-slate-600' : 'h-[168px]',
+      )}
+    >
       {coverImageUrl && (
         <img
           src={coverImageUrl}
-          className="h-70 w-full object-cover"
+          className={twMerge(
+            'w-full object-cover',
+            hasCoverImage ? 'h-70' : 'h-[168px]',
+          )}
           crossOrigin="anonymous"
           alt={coverImageAltText}
         />


### PR DESCRIPTION
## What does this PR do and why?

Closes https://linear.app/peel/issue/JB-605/if-no-project-cover-photo-hide-component

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
