### PR TITLE
better clickability on checkbox create [2/2]

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/ReviewDeployPage.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/ReviewDeployPage.tsx
@@ -196,7 +196,7 @@ export const ReviewDeployPage = () => {
             <Form.Item noStyle name="termsAccepted" valuePropName="checked">
               <Checkbox />
             </Form.Item>
-            <div>
+            <label htmlFor="termsAccepted">
               <Trans>
                 I have read and accept the{' '}
                 <ExternalLink href={TERMS_OF_SERVICE_URL}>
@@ -208,7 +208,7 @@ export const ReviewDeployPage = () => {
                 </ExternalLink>
                 .
               </Trans>
-            </div>
+            </label>
           </div>
         </Callout.Info>
         <Wizard.Page.ButtonControl


### PR DESCRIPTION
## What does this PR do and why?

https://github.com/jbx-protocol/juice-interface/assets/104132113/b03793f5-4d84-4d34-9450-9e0832e87eb6

Closes [JB-650 : create: "i have read..." make label clickable](https://linear.app/peel/issue/JB-650/create-i-have-read-make-label-clickable)


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
