### PR TITLE
[4/4] New Payouts table: Switch between limited and unlimited payouts

### DIFF
--- a/src/components/ProjectDashboard/components/ui/ExternalLinkWithIcon.tsx
+++ b/src/components/ProjectDashboard/components/ui/ExternalLinkWithIcon.tsx
@@ -1,0 +1,16 @@
+import { ArrowRightIcon } from '@heroicons/react/24/outline'
+import ExternalLink from 'components/ExternalLink'
+
+export function ExternalLinkWithIcon({
+  href,
+  children,
+}: React.PropsWithChildren<{ href: string }>) {
+  return (
+    <ExternalLink href={href}>
+      <div className="flex items-center gap-1">
+        {children}
+        <ArrowRightIcon className="h-3 w-3" />
+      </div>
+    </ExternalLink>
+  )
+}

--- a/src/components/ui/PopupMenu.tsx
+++ b/src/components/ui/PopupMenu.tsx
@@ -27,6 +27,7 @@ export type PopupMenuItem = ComponentItem | LinkItem | ButtonItem
 
 export type PopupMenuProps = {
   className?: string
+  popupClassName?: string
   menuButtonIconClassName?: string
   items: PopupMenuItem[]
 }
@@ -41,6 +42,7 @@ function isButtonItem(item: PopupMenuItem): item is ButtonItem {
 
 export const PopupMenu = ({
   className,
+  popupClassName,
   items,
   menuButtonIconClassName,
 }: PopupMenuProps) => {
@@ -61,7 +63,10 @@ export const PopupMenu = ({
 
             <Menu.Items
               as="div"
-              className="absolute top-7 right-0 z-10 overflow-hidden rounded-lg border border-grey-200 bg-white shadow-md dark:border-slate-500 dark:bg-slate-900"
+              className={twMerge(
+                `absolute top-7 right-0 z-10 overflow-hidden rounded-lg border border-grey-200 bg-white shadow-md dark:border-slate-500 dark:bg-slate-900`,
+                popupClassName,
+              )}
             >
               {items.map(item => (
                 <Menu.Item key={item.id}>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { Button, Form } from 'antd'
-import ExternalLink from 'components/ExternalLink'
 import Loading from 'components/Loading'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import Link from 'next/link'
@@ -17,7 +17,7 @@ export function EditCyclePage() {
   const { handle } = useContext(V2V3ProjectContext)
 
   const { editCycleForm, initialFormData } = useEditCycleFormContext()
-  if (!initialFormData) return <Loading className="h-24" />
+  if (!initialFormData) return <Loading className="h-70" />
   return (
     <div>
       <p>
@@ -26,7 +26,11 @@ export function EditCyclePage() {
           Any adjustments made will be published on Ethereum to inform
           contributors.
         </Trans>{' '}
-        <ExternalLink href={helpPagePath('')}>Learn more</ExternalLink>
+        <ExternalLinkWithIcon
+          href={helpPagePath('/user/project/#project-settings')}
+        >
+          <Trans>Learn more</Trans>
+        </ExternalLinkWithIcon>
       </p>
 
       {/* Details */}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -2,7 +2,7 @@ import { PlusOutlined } from '@ant-design/icons'
 import { Trans } from '@lingui/macro'
 
 import { Button } from 'antd'
-import ExternalLink from 'components/ExternalLink'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
 import {
   AddEditAllocationModal,
   AddEditAllocationModalEntity,
@@ -41,9 +41,11 @@ export function HeaderRows() {
               <Trans>
                 Juicebox provides trustless payroll capabilities to run
                 automated payouts completely on-chain.{' '}
-                <ExternalLink href={helpPagePath(`/dao/reference/jbx/`)}>
-                  Learn more about payouts
-                </ExternalLink>
+                <ExternalLinkWithIcon
+                  href={helpPagePath(`/user/project/#payouts`)}
+                >
+                  <Trans>Learn more about payouts</Trans>
+                </ExternalLinkWithIcon>
               </Trans>
             </div>
           </Cell>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutTableSettings.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutTableSettings.tsx
@@ -1,29 +1,54 @@
 import { ReceiptPercentIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { Trans } from '@lingui/macro'
-import { PopupMenu } from 'components/ui/PopupMenu'
+import { PopupMenu, PopupMenuItem } from 'components/ui/PopupMenu'
 import { useState } from 'react'
 import { usePayoutsTable } from '../hooks/usePayoutsTable'
 import { DeleteAllPayoutsModal } from './modals/DeleteAllPayoutsModal'
+import { SwitchToLimitedModal } from './modals/SwitchToLimitedModal'
+import { SwitchToUnlimitedModal } from './modals/SwitchToUnlimitedModal'
 
 export function PayoutTableSettings() {
+  const [switchToUnlimitedModalOpen, setSwitchToUnlimitedModalOpen] =
+    useState<boolean>(false)
+  const [switchToLimitedModalOpen, setSwitchToLimitedModalOpen] =
+    useState<boolean>(false)
   const [deleteAllModalOpen, setDeleteAllModalOpen] = useState<boolean>(false)
 
-  const { payoutSplits } = usePayoutsTable()
+  const { payoutSplits, distributionLimitIsInfinite } = usePayoutsTable()
 
-  const menuItemsLabelClass = 'flex gap-2 items-center'
+  const menuItemsLabelClass = 'flex gap-2 items-center text-sm'
   const menuItemsIconClass = 'h-5 w-5'
-  let menuItems = [
-    {
-      id: 'unlimited',
-      label: (
-        <div className={menuItemsLabelClass}>
-          <ReceiptPercentIcon className={menuItemsIconClass} />
-          <Trans>Switch to unlimited</Trans>
-        </div>
-      ),
-      onClick: () => console.info('Switch to unlimited modal open'),
-    },
-  ]
+  let menuItems: PopupMenuItem[] = []
+
+  if (distributionLimitIsInfinite) {
+    menuItems = [
+      ...menuItems,
+      {
+        id: 'limited',
+        label: (
+          <div className={menuItemsLabelClass}>
+            <ReceiptPercentIcon className={menuItemsIconClass} />
+            <Trans>Switch to limited</Trans>
+          </div>
+        ),
+        onClick: () => setSwitchToLimitedModalOpen(true),
+      },
+    ]
+  } else {
+    menuItems = [
+      ...menuItems,
+      {
+        id: 'unlimited',
+        label: (
+          <div className={menuItemsLabelClass}>
+            <ReceiptPercentIcon className={menuItemsIconClass} />
+            <Trans>Switch to unlimited</Trans>
+          </div>
+        ),
+        onClick: () => setSwitchToUnlimitedModalOpen(true),
+      },
+    ]
+  }
 
   if (payoutSplits.length > 0) {
     menuItems = [
@@ -43,10 +68,18 @@ export function PayoutTableSettings() {
 
   return (
     <>
-      <PopupMenu items={menuItems} className="w-50" />
+      <PopupMenu items={menuItems} popupClassName="w-52" />
       <DeleteAllPayoutsModal
         open={deleteAllModalOpen}
         onClose={() => setDeleteAllModalOpen(false)}
+      />
+      <SwitchToUnlimitedModal
+        open={switchToUnlimitedModalOpen}
+        onClose={() => setSwitchToUnlimitedModalOpen(false)}
+      />
+      <SwitchToLimitedModal
+        open={switchToLimitedModalOpen}
+        onClose={() => setSwitchToLimitedModalOpen(false)}
       />
     </>
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTable.tsx
@@ -16,17 +16,20 @@ const Cell = PayoutsTableCell
 export function PayoutsTable() {
   const { editCycleForm, initialFormData } = useEditCycleFormContext()
 
-  const { payoutSplits, distributionLimit, currency, handleDeletePayoutSplit } =
+  const { payoutSplits, currency, handleDeletePayoutSplit, setCurrency } =
     usePayoutsTable()
 
   if (!editCycleForm || !initialFormData) return null
 
-  const emptyState = payoutSplits.length === 0 || distributionLimit === 0
+  const emptyState = payoutSplits.length === 0
 
   return (
     <>
       <div className="rounded-lg border border-smoke-200 dark:border-grey-600">
-        <Allocation allocationCurrency={getV2V3CurrencyOption(currency)}>
+        <Allocation
+          allocationCurrency={getV2V3CurrencyOption(currency)}
+          setAllocationCurrency={setCurrency}
+        >
           <table className="w-full text-left">
             <HeaderRows />
             <tbody>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToLimitedModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToLimitedModal.tsx
@@ -1,0 +1,70 @@
+import { Trans } from '@lingui/macro'
+import { Modal } from 'antd'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
+import CurrencySwitch from 'components/currency/CurrencySwitch'
+import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
+import { useState } from 'react'
+import { helpPagePath } from 'utils/routes'
+import { V2V3_CURRENCY_ETH, V2V3_CURRENCY_USD } from 'utils/v2v3/currency'
+import { useEditCycleFormContext } from '../../../EditCycleFormContext'
+import { usePayoutsTable } from '../../hooks/usePayoutsTable'
+
+export function SwitchToLimitedModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const [limit, setLimit] = useState<string>('')
+
+  const { editCycleForm } = useEditCycleFormContext()
+  const { setCurrency, currency } = usePayoutsTable()
+
+  const onOk = () => {
+    editCycleForm?.setFieldsValue({
+      distributionLimit: parseFloat(limit),
+    })
+    onClose()
+  }
+
+  return (
+    <Modal
+      title={<Trans>Switch to limited payouts</Trans>}
+      open={open}
+      onCancel={onClose}
+      onOk={onOk}
+      okText={<Trans>Save</Trans>}
+      destroyOnClose
+    >
+      <p>
+        <Trans>
+          Edit your cycles max. payout limit. Note that increases to the limit
+          will take effect next cycle.
+        </Trans>{' '}
+        <ExternalLinkWithIcon href={helpPagePath(`/user/project/#payouts`)}>
+          <Trans>Learn more about payout limits</Trans>
+        </ExternalLinkWithIcon>
+      </p>
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">
+          <Trans>Payout limit (max.)</Trans>
+        </span>
+        <FormattedNumberInput
+          className="flex-1"
+          value={limit}
+          onChange={val => setLimit(val ?? '0')}
+          accessory={
+            <CurrencySwitch
+              currency={currency}
+              onCurrencyChange={c =>
+                setCurrency(c === 'ETH' ? V2V3_CURRENCY_ETH : V2V3_CURRENCY_USD)
+              }
+              className="rounded"
+            />
+          }
+        />
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToUnlimitedModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/modals/SwitchToUnlimitedModal.tsx
@@ -1,0 +1,43 @@
+import { Trans } from '@lingui/macro'
+import { Modal } from 'antd'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
+import { helpPagePath } from 'utils/routes'
+import { useEditCycleFormContext } from '../../../EditCycleFormContext'
+
+export function SwitchToUnlimitedModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const { editCycleForm } = useEditCycleFormContext()
+
+  const onOk = () => {
+    editCycleForm?.setFieldsValue({
+      distributionLimit: undefined,
+    })
+    onClose()
+  }
+
+  return (
+    <Modal
+      title={<Trans>Switch to unlimited payouts</Trans>}
+      open={open}
+      onCancel={onClose}
+      onOk={onOk}
+      okText={<Trans>Confirm</Trans>}
+      destroyOnClose
+    >
+      <p>
+        <Trans>
+          Turn on unlimited payouts, and convert all your amounts to
+          percentages.
+        </Trans>
+      </p>
+      <ExternalLinkWithIcon href={helpPagePath(`/user/project/#payouts`)}>
+        <Trans>Learn more about unlimited payouts</Trans>
+      </ExternalLinkWithIcon>
+    </Modal>
+  )
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -710,6 +710,9 @@ msgstr ""
 msgid "Change networks to deploy"
 msgstr ""
 
+msgid "Switch to limited"
+msgstr ""
+
 msgid "While transfers are paused, this project's tokens can't be transferred to other addresses. The project's ERC-20 tokens (if already issued) are always transferable, and will not be affected by this rule."
 msgstr ""
 
@@ -1631,6 +1634,9 @@ msgstr ""
 msgid "{userTokenBalance} tokens"
 msgstr ""
 
+msgid "Switch to unlimited payouts"
+msgstr ""
+
 msgid "NO LIMIT"
 msgstr ""
 
@@ -1691,10 +1697,16 @@ msgstr ""
 msgid "V1"
 msgstr ""
 
+msgid "Switch to limited payouts"
+msgstr ""
+
 msgid "Export payout CSV"
 msgstr ""
 
 msgid "JuiceboxDAO is a community of passionate builders, creators, and innovators working together to push the boundaries of decentralized funding. Using the Juicebox protocol, we've created a DAO to coordinate thousands of JBX holders, build in the open, and govern the protocol over time."
+msgstr ""
+
+msgid "Learn more about payout limits"
 msgstr ""
 
 msgid "This address is an unrecognized strategy contract. Make sure it is correct!"
@@ -2513,6 +2525,9 @@ msgstr ""
 msgid "Deselect all"
 msgstr ""
 
+msgid "Payout limit (max.)"
+msgstr ""
+
 msgid "Migrate project's payment terminal"
 msgstr ""
 
@@ -2850,6 +2865,9 @@ msgid "It's fast, powerful and easy to use. Launch your project and get funded i
 msgstr ""
 
 msgid "Redemptions aren't possible when all of a project's ETH is being used for payouts."
+msgstr ""
+
+msgid "Turn on unlimited payouts, and convert all your amounts to percentages."
 msgstr ""
 
 msgid "Redeem tokens"
@@ -3719,6 +3737,9 @@ msgstr ""
 msgid "NFTs, tokens and rewards will be sent to <0/>"
 msgstr ""
 
+msgid "Edit your cycles max. payout limit. Note that increases to the limit will take effect next cycle."
+msgstr ""
+
 msgid "See the code"
 msgstr ""
 
@@ -4068,6 +4089,9 @@ msgid "Your project's first cycle will start on <0>{0} at {1}</0>. Your project 
 msgstr ""
 
 msgid "MoonDAO has built an enthusiastic community of over 10,000 members, successfully sent their first astronaut to space, and is currently coordinating the spaceflight for their second astronaut. Their ambitious long-term roadmap goals include building a settlement on the Moon by 2030. In collaboration with StudioDAO, a decentralized movie studio running on Juicebox, MoonDAO has donated $100,000 to help fund the production of Ticket To Space, the first DAO documentary. The film will cover the story of Yan, a MoonDAO member from China, who will be sent to space on an upcoming Blue Origin flight after minting a free NFT."
+msgstr ""
+
+msgid "Learn more about unlimited payouts"
 msgstr ""
 
 msgid "V2 7-day deadline"
@@ -4899,6 +4923,9 @@ msgid "Edit handle of {projectTitle}"
 msgstr ""
 
 msgid "Other assets in this project's owner's wallet."
+msgstr ""
+
+msgid "Learn more"
 msgstr ""
 
 msgid "Payout Recipients"


### PR DESCRIPTION
- Creates two modals to switch between limited and unlimited payouts from the payouts table settings

https://github.com/jbx-protocol/juice-interface/assets/96150256/2fa38806-e1df-4401-9cab-c9ec4521431f

- Also adds a component `<ExternalLinkWithIcon` and implements throughout the settings page:

<img width="257" alt="Screen Shot 2023-08-08 at 12 15 55 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/c1a8aafe-bb1d-464a-8f9f-11f507434e42">

