### PR TITLE
fix: Save project details not showing any confirmation it was successful

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
@@ -10,6 +10,7 @@ import { useEditProjectDetailsTx } from 'hooks/v2v3/transactor/useEditProjectDet
 import { uploadProjectMetadata } from 'lib/api/ipfs'
 import { revalidateProject } from 'lib/api/nextjs'
 import { useCallback, useContext, useEffect, useState } from 'react'
+import { emitInfoNotification } from 'utils/notifications'
 
 export function ProjectDetailsSettingsPage() {
   const { projectId } = useContext(ProjectMetadataContext)
@@ -54,6 +55,11 @@ export function ProjectDetailsSettingsPage() {
       {
         onConfirmed: async () => {
           setLoadingSaveChanges(false)
+
+          emitInfoNotification('Project details saved', {
+            description: 'Your project details have been saved.',
+          })
+
           if (projectId) {
             await revalidateProject({
               pv: PV_V2,


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-697 : Save project details not showing any confirmation it was successful](https://linear.app/peel/issue/JB-697/save-project-details-not-showing-any-confirmation-it-was-successful)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
