### PR TITLE
feat: legal notice on wallet connect

### DIFF
--- a/src/components/Navbar/components/Wallet/WalletButton.tsx
+++ b/src/components/Navbar/components/Wallet/WalletButton.tsx
@@ -2,8 +2,10 @@ import { WarningOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import { useWallet } from 'hooks/Wallet'
+import LegalNoticeModal from 'components/modals/LegalNoticeModal'
 
 import WalletMenu from './WalletMenu'
+import { useEffect, useState } from 'react'
 
 export default function WalletButton() {
   const {
@@ -13,6 +15,36 @@ export default function WalletButton() {
     chainUnsupported,
     changeNetworks,
   } = useWallet()
+
+  const [legalNoticeAccepted, setLegalNoticeAccepted] = useState<boolean>(
+    localStorage.getItem('hasAcceptedLegalNotice') === 'true',
+  )
+  const [legalNoticeVisible, setLegalNoticeVisible] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (!legalNoticeVisible) {
+      setLegalNoticeAccepted(
+        localStorage.getItem('hasAcceptedLegalNotice') === 'true',
+      )
+    }
+  }, [legalNoticeVisible])
+
+  const onOk = () => {
+    localStorage.setItem('hasAcceptedLegalNotice', 'true')
+    setLegalNoticeAccepted(true)
+    setLegalNoticeVisible(false)
+  }
+
+  if (!legalNoticeAccepted) {
+    return (
+      <>
+        <Button onClick={() => setLegalNoticeVisible(true)} block>
+          <Trans>Connect</Trans>
+        </Button>
+        <LegalNoticeModal open={legalNoticeVisible} onOk={onOk} />
+      </>
+    )
+  }
 
   if (!isConnected) {
     return (

--- a/src/components/Navbar/components/Wallet/WalletButton.tsx
+++ b/src/components/Navbar/components/Wallet/WalletButton.tsx
@@ -33,6 +33,7 @@ export default function WalletButton() {
     localStorage.setItem('hasAcceptedLegalNotice', 'true')
     setLegalNoticeAccepted(true)
     setLegalNoticeVisible(false)
+    connect()
   }
 
   if (!legalNoticeAccepted) {
@@ -41,7 +42,11 @@ export default function WalletButton() {
         <Button onClick={() => setLegalNoticeVisible(true)} block>
           <Trans>Connect</Trans>
         </Button>
-        <LegalNoticeModal open={legalNoticeVisible} onOk={onOk} />
+        <LegalNoticeModal
+          open={legalNoticeVisible}
+          onOk={onOk}
+          onCancel={() => setLegalNoticeVisible(false)}
+        />
       </>
     )
   }

--- a/src/components/Navbar/components/Wallet/WalletButton.tsx
+++ b/src/components/Navbar/components/Wallet/WalletButton.tsx
@@ -16,18 +16,14 @@ export default function WalletButton() {
     changeNetworks,
   } = useWallet()
 
-  const [legalNoticeAccepted, setLegalNoticeAccepted] = useState<boolean>(
-    localStorage.getItem('hasAcceptedLegalNotice') === 'true',
-  )
+  const [legalNoticeAccepted, setLegalNoticeAccepted] = useState<boolean>(false)
   const [legalNoticeVisible, setLegalNoticeVisible] = useState<boolean>(false)
 
   useEffect(() => {
-    if (!legalNoticeVisible) {
-      setLegalNoticeAccepted(
-        localStorage.getItem('hasAcceptedLegalNotice') === 'true',
-      )
-    }
-  }, [legalNoticeVisible])
+    setLegalNoticeAccepted(
+      localStorage.getItem('hasAcceptedLegalNotice') === 'true',
+    )
+  }, [])
 
   const onOk = () => {
     localStorage.setItem('hasAcceptedLegalNotice', 'true')

--- a/src/components/Navbar/components/Wallet/WalletButton.tsx
+++ b/src/components/Navbar/components/Wallet/WalletButton.tsx
@@ -1,11 +1,12 @@
 import { WarningOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 import { Button } from 'antd'
-import { useWallet } from 'hooks/Wallet'
 import LegalNoticeModal from 'components/modals/LegalNoticeModal'
-
-import WalletMenu from './WalletMenu'
+import { useWallet } from 'hooks/Wallet'
 import { useEffect, useState } from 'react'
+import WalletMenu from './WalletMenu'
+
+const LEGAL_NOTICE_STORAGE_KEY = 'jbm_hasAcceptedLegalNotice'
 
 export default function WalletButton() {
   const {
@@ -21,12 +22,12 @@ export default function WalletButton() {
 
   useEffect(() => {
     setLegalNoticeAccepted(
-      localStorage.getItem('hasAcceptedLegalNotice') === 'true',
+      localStorage.getItem(LEGAL_NOTICE_STORAGE_KEY) === 'true',
     )
   }, [])
 
   const onOk = () => {
-    localStorage.setItem('hasAcceptedLegalNotice', 'true')
+    localStorage.setItem(LEGAL_NOTICE_STORAGE_KEY, 'true')
     setLegalNoticeAccepted(true)
     setLegalNoticeVisible(false)
     connect()

--- a/src/components/modals/LegalNoticeModal.tsx
+++ b/src/components/modals/LegalNoticeModal.tsx
@@ -1,0 +1,102 @@
+import { t } from '@lingui/macro'
+import { Button, Modal } from 'antd'
+import ExternalLink from 'components/ExternalLink'
+import { helpPagePath } from 'utils/routes'
+
+export default function LegalNoticeModal({
+  open,
+  onOk,
+}: {
+  open: boolean
+  onOk: () => void
+  onCancel: () => void
+}) {
+  return (
+    <Modal
+      title={t`Legal Notice`}
+      okText={t`I Agree`}
+      open={open}
+      destroyOnClose
+      footer={[
+        <Button key="submit" type="primary" onClick={onOk}>
+          OK
+        </Button>,
+      ]}
+    >
+      <p>
+        By selecting "I Agree", you commit to adhering to the{' '}
+        <ExternalLink href={helpPagePath('/tos')}>
+          JuiceboxDAO Terms of Service
+        </ExternalLink>
+        , and acknowledge your understanding that:
+      </p>
+      <ol>
+        <li>
+          The Juicebox protocol and juicebox.money operate on blockchain
+          technology as decentralized projects. Your interaction with these
+          platforms carries inherent risks.
+        </li>
+        <li>
+          The Juicebox protocol and juicebox.money are provided "as is", with no
+          definitive guarantees concerning security. The Juicebox protocol
+          consists of unchangeable code and can be interacted with via multiple
+          user interfaces.
+        </li>
+        <li>
+          There is no single entity controlling the Juicebox protocol. Its
+          operation and decision-making are administered by JuiceboxDAO, a
+          widespread group of participants who jointly govern and sustain it.
+        </li>
+        <li>
+          You can take part in JuiceboxDAO governance by participating in
+          discussions on the{' '}
+          <ExternalLink href="https://discord.gg/juicebox">
+            JuiceboxDAO Discord server
+          </ExternalLink>{' '}
+          or following the procedures outlined in the{' '}
+          <ExternalLink href={helpPagePath('/dao/process')}>
+            JuiceboxDAO Governance Process
+          </ExternalLink>
+          .
+        </li>
+        <li>
+          Rules and guidelines associated with the Juicebox protocol and
+          JuiceboxDAO governance may be subject to alterations.
+        </li>
+        <li>
+          Your use of juicebox.money is conditional on your agreement to comply
+          with the{' '}
+          <ExternalLink href={helpPagePath('/tos')}>
+            Juicebox Terms of Service
+          </ExternalLink>
+          .
+        </li>
+        <li>
+          Legal implications related to your use of Juicebox may vary based on
+          your jurisdiction. We highly recommend seeking advice from a legal
+          professional in your jurisdiction if you have any questions about your
+          use of Juicebox.
+        </li>
+        <li>
+          This agreement doesn't constitute a partnership agreement. You
+          recognize that Juicebox is a decentralized protocol offered "as is".
+        </li>
+        <li>
+          You hereby release any current and future claims against JuiceboxDAO
+          and its affiliates connected to your use of the protocol, JBX,
+          JuiceboxDAO, or any other aspect of the protocol and community.
+        </li>
+        <li>
+          You agree to indemnify and hold harmless JuiceboxDAO and its
+          affiliates for any costs arising from or related to your use of
+          juicebox.money or the Juicebox protocol.
+        </li>
+        <li>
+          You affirm that you are not accessing the protocol from any other
+          jurisdiction listed as a Specially Designated National by the United
+          States Office of Foreign Asset Control ("OFAC").
+        </li>
+      </ol>
+    </Modal>
+  )
+}

--- a/src/components/modals/LegalNoticeModal.tsx
+++ b/src/components/modals/LegalNoticeModal.tsx
@@ -23,11 +23,11 @@ export default function LegalNoticeModal({
     >
       <h2 className="font-display text-2xl">Notice</h2>
       <p className="mb-4 text-center">
-        By selecting "I Agree", you commit to adhering to the{' '}
+        By selecting "I Agree", you accept and agree to the{' '}
         <ExternalLink href={helpPagePath('/tos')}>
-          JuiceboxDAO Terms of Service
+          Terms of Service
         </ExternalLink>
-        , and acknowledge your understanding that:
+        , and acknowledge the following:
       </p>
       <div className="overflow-y-auto" style={{ maxHeight: '60vh' }}>
         <ol className="list-decimal space-y-4 px-8">

--- a/src/components/modals/LegalNoticeModal.tsx
+++ b/src/components/modals/LegalNoticeModal.tsx
@@ -1,101 +1,103 @@
 import { t } from '@lingui/macro'
-import { Button, Modal } from 'antd'
+import { Modal } from 'antd'
 import ExternalLink from 'components/ExternalLink'
 import { helpPagePath } from 'utils/routes'
 
 export default function LegalNoticeModal({
   open,
   onOk,
+  onCancel,
 }: {
   open: boolean
   onOk: () => void
+  onCancel: () => void
 }) {
   return (
     <Modal
-      title={t`Legal Notice`}
       okText={t`I Agree`}
       open={open}
       destroyOnClose
-      footer={[
-        <Button key="submit" type="primary" onClick={onOk}>
-          OK
-        </Button>,
-      ]}
+      centered={true}
+      onOk={onOk}
+      onCancel={onCancel}
     >
-      <p>
+      <h2 className="font-display text-2xl">Notice</h2>
+      <p className="mb-4 text-center">
         By selecting "I Agree", you commit to adhering to the{' '}
         <ExternalLink href={helpPagePath('/tos')}>
           JuiceboxDAO Terms of Service
         </ExternalLink>
         , and acknowledge your understanding that:
       </p>
-      <ol>
-        <li>
-          The Juicebox protocol and juicebox.money operate on blockchain
-          technology as decentralized projects. Your interaction with these
-          platforms carries inherent risks.
-        </li>
-        <li>
-          The Juicebox protocol and juicebox.money are provided "as is", with no
-          definitive guarantees concerning security. The Juicebox protocol
-          consists of unchangeable code and can be interacted with via multiple
-          user interfaces.
-        </li>
-        <li>
-          There is no single entity controlling the Juicebox protocol. Its
-          operation and decision-making are administered by JuiceboxDAO, a
-          widespread group of participants who jointly govern and sustain it.
-        </li>
-        <li>
-          You can take part in JuiceboxDAO governance by participating in
-          discussions on the{' '}
-          <ExternalLink href="https://discord.gg/juicebox">
-            JuiceboxDAO Discord server
-          </ExternalLink>{' '}
-          or following the procedures outlined in the{' '}
-          <ExternalLink href={helpPagePath('/dao/process')}>
-            JuiceboxDAO Governance Process
-          </ExternalLink>
-          .
-        </li>
-        <li>
-          Rules and guidelines associated with the Juicebox protocol and
-          JuiceboxDAO governance may be subject to alterations.
-        </li>
-        <li>
-          Your use of juicebox.money is conditional on your agreement to comply
-          with the{' '}
-          <ExternalLink href={helpPagePath('/tos')}>
-            Juicebox Terms of Service
-          </ExternalLink>
-          .
-        </li>
-        <li>
-          Legal implications related to your use of Juicebox may vary based on
-          your jurisdiction. We highly recommend seeking advice from a legal
-          professional in your jurisdiction if you have any questions about your
-          use of Juicebox.
-        </li>
-        <li>
-          This agreement doesn't constitute a partnership agreement. You
-          recognize that Juicebox is a decentralized protocol offered "as is".
-        </li>
-        <li>
-          You hereby release any current and future claims against JuiceboxDAO
-          and its affiliates connected to your use of the protocol, JBX,
-          JuiceboxDAO, or any other aspect of the protocol and community.
-        </li>
-        <li>
-          You agree to indemnify and hold harmless JuiceboxDAO and its
-          affiliates for any costs arising from or related to your use of
-          juicebox.money or the Juicebox protocol.
-        </li>
-        <li>
-          You affirm that you are not accessing the protocol from any other
-          jurisdiction listed as a Specially Designated National by the United
-          States Office of Foreign Asset Control ("OFAC").
-        </li>
-      </ol>
+      <div className="overflow-y-auto" style={{ maxHeight: '60vh' }}>
+        <ol className="list-decimal space-y-4 px-8">
+          <li>
+            The Juicebox protocol and juicebox.money operate on blockchain
+            technology as decentralized projects. Your interaction with these
+            platforms carries inherent risks.
+          </li>
+          <li>
+            The Juicebox protocol and juicebox.money are provided "as is", with
+            no definitive guarantees concerning security. The Juicebox protocol
+            consists of unchangeable code and can be interacted with via
+            multiple user interfaces.
+          </li>
+          <li>
+            There is no single entity controlling the Juicebox protocol. Its
+            operation and decision-making are administered by JuiceboxDAO, a
+            widespread group of participants who jointly govern and sustain it.
+          </li>
+          <li>
+            You can take part in JuiceboxDAO governance by participating in
+            discussions on the{' '}
+            <ExternalLink href="https://discord.gg/juicebox">
+              JuiceboxDAO Discord server
+            </ExternalLink>{' '}
+            or following the procedures outlined in the{' '}
+            <ExternalLink href={helpPagePath('/dao/process')}>
+              JuiceboxDAO Governance Process
+            </ExternalLink>
+            .
+          </li>
+          <li>
+            Rules and guidelines associated with the Juicebox protocol and
+            JuiceboxDAO governance may be subject to alterations.
+          </li>
+          <li>
+            Your use of juicebox.money is conditional on your agreement to
+            comply with the{' '}
+            <ExternalLink href={helpPagePath('/tos')}>
+              Juicebox Terms of Service
+            </ExternalLink>
+            .
+          </li>
+          <li>
+            Legal implications related to your use of Juicebox may vary based on
+            your jurisdiction. We highly recommend seeking advice from a legal
+            professional in your jurisdiction if you have any questions about
+            your use of Juicebox.
+          </li>
+          <li>
+            This agreement doesn't constitute a partnership agreement. You
+            recognize that Juicebox is a decentralized protocol offered "as is".
+          </li>
+          <li>
+            You hereby release any current and future claims against JuiceboxDAO
+            and its affiliates connected to your use of the protocol, JBX,
+            JuiceboxDAO, or any other aspect of the protocol and community.
+          </li>
+          <li>
+            You agree to indemnify and hold harmless JuiceboxDAO and its
+            affiliates for any costs arising from or related to your use of
+            juicebox.money or the Juicebox protocol.
+          </li>
+          <li>
+            You affirm that you are not accessing the protocol from any other
+            jurisdiction listed as a Specially Designated National by the United
+            States Office of Foreign Asset Control ("OFAC").
+          </li>
+        </ol>
+      </div>
     </Modal>
   )
 }

--- a/src/components/modals/LegalNoticeModal.tsx
+++ b/src/components/modals/LegalNoticeModal.tsx
@@ -9,7 +9,6 @@ export default function LegalNoticeModal({
 }: {
   open: boolean
   onOk: () => void
-  onCancel: () => void
 }) {
   return (
     <Modal

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -383,6 +383,9 @@ msgstr ""
 msgid "<0>You're about to delete all NFTs from your collection. This will take effect immediately, and you can add NFTs back to the collection at any time.</0><1>If you want to COMPLETELY detach NFTs from your project, you can do so in the <2>Danger Zone</2> section below.</1>"
 msgstr ""
 
+msgid "Legal Notice"
+msgstr ""
+
 msgid "<0>Owned by</0><1/>"
 msgstr ""
 
@@ -3117,6 +3120,9 @@ msgid "Other Rules"
 msgstr ""
 
 msgid "Disabled when your project's cycle has no duration."
+msgstr ""
+
+msgid "I Agree"
 msgstr ""
 
 msgid "Twitter handle"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -383,9 +383,6 @@ msgstr ""
 msgid "<0>You're about to delete all NFTs from your collection. This will take effect immediately, and you can add NFTs back to the collection at any time.</0><1>If you want to COMPLETELY detach NFTs from your project, you can do so in the <2>Danger Zone</2> section below.</1>"
 msgstr ""
 
-msgid "Legal Notice"
-msgstr ""
-
 msgid "<0>Owned by</0><1/>"
 msgstr ""
 

--- a/src/styles/web3-onboard-overrides/onboard/connect.scss
+++ b/src/styles/web3-onboard-overrides/onboard/connect.scss
@@ -1,5 +1,6 @@
 :root {
-  --onboard-modal-z-index: 100; // Ensure greater than other modal indices of 20 
+  // Ensure greater than other modal indices of 20, but less than walletconnect (uses z-index=90)
+  --onboard-modal-z-index: 89; 
 
   --onboard-connect-sidebar-background: theme(colors.smoke.100);
   --onboard-connect-sidebar-color: theme(colors.black);


### PR DESCRIPTION
If a user attempts to connect their wallet, show them a legal notice. Once they accept, they can connect as normal.

If a user accepts: `localStorage.setItem('hasAcceptedLegalNotice', 'true')`.

If this is true, they won't be prompted again.