### PR TITLE
JB-594 - Add hover tooltip to diff view in cycle config

### DIFF
--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationTable.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationTable.tsx
@@ -1,4 +1,6 @@
 import { MinusCircleIcon, PlusCircleIcon } from '@heroicons/react/24/outline'
+import { t } from '@lingui/macro'
+import { Tooltip } from 'antd'
 import { ReactNode, useMemo } from 'react'
 import { ConfigurationPanelTableData } from './ConfigurationPanel'
 
@@ -82,13 +84,19 @@ const ConfigurationTableRow = ({
 
 const Diff: React.FC<{ old?: ReactNode; new: ReactNode }> = props => (
   <div className="flex flex-col items-center gap-2">
-    <div className="flex w-full items-center justify-between gap-3.5 rounded bg-error-100 p-1 font-medium text-error-700 dark:bg-error-500 dark:text-error-950">
+    <Tooltip
+      className="flex flex-1 items-center justify-between gap-3.5 rounded bg-error-100 p-1 font-medium text-error-700 dark:bg-error-500 dark:text-error-950"
+      title={t`Data from current cycle`}
+    >
       <MinusCircleIcon className="inline-block h-5 w-5" />
       <span>{props.old}</span>
-    </div>
-    <div className="flex w-full items-center justify-between gap-3.5 rounded bg-melon-100 p-1 font-medium text-melon-700 dark:bg-melon-500 dark:text-melon-950">
+    </Tooltip>
+    <Tooltip
+      className="flex flex-1 items-center justify-between gap-3.5 rounded bg-melon-100 p-1 font-medium text-melon-700 dark:bg-melon-500 dark:text-melon-950"
+      title={t`Data from upcoming cycle`}
+    >
       <PlusCircleIcon className="inline-block h-5 w-5" />
       <span>{props.new}</span>
-    </div>
+    </Tooltip>
   </div>
 )

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationTable.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationTable.test.tsx.snap
@@ -26,8 +26,8 @@ exports[`ConfigurationTable renders 1`] = `
             <div
               class="flex flex-col items-center gap-2"
             >
-              <div
-                class="flex w-full items-center justify-between gap-3.5 rounded bg-error-100 p-1 font-medium text-error-700 dark:bg-error-500 dark:text-error-950"
+              <span
+                class="flex flex-1 items-center justify-between gap-3.5 rounded bg-error-100 p-1 font-medium text-error-700 dark:bg-error-500 dark:text-error-950"
               >
                 <svg
                   aria-hidden="true"
@@ -47,9 +47,9 @@ exports[`ConfigurationTable renders 1`] = `
                 <span>
                   old
                 </span>
-              </div>
-              <div
-                class="flex w-full items-center justify-between gap-3.5 rounded bg-melon-100 p-1 font-medium text-melon-700 dark:bg-melon-500 dark:text-melon-950"
+              </span>
+              <span
+                class="flex flex-1 items-center justify-between gap-3.5 rounded bg-melon-100 p-1 font-medium text-melon-700 dark:bg-melon-500 dark:text-melon-950"
               >
                 <svg
                   aria-hidden="true"
@@ -69,7 +69,7 @@ exports[`ConfigurationTable renders 1`] = `
                 <span>
                   new
                 </span>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -101,8 +101,8 @@ exports[`ConfigurationTable renders 1`] = `
             <div
               class="flex flex-col items-center gap-2"
             >
-              <div
-                class="flex w-full items-center justify-between gap-3.5 rounded bg-error-100 p-1 font-medium text-error-700 dark:bg-error-500 dark:text-error-950"
+              <span
+                class="flex flex-1 items-center justify-between gap-3.5 rounded bg-error-100 p-1 font-medium text-error-700 dark:bg-error-500 dark:text-error-950"
               >
                 <svg
                   aria-hidden="true"
@@ -122,9 +122,9 @@ exports[`ConfigurationTable renders 1`] = `
                 <span>
                   old
                 </span>
-              </div>
-              <div
-                class="flex w-full items-center justify-between gap-3.5 rounded bg-melon-100 p-1 font-medium text-melon-700 dark:bg-melon-500 dark:text-melon-950"
+              </span>
+              <span
+                class="flex flex-1 items-center justify-between gap-3.5 rounded bg-melon-100 p-1 font-medium text-melon-700 dark:bg-melon-500 dark:text-melon-950"
               >
                 <svg
                   aria-hidden="true"
@@ -144,7 +144,7 @@ exports[`ConfigurationTable renders 1`] = `
                 <span>
                   new
                 </span>
-              </div>
+              </span>
             </div>
           </div>
         </div>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -140,6 +140,9 @@ msgstr ""
 msgid "Determines whether tokens will be minted by payments made through this address."
 msgstr ""
 
+msgid "Data from current cycle"
+msgstr ""
+
 msgid "You're about to add NFTs to your cycle. You'll need to <0>grant NFT permissions</0> before deploying the new cycle"
 msgstr ""
 
@@ -4314,6 +4317,9 @@ msgid "ETH currently available to send to the payout recipients below (before th
 msgstr ""
 
 msgid "You will receive {0}<0/>"
+msgstr ""
+
+msgid "Data from upcoming cycle"
 msgstr ""
 
 msgid "Your project's NFTs."


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-594 : Add hover tooltip to diff view in cycle config](https://linear.app/peel/issue/JB-594/add-hover-tooltip-to-diff-view-in-cycle-config)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
