### PR TITLE
fix: strip out html tags in project description subtitle, and show read more if using project description in lieu of tagline

### DIFF
--- a/src/components/ProjectDashboard/components/ProjectHeader/ProjectHeader.tsx
+++ b/src/components/ProjectDashboard/components/ProjectHeader/ProjectHeader.tsx
@@ -8,14 +8,12 @@ import { useProjectHeader } from 'components/ProjectDashboard/hooks'
 import { SubscribeButton } from 'components/SubscribeButton'
 import { TruncatedText } from 'components/TruncatedText'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
-import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { PV_V2 } from 'constants/pv'
 import useMobile from 'hooks/useMobile'
 import { useV2V3WalletHasPermission } from 'hooks/v2v3/contractReader/useV2V3WalletHasPermission'
 import { V2V3OperatorPermission } from 'models/v2v3/permissions'
 import Link from 'next/link'
 import { twMerge } from 'tailwind-merge'
-import { featureFlagEnabled } from 'utils/featureFlags'
 import { settingsPagePath } from 'utils/routes'
 import { ProjectHeaderLogo } from './components/ProjectHeaderLogo'
 import { ProjectHeaderPopupMenu } from './components/ProjectHeaderPopupMenu'
@@ -28,10 +26,6 @@ export const ProjectHeader = ({ className }: { className?: string }) => {
   const isMobile = useMobile()
   const canReconfigure = useV2V3WalletHasPermission(
     V2V3OperatorPermission.RECONFIGURE,
-  )
-
-  const richProjectDescriptionEnabled = featureFlagEnabled(
-    FEATURE_FLAGS.RICH_PROJECT_DESCRIPTION,
   )
 
   return (
@@ -76,13 +70,13 @@ export const ProjectHeader = ({ className }: { className?: string }) => {
         <div className="flex flex-col justify-between gap-8 md:flex-row md:gap-12">
           <div className="flex min-w-0 flex-col gap-3">
             {subtitle &&
-              (richProjectDescriptionEnabled ? (
+              (subtitle.type === 'tagline' ? (
                 <TruncatedText
                   className="text-grey-700 dark:text-slate-50 md:text-lg"
-                  text={subtitle}
+                  text={subtitle.text}
                 />
               ) : (
-                <Subtitle subtitle={subtitle} />
+                <Subtitle subtitle={subtitle.text} />
               ))}
             <div className="text-grey-500 dark:text-slate-200">
               {projectId ? (

--- a/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStats.test.tsx
+++ b/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStats.test.tsx
@@ -25,7 +25,7 @@ function mockUseProjectPageQueries() {
 
 const MOCK_PROJECT_HEADER_DATA: ProjectHeaderData = {
   title: 'bongdao',
-  subtitle: 'big rips',
+  subtitle: { text: 'big rips', type: 'tagline' },
   handle: 'bongdao',
   projectId: 420,
   owner: '0x1234',

--- a/src/components/ProjectDashboard/hooks/useProjectHeader.ts
+++ b/src/components/ProjectDashboard/hooks/useProjectHeader.ts
@@ -6,9 +6,10 @@ import { GnosisSafe } from 'models/safe'
 import { useContext, useMemo } from 'react'
 import { useProjectMetadata } from './useProjectMetadata'
 
+type SubtitleType = 'tagline' | 'description'
 export interface ProjectHeaderData {
   title: string | undefined
-  subtitle: string | undefined
+  subtitle: { text: string; type: SubtitleType } | undefined
   handle: string | undefined
   projectId: number | undefined
   owner: string | undefined
@@ -36,7 +37,22 @@ export const useProjectHeader = (): ProjectHeaderData => {
   const subtitle = useMemo(() => {
     const tagline = projectMetadata?.projectTagline
     const description = projectMetadata?.description
-    return tagline ?? description
+      ? stripHtmlTags(projectMetadata?.description)
+      : undefined
+
+    if (tagline) {
+      return {
+        text: tagline,
+        type: 'tagline' as SubtitleType,
+      }
+    }
+
+    if (description) {
+      return {
+        text: description,
+        type: 'description' as SubtitleType,
+      }
+    }
   }, [projectMetadata?.description, projectMetadata?.projectTagline])
 
   return {
@@ -50,4 +66,8 @@ export const useProjectHeader = (): ProjectHeaderData => {
     last7DaysPercent,
     gnosisSafe,
   }
+}
+
+const stripHtmlTags = (html: string): string => {
+  return html.replace(/<[^>]*>/g, '')
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes JB-702 https://linear.app/peel/issue/JB-702/when-falling-back-to-project-description-as-project-tagline-strip-out

## Screenshots or screen recordings

### Before

![Screen Shot 2023-08-04 at 3.18.29 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/99a939ed-3040-4971-a975-7da9b06a02f3/Screen%20Shot%202023-08-04%20at%203.18.29%20pm.png)

---

### After

![Screen Shot 2023-08-04 at 3.16.13 pm.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pinTSPPZHK80UCzWAYgo/a9d15d93-7a2d-4c72-9f26-fc35690092ce/Screen%20Shot%202023-08-04%20at%203.16.13%20pm.png)


## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
