### PR TITLE
fix: Hyperlink addition not respecting dark theme [3/n]

### DIFF
--- a/src/styles/quill-js-overrides.scss
+++ b/src/styles/quill-js-overrides.scss
@@ -32,4 +32,16 @@
 
 .ql-tooltip {
   @apply z-10;
+  @apply dark:bg-slate-700;
+  @apply dark:border-slate-300;
+  @apply dark:shadow-[0_0_5px_#494361];
+  @apply rounded-lg;
+}
+
+.ql-snow .ql-tooltip input[type='text'] {
+  @apply dark:border-slate-300;
+}
+
+.ql-tooltip::before {
+  @apply dark:text-slate-200;
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-692 : Hyperlink addition not respecting dark theme](https://linear.app/peel/issue/JB-692/hyperlink-addition-not-respecting-dark-theme)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
