### PR TITLE
make orange loader 260x260

### DIFF
--- a/src/components/ProjectDashboard/components/PayProjectModal/PayProjectModal.tsx
+++ b/src/components/ProjectDashboard/components/PayProjectModal/PayProjectModal.tsx
@@ -68,8 +68,8 @@ export const PayProjectModal: React.FC = () => {
                 <Image
                   src="/assets/images/orange-loading.webp"
                   alt={t`Juicebox loading animation`}
-                  width={140}
-                  height={140}
+                  width={260}
+                  height={260}
                   style={{
                     maxWidth: '100%',
                     height: 'auto',

--- a/src/components/modals/TransactionModal.tsx
+++ b/src/components/modals/TransactionModal.tsx
@@ -28,8 +28,8 @@ const PendingTransactionModalBody = () => {
         <Image
           src="/assets/images/orange-loading.webp"
           alt={t`Juicebox loading animation`}
-          width={140}
-          height={140}
+          width={260}
+          height={260}
           style={{
             maxWidth: '100%',
             height: 'auto',


### PR DESCRIPTION
## What does this PR do and why?

Closes JB-648
https://linear.app/peel/issue/JB-648/replace-transaction-pending-loading-animation

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
