### PR TITLE
fix: show filler image on failure to load avatar in about us contributor

### DIFF
--- a/src/components/AboutDashboard/components/BuiltByTheBestSection.tsx
+++ b/src/components/AboutDashboard/components/BuiltByTheBestSection.tsx
@@ -99,13 +99,20 @@ const ContributorCard: React.FC<
     avatarUrl: string | undefined
   }>
 > = ({ name, title, avatarUrl }) => {
+  const [validAvatar, setValidImage] = useState(true)
+
+  const handleImageError = () => {
+    setValidImage(false)
+  }
+
   return (
     <div className="max-w-[216px] overflow-hidden">
-      {avatarUrl ? (
+      {avatarUrl && validAvatar ? (
         <img
+          className="mx-auto mb-5 h-14 w-14 rounded-full md:h-20 md:w-20"
           src={avatarUrl}
           alt={name}
-          className="mx-auto mb-5 h-14 w-14 rounded-full md:h-20 md:w-20"
+          onError={handleImageError}
         />
       ) : (
         <div className="mx-auto mb-5 h-20 w-20 rounded-full bg-bluebs-400" />

--- a/src/components/AboutDashboard/components/BuiltByTheBestSection.tsx
+++ b/src/components/AboutDashboard/components/BuiltByTheBestSection.tsx
@@ -99,10 +99,10 @@ const ContributorCard: React.FC<
     avatarUrl: string | undefined
   }>
 > = ({ name, title, avatarUrl }) => {
-  const [validAvatar, setValidImage] = useState(true)
+  const [validAvatar, setValidAvatar] = useState(true)
 
   const handleImageError = () => {
-    setValidImage(false)
+    setValidAvatar(false)
   }
 
   return (


### PR DESCRIPTION
## What does this PR do and why?

_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

## Screenshots or screen recordings


![Screen Shot 2023-08-04 at 2.30.07 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/62eb1be6-439d-4eab-9f04-8057038fbc30/Screen%20Shot%202023-08-04%20at%202.30.07%20pm.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
