### PR TITLE
fix: more vigorous url wrapping

### DIFF
--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
@@ -3,7 +3,9 @@ import EthereumAddress from 'components/EthereumAddress'
 import ProjectLogo from 'components/ProjectLogo'
 import { ProjectTagsList } from 'components/ProjectTags/ProjectTagsList'
 import { RichPreview } from 'components/RichPreview'
+import { useMemo } from 'react'
 import { useAppSelector } from 'redux/hooks/useAppSelector'
+import { wrapNonAnchorsInAnchor } from 'utils/wrapNonAnchorsInAnchor'
 import { ReviewDescription } from '../ReviewDescription'
 
 export const ProjectDetailsReview = () => {
@@ -23,6 +25,11 @@ export const ProjectDetailsReview = () => {
     },
     inputProjectOwner,
   } = useAppSelector(state => state.editingV2Project)
+
+  const wrappedDescription = useMemo(() => {
+    if (!description) return undefined
+    return wrapNonAnchorsInAnchor(description)
+  }, [description])
 
   return (
     <div className="flex flex-col gap-y-10 pt-5 pb-12 md:grid md:grid-cols-4">
@@ -50,7 +57,7 @@ export const ProjectDetailsReview = () => {
         className="col-span-4 whitespace-pre-wrap"
         title={t`Project description`}
         placeholder={t`No description`}
-        desc={<RichPreview source={description ?? ''} />}
+        desc={<RichPreview source={wrappedDescription ?? ''} />}
       />
       {/* END: Top */}
 

--- a/src/components/ProjectDashboard/hooks/useAboutPanel.ts
+++ b/src/components/ProjectDashboard/hooks/useAboutPanel.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { linkUrl } from 'utils/url'
+import { wrapNonAnchorsInAnchor } from 'utils/wrapNonAnchorsInAnchor'
 import { useProjectMetadata } from './useProjectMetadata'
 
 export type SocialLink = 'twitter' | 'discord' | 'telegram' | 'website'
@@ -36,15 +37,6 @@ export const useAboutPanel = () => {
     socialLinks,
     projectName: projectMetadata?.name,
   }
-}
-
-const wrapNonAnchorsInAnchor = (text: string) => {
-  const urlRegex =
-    /\b((http|https):\/\/[a-zA-Z0-9-._~:/?#@\\[\]!$&'()*+,;=%]+)\b/g
-
-  return text.replace(urlRegex, url => {
-    return '<a href="' + url + '">' + url + '</a>'
-  })
 }
 
 const linkOrUndefined = (link: string | undefined) => {

--- a/src/utils/wrapNonAnchorsInAnchor.ts
+++ b/src/utils/wrapNonAnchorsInAnchor.ts
@@ -1,0 +1,8 @@
+export const wrapNonAnchorsInAnchor = (text: string) => {
+  const urlRegex =
+    /(?<!")\b((http|https):\/\/[a-zA-Z0-9-._~:/?#@\\[\]!$&'()*+,;=%]+)\b(?!")/g
+
+  return text.replace(urlRegex, url => {
+    return '<a href="' + url + '">' + url + '</a>'
+  })
+}


### PR DESCRIPTION
## What does this PR do and why?

Fixes a bug where `img src="<LINK>...` was getting picked up in the anchor link wrapping. Also added the same link wrapping to review

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
