### PR TITLE
JB-597 - Add tooltip icons to cycle config cards

### DIFF
--- a/src/components/ProjectDashboard/components/CurrentCycleCard/CurrentCycleCard.tsx
+++ b/src/components/ProjectDashboard/components/CurrentCycleCard/CurrentCycleCard.tsx
@@ -1,3 +1,4 @@
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 import { LockClosedIcon, LockOpenIcon } from '@heroicons/react/24/solid'
 import { Trans, t } from '@lingui/macro'
 import { Tooltip } from 'antd'
@@ -34,10 +35,11 @@ export const CurrentCycleCard = ({ className }: { className?: string }) => {
       className={twMerge('min-w-0 cursor-pointer pr-9', className)}
       onClick={openCyclePayoutsTab}
     >
-      <Tooltip title={cycleTooltip}>
-        <div className="truncate whitespace-nowrap text-base font-medium">
+      <Tooltip className="inline-flex items-center gap-1" title={cycleTooltip}>
+        <span className="truncate whitespace-nowrap text-base font-medium">
           <Trans>Current Cycle: #{currentCycleNumber}</Trans>
-        </div>
+        </span>
+        <QuestionMarkCircleIcon className="h-4 w-4 text-grey-500 dark:text-slate-200" />
       </Tooltip>
       <div className="mt-4 flex min-w-0 items-center gap-2">
         <TruncatedText className="text-2xl font-medium" text={text} />

--- a/src/components/ProjectDashboard/components/CurrentCycleCard/__snapshots__/CurrentCycleCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CurrentCycleCard/__snapshots__/CurrentCycleCard.test.tsx.snap
@@ -5,11 +5,30 @@ exports[`CurrentCycleCard renders 1`] = `
   <div
     class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 min-w-0 cursor-pointer pr-9"
   >
-    <div
-      class="truncate whitespace-nowrap text-base font-medium"
+    <span
+      class="inline-flex items-center gap-1"
     >
-      Current Cycle: #1
-    </div>
+      <span
+        class="truncate whitespace-nowrap text-base font-medium"
+      >
+        Current Cycle: #1
+      </span>
+      <svg
+        aria-hidden="true"
+        class="h-4 w-4 text-grey-500 dark:text-slate-200"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </span>
     <div
       class="mt-4 flex min-w-0 items-center gap-2"
     >

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/TreasuryStats.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/TreasuryStats.tsx
@@ -24,21 +24,21 @@ export const TreasuryStats = () => {
   )
 
   return (
-    <div className="grid w-full grid-cols-2 gap-4 md:flex md:items-center">
+    <div className="flex w-full flex-wrap items-center gap-4">
       <TitleDescriptionDisplayCard
-        className="flex w-full"
+        className="flex flex-1"
         title={t`Treasury balance`}
         description={treasuryBalance}
         tooltip={treasuryBalanceTooltip}
       />
       <TitleDescriptionDisplayCard
-        className="flex w-full"
+        className="flex flex-1"
         title={t`Overflow`}
         description={overflow}
         tooltip={overflowTooltip}
       />
       <TitleDescriptionDisplayCard
-        className="col-span-2 flex w-full"
+        className="flex flex-1"
         title={t`Available to pay out`}
         description={availableToPayout}
         tooltip={availableToPayOutTooltip}

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/CurrentUpcomingSubPanel.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/CurrentUpcomingSubPanel.test.tsx.snap
@@ -12,67 +12,101 @@ exports[`CurrentUpcomingSubPanel renders "current" 1`] = `
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:max-w-[127px]"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Cycle #
+                <span>
+                  Cycle #
+                </span>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:w-fit"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Status
+                <span
+                  class="leading-none"
+                >
+                  Status
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               Active
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 col-span-2 md:flex-1"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Remaining time
+                <span
+                  class="leading-none"
+                >
+                  Remaining time
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1 day
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -99,67 +133,84 @@ exports[`CurrentUpcomingSubPanel renders "upcoming" 1`] = `
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:max-w-[127px]"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Cycle #
+                <span>
+                  Cycle #
+                </span>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:w-fit"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Status
+                <span
+                  class="leading-none"
+                >
+                  Status
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               Active
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 col-span-2 md:flex-1"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Cycle length
+                <span>
+                  Cycle length
+                </span>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1 day
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -186,67 +237,101 @@ exports[`CurrentUpcomingSubPanel renders a skeleton when loading "current" 1`] =
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:max-w-[127px]"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Cycle #
+                <span>
+                  Cycle #
+                </span>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:w-fit"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Status
+                <span
+                  class="leading-none"
+                >
+                  Status
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               Active
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 col-span-2 md:flex-1"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Remaining time
+                <span
+                  class="leading-none"
+                >
+                  Remaining time
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1 day
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -273,67 +358,84 @@ exports[`CurrentUpcomingSubPanel renders a skeleton when loading "upcoming" 1`] 
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:max-w-[127px]"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Cycle #
+                <span>
+                  Cycle #
+                </span>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full md:w-fit"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Status
+                <span
+                  class="leading-none"
+                >
+                  Status
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               Active
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 col-span-2 md:flex-1"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Cycle length
+                <span>
+                  Cycle length
+                </span>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               1 day
-            </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/ProjectDashboard/components/PayProjectCard/PayProjectCard.tsx
+++ b/src/components/ProjectDashboard/components/PayProjectCard/PayProjectCard.tsx
@@ -1,3 +1,4 @@
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 import { Trans, t } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
 import { usePayProjectCard } from 'components/ProjectDashboard/hooks'
@@ -16,10 +17,14 @@ export const PayProjectCard = ({ className }: { className?: string }) => {
       className={twMerge('flex flex-col gap-2 px-4 md:pr-9 md:pl-6', className)}
     >
       <div className="text-base font-medium">
-        <Tooltip title={<Trans>Send ETH payments to this project.</Trans>}>
+        <Tooltip
+          className="inline-flex items-center gap-1"
+          title={<Trans>Send ETH payments to this project.</Trans>}
+        >
           <span>
             <Trans>Pay Project</Trans>
           </span>
+          <QuestionMarkCircleIcon className="h-4 w-4 text-grey-500 dark:text-slate-200" />
         </Tooltip>
       </div>
       <Formik

--- a/src/components/ProjectDashboard/components/PayProjectCard/__snapshots__/PayProjectCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/PayProjectCard/__snapshots__/PayProjectCard.test.tsx.snap
@@ -8,8 +8,27 @@ exports[`PayProjectCard renders 1`] = `
     <div
       class="text-base font-medium"
     >
-      <span>
-        Pay Project
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <span>
+          Pay Project
+        </span>
+        <svg
+          aria-hidden="true"
+          class="h-4 w-4 text-grey-500 dark:text-slate-200"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
       </span>
     </div>
     <form

--- a/src/components/ProjectDashboard/components/TokensPanel/components/__snapshots__/ReservedTokensSubPanel.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/TokensPanel/components/__snapshots__/ReservedTokensSubPanel.test.tsx.snap
@@ -19,61 +19,95 @@ exports[`ReservedTokensSubPanel renders 1`] = `
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full min-w-min flex-[1_0_0]"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Reserved tokens
+                <span
+                  class="leading-none"
+                >
+                  Reserved tokens
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               21%
-            </span>
+            </div>
           </div>
         </div>
         <div
           class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full min-w-min flex-[1_0_0]"
         >
-          <div
-            class="flex w-full flex-col gap-2"
-          >
-            <span
-              class="flex items-center justify-between gap-3"
+          <div>
+            <div
+              class="flex flex-1 items-center justify-between"
             >
               <span
-                class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+                class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
               >
-                Reserved rate
+                <span
+                  class="leading-none"
+                >
+                  Reserved rate
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="h-4 w-4 text-grey-500 dark:text-slate-200"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
               </span>
-            </span>
-            <span
-              class="truncate font-heading text-xl font-medium dark:text-slate-50"
+            </div>
+            <div
+              class="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50"
             >
               82%
-            </span>
+            </div>
           </div>
         </div>
       </div>
       <div
         class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700 w-full"
       >
-        <div
-          class="flex w-full flex-col gap-2"
-        >
-          <span
-            class="flex items-center justify-between gap-3"
+        <div>
+          <div
+            class="flex flex-1 items-center justify-between"
           >
             <span
-              class="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
+              class="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200"
             >
-              Reserved tokens list
+              <span>
+                Reserved tokens list
+              </span>
             </span>
             <div
               class="relative"
@@ -104,7 +138,7 @@ exports[`ReservedTokensSubPanel renders 1`] = `
                 </svg>
               </button>
             </div>
-          </span>
+          </div>
         </div>
         <div
           class="mt-4 flex w-full flex-col divide-y divide-grey-200 border-b border-grey-200 dark:divide-slate-500 dark:border-slate-500"

--- a/src/components/ProjectDashboard/components/ui/TitleDescriptionDisplayCard.tsx
+++ b/src/components/ProjectDashboard/components/ui/TitleDescriptionDisplayCard.tsx
@@ -1,3 +1,4 @@
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 import { Tooltip } from 'antd'
 import { AriaRole, MouseEventHandler, ReactNode } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -27,22 +28,27 @@ export const TitleDescriptionDisplayCard = ({
   children,
   ...rest
 }: Props) => {
+  const hasKebabMenu = !!kebabMenu?.items.length
   return (
     <DisplayCard className={twMerge(className)} {...rest}>
-      <div className="flex w-full flex-col gap-2">
-        <Tooltip
-          className="flex items-center justify-between gap-3"
-          title={tooltip}
-        >
-          <span className="max-w-min whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200">
-            {title}
-          </span>
-          {!!kebabMenu?.items.length && <PopupMenu {...kebabMenu} />}
-        </Tooltip>
+      <div>
+        <div className="flex flex-1 items-center justify-between">
+          <Tooltip title={tooltip}>
+            <span className="inline-flex max-w-min items-center gap-1 whitespace-nowrap font-body text-sm font-medium text-grey-600 dark:text-slate-200">
+              <span className={tooltip ? 'leading-none' : undefined}>
+                {title}
+              </span>
+              {!!tooltip && (
+                <QuestionMarkCircleIcon className="h-4 w-4 text-grey-500 dark:text-slate-200" />
+              )}
+            </span>
+          </Tooltip>
+          {hasKebabMenu && <PopupMenu {...kebabMenu} />}
+        </div>
         {description && (
-          <span className="truncate font-heading text-xl font-medium dark:text-slate-50">
+          <div className="mt-2 truncate font-heading text-xl font-medium dark:text-slate-50">
             {description}
-          </span>
+          </div>
         )}
       </div>
       {children}


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-597 : Add tooltip icons to cycle config cards](https://linear.app/peel/issue/JB-597/add-tooltip-icons-to-cycle-config-cards)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
