### PR TITLE
fix: add support for JB_ETH_PAYMENT_TERMINAL_V_3_1_1 in distribute payouts

### DIFF
--- a/src/hooks/v2v3/transactor/useDistributePayouts.ts
+++ b/src/hooks/v2v3/transactor/useDistributePayouts.ts
@@ -17,6 +17,7 @@ import {
   JBETHPaymentTerminalVersion,
   JB_ETH_PAYMENT_TERMINAL_V_3,
   JB_ETH_PAYMENT_TERMINAL_V_3_1,
+  JB_ETH_PAYMENT_TERMINAL_V_3_1_1,
 } from '../V2V3ProjectContracts/projectContractLoaders/useProjectPrimaryEthTerminal'
 import { useV2ProjectTitle } from '../useProjectTitle'
 
@@ -67,6 +68,13 @@ function buildTxArgs({
   }
 
   if (JBETHPaymentTerminalVersion === JB_ETH_PAYMENT_TERMINAL_V_3_1) {
+    return [
+      ...baseArgs,
+      (args as DISTRIBUTE_PAYOUTS_TX_V3_1_PARAMS).metadata ?? DEFAULT_METADATA, // _metadata
+    ]
+  }
+
+  if (JBETHPaymentTerminalVersion === JB_ETH_PAYMENT_TERMINAL_V_3_1_1) {
     return [
       ...baseArgs,
       (args as DISTRIBUTE_PAYOUTS_TX_V3_1_PARAMS).metadata ?? DEFAULT_METADATA, // _metadata


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-678 : Unable to send payouts from JBDAO V3 project](https://linear.app/peel/issue/JB-678/unable-to-send-payouts-from-jbdao-v3-project)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
