### PR TITLE
Allow pasting of text in rich description [4/n]

### DIFF
--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -77,12 +77,24 @@ export const RichEditor: React.FC<RichEditorProps> = ({ value, onChange }) => {
     const event = async (e: ClipboardEvent) => {
       e.preventDefault()
       e.stopPropagation()
+
       if (
         !e.clipboardData ||
         !e.clipboardData.files ||
         !e.clipboardData.files[0]
-      )
+      ) {
+        // standard paste - strip formatting
+        const text = e.clipboardData?.getData('text/plain')
+        if (text) {
+          // @ts-ignore
+          const editor = quillRef?.current?.getEditor()
+          // @ts-ignore
+          const range = editor.getSelection(true)
+          // @ts-ignore
+          editor.insertText(range.index, text)
+        }
         return
+      }
 
       for (const file of e.clipboardData.files) {
         if (!file.type.match('image.*')) {


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-701 : Can't paste text into the rich text editor that is copied from clipboard](https://linear.app/peel/issue/JB-701/cant-paste-text-into-the-rich-text-editor-that-is-copied-from)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
