### PR TITLE
Filter invalid tags from project metadata

### DIFF
--- a/src/models/project-tags.ts
+++ b/src/models/project-tags.ts
@@ -40,4 +40,14 @@ export type ProjectTagName = typeof projectTagOptions extends Readonly<
   ? T
   : never
 
+export function isValidProjectTag(
+  tag: ProjectTagName | string,
+): tag is ProjectTagName {
+  return projectTagOptions.includes(tag as ProjectTagName)
+}
+
+export function filterValidTags(tags: string[] | null | undefined) {
+  return tags?.filter(isValidProjectTag).slice(0, MAX_PROJECT_TAGS)
+}
+
 export const MAX_PROJECT_TAGS = 3

--- a/src/models/projectMetadata.ts
+++ b/src/models/projectMetadata.ts
@@ -1,5 +1,5 @@
 import { NftPostPayModalConfig } from './nftRewards'
-import { ProjectTagName } from './project-tags'
+import { ProjectTagName, filterValidTags } from './project-tags'
 import { TokenRef } from './tokenRef'
 
 type ProjectMetadataV1 = Partial<{
@@ -98,6 +98,7 @@ export const consolidateMetadata = (
 ): ProjectMetadata => {
   return {
     ...metadata,
+    tags: filterValidTags((metadata as ProjectMetadataV8).tags),
     payButton:
       (metadata as ProjectMetadataV3).payButton ??
       (metadata as ProjectMetadataV2).payText,

--- a/src/utils/sgDbProjects.ts
+++ b/src/utils/sgDbProjects.ts
@@ -1,7 +1,11 @@
 import { ipfsGet } from 'lib/api/ipfs'
 import { DBProject, DBProjectRow, SGSBCompareKey } from 'models/dbProject'
 import { Json } from 'models/json'
-import { ProjectTagName } from 'models/project-tags'
+import {
+  ProjectTagName,
+  filterValidTags,
+  isValidProjectTag,
+} from 'models/project-tags'
 import { ProjectMetadata, consolidateMetadata } from 'models/projectMetadata'
 import { PV } from 'models/pv'
 
@@ -185,6 +189,10 @@ export function getChangedSubgraphProjects({
         return true
       }
 
+      if (dbProject.tags?.some(t => !isValidProjectTag(t))) {
+        return true
+      }
+
       // Deep compare Subgraph project vs. database project and find any discrepancies
       const propertiesToUpdate = sgDbCompareKeys.filter(k => {
         const oldVal = dbProject[k]
@@ -277,7 +285,7 @@ export async function formatWithMetadata({
         description,
         logoUri,
         name,
-        tags,
+        tags: filterValidTags(tags) ?? null,
       },
     }
   }
@@ -297,7 +305,7 @@ export async function formatWithMetadata({
         name: name ?? null,
         description: description ?? null,
         logoUri: logoUri ?? null,
-        tags: tags ?? null,
+        tags: filterValidTags(tags) ?? null,
         archived: archived ?? null,
       },
     }


### PR DESCRIPTION
Filter out any invalid tags from project metadata.

I noticed a bug (on goerli) where some older projects are using tags that are now "invalid" (not recognized by the UI) which cause breaking runtime errors. I suspect this issue is nonexistent in mainnet prod, but in the case of a project having invalid tags for any reason in the future, this will prevent them from making it to the UI and causing errors.