### PR TITLE
fix: FormattedNumberInput has lost y padding

### DIFF
--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -1,6 +1,5 @@
 import { InputNumberProps } from 'antd'
 import { twMerge } from 'tailwind-merge'
-import { classNames } from 'utils/classNames'
 import { formattedNum } from 'utils/format/formatNumber'
 import { JuiceInputNumber } from './JuiceInputNumber'
 
@@ -53,8 +52,9 @@ export default function FormattedNumberInput({
   return (
     <div className={twMerge('relative flex items-center', className)}>
       <JuiceInputNumber
-        className={classNames(
+        className={twMerge(
           'h-full w-full',
+          'formatted-number-input',
           accessory ? 'antd-no-number-handler' : '',
         )}
         value={value !== undefined ? parseFloat(value) : undefined}

--- a/src/components/inputs/JuiceInputNumber.tsx
+++ b/src/components/inputs/JuiceInputNumber.tsx
@@ -1,11 +1,11 @@
 import { InputNumber, InputNumberProps } from 'antd'
-import { classNames } from 'utils/classNames'
+import { twMerge } from 'tailwind-merge'
 
 export const JuiceInputNumber = (props: InputNumberProps) => {
   return (
     <InputNumber
       {...props}
-      className={classNames(
+      className={twMerge(
         'border-smoke-300 bg-smoke-50 text-black dark:border-slate-300 dark:bg-slate-600 dark:text-slate-100 dark:placeholder:text-slate-300',
         props.className,
       )}

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -40,13 +40,16 @@
   @apply h-full;
 }
 
+.formatted-number-input .ant-input-number-input-wrap input {
+  @apply py-1;
+}
 
 .ant-input-lg {
   @apply h-11;
 }
 
 .ant-input-number-lg input {
-  height: 46px; // Ant-d has different rules for number inputs. Needs to be [48-2]px to account for borders. 
+  height: 46px; // Ant-d has different rules for number inputs. Needs to be [48-2]px to account for borders.
 }
 
 .ant-form-item-explain.ant-form-item-explain-error {
@@ -240,9 +243,11 @@ textarea.ant-input::placeholder {
   background: transparent;
 }
 
-
 /* EXPLORE PAGE SEARCH BAR */
-.ant-input-search > .ant-input-group > .ant-input-group-addon:last-child .ant-input-search-button:not(.ant-btn-primary),
+.ant-input-search
+  > .ant-input-group
+  > .ant-input-group-addon:last-child
+  .ant-input-search-button:not(.ant-btn-primary),
 .ant-input-search-button {
   border: 1px solid;
   @apply stroke-primary;
@@ -280,16 +285,6 @@ textarea.ant-input::placeholder {
   &:hover {
     @apply text-primary;
   }
-}
-
-/* FORMATTED NUMBER INPUT */
-.formatted-number-input {
-  display: flex;
-  width: 100%;
-}
-.ant-form-item.formatted-number-input {
-  margin-bottom: 0;
-  width: 100%;
 }
 
 .ant-form-item-label > label .ant-form-item-optional {


### PR DESCRIPTION
## What does this PR do and why?

Before

![image (3).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/9f4128e6-1cea-42f9-951b-a982c3dd1a92/image%20(3).png)


After

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/10577fad-da58-4650-aa6f-5a7f8ad67029/image.png)


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
