### PR TITLE
fix: Project description has html tags in it in project cards

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -9,6 +9,7 @@ import { formatDate } from 'utils/format/formatDate'
 import { v2v3ProjectRoute } from 'utils/routes'
 
 import { useProjectMetadata } from 'hooks/useProjectMetadata'
+import { useSubtitle } from 'hooks/useSubtitle'
 import { DBProject } from 'models/dbProject'
 import { ArchivedBadge } from './ArchivedBadge'
 import Loading from './Loading'
@@ -28,6 +29,8 @@ export default function ProjectCard({
     handle: project?.handle,
     projectId: project?.projectId,
   })
+
+  const subtitle = useSubtitle(metadata)
 
   if (!project) return null
 
@@ -106,9 +109,9 @@ export default function ProjectCard({
             <div className="mt-1">
               <ProjectTagsList tagClassName="text-xs" tags={tags} />
             </div>
-          ) : metadata?.description ? (
+          ) : subtitle ? (
             <div className="max-h-5 overflow-hidden overflow-ellipsis text-grey-400 dark:text-slate-200">
-              {metadata.description}
+              {subtitle.text}
             </div>
           ) : null}
         </div>

--- a/src/components/ProjectDashboard/hooks/useProjectHeader.ts
+++ b/src/components/ProjectDashboard/hooks/useProjectHeader.ts
@@ -2,11 +2,11 @@ import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { BigNumber } from 'ethers'
 import { useGnosisSafe } from 'hooks/safe/useGnosisSafe'
 import { useProjectTrendingPercentageIncrease } from 'hooks/useProjects'
+import { SubtitleType, useSubtitle } from 'hooks/useSubtitle'
 import { GnosisSafe } from 'models/safe'
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import { useProjectMetadata } from './useProjectMetadata'
 
-type SubtitleType = 'tagline' | 'description'
 export interface ProjectHeaderData {
   title: string | undefined
   subtitle: { text: string; type: SubtitleType } | undefined
@@ -34,26 +34,7 @@ export const useProjectHeader = (): ProjectHeaderData => {
   })
   const { data: gnosisSafe } = useGnosisSafe(projectOwnerAddress)
 
-  const subtitle = useMemo(() => {
-    const tagline = projectMetadata?.projectTagline
-    const description = projectMetadata?.description
-      ? stripHtmlTags(projectMetadata?.description)
-      : undefined
-
-    if (tagline) {
-      return {
-        text: tagline,
-        type: 'tagline' as SubtitleType,
-      }
-    }
-
-    if (description) {
-      return {
-        text: description,
-        type: 'description' as SubtitleType,
-      }
-    }
-  }, [projectMetadata?.description, projectMetadata?.projectTagline])
+  const subtitle = useSubtitle(projectMetadata)
 
   return {
     title: projectMetadata?.name,
@@ -66,8 +47,4 @@ export const useProjectHeader = (): ProjectHeaderData => {
     last7DaysPercent,
     gnosisSafe,
   }
-}
-
-const stripHtmlTags = (html: string): string => {
-  return html.replace(/<[^>]*>/g, '')
 }

--- a/src/hooks/useSubtitle.ts
+++ b/src/hooks/useSubtitle.ts
@@ -1,0 +1,37 @@
+import { ProjectMetadata } from 'models/projectMetadata'
+import { useMemo } from 'react'
+
+export type SubtitleType = 'tagline' | 'description'
+
+export const useSubtitle = (
+  projectMetadata:
+    | Pick<ProjectMetadata, 'projectTagline' | 'description'>
+    | undefined,
+) => {
+  const subtitle = useMemo(() => {
+    const tagline = projectMetadata?.projectTagline
+    const description = projectMetadata?.description
+      ? stripHtmlTags(projectMetadata?.description)
+      : undefined
+
+    if (tagline) {
+      return {
+        text: tagline,
+        type: 'tagline' as SubtitleType,
+      }
+    }
+
+    if (description) {
+      return {
+        text: description,
+        type: 'description' as SubtitleType,
+      }
+    }
+  }, [projectMetadata?.description, projectMetadata?.projectTagline])
+
+  return subtitle
+}
+
+const stripHtmlTags = (html: string): string => {
+  return html.replace(/<[^>]*>/g, '')
+}


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-712 : Project description has html tags in it in project cards](https://linear.app/peel/issue/JB-712/project-description-has-html-tags-in-it-in-project-cards)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
