### PR TITLE
fix: make configuration panel dropdown values selectable and not close the panel [1/n]

### DIFF
--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationDisplayCard.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationDisplayCard.tsx
@@ -19,8 +19,8 @@ export const ConfigurationDisplayCard = ({
       className={twMerge('rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700')}
     >
       {({ open }) => (
-        <Disclosure.Button className="w-full outline-none">
-          <div className="flex w-full items-center justify-between text-start">
+        <div className="w-full outline-none">
+          <Disclosure.Button className="flex w-full items-center justify-between text-start">
             <div className="flex flex-col gap-2 text-sm font-medium text-grey-600 dark:text-slate-200">
               {title}
               <div className="font-heading text-xl font-medium text-grey-900 dark:text-slate-50">
@@ -30,7 +30,7 @@ export const ConfigurationDisplayCard = ({
             <ChevronDownIcon
               className={twMerge('h-6 w-6', open && 'rotate-180')}
             />
-          </div>
+          </Disclosure.Button>
 
           <Transition
             show={open}
@@ -47,7 +47,7 @@ export const ConfigurationDisplayCard = ({
               <CurrentUpcomingConfigurationPanel type={type} />
             </Disclosure.Panel>
           </Transition>
-        </Disclosure.Button>
+        </div>
       )}
     </Disclosure>
   )

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/HistorySubPanel.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/HistorySubPanel.tsx
@@ -58,12 +58,12 @@ export const HistorySubPanel = () => {
             {data.map(cycle => (
               <Disclosure key={cycle.cycleNumber} as={Fragment}>
                 {({ open }) => (
-                  <Disclosure.Button
-                    data-testid={`disclosure-button-${cycle.cycleNumber}`}
-                    as="div"
-                    className="cursor-pointer p-4 pr-2"
-                  >
-                    <div className="grid grid-cols-config-table gap-3 whitespace-nowrap text-sm font-medium">
+                  <div className="p-4 pr-2">
+                    <Disclosure.Button
+                      data-testid={`disclosure-button-${cycle.cycleNumber}`}
+                      as="div"
+                      className="grid cursor-pointer grid-cols-config-table gap-3 whitespace-nowrap text-sm font-medium"
+                    >
                       <div>#{cycle.cycleNumber}</div>
                       <div>{cycle.withdrawn}</div>
                       <div className="text-grey-500 dark:text-slate-200">
@@ -74,7 +74,7 @@ export const HistorySubPanel = () => {
                           className={twMerge(open && 'rotate-180', 'h-5 w-5')}
                         />
                       </div>
-                    </div>
+                    </Disclosure.Button>
                     <Transition
                       show={open}
                       as={Fragment}
@@ -89,7 +89,7 @@ export const HistorySubPanel = () => {
                         <HistoricalConfigurationPanel {...cycle._metadata} />
                       </Disclosure.Panel>
                     </Transition>
-                  </Disclosure.Button>
+                  </div>
                 )}
               </Disclosure>
             ))}

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
@@ -6,15 +6,15 @@ exports[`ConfigurationDisplayCard renders 1`] = `
     class="rounded-lg bg-smoke-50 py-5 px-6 dark:bg-slate-700"
     data-headlessui-state=""
   >
-    <button
-      aria-expanded="false"
+    <div
       class="w-full outline-none"
-      data-headlessui-state=""
-      id="headlessui-disclosure-button-:r0:"
-      type="button"
     >
-      <div
+      <button
+        aria-expanded="false"
         class="flex w-full items-center justify-between text-start"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r0:"
+        type="button"
       >
         <div
           class="flex flex-col gap-2 text-sm font-medium text-grey-600 dark:text-slate-200"
@@ -41,8 +41,8 @@ exports[`ConfigurationDisplayCard renders 1`] = `
             stroke-linejoin="round"
           />
         </svg>
-      </div>
-    </button>
+      </button>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-685 : Cannot highlight \(copy & paste\) values in cycle tab](https://linear.app/peel/issue/JB-685/cannot-highlight-copy-and-paste-values-in-cycle-tab)

Closes JB-685

This change makes only the dropdown title clickable, rather than the whole dropdown so users can still copy values from config

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
