### PR TITLE
fix: whitespace pre-wrap for project descriptions

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
@@ -47,7 +47,7 @@ export const ProjectDetailsReview = () => {
         }
       />
       <ReviewDescription
-        className="col-span-4"
+        className="col-span-4 whitespace-pre-wrap"
         title={t`Project description`}
         placeholder={t`No description`}
         desc={<RichPreview source={description ?? ''} />}

--- a/src/components/ProjectDashboard/components/AboutPanel/AboutPanel.tsx
+++ b/src/components/ProjectDashboard/components/AboutPanel/AboutPanel.tsx
@@ -24,7 +24,7 @@ export const AboutPanel = () => {
             ))}
         </div>
       )}
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 whitespace-pre-wrap">
         {description ? (
           <RichPreview source={description} />
         ) : (


### PR DESCRIPTION
In response to a request from a project creator: https://discord.com/channels/775859454780244028/1131641349230305302/1136189740656377856