### PR TITLE
[2/4] New Payouts table: Handle % payouts

### DIFF
--- a/src/components/ProjectDashboard/components/ui/ExternalLinkWithIcon.tsx
+++ b/src/components/ProjectDashboard/components/ui/ExternalLinkWithIcon.tsx
@@ -1,0 +1,16 @@
+import { ArrowRightIcon } from '@heroicons/react/24/outline'
+import ExternalLink from 'components/ExternalLink'
+
+export function ExternalLinkWithIcon({
+  href,
+  children,
+}: React.PropsWithChildren<{ href: string }>) {
+  return (
+    <ExternalLink href={href}>
+      <div className="flex items-center gap-1">
+        {children}
+        <ArrowRightIcon className="h-3 w-3" />
+      </div>
+    </ExternalLink>
+  )
+}

--- a/src/components/ui/PopupMenu.tsx
+++ b/src/components/ui/PopupMenu.tsx
@@ -27,6 +27,7 @@ export type PopupMenuItem = ComponentItem | LinkItem | ButtonItem
 
 export type PopupMenuProps = {
   className?: string
+  popupClassName?: string
   menuButtonIconClassName?: string
   items: PopupMenuItem[]
 }
@@ -41,6 +42,7 @@ function isButtonItem(item: PopupMenuItem): item is ButtonItem {
 
 export const PopupMenu = ({
   className,
+  popupClassName,
   items,
   menuButtonIconClassName,
 }: PopupMenuProps) => {
@@ -61,7 +63,10 @@ export const PopupMenu = ({
 
             <Menu.Items
               as="div"
-              className="absolute top-7 right-0 z-10 overflow-hidden rounded-lg border border-grey-200 bg-white shadow-md dark:border-slate-500 dark:bg-slate-900"
+              className={twMerge(
+                `absolute top-7 right-0 z-10 overflow-hidden rounded-lg border border-grey-200 bg-white shadow-md dark:border-slate-500 dark:bg-slate-900`,
+                popupClassName,
+              )}
             >
               {items.map(item => (
                 <Menu.Item key={item.id}>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { Button, Form } from 'antd'
-import ExternalLink from 'components/ExternalLink'
 import Loading from 'components/Loading'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import Link from 'next/link'
@@ -17,7 +17,7 @@ export function EditCyclePage() {
   const { handle } = useContext(V2V3ProjectContext)
 
   const { editCycleForm, initialFormData } = useEditCycleFormContext()
-  if (!initialFormData) return <Loading className="h-24" />
+  if (!initialFormData) return <Loading className="h-70" />
   return (
     <div>
       <p>
@@ -26,7 +26,11 @@ export function EditCyclePage() {
           Any adjustments made will be published on Ethereum to inform
           contributors.
         </Trans>{' '}
-        <ExternalLink href={helpPagePath('')}>Learn more</ExternalLink>
+        <ExternalLinkWithIcon
+          href={helpPagePath('/user/project/#project-settings')}
+        >
+          <Trans>Learn more</Trans>
+        </ExternalLinkWithIcon>
       </p>
 
       {/* Details */}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -1,10 +1,8 @@
 import { PlusOutlined } from '@ant-design/icons'
-import { ReceiptPercentIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { Trans } from '@lingui/macro'
 
 import { Button } from 'antd'
-import ExternalLink from 'components/ExternalLink'
-import { PopupMenu } from 'components/ui/PopupMenu'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
 import {
   AddEditAllocationModal,
   AddEditAllocationModalEntity,
@@ -12,6 +10,7 @@ import {
 import { useState } from 'react'
 import { helpPagePath } from 'utils/routes'
 import { usePayoutsTable } from '../hooks/usePayoutsTable'
+import { PayoutTableSettings } from './PayoutTableSettings'
 import { PayoutsTableCell } from './PayoutsTableCell'
 import { PayoutsTableRow } from './PayoutsTableRow'
 
@@ -20,32 +19,8 @@ const Cell = PayoutsTableCell
 
 export function HeaderRows() {
   const [addRecipientModalOpen, setAddRecipientModalOpen] = useState<boolean>()
-  const { distributionLimitIsInfinite, handleNewPayoutSplit } =
+  const { distributionLimitIsInfinite, handleNewPayoutSplit, payoutSplits } =
     usePayoutsTable()
-  const menuItemsLabelClass = 'flex gap-2 items-center'
-  const menuItemsIconClass = 'h-5 w-5'
-  const menuItems = [
-    {
-      id: 'unlimited',
-      label: (
-        <div className={menuItemsLabelClass}>
-          <ReceiptPercentIcon className={menuItemsIconClass} />
-          <Trans>Switch to unlimited</Trans>
-        </div>
-      ),
-      onClick: () => console.info('Switch to unlimited modal open'),
-    },
-    {
-      id: 'delete',
-      label: (
-        <div className={menuItemsLabelClass}>
-          <TrashIcon className={menuItemsIconClass} />
-          <Trans>Delete all</Trans>
-        </div>
-      ),
-      onClick: () => console.info('Delete clicked'),
-    },
-  ]
 
   const handleAddRecipientModalOk = (
     newSplit: AddEditAllocationModalEntity,
@@ -66,9 +41,11 @@ export function HeaderRows() {
               <Trans>
                 Juicebox provides trustless payroll capabilities to run
                 automated payouts completely on-chain.{' '}
-                <ExternalLink href={helpPagePath(`/dao/reference/jbx/`)}>
-                  Learn more about payouts
-                </ExternalLink>
+                <ExternalLinkWithIcon
+                  href={helpPagePath(`/user/project/#payouts`)}
+                >
+                  <Trans>Learn more about payouts</Trans>
+                </ExternalLinkWithIcon>
               </Trans>
             </div>
           </Cell>
@@ -83,23 +60,19 @@ export function HeaderRows() {
                   <Trans>Add recipient</Trans>
                 </span>
               </Button>
-              <PopupMenu items={menuItems} className="w-50" />
+              <PayoutTableSettings />
             </div>
-          </Cell>
-        </Row>
-        <Row className="font-medium" highlighted>
-          <Cell>
-            <Trans>Address or ID</Trans>
-          </Cell>
-          <Cell>
-            <Trans>Amount</Trans>
           </Cell>
         </Row>
       </thead>
       <AddEditAllocationModal
         allocationName="payout"
         availableModes={
-          new Set([distributionLimitIsInfinite ? 'percentage' : 'amount'])
+          new Set([
+            distributionLimitIsInfinite && payoutSplits?.length > 0
+              ? 'percentage'
+              : 'amount',
+          ])
         }
         open={addRecipientModalOpen}
         onOk={handleAddRecipientModalOk}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutTableSettings.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutTableSettings.tsx
@@ -1,0 +1,88 @@
+import { ReceiptPercentIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { Trans } from '@lingui/macro'
+import { handleConfirmationDeletion } from 'components/ProjectDashboard/utils/modals'
+import { PopupMenu, PopupMenuItem } from 'components/ui/PopupMenu'
+import { useState } from 'react'
+import { usePayoutsTable } from '../hooks/usePayoutsTable'
+import { SwitchToLimitedModal } from './modals/SwitchToLimitedModal'
+import { SwitchToUnlimitedModal } from './modals/SwitchToUnlimitedModal'
+
+export function PayoutTableSettings() {
+  const [switchToUnlimitedModalOpen, setSwitchToUnlimitedModalOpen] =
+    useState<boolean>(false)
+  const [switchToLimitedModalOpen, setSwitchToLimitedModalOpen] =
+    useState<boolean>(false)
+
+  const {
+    payoutSplits,
+    distributionLimitIsInfinite,
+    handleDeleteAllPayoutSplits,
+  } = usePayoutsTable()
+
+  const menuItemsLabelClass = 'flex gap-2 items-center text-sm'
+  const menuItemsIconClass = 'h-5 w-5'
+  let menuItems: PopupMenuItem[] = []
+
+  if (distributionLimitIsInfinite) {
+    menuItems = [
+      ...menuItems,
+      {
+        id: 'limited',
+        label: (
+          <div className={menuItemsLabelClass}>
+            <ReceiptPercentIcon className={menuItemsIconClass} />
+            <Trans>Switch to limited</Trans>
+          </div>
+        ),
+        onClick: () => setSwitchToLimitedModalOpen(true),
+      },
+    ]
+  } else {
+    menuItems = [
+      ...menuItems,
+      {
+        id: 'unlimited',
+        label: (
+          <div className={menuItemsLabelClass}>
+            <ReceiptPercentIcon className={menuItemsIconClass} />
+            <Trans>Switch to unlimited</Trans>
+          </div>
+        ),
+        onClick: () => setSwitchToUnlimitedModalOpen(true),
+      },
+    ]
+  }
+
+  if (payoutSplits.length > 0) {
+    menuItems = [
+      ...menuItems,
+      {
+        id: 'delete',
+        label: (
+          <div className={menuItemsLabelClass}>
+            <TrashIcon className={menuItemsIconClass} />
+            <Trans>Delete all</Trans>
+          </div>
+        ),
+        onClick: handleConfirmationDeletion({
+          type: 'all payout recipients',
+          onConfirm: handleDeleteAllPayoutSplits,
+        }),
+      },
+    ]
+  }
+
+  return (
+    <>
+      <PopupMenu items={menuItems} popupClassName="w-52" />
+      <SwitchToUnlimitedModal
+        open={switchToUnlimitedModalOpen}
+        onClose={() => setSwitchToUnlimitedModalOpen(false)}
+      />
+      <SwitchToLimitedModal
+        open={switchToLimitedModalOpen}
+        onClose={() => setSwitchToLimitedModalOpen(false)}
+      />
+    </>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTable.tsx
@@ -20,17 +20,20 @@ export function PayoutsTable() {
   const {
     payoutSplits,
     distributionLimit,
+    distributionLimitIsInfinite,
     totalFeeAmount,
     subTotal,
     roundingPrecision,
     ownerRemainderValue,
     currency,
+    currencyOrPercentSymbol,
     handleDeletePayoutSplit,
   } = usePayoutsTable()
 
-  const formattedDistributionLimit = distributionLimit
-    ? round(distributionLimit, roundingPrecision)
-    : 'X'
+  const formattedDistributionLimit =
+    distributionLimit && !distributionLimitIsInfinite
+      ? round(distributionLimit, roundingPrecision)
+      : t`Unlimited`
 
   if (!editCycleForm || !initialFormData) return null
 
@@ -50,7 +53,9 @@ export function PayoutsTable() {
               ))}
               <Row>
                 <Cell>Sub-total</Cell>
-                <Cell>{round(subTotal, roundingPrecision)}</Cell>
+                <Cell>
+                  {currencyOrPercentSymbol} {round(subTotal, roundingPrecision)}
+                </Cell>
               </Row>
               {ownerRemainderValue ? (
                 <Row>
@@ -60,16 +65,30 @@ export function PayoutsTable() {
                       label={<Trans>Remaining balance</Trans>}
                     />
                   </Cell>
-                  <Cell>{ownerRemainderValue}</Cell>
+                  <Cell
+                    className={ownerRemainderValue < 0 ? 'text-error-500' : ''}
+                  >
+                    {currencyOrPercentSymbol} {ownerRemainderValue}
+                  </Cell>
                 </Row>
               ) : null}
               <Row>
                 <Cell>Fees</Cell>
-                <Cell>{round(totalFeeAmount, roundingPrecision)}</Cell>
+                <Cell>
+                  {currencyOrPercentSymbol}{' '}
+                  {round(totalFeeAmount, roundingPrecision)}
+                </Cell>
               </Row>
               <Row className="border-none font-medium" highlighted>
                 <Cell>Total</Cell>
-                <Cell>{formattedDistributionLimit}</Cell>
+                <Cell>
+                  <>
+                    {distributionLimitIsInfinite ? null : (
+                      <>{currencyOrPercentSymbol} </>
+                    )}
+                    {formattedDistributionLimit}
+                  </>
+                </Cell>
               </Row>
             </tbody>
           </table>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTable.tsx
@@ -1,8 +1,6 @@
-import { Trans, t } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 import { Form } from 'antd'
-import TooltipLabel from 'components/TooltipLabel'
 import { Allocation } from 'components/v2v3/shared/Allocation'
-import round from 'lodash/round'
 import { getV2V3CurrencyOption } from 'utils/v2v3/currency'
 import { useEditCycleFormContext } from '../../EditCycleFormContext'
 import { usePayoutsTable } from '../hooks/usePayoutsTable'
@@ -10,6 +8,7 @@ import { HeaderRows } from './HeaderRows'
 import { PayoutSplitRow } from './PayoutSplitRow'
 import { PayoutsTableCell } from './PayoutsTableCell'
 import { PayoutsTableRow } from './PayoutsTableRow'
+import { TotalRows } from './TotalRows'
 
 const Row = PayoutsTableRow
 const Cell = PayoutsTableCell
@@ -17,87 +16,59 @@ const Cell = PayoutsTableCell
 export function PayoutsTable() {
   const { editCycleForm, initialFormData } = useEditCycleFormContext()
 
-  const {
-    payoutSplits,
-    distributionLimit,
-    distributionLimitIsInfinite,
-    totalFeeAmount,
-    subTotal,
-    roundingPrecision,
-    ownerRemainderValue,
-    currency,
-    currencyOrPercentSymbol,
-    handleDeletePayoutSplit,
-  } = usePayoutsTable()
-
-  const formattedDistributionLimit =
-    distributionLimit && !distributionLimitIsInfinite
-      ? round(distributionLimit, roundingPrecision)
-      : t`Unlimited`
+  const { payoutSplits, currency, handleDeletePayoutSplit, setCurrency } =
+    usePayoutsTable()
 
   if (!editCycleForm || !initialFormData) return null
+
+  const emptyState = payoutSplits.length === 0
 
   return (
     <>
       <div className="rounded-lg border border-smoke-200 dark:border-grey-600">
-        <Allocation allocationCurrency={getV2V3CurrencyOption(currency)}>
+        <Allocation
+          allocationCurrency={getV2V3CurrencyOption(currency)}
+          setAllocationCurrency={setCurrency}
+        >
           <table className="w-full text-left">
             <HeaderRows />
             <tbody>
-              {payoutSplits.map((payoutSplit, index) => (
-                <PayoutSplitRow
-                  key={index}
-                  payoutSplit={payoutSplit}
-                  onDeleteClick={() => handleDeletePayoutSplit({ payoutSplit })}
-                />
-              ))}
-              <Row>
-                <Cell>Sub-total</Cell>
-                <Cell>
-                  {currencyOrPercentSymbol} {round(subTotal, roundingPrecision)}
-                </Cell>
-              </Row>
-              {ownerRemainderValue ? (
-                <Row>
-                  <Cell>
-                    <TooltipLabel
-                      tip={t`The unallocated portion of your total will go to the wallet that owns the project by default.`}
-                      label={<Trans>Remaining balance</Trans>}
-                    />
-                  </Cell>
-                  <Cell
-                    className={ownerRemainderValue < 0 ? 'text-error-500' : ''}
-                  >
-                    {currencyOrPercentSymbol} {ownerRemainderValue}
+              {emptyState ? (
+                <Row className="border-0 text-center">
+                  <Cell colSpan={4} className="text-tertiary py-32">
+                    <Trans>No payout recipients</Trans>
                   </Cell>
                 </Row>
-              ) : null}
-              <Row>
-                <Cell>Fees</Cell>
-                <Cell>
-                  {currencyOrPercentSymbol}{' '}
-                  {round(totalFeeAmount, roundingPrecision)}
-                </Cell>
-              </Row>
-              <Row className="border-none font-medium" highlighted>
-                <Cell>Total</Cell>
-                <Cell>
-                  <>
-                    {distributionLimitIsInfinite ? null : (
-                      <>{currencyOrPercentSymbol} </>
-                    )}
-                    {formattedDistributionLimit}
-                  </>
-                </Cell>
-              </Row>
+              ) : (
+                <>
+                  <Row className="font-medium" highlighted>
+                    <Cell>
+                      <Trans>Address or ID</Trans>
+                    </Cell>
+                    <Cell>
+                      <Trans>Amount</Trans>
+                    </Cell>
+                  </Row>
+                  {payoutSplits.map((payoutSplit, index) => (
+                    <PayoutSplitRow
+                      key={index}
+                      payoutSplit={payoutSplit}
+                      onDeleteClick={() =>
+                        handleDeletePayoutSplit({ payoutSplit })
+                      }
+                    />
+                  ))}
+                  <TotalRows />
+                </>
+              )}
             </tbody>
           </table>
         </Allocation>
       </div>
       {/* Empty form items just to keep AntD useWatch happy */}
-      <Form.Item name="payoutSplits" />
-      <Form.Item name="distributionLimit" />
-      <Form.Item name="distributionLimitCurrency" />
+      <Form.Item name="payoutSplits" className="mb-0" />
+      <Form.Item name="distributionLimit" className="mb-0" />
+      <Form.Item name="distributionLimitCurrency" className="mb-0" />
     </>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
@@ -1,0 +1,68 @@
+import { Trans, t } from '@lingui/macro'
+import TooltipLabel from 'components/TooltipLabel'
+import round from 'lodash/round'
+import { usePayoutsTable } from '../hooks/usePayoutsTable'
+import { PayoutsTableCell } from './PayoutsTableCell'
+import { PayoutsTableRow } from './PayoutsTableRow'
+
+const Row = PayoutsTableRow
+const Cell = PayoutsTableCell
+
+/* Bottom few rows of the payouts table which show total amounts and fees */
+export function TotalRows() {
+  const {
+    distributionLimit,
+    distributionLimitIsInfinite,
+    totalFeeAmount,
+    subTotal,
+    roundingPrecision,
+    ownerRemainderValue,
+    currencyOrPercentSymbol,
+  } = usePayoutsTable()
+
+  const formattedDistributionLimit =
+    distributionLimit && !distributionLimitIsInfinite
+      ? round(distributionLimit, roundingPrecision)
+      : t`Unlimited`
+
+  return (
+    <>
+      <Row>
+        <Cell>Sub-total</Cell>
+        <Cell>
+          {currencyOrPercentSymbol} {round(subTotal, roundingPrecision)}
+        </Cell>
+      </Row>
+      {ownerRemainderValue ? (
+        <Row>
+          <Cell>
+            <TooltipLabel
+              tip={t`The unallocated portion of your total will go to the wallet that owns the project by default.`}
+              label={<Trans>Remaining balance</Trans>}
+            />
+          </Cell>
+          <Cell className={ownerRemainderValue < 0 ? 'text-error-500' : ''}>
+            {currencyOrPercentSymbol} {ownerRemainderValue}
+          </Cell>
+        </Row>
+      ) : null}
+      <Row>
+        <Cell>Fees</Cell>
+        <Cell>
+          {currencyOrPercentSymbol} {round(totalFeeAmount, roundingPrecision)}
+        </Cell>
+      </Row>
+      <Row className="border-none font-medium" highlighted>
+        <Cell>Total</Cell>
+        <Cell>
+          <>
+            {distributionLimitIsInfinite ? null : (
+              <>{currencyOrPercentSymbol} </>
+            )}
+            {formattedDistributionLimit}
+          </>
+        </Cell>
+      </Row>
+    </>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToLimitedModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToLimitedModal.tsx
@@ -1,0 +1,70 @@
+import { Trans } from '@lingui/macro'
+import { Modal } from 'antd'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
+import CurrencySwitch from 'components/currency/CurrencySwitch'
+import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
+import { useState } from 'react'
+import { helpPagePath } from 'utils/routes'
+import { V2V3_CURRENCY_ETH, V2V3_CURRENCY_USD } from 'utils/v2v3/currency'
+import { useEditCycleFormContext } from '../../../EditCycleFormContext'
+import { usePayoutsTable } from '../../hooks/usePayoutsTable'
+
+export function SwitchToLimitedModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const [limit, setLimit] = useState<string>('')
+
+  const { editCycleForm } = useEditCycleFormContext()
+  const { setCurrency, currency } = usePayoutsTable()
+
+  const onOk = () => {
+    editCycleForm?.setFieldsValue({
+      distributionLimit: parseFloat(limit),
+    })
+    onClose()
+  }
+
+  return (
+    <Modal
+      title={<Trans>Switch to limited payouts</Trans>}
+      open={open}
+      onCancel={onClose}
+      onOk={onOk}
+      okText={<Trans>Save</Trans>}
+      destroyOnClose
+    >
+      <p>
+        <Trans>
+          Edit your cycles max. payout limit. Note that increases to the limit
+          will take effect next cycle.
+        </Trans>{' '}
+        <ExternalLinkWithIcon href={helpPagePath(`/user/project/#payouts`)}>
+          <Trans>Learn more about payout limits</Trans>
+        </ExternalLinkWithIcon>
+      </p>
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">
+          <Trans>Payout limit (max.)</Trans>
+        </span>
+        <FormattedNumberInput
+          className="flex-1"
+          value={limit}
+          onChange={val => setLimit(val ?? '0')}
+          accessory={
+            <CurrencySwitch
+              currency={currency}
+              onCurrencyChange={c =>
+                setCurrency(c === 'ETH' ? V2V3_CURRENCY_ETH : V2V3_CURRENCY_USD)
+              }
+              className="rounded"
+            />
+          }
+        />
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToUnlimitedModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToUnlimitedModal.tsx
@@ -1,0 +1,43 @@
+import { Trans } from '@lingui/macro'
+import { Modal } from 'antd'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
+import { helpPagePath } from 'utils/routes'
+import { useEditCycleFormContext } from '../../../EditCycleFormContext'
+
+export function SwitchToUnlimitedModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const { editCycleForm } = useEditCycleFormContext()
+
+  const onOk = () => {
+    editCycleForm?.setFieldsValue({
+      distributionLimit: undefined,
+    })
+    onClose()
+  }
+
+  return (
+    <Modal
+      title={<Trans>Switch to unlimited payouts</Trans>}
+      open={open}
+      onCancel={onClose}
+      onOk={onOk}
+      okText={<Trans>Confirm</Trans>}
+      destroyOnClose
+    >
+      <p>
+        <Trans>
+          Turn on unlimited payouts, and convert all your amounts to
+          percentages.
+        </Trans>
+      </p>
+      <ExternalLinkWithIcon href={helpPagePath(`/user/project/#payouts`)}>
+        <Trans>Learn more about unlimited payouts</Trans>
+      </ExternalLinkWithIcon>
+    </Modal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -5,6 +5,7 @@ import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
 import { ONE_BILLION } from 'constants/numbers'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
+import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useMemo } from 'react'
 import { parseWad } from 'utils/format/formatNumber'
 import {
@@ -13,6 +14,7 @@ import {
   totalSplitsPercent,
 } from 'utils/splits'
 import {
+  V2V3CurrencyName,
   V2V3_CURRENCY_METADATA,
   getV2V3CurrencyOption,
 } from 'utils/v2v3/currency'
@@ -55,6 +57,16 @@ export const usePayoutsTable = () => {
   const currencyOrPercentSymbol = distributionLimitIsInfinite
     ? '%'
     : V2V3_CURRENCY_METADATA[getV2V3CurrencyOption(currency)].symbol
+
+  /**
+   * Sets the currency for the distributionLimit
+   * @param currency - Currency as a V2V3CurrencyOption (1 | 2)
+   */
+  function setCurrency(currency: V2V3CurrencyOption) {
+    editCycleForm?.setFieldsValue({
+      distributionLimitCurrency: V2V3CurrencyName(currency),
+    })
+  }
 
   /**
    * Derive payout amount before the fee has been applied.
@@ -139,7 +151,7 @@ export const usePayoutsTable = () => {
         : undefined // undefined means DL is infinite
 
       newSplitPercentPPB =
-        ((newAmount / (newDistributionLimit ?? 0)) * ONE_BILLION) / 100
+        (newAmount / (newDistributionLimit ?? 0)) * ONE_BILLION
 
       // recalculate all split percents based on newly added split amount
       if (newDistributionLimit && !distributionLimitIsInfinite) {
@@ -306,14 +318,27 @@ export const usePayoutsTable = () => {
     })
   }
 
-  const amountOrPercentValue = (payoutSplit: Split) =>
+  function handleDeleteAllPayoutSplits() {
+    editCycleForm?.setFieldsValue({
+      distributionLimit: 0,
+      payoutSplits: [],
+    })
+  }
+
+  const amountOrPercentValue = ({
+    payoutSplit,
+    dontApplyFee,
+  }: {
+    payoutSplit: Split
+    dontApplyFee?: boolean
+  }) =>
     distributionLimitIsInfinite
       ? (payoutSplit.percent / ONE_BILLION) * 100
-      : derivePayoutAmount({ payoutSplit })
+      : derivePayoutAmount({ payoutSplit, dontApplyFee })
 
   /* Total amount that leaves the treasury minus fees */
   const subTotal = payoutSplits.reduce((acc, payoutSplit) => {
-    const reducer = amountOrPercentValue(payoutSplit)
+    const reducer = amountOrPercentValue({ payoutSplit })
     return acc + reducer
   }, 0)
 
@@ -324,16 +349,20 @@ export const usePayoutsTable = () => {
 
   /* Count the total fee amount. If % of payouts sums > 100, just set fees to 2.5% (maximum)*/
   const totalFeeAmount =
-    distributionLimitIsInfinite && subTotal > 100
+    distributionLimitIsInfinite && round(subTotal, roundingPrecision) > 100
       ? 2.5
       : nonJuiceboxProjectPayoutSplits.reduce((acc, payoutSplit) => {
-          return acc + amountOrPercentValue(payoutSplit) * JB_FEE
+          return (
+            acc +
+            amountOrPercentValue({ payoutSplit, dontApplyFee: true }) * JB_FEE
+          )
         }, 0)
 
   return {
     distributionLimit,
     distributionLimitIsInfinite,
     currency,
+    setCurrency,
     currencyOrPercentSymbol,
     payoutSplits,
     derivePayoutAmount,
@@ -343,6 +372,7 @@ export const usePayoutsTable = () => {
     handleNewPayoutSplit,
     handlePayoutSplitChanged,
     handleDeletePayoutSplit,
+    handleDeleteAllPayoutSplits,
     subTotal,
     ownerRemainderValue,
     totalFeeAmount,

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -710,6 +710,9 @@ msgstr ""
 msgid "Change networks to deploy"
 msgstr ""
 
+msgid "Switch to limited"
+msgstr ""
+
 msgid "While transfers are paused, this project's tokens can't be transferred to other addresses. The project's ERC-20 tokens (if already issued) are always transferable, and will not be affected by this rule."
 msgstr ""
 
@@ -750,6 +753,9 @@ msgid "Use me as a base!"
 msgstr ""
 
 msgid "Receive ERC-20 tokens"
+msgstr ""
+
+msgid "Confirm"
 msgstr ""
 
 msgid "Delete token allocation"
@@ -1628,6 +1634,9 @@ msgstr ""
 msgid "{userTokenBalance} tokens"
 msgstr ""
 
+msgid "Switch to unlimited payouts"
+msgstr ""
+
 msgid "NO LIMIT"
 msgstr ""
 
@@ -1688,10 +1697,16 @@ msgstr ""
 msgid "V1"
 msgstr ""
 
+msgid "Switch to limited payouts"
+msgstr ""
+
 msgid "Export payout CSV"
 msgstr ""
 
 msgid "JuiceboxDAO is a community of passionate builders, creators, and innovators working together to push the boundaries of decentralized funding. Using the Juicebox protocol, we've created a DAO to coordinate thousands of JBX holders, build in the open, and govern the protocol over time."
+msgstr ""
+
+msgid "Learn more about payout limits"
 msgstr ""
 
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
@@ -2507,6 +2522,9 @@ msgstr ""
 msgid "Deselect all"
 msgstr ""
 
+msgid "Payout limit (max.)"
+msgstr ""
+
 msgid "Migrate project's payment terminal"
 msgstr ""
 
@@ -2844,6 +2862,9 @@ msgid "It's fast, powerful and easy to use. Launch your project and get funded i
 msgstr ""
 
 msgid "Redemptions aren't possible when all of a project's ETH is being used for payouts."
+msgstr ""
+
+msgid "Turn on unlimited payouts, and convert all your amounts to percentages."
 msgstr ""
 
 msgid "Redeem tokens"
@@ -3713,6 +3734,9 @@ msgstr ""
 msgid "NFTs, tokens and rewards will be sent to <0/>"
 msgstr ""
 
+msgid "Edit your cycles max. payout limit. Note that increases to the limit will take effect next cycle."
+msgstr ""
+
 msgid "See the code"
 msgstr ""
 
@@ -4059,6 +4083,9 @@ msgid "Your project's first cycle will start on <0>{0} at {1}</0>. Your project 
 msgstr ""
 
 msgid "MoonDAO has built an enthusiastic community of over 10,000 members, successfully sent their first astronaut to space, and is currently coordinating the spaceflight for their second astronaut. Their ambitious long-term roadmap goals include building a settlement on the Moon by 2030. In collaboration with StudioDAO, a decentralized movie studio running on Juicebox, MoonDAO has donated $100,000 to help fund the production of Ticket To Space, the first DAO documentary. The film will cover the story of Yan, a MoonDAO member from China, who will be sent to space on an upcoming Blue Origin flight after minting a free NFT."
+msgstr ""
+
+msgid "Learn more about unlimited payouts"
 msgstr ""
 
 msgid "V2 7-day deadline"
@@ -4772,6 +4799,9 @@ msgstr ""
 msgid "MoonDAO is a worldwide collective united by the mission of decentralizing access to space research and exploration. With privatized space exploration on the rise, MoonDAO is uniting space enthusiasts from around the globe to help make it more accessible while continuing to push research forward. In 2021, they launched a campaign to buy two tickets on a Blue Origin rocket and raised over $8 million on Juicebox. A year later, they sent Coby Cotton from viral YouTube channel Dude Perfect to space as their first astronaut."
 msgstr ""
 
+msgid "No payout recipients"
+msgstr ""
+
 msgid "V3"
 msgstr ""
 
@@ -4887,6 +4917,9 @@ msgid "Edit handle of {projectTitle}"
 msgstr ""
 
 msgid "Other assets in this project's owner's wallet."
+msgstr ""
+
+msgid "Learn more"
 msgstr ""
 
 msgid "Payout Recipients"


### PR DESCRIPTION
Handle the whole payouts table for infinite DL:
- edit and add payouts with %s.
- modify the bottom rows of the table and their computations (subtotal, fees, etc.) to work with %s according to the design. 

<img width="738" alt="Screen Shot 2023-08-07 at 1 24 27 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/64838166-4aa0-4a8b-9d28-7237b12665ff">
<img width="708" alt="Screen Shot 2023-08-07 at 1 28 25 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/ac310042-8a01-40e3-b127-547b23e0c00c">