### PR TITLE
Hyperlink addition not respecting z-level [2/n]

### DIFF
--- a/src/styles/quill-js-overrides.scss
+++ b/src/styles/quill-js-overrides.scss
@@ -29,3 +29,7 @@
 .ql-snow .ql-stroke.ql-fill {
   @apply fill-grey-400 stroke-grey-400 dark:fill-slate-400 dark:stroke-slate-400;
 }
+
+.ql-tooltip {
+  @apply z-10;
+}


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-693 : Hyperlink addition not respecting z-level](https://linear.app/peel/issue/JB-693/hyperlink-addition-not-respecting-z-level)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
