### PR TITLE
Fix distributable amount bug in settings

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/ProjectSettingsDashboard.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/ProjectSettingsDashboard.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/macro'
 import { Button } from 'antd'
 import EthereumAddress from 'components/EthereumAddress'
 import Loading from 'components/Loading'
+import { useDistributableAmount } from 'components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useDistributableAmount'
 import { AmountInCurrency } from 'components/currency/AmountInCurrency'
 import ETHAmount from 'components/currency/ETHAmount'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
@@ -61,11 +62,11 @@ export function ProjectSettingsDashboard() {
     projectOwnerAddress,
     handle,
     ETHBalance,
-    distributionLimit,
-    distributionLimitCurrency,
     loading: { distributionLimitLoading },
   } = useContext(V2V3ProjectContext)
   const { projectId, projectMetadata } = useContext(ProjectMetadataContext)
+
+  const { distributableAmount, currency } = useDistributableAmount()
 
   return (
     <ProjectSettingsLayout>
@@ -107,15 +108,13 @@ export function ProjectSettingsDashboard() {
           <div className="flex items-center justify-between">
             <div>
               <div className="mb-1  font-medium">
-                <Trans>Current payout</Trans>
+                <Trans>Available payout</Trans>
               </div>
               <div className="text-xl">
-                {distributionLimitCurrency && !distributionLimitLoading ? (
+                {currency && !distributionLimitLoading ? (
                   <AmountInCurrency
-                    amount={distributionLimit}
-                    currency={V2V3CurrencyName(
-                      distributionLimitCurrency.toNumber() as V2V3CurrencyOption,
-                    )}
+                    amount={distributableAmount}
+                    currency={V2V3CurrencyName(currency as V2V3CurrencyOption)}
                   />
                 ) : (
                   <Loading />

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2675,9 +2675,6 @@ msgstr ""
 msgid "Read case studies"
 msgstr ""
 
-msgid "Current payout"
-msgstr ""
-
 msgid "tokens"
 msgstr ""
 
@@ -3462,6 +3459,9 @@ msgid "Burn your {tokensLabel}. You won't receive ETH in return because this pro
 msgstr ""
 
 msgid "JB vs. Kickstarter"
+msgstr ""
+
+msgid "Available payout"
 msgstr ""
 
 msgid "Big ups to the Ethereum community for crafting the infrastructure and economy to make Juicebox possible."


### PR DESCRIPTION
Fixes JB-664 - https://linear.app/peel/issue/JB-664/unlimited-payouts-displayed-incorrectly

BEFORE:
<img width="1068" alt="Screen Shot 2023-08-08 at 3 13 08 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/2985a8c1-fae3-4d4f-83ac-cdec92d5191a">

AFTER:
<img width="1042" alt="Screen Shot 2023-08-08 at 3 12 57 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/ef840e25-1757-4219-b581-6488dfc79987">
