### PR TITLE
Allow wad precision in JuiceInputNumber

### DIFF
--- a/src/components/Project/PayProjectForm/PayProjectForm.tsx
+++ b/src/components/Project/PayProjectForm/PayProjectForm.tsx
@@ -83,7 +83,7 @@ export function PayProjectForm({ disabled }: { disabled?: boolean }) {
       <div className="flex w-full flex-wrap gap-2">
         <div className="min-w-[50%] flex-[2]">
           <FormattedNumberInput
-            size="large"
+            className="h-12"
             placeholder="0"
             onChange={onPayAmountChange}
             value={payAmount}

--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -1,4 +1,5 @@
-import { InputNumberProps } from 'antd'
+import { WAD_DECIMALS } from 'constants/numbers'
+import { DetailedHTMLProps, InputHTMLAttributes } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { formattedNum } from 'utils/format/formatNumber'
 import { JuiceInputNumber } from './JuiceInputNumber'
@@ -16,7 +17,10 @@ export default function FormattedNumberInput({
   onBlur,
   isInteger,
   ...props
-}: Omit<InputNumberProps, 'onChange'> & {
+}: Omit<
+  DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+  'onChange'
+> & {
   className?: string
   step?: number
   value?: string
@@ -61,11 +65,10 @@ export default function FormattedNumberInput({
           accessoryPosition === 'left' ? 'pl-7' : null,
           className,
         )}
-        value={value !== undefined ? parseFloat(value) : undefined}
+        value={value}
         step={step ?? 1}
-        stringMode
         placeholder={placeholder}
-        formatter={(val?: string | number | undefined) =>
+        formatter={(val?: string | undefined) =>
           _prefix +
           (val
             ? formattedNum(val, {
@@ -86,12 +89,15 @@ export default function FormattedNumberInput({
               .replace(_suffix, '')
               .split('')
               .filter(char => allowedValueChars.includes(char))
-              .join('') || '0'
+              .join('')
+              .substring(0, WAD_DECIMALS) || '0'
+
           // Enforce the presence of the prefix
           if (_prefix && !val.startsWith(_prefix)) {
             processedValue = _prefix + processedValue
           }
-          return parseFloat(processedValue)
+
+          return processedValue
         }}
         onBlur={_value => {
           onBlur?.(_value?.toString())

--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -68,16 +68,33 @@ export default function FormattedNumberInput({
         value={value}
         step={step ?? 1}
         placeholder={placeholder}
-        formatter={(val?: string | undefined) =>
-          _prefix +
-          (val
-            ? formattedNum(val, {
-                thousandsSeparator,
-                decimalSeparator,
-              })
-            : '') +
-          _suffix
-        }
+        formatter={(val?: string | undefined) => {
+          let formatted =
+            _prefix +
+            (val
+              ? formattedNum(val, {
+                  thousandsSeparator,
+                  decimalSeparator,
+                })
+              : '') +
+            _suffix
+
+          // Remove any unallowed chars that may be added by formattedNum()
+          formatted = formatted
+            .split('')
+            .filter(char => allowedValueChars.includes(char))
+            .join('')
+
+          if (
+            val?.endsWith(decimalSeparator) &&
+            !formatted.endsWith(decimalSeparator)
+          ) {
+            // Include decimal if stripped by formattedNum()
+            formatted += decimalSeparator
+          }
+
+          return formatted
+        }}
         parser={(val?: string) => {
           if (val === undefined || !val.length) return ''
           // Stops user from entering hex values

--- a/src/components/inputs/JuiceInputNumber.tsx
+++ b/src/components/inputs/JuiceInputNumber.tsx
@@ -17,11 +17,11 @@ export const JuiceInputNumber = ({
   value?: string
   formatter?: (s?: string | undefined) => string
   parser?: (s?: string | undefined) => string
-  onChange?: (s: string) => void
+  onChange?: (s?: string) => void
   className?: string
-} & DetailedHTMLProps<
-  InputHTMLAttributes<HTMLInputElement>,
-  HTMLInputElement
+} & Omit<
+  DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+  'onChange'
 >) => {
   const [val, setVal] = useState<string>()
 

--- a/src/components/inputs/JuiceInputNumber.tsx
+++ b/src/components/inputs/JuiceInputNumber.tsx
@@ -37,9 +37,11 @@ export const JuiceInputNumber = ({
         className,
       )}
       onChange={e => {
+        if (!onChange) return
+
         const _value = e.target.value
         const parsedVal = parser ? parser(_value) : _value
-        onChange?.(parsedVal)
+        onChange(parsedVal)
       }}
       {...props}
     />

--- a/src/components/inputs/JuiceInputNumber.tsx
+++ b/src/components/inputs/JuiceInputNumber.tsx
@@ -1,14 +1,47 @@
-import { InputNumber, InputNumberProps } from 'antd'
+import {
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+  useEffect,
+  useState,
+} from 'react'
 import { twMerge } from 'tailwind-merge'
 
-export const JuiceInputNumber = (props: InputNumberProps) => {
+export const JuiceInputNumber = ({
+  value,
+  formatter,
+  parser,
+  onChange,
+  className,
+  ...props
+}: {
+  value?: string
+  formatter?: (s?: string | undefined) => string
+  parser?: (s?: string | undefined) => string
+  onChange?: (s: string) => void
+  className?: string
+} & DetailedHTMLProps<
+  InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+>) => {
+  const [val, setVal] = useState<string>()
+
+  useEffect(() => {
+    setVal(formatter ? formatter(value) : value)
+  }, [value, formatter])
+
   return (
-    <InputNumber
-      {...props}
+    <input
+      value={val}
       className={twMerge(
-        'border-smoke-300 bg-smoke-50 text-black dark:border-slate-300 dark:bg-slate-600 dark:text-slate-100 dark:placeholder:text-slate-300',
-        props.className,
+        'text-primary stroke-secondary rounded-lg border border-smoke-300 bg-smoke-50 px-4 py-2 text-black dark:border-slate-300 dark:bg-slate-600 dark:text-slate-100 dark:placeholder:text-slate-300',
+        className,
       )}
+      onChange={e => {
+        const _value = e.target.value
+        const parsedVal = parser ? parser(_value) : _value
+        onChange?.(parsedVal)
+      }}
+      {...props}
     />
   )
 }

--- a/src/components/inputs/NumberSlider.tsx
+++ b/src/components/inputs/NumberSlider.tsx
@@ -66,9 +66,9 @@ export default function NumberSlider({
         >
           <JuiceInputNumber
             {...inputConfig}
-            value={_value}
+            value={_value?.toString()}
             disabled={disabled}
-            formatter={(val?: string | number | undefined) => {
+            formatter={(val?: string | undefined) => {
               let _val = val?.toString() ?? '0'
 
               if (_val.includes('.') && _val.split('.')[1].length > decimals) {
@@ -77,12 +77,10 @@ export default function NumberSlider({
 
               return `${_val ?? ''}${suffix ?? ''}`
             }}
-            parser={(val?: string) =>
-              parseFloat(val?.replace(suffix ?? '', '') ?? '0')
-            }
-            onChange={(val: string | number | null | undefined) => {
+            parser={(val?: string) => val?.replace(suffix ?? '', '') ?? '0'}
+            onChange={(val: string | undefined) => {
               const newVal =
-                (typeof val === 'string' ? parseFloat(val) : val) ?? undefined
+                val !== undefined && val !== '' ? parseFloat(val) : undefined
               updateValue(newVal)
             }}
           />


### PR DESCRIPTION
This PR removes the Antd number input from JuiceInputNumber and replaces it with custom logic. This avoids an issue where numbers were previously being limited to JS MAX_INT, presumably because the Antd component was doing some Number logic under the hood.