### PR TITLE
JB-599 - Add 'extension' data to cycles & payouts

### DIFF
--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationPanel.test.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationPanel.test.tsx
@@ -31,6 +31,7 @@ describe('ConfigurationPanel', () => {
         cycle={mockData}
         token={mockData}
         otherRules={mockData}
+        extension={mockData}
       />,
     )
   })
@@ -41,6 +42,7 @@ describe('ConfigurationPanel', () => {
         cycle={mockData}
         token={mockData}
         otherRules={mockData}
+        extension={mockData}
       />,
     )
 

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationPanel.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationPanel.tsx
@@ -16,18 +16,23 @@ type ConfigurationPanelProps = {
   cycle: ConfigurationPanelTableData
   token: ConfigurationPanelTableData
   otherRules: ConfigurationPanelTableData
+  extension: ConfigurationPanelTableData | null
 }
 
 export const ConfigurationPanel: React.FC<ConfigurationPanelProps> = ({
   cycle,
   token,
   otherRules,
+  extension,
 }) => {
   return (
     <div className="flex flex-col gap-8">
       <ConfigurationTable title={t`Cycle`} data={cycle} />
       <ConfigurationTable title={t`Token`} data={token} />
       <ConfigurationTable title={t`Other rules`} data={otherRules} />
+      {extension && (
+        <ConfigurationTable title={t`Extension`} data={extension} />
+      )}
     </div>
   )
 }

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/UpcomingCycleChangesCallout.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/UpcomingCycleChangesCallout.tsx
@@ -10,7 +10,7 @@ export const UpcomingCycleChangesCallout = () => {
   const loading = useMemo(
     () =>
       Object.values(data).some(value =>
-        Object.values(value).some(v => v.new === undefined),
+        Object.values(value ?? {}).some(v => v.new === undefined),
       ),
     [data],
   )
@@ -18,7 +18,7 @@ export const UpcomingCycleChangesCallout = () => {
   const hasChanges = useMemo(
     () =>
       Object.values(data).some(value => {
-        return Object.values(value).some(v => v.old !== v.new)
+        return Object.values(value ?? {}).some(v => v.old !== v.new)
       }),
     [data],
   )

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useCurrentUpcomingConfigurationPanel.ts
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useCurrentUpcomingConfigurationPanel.ts
@@ -1,4 +1,5 @@
 import { useCycleSection } from './useCycleSection'
+import { useExtensionSection } from './useExtensionSection.ts'
 import { useOtherRulesSection } from './useOtherRulesSection'
 import { useTokenSection } from './useTokenSection'
 
@@ -8,10 +9,12 @@ export const useCurrentUpcomingConfigurationPanel = (
   const cycle = useCycleSection(type)
   const token = useTokenSection(type)
   const otherRules = useOtherRulesSection(type)
+  const extension = useExtensionSection(type)
 
   return {
     cycle,
     token,
     otherRules,
+    extension,
   }
 }

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useExtensionSection.ts.ts
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useExtensionSection.ts.ts
@@ -1,0 +1,27 @@
+import {
+  useProjectContext,
+  useProjectMetadata,
+} from 'components/ProjectDashboard/hooks'
+import { useProjectUpcomingFundingCycle } from 'hooks/v2v3/contractReader/useProjectUpcomingFundingCycle'
+import { ConfigurationPanelTableData } from '../../components/ConfigurationPanel'
+import { useFormatConfigurationExtensionSection } from './useFormatConfigurationExtensionSection'
+
+export const useExtensionSection = (
+  type: 'current' | 'upcoming',
+): ConfigurationPanelTableData | null => {
+  const { projectId } = useProjectMetadata()
+
+  const { fundingCycleMetadata } = useProjectContext()
+  const { data: upcomingFundingCycleData } = useProjectUpcomingFundingCycle({
+    projectId,
+  })
+  const [, upcomingFundingCycleMetadata] = upcomingFundingCycleData ?? []
+
+  return useFormatConfigurationExtensionSection({
+    fundingCycleMetadata,
+    upcomingFundingCycleMetadata,
+    ...(type === 'current' && {
+      upcomingFundingCycleMetadata: null,
+    }),
+  })
+}

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationExtensionSection.ts
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationExtensionSection.ts
@@ -1,0 +1,83 @@
+import { t } from '@lingui/macro'
+import { V2V3FundingCycleMetadata } from 'models/v2v3/fundingCycle'
+import { useMemo } from 'react'
+import { isZeroAddress } from 'utils/address'
+import {
+  ConfigurationPanelDatum,
+  ConfigurationPanelTableData,
+} from '../../components/ConfigurationPanel'
+import { flagPairToDatum } from '../../utils/flagPairToDatum'
+import { pairToDatum } from '../../utils/pairToDatum'
+
+export const useFormatConfigurationExtensionSection = ({
+  fundingCycleMetadata,
+  upcomingFundingCycleMetadata,
+}: {
+  fundingCycleMetadata: V2V3FundingCycleMetadata | undefined
+  upcomingFundingCycleMetadata?: V2V3FundingCycleMetadata | null
+}): ConfigurationPanelTableData | null => {
+  const contractDatum: ConfigurationPanelDatum = useMemo(() => {
+    const currentContract = fundingCycleMetadata?.dataSource
+    const upcomingContract = upcomingFundingCycleMetadata?.dataSource
+
+    if (upcomingFundingCycleMetadata === null) {
+      return pairToDatum(t`Contract`, currentContract, null)
+    }
+
+    return pairToDatum(t`Contract`, currentContract, upcomingContract)
+  }, [fundingCycleMetadata?.dataSource, upcomingFundingCycleMetadata])
+
+  const useForPaymentsDatum: ConfigurationPanelDatum = useMemo(() => {
+    const currentUseForPayments = fundingCycleMetadata?.useDataSourceForPay
+    const upcomingUseForPayments =
+      upcomingFundingCycleMetadata?.useDataSourceForPay
+
+    if (upcomingFundingCycleMetadata === null) {
+      return flagPairToDatum(t`Use for payments`, currentUseForPayments, null)
+    }
+
+    return flagPairToDatum(
+      t`Use for payments`,
+      currentUseForPayments,
+      upcomingUseForPayments,
+    )
+  }, [fundingCycleMetadata?.useDataSourceForPay, upcomingFundingCycleMetadata])
+
+  const useForRedemptionsDatum: ConfigurationPanelDatum = useMemo(() => {
+    const currentUseForRedemptions =
+      fundingCycleMetadata?.useDataSourceForRedeem
+    const upcomingUseForRedemptions =
+      upcomingFundingCycleMetadata?.useDataSourceForRedeem
+
+    if (upcomingFundingCycleMetadata === null) {
+      return flagPairToDatum(
+        t`Use for redemptions`,
+        currentUseForRedemptions,
+        null,
+      )
+    }
+
+    return flagPairToDatum(
+      t`Use for redemptions`,
+      currentUseForRedemptions,
+      upcomingUseForRedemptions,
+    )
+  }, [
+    fundingCycleMetadata?.useDataSourceForRedeem,
+    upcomingFundingCycleMetadata,
+  ])
+
+  const formatted = useMemo(() => {
+    return {
+      contract: contractDatum,
+      useForPayments: useForPaymentsDatum,
+      useForRedemptions: useForRedemptionsDatum,
+    }
+  }, [contractDatum, useForPaymentsDatum, useForRedemptionsDatum])
+
+  if (isZeroAddress(fundingCycleMetadata?.dataSource)) {
+    return null
+  }
+
+  return formatted
+}

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useHistoricalConfigurationPanel.ts
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useHistoricalConfigurationPanel.ts
@@ -8,6 +8,7 @@ import {
   V2V3FundingCycleMetadata,
 } from 'models/v2v3/fundingCycle'
 import { useFormatConfigurationCyclesSection } from './useFormatConfigurationCyclesSection'
+import { useFormatConfigurationExtensionSection } from './useFormatConfigurationExtensionSection'
 import { useFormatConfigurationOtherRulesSection } from './useFormatConfigurationOtherRulesSection'
 import { useFormatConfigurationTokenSection } from './useFormatConfigurationTokenSection'
 
@@ -49,9 +50,15 @@ export const useHistoricalConfigurationPanel = ({
     upcomingFundingCycleMetadata: null,
   })
 
+  const extension = useFormatConfigurationExtensionSection({
+    fundingCycleMetadata: metadata,
+    upcomingFundingCycleMetadata: null,
+  })
+
   return {
     cycle,
     token,
     otherRules,
+    extension,
   }
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-599 : Add 'extension' data to cycles & payouts](https://linear.app/peel/issue/JB-599/add-extension-data-to-cycles-and-payouts)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
