### PR TITLE
Fix: nft edit in create now works again

### DIFF
--- a/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
+++ b/src/components/Create/components/RewardsList/AddEditRewardModal.tsx
@@ -16,7 +16,7 @@ import { pinFile } from 'lib/api/ipfs'
 import random from 'lodash/random'
 import { NftRewardTier } from 'models/nftRewards'
 import { UploadRequestOption } from 'rc-upload/lib/interface'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import {
   inputIsIntegerRule,
   inputIsValidUrlRule,
@@ -67,9 +67,8 @@ export const AddEditRewardModal = ({
   const [isReservingNfts, setIsReservingNfts] = useState<boolean>(false)
   const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState<boolean>(false)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!open) return
-
     if (!editingData) {
       setLimitedSupply(false)
       return
@@ -80,17 +79,21 @@ export const AddEditRewardModal = ({
         editingData.maxSupply !== DEFAULT_NFT_MAX_SUPPLY,
     )
     setIsReservingNfts(!!editingData.beneficiary && !!editingData.reservedRate)
-    form.setFieldsValue({
-      fileUrl: editingData.fileUrl.toString(),
-      rewardName: editingData.name,
-      description: editingData.description,
-      contributionFloor: editingData.contributionFloor.toString(),
-      maxSupply: editingData.maxSupply?.toString(),
-      externalUrl: editingData.externalLink,
-      beneficiary: editingData.beneficiary,
-      nftReservedRate: editingData.reservedRate,
-      votingWeight: editingData.votingWeight,
-    })
+
+    // Wait for form to be visible before setting values
+    setTimeout(() => {
+      form.setFieldsValue({
+        fileUrl: editingData.fileUrl.toString(),
+        rewardName: editingData.name,
+        description: editingData.description,
+        contributionFloor: editingData.contributionFloor.toString(),
+        maxSupply: editingData.maxSupply?.toString(),
+        externalUrl: editingData.externalLink,
+        beneficiary: editingData.beneficiary,
+        nftReservedRate: editingData.reservedRate,
+        votingWeight: editingData.votingWeight,
+      })
+    }, 0)
   }, [editingData, form, open])
 
   // Due to the way antd works, if advanced options are set, we need to open it on load

--- a/src/components/Create/components/pages/NftRewards/hooks/useNftRewardsForm.ts
+++ b/src/components/Create/components/pages/NftRewards/hooks/useNftRewardsForm.ts
@@ -9,7 +9,6 @@ import {
   defaultNftCollectionDescription,
   defaultNftCollectionName,
 } from 'utils/nftRewards'
-import { v4 } from 'uuid'
 import { useFormDispatchWatch } from '../../hooks'
 
 type NftRewardsFormProps = Partial<{
@@ -48,7 +47,7 @@ export const useNftRewardsForm = () => {
 
     const rewards: NftRewardTier[] =
       rewardTiers?.map(t => ({
-        id: parseInt(v4()),
+        id: Math.floor(Math.random() * 1000000),
         name: t.name,
         contributionFloor: t.contributionFloor,
         description: t.description,


### PR DESCRIPTION
## What does this PR do and why?

Closes JB-652
https://linear.app/peel/issue/JB-652/edit-nft-in-create-broken

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
