### PR TITLE
fix Project tag line not set in edit project settings

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectDetailsSettingsPage/ProjectDetailsSettingsPage.tsx
@@ -89,6 +89,7 @@ export function ProjectDetailsSettingsPage() {
       logoUri: projectMetadata?.logoUri ?? '',
       coverImageUri: projectMetadata?.coverImageUri ?? '',
       description: projectMetadata?.description ?? '',
+      projectTagline: projectMetadata?.projectTagline ?? '',
       twitter: projectMetadata?.twitter ?? '',
       discord: projectMetadata?.discord ?? '',
       telegram: projectMetadata?.telegram ?? '',
@@ -97,18 +98,19 @@ export function ProjectDetailsSettingsPage() {
       tags: projectMetadata?.tags ?? [],
     })
   }, [
+    projectForm,
     projectMetadata?.name,
     projectMetadata?.infoUri,
     projectMetadata?.logoUri,
     projectMetadata?.coverImageUri,
     projectMetadata?.description,
+    projectMetadata?.projectTagline,
     projectMetadata?.twitter,
     projectMetadata?.discord,
     projectMetadata?.telegram,
-    projectMetadata?.payDisclosure,
     projectMetadata?.payButton,
+    projectMetadata?.payDisclosure,
     projectMetadata?.tags,
-    projectForm,
   ])
 
   // initially fill form with any existing redux state


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-713 : Project tag line not set in edit project settings](https://linear.app/peel/issue/JB-713/project-tag-line-not-set-in-edit-project-settings)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
