### PR TITLE
feat: add project logo api

### DIFF
--- a/src/components/ProjectDashboard/components/Cart/components/__snapshots__/SummaryExpandedView.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/Cart/components/__snapshots__/SummaryExpandedView.test.tsx.snap
@@ -45,13 +45,11 @@ exports[`SummaryExpandedView should render correctly 1`] = `
               class="flex min-w-0 items-center"
             >
               <div
-                class="flex items-center justify-center overflow-hidden bg-smoke-100 dark:bg-slate-700 h-14 w-14 rounded-full"
+                class="flex items-center justify-center overflow-hidden text-4xl bg-smoke-100 dark:bg-slate-700 animate-pulse h-14 w-14 rounded-full"
               >
-                <div
-                  class="text-4xl"
-                >
+                <span>
                   🧃
-                </div>
+                </span>
               </div>
               <span
                 class="ml-3 min-w-0 font-medium dark:text-slate-50"

--- a/src/components/ProjectLogo.tsx
+++ b/src/components/ProjectLogo.tsx
@@ -13,21 +13,26 @@ export default function ProjectLogo({
   name,
   projectId,
   lazyLoad,
+  fallback = '🧃',
 }: {
-  className?: string
-  uri: string | undefined
   name: string | undefined
+  className?: string
+  uri?: string | undefined
   projectId?: number | undefined
   lazyLoad?: boolean
+  fallback?: string | JSX.Element | null
 }) {
   const [srcLoadError, setSrcLoadError] = useState(false)
-  const validImg = uri && !srcLoadError
+  const [loading, setLoading] = useState(true)
 
   const imageSrc = useMemo(() => {
-    if (projectId && IMAGE_URI_OVERRIDES[projectId]) {
+    if (!projectId) return undefined
+
+    if (IMAGE_URI_OVERRIDES[projectId]) {
       return IMAGE_URI_OVERRIDES[projectId]
     }
-    if (!uri) return undefined
+
+    if (!uri) return `/api/juicebox/projectLogo/${projectId}`
 
     // Some older JB projects have a logo URI hardcoded to use Pinata.
     // JBM no longer uses Pinata.
@@ -40,11 +45,14 @@ export default function ProjectLogo({
     return ipfsUriToGatewayUrl(uri)
   }, [uri, projectId])
 
+  const validImg = imageSrc && !srcLoadError
+
   return (
     <div
       className={twMerge(
-        'flex h-20 w-20 items-center justify-center overflow-hidden rounded-lg',
+        'flex h-20 w-20 items-center justify-center overflow-hidden rounded-lg text-4xl',
         'bg-smoke-100 dark:bg-slate-700',
+        loading ? 'animate-pulse' : undefined,
         className,
       )}
     >
@@ -54,15 +62,14 @@ export default function ProjectLogo({
           src={imageSrc}
           alt={name + ' logo'}
           onError={() => setSrcLoadError(true)}
+          onLoad={() => setLoading(false)}
           loading={lazyLoad ? 'lazy' : undefined}
           crossOrigin="anonymous"
           title={name}
         />
-      ) : (
-        <div className="text-4xl" title={name}>
-          🧃
-        </div>
-      )}
+      ) : null}
+
+      {!validImg ? <span title={name}>{fallback}</span> : null}
     </div>
   )
 }

--- a/src/components/v2v3/shared/V2V3ProjectHandleLink.tsx
+++ b/src/components/v2v3/shared/V2V3ProjectHandleLink.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro'
 import { Tooltip } from 'antd'
+import ProjectLogo from 'components/ProjectLogo'
 import { useProjectHandleText } from 'hooks/useProjectHandleText'
 import Link from 'next/link'
 import { useMemo } from 'react'
@@ -44,11 +45,14 @@ export default function V2V3ProjectHandleLink({
       title={tooltipText}
       open={tooltipText ? undefined : false}
     >
-      {withProjectAvatar && firstLetterOfHandleText && (
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-grey-300 font-medium uppercase text-grey-600 dark:bg-slate-400 dark:text-slate-100">
-          {firstLetterOfHandleText}
-        </div>
-      )}
+      {withProjectAvatar ? (
+        <ProjectLogo
+          className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg bg-grey-300 text-base font-medium uppercase text-grey-600 dark:bg-slate-400 dark:text-slate-100"
+          name={name ?? undefined}
+          projectId={projectId}
+          fallback={firstLetterOfHandleText}
+        />
+      ) : null}
       <Link
         prefetch={false}
         href={v2v3ProjectRoute({ projectId })}

--- a/src/pages/api/juicebox/projectLogo/[projectId].page.ts
+++ b/src/pages/api/juicebox/projectLogo/[projectId].page.ts
@@ -1,0 +1,93 @@
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import axios from 'axios'
+import { getLogger } from 'lib/logger'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { Database } from 'types/database.types'
+import {
+  cidFromUrl,
+  ipfsGatewayUrl,
+  ipfsUriToGatewayUrl,
+  isIpfsUri,
+} from 'utils/ipfs'
+import { getProjectMetadata } from 'utils/server/metadata'
+
+const logger = getLogger('api/juicebox/projectLogo/[projectId]')
+
+async function findLogoFromDb(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  projectId: string,
+) {
+  const supabase = createServerSupabaseClient<Database>({ req, res })
+
+  const query = await supabase
+    .from('projects')
+    .select('logo_uri')
+    .eq('project_id', projectId)
+
+  if (query.error) throw query.error
+
+  return query.data?.[0]?.logo_uri as string | undefined
+}
+
+async function findLogoOnChain(projectId: string) {
+  const { logoUri } = (await getProjectMetadata(projectId as string)) ?? {}
+  return logoUri
+}
+
+/**
+ *
+ * @dev 2 network requests happen here:
+ * 1. fetch the project metadata CID (DB fetch is prioritized)
+ * 2. fetch the project logo image data
+ *
+ * Note, if DB request fails, we still try to fetch the logo from chain. This will be 2 more requests.
+ *
+ * Thus this endpoint should be cached.
+ * However, the ideal duration is TBD.
+ * Please consider changing (lowering) if it causes issues with users.
+ */
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    return res.status(404)
+  }
+
+  try {
+    const { projectId } = req.query
+    if (!projectId) {
+      return res.status(400).json({ error: 'projectId is required' })
+    }
+
+    // try getting logo from db. if for some reason its not there, try getting it from chain.
+    const logoUri =
+      (await findLogoFromDb(req, res, projectId as string)) ??
+      (await findLogoOnChain(projectId as string))
+    if (!logoUri) {
+      return res.status(404).json({ error: 'project metadata not found' })
+    }
+
+    const imageUrl = isIpfsUri(logoUri)
+      ? ipfsUriToGatewayUrl(logoUri)
+      : // Some older JB projects have a logo URI hardcoded to use Pinata.
+        // JBM no longer uses Pinata.
+        // This rewrites those URLs to use the Infura gateway.
+        ipfsGatewayUrl(cidFromUrl(logoUri))
+
+    const logoImageRes = await axios.get(imageUrl, {
+      responseType: 'arraybuffer',
+    })
+
+    const contentType = logoImageRes.headers['content-type'] ?? 'image/png'
+    res.setHeader('Content-Type', contentType)
+    res.setHeader('Content-Length', logoImageRes.data.length)
+    // cache for 5 minutes
+    res.setHeader('Cache-Control', `s-maxage=${60 * 5}, stale-while-revalidate`)
+
+    return res.end(logoImageRes.data, 'binary')
+  } catch (err) {
+    logger.error({ error: err })
+    return res.status(500).json({ error: 'failed to resolve project logo' })
+  }
+}
+
+export default handler

--- a/src/pages/home/HomepageProjectCard.tsx
+++ b/src/pages/home/HomepageProjectCard.tsx
@@ -60,7 +60,6 @@ export function HomepageProjectCard({
       img={
         <ProjectLogo
           className="h-[192px] w-full rounded-none object-cover"
-          uri={metadata?.logoUri}
           name={metadata?.name}
           projectId={project.projectId}
           lazyLoad={lazyLoad}


### PR DESCRIPTION
per title. used in:
- homepage project logos
- payouts

Can be added in other places later (like activity feed).

Please validate locally!

Notes:
- Cached for 1 day but that may be too long - might want to shorten.
- Some projects with massive logos may fail (cos of Next/vercel API limits)
- Open question: https://github.com/jbx-protocol/juice-interface/pull/3945#discussion_r1284519801

This is an MVP. An optimized solution would:
- replicate (send) images to some image CDN
- the image CDN would auto-downscale/size images 
- we could request whatever size of the image we want
- it would be cached, but we can refresh the cache on-demand, if the project changes their logo.

<img width="578" alt="Screenshot 2023-08-04 at 4 12 25 PM" src="https://github.com/jbx-protocol/juice-interface/assets/12551741/18a8b3c8-abdf-4fb5-a54c-4e8bd532500c">
