### PR TITLE
fix: mobile view of success card

### DIFF
--- a/src/components/ProjectDashboard/components/SuccessPayView/components/SuccessPayCard.tsx
+++ b/src/components/ProjectDashboard/components/SuccessPayView/components/SuccessPayCard.tsx
@@ -31,13 +31,13 @@ export const SuccessPayCard = ({ className }: { className?: string }) => {
       )}
     >
       <div className="flex w-full justify-between gap-3 pb-6 md:pb-0">
-        <div className="flex gap-3 text-start">
+        <div className="flex min-w-0 gap-3 text-start">
           <ProjectHeaderLogo className="h-20 w-20 bg-white" />
-          <div className="flex flex-col gap-1">
+          <div className="flex min-w-0 flex-col gap-1">
             <span className="text-xs text-grey-500 dark:text-slate-200">
               <Trans>Paid</Trans>
             </span>
-            <span className="truncate text-sm font-medium">{name}</span>
+            <span className="text-sm font-medium">{name}</span>
             <span className="font-heading text-2xl font-medium">
               {formatCurrencyAmount({
                 ...projectPayReceipt.totalAmount,
@@ -49,14 +49,16 @@ export const SuccessPayCard = ({ className }: { className?: string }) => {
 
         <div className="flex flex-col items-end">
           <div className="flex items-center gap-2 ">
-            <span className="text-xs text-grey-500 dark:text-slate-200">
+            <span className="whitespace-nowrap text-xs text-grey-500 dark:text-slate-200">
               {transactionDateString}
             </span>
-            <EtherscanLink
-              linkClassName="text-black dark:text-slate-50"
-              type="tx"
-              value={projectPayReceipt.transactionHash}
-            />
+            {!isMobile && (
+              <EtherscanLink
+                linkClassName="text-black dark:text-slate-50"
+                type="tx"
+                value={projectPayReceipt.transactionHash}
+              />
+            )}
           </div>
           {!isMobile && (
             <EthereumAddress
@@ -68,11 +70,17 @@ export const SuccessPayCard = ({ className }: { className?: string }) => {
         </div>
       </div>
       {isMobile && (
-        <div className="flex justify-between pt-6">
+        <div className="flex items-center justify-between pt-6">
           <EthereumAddress
             tooltipDisabled
             address={projectPayReceipt.fromAddress}
             withEnsAvatar
+          />
+          <EtherscanLink
+            className="rounded-lg border border-grey-200 py-1 px-2 text-base dark:border-slate-300"
+            linkClassName="text-black text-base dark:text-slate-100"
+            type="tx"
+            value={projectPayReceipt.transactionHash}
           />
         </div>
       )}


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-649 : Payment success bad design on mobile](https://linear.app/peel/issue/JB-649/payment-success-bad-design-on-mobile)

Closes JB-649

## Screenshots or screen recordings

---
### Before
![image (4).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/34de4a54-49b9-46b6-ab3e-a292d919a4df/image%20(4).png)

---
### After
![Screen Shot 2023-08-04 at 11.01.40 am.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/cd40de8e-3e08-442f-be4c-e19c90a3e919/Screen%20Shot%202023-08-04%20at%2011.01.40%20am.png)

![Screen Shot 2023-08-04 at 11.01.31 am.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/0c233547-94a8-4c3d-8896-b4cf7a75e81d/Screen%20Shot%202023-08-04%20at%2011.01.31%20am.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
