### PR TITLE
fix: small regex correction

### DIFF
--- a/src/components/ProjectDashboard/hooks/useAboutPanel.ts
+++ b/src/components/ProjectDashboard/hooks/useAboutPanel.ts
@@ -40,7 +40,7 @@ export const useAboutPanel = () => {
 
 const wrapNonAnchorsInAnchor = (text: string) => {
   const urlRegex =
-    /\b((http|https):\/\/[a-zA-Z0-9-._~:/?#@\\[\]!$&'()*+,;=%]+)/g
+    /\b((http|https):\/\/[a-zA-Z0-9-._~:/?#@\\[\]!$&'()*+,;=%]+)\b/g
 
   return text.replace(urlRegex, url => {
     return '<a href="' + url + '">' + url + '</a>'


### PR DESCRIPTION
![image](https://github.com/jbx-protocol/juice-interface/assets/96905094/faa78125-f8fd-4c04-a8af-d2be9d6f5973)
Currently matches periods, causing some 404s. Adding an extra `\b` (outside of parens) to match word boundaries (before punctuation).