### PR TITLE
[1/n] New edit NFTs:  Enable NFTs (setOperatorPermission)

### DIFF
--- a/src/components/ProjectDashboard/components/ui/ExternalLinkWithIcon.tsx
+++ b/src/components/ProjectDashboard/components/ui/ExternalLinkWithIcon.tsx
@@ -7,10 +7,10 @@ export function ExternalLinkWithIcon({
 }: React.PropsWithChildren<{ href: string }>) {
   return (
     <ExternalLink href={href}>
-      <div className="flex items-center gap-1">
+      <span className="whitespace-nowrap">
         {children}
-        <ArrowRightIcon className="h-3 w-3" />
-      </div>
+        <ArrowRightIcon className="ml-1 inline h-3 w-3" />
+      </span>
     </ExternalLink>
   )
 }

--- a/src/components/inputs/FormattedNumberInput.tsx
+++ b/src/components/inputs/FormattedNumberInput.tsx
@@ -62,7 +62,7 @@ export default function FormattedNumberInput({
           'h-full w-full',
           'formatted-number-input',
           accessory ? 'antd-no-number-handler' : '',
-          accessoryPosition === 'left' ? 'pl-9' : null,
+          accessoryPosition === 'left' ? 'pl-10' : null,
           className,
         )}
         value={value}

--- a/src/components/inputs/JuiceInputNumber.tsx
+++ b/src/components/inputs/JuiceInputNumber.tsx
@@ -33,7 +33,8 @@ export const JuiceInputNumber = ({
     <input
       value={val}
       className={twMerge(
-        'text-primary stroke-secondary rounded-lg border border-smoke-300 bg-smoke-50 px-4 py-2 text-black dark:border-slate-300 dark:bg-slate-600 dark:text-slate-100 dark:placeholder:text-slate-300',
+        'stroke-secondary rounded-lg border border-smoke-300 bg-smoke-50 px-4 py-2 text-black dark:border-slate-300 dark:bg-slate-600 dark:placeholder:text-slate-300',
+        props.disabled ? 'text-tertiary' : 'text-primary dark:text-slate-100',
         className,
       )}
       onChange={e => {

--- a/src/components/modals/TransactionModal.tsx
+++ b/src/components/modals/TransactionModal.tsx
@@ -83,7 +83,7 @@ export default function TransactionModal(props: TransactionModalProps) {
     ...props,
     ...{
       confirmLoading: props.transactionPending || props.confirmLoading,
-      cancelText: t`Close`,
+      cancelText: props.cancelText ?? t`Close`,
       okButtonProps: {
         ...props.okButtonProps,
       },

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from 'antd'
+import { twMerge } from 'tailwind-merge'
 import { classNames } from 'utils/classNames'
 import { DiffedItem } from '../../../shared/DiffedItem'
 
@@ -9,12 +10,14 @@ export function FundingCycleListItem({
   value,
   oldValue,
   subItem,
+  className,
 }: {
   name: string
   value: string | JSX.Element
   oldValue?: string | JSX.Element
   helperText?: string | JSX.Element
   subItem?: boolean
+  className?: string
 }) {
   const hasDiff = oldValue && value !== oldValue
 
@@ -28,9 +31,10 @@ export function FundingCycleListItem({
   if (helperText) {
     return (
       <div
-        className={classNames(
-          'mb-2 flex cursor-default flex-wrap',
+        className={twMerge(
+          'mb-2 flex cursor-default flex-wrap items-center',
           subItem ? 'ml-5 text-xs' : 'text-sm',
+          className,
         )}
       >
         <Tooltip title={helperText} overlayInnerStyle={{ width: '400px' }}>
@@ -54,8 +58,9 @@ export function FundingCycleListItem({
   return (
     <div
       className={classNames(
-        'mb-2 flex flex-wrap',
+        'mb-2 flex flex-wrap items-center',
         subItem ? 'ml-5 text-xs' : 'text-sm',
+        className,
       )}
     >
       <div className="font-medium">{name}:</div> {_value}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/EditNftsPage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/EditNftsPage.tsx
@@ -1,15 +1,18 @@
 import { t, Trans } from '@lingui/macro'
 import { Button, Empty, Tabs } from 'antd'
 import Loading from 'components/Loading'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { useHasNftRewards } from 'hooks/JB721Delegate/useHasNftRewards'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useContext } from 'react'
+import { featureFlagEnabled } from 'utils/featureFlags'
 import { settingsPagePath } from 'utils/routes'
 import { EditCollectionDetailsSection } from './EditCollectionDetailsSection'
 import { EditNftsSection } from './EditNftsSection'
+import { NewEditNftsSection } from './NewEditNftsSection'
 import blueberry from '/public/assets/images/blueberry-ol.png'
 
 export function EditNftsPage() {
@@ -28,6 +31,10 @@ export function EditNftsPage() {
 
   if (hasNftsLoading) {
     return <Loading />
+  }
+
+  if (featureFlagEnabled(FEATURE_FLAGS.NEW_EDIT_NFTS)) {
+    return <NewEditNftsSection />
   }
 
   if (!hasExistingNfts) {

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/EnableNftsCard.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/EnableNftsCard.tsx
@@ -1,0 +1,38 @@
+import { Trans } from '@lingui/macro'
+import { Button } from 'antd'
+import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
+import { useState } from 'react'
+import { helpPagePath } from 'utils/routes'
+import { EditCycleHeader } from '../NewEditCyclePage/EditCycleHeader'
+import { EnableNftsModal } from './EnableNftsModal'
+
+export function EnableNftsCard() {
+  const [enableNftsModalOpen, setEnableNftsModalOpen] = useState<boolean>(false)
+  return (
+    <>
+      <div className="flex items-center gap-10 rounded-lg border border-smoke-200 bg-smoke-50 p-5 dark:border-grey-600 dark:bg-slate-600">
+        <EditCycleHeader
+          title={<Trans>Enable NFTs for your project</Trans>}
+          description={
+            <Trans>
+              Juicebox mints and provides extended functionality for you to sell
+              or reward contributors with NFTs for your project.{' '}
+              <ExternalLinkWithIcon href={helpPagePath('/user/project/#nfts')}>
+                <Trans>Learn more about NFTs</Trans>
+              </ExternalLinkWithIcon>
+            </Trans>
+          }
+        />
+        <Button type="ghost" onClick={() => setEnableNftsModalOpen(true)}>
+          <span>
+            <Trans>Enable NFTs</Trans>
+          </span>
+        </Button>
+      </div>
+      <EnableNftsModal
+        open={enableNftsModalOpen}
+        onClose={() => setEnableNftsModalOpen(false)}
+      />
+    </>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/EnableNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/EnableNftsModal.tsx
@@ -1,0 +1,64 @@
+import { Trans, t } from '@lingui/macro'
+import ExternalLink from 'components/ExternalLink'
+import TooltipIcon from 'components/TooltipIcon'
+import TransactionModal from 'components/modals/TransactionModal'
+import { useSetNftOperatorPermissionsTx } from 'hooks/JB721Delegate/transactor/useSetNftOperatorPermissionsTx'
+import { useState } from 'react'
+
+export function EnableNftsModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const setNftOperatorPermissionsTx = useSetNftOperatorPermissionsTx()
+
+  const setPermissions = async () => {
+    setLoading(true)
+    await setNftOperatorPermissionsTx(undefined, {
+      onConfirmed: () => {
+        setLoading(false)
+        onClose()
+      },
+      onDone() {
+        setLoading(false)
+      },
+      onError() {
+        setLoading(false)
+      },
+    })
+  }
+
+  return (
+    <TransactionModal
+      open={open}
+      onCancel={onClose}
+      okText={t`Grant NFT permissions`}
+      title={t`Enable NFTs`}
+      onOk={setPermissions}
+      cancelText={t`Cancel`}
+      confirmLoading={loading}
+    >
+      <Trans>
+        To add NFTs to your cycle. You'll need to{' '}
+        <strong>grant NFT permissions</strong> before launching your new cycle.
+      </Trans>{' '}
+      <TooltipIcon
+        tip={
+          <Trans>
+            Allow the{' '}
+            <ExternalLink
+              href={`https://github.com/jbx-protocol/juice-721-delegate/blob/main/contracts/JBTiered721DelegateDeployer.sol`}
+            >
+              Juicebox NFT deployer contract
+            </ExternalLink>{' '}
+            to edit this project's cycle.
+          </Trans>
+        }
+      />
+    </TransactionModal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/HasExistingNftsState.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/HasExistingNftsState.tsx
@@ -1,0 +1,3 @@
+export function HasExistingNftsState() {
+  return <>Go to NFT page</>
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/NewEditNftsSection.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/NewEditNftsSection.tsx
@@ -1,0 +1,44 @@
+import { Trans } from '@lingui/macro'
+import { Form } from 'antd'
+import TooltipLabel from 'components/TooltipLabel'
+import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
+import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
+import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
+import { useNftDeployerCanReconfigure } from 'hooks/JB721Delegate/contractReader/useNftDeployerCanReconfigure'
+import { useContext } from 'react'
+import { AdvancedDropdown } from '../NewEditCyclePage/AdvancedDropdown'
+import { EnableNftsCard } from './EnableNftsCard'
+import { NftsTable } from './NftsTable'
+
+export function NewEditNftsSection() {
+  const { projectOwnerAddress } = useContext(V2V3ProjectContext)
+  const { projectId } = useContext(ProjectMetadataContext)
+
+  const nftDeployerCanReconfigure = useNftDeployerCanReconfigure({
+    projectId,
+    projectOwnerAddress,
+  })
+
+  return (
+    <div className="flex flex-col gap-5">
+      {nftDeployerCanReconfigure ? <NftsTable /> : <EnableNftsCard />}
+      <AdvancedDropdown>
+        <Form.Item name="useDataSourceForRedeem">
+          <JuiceSwitch
+            label={
+              <TooltipLabel
+                label={<Trans>Use NFTs for redemption</Trans>}
+                tip={
+                  <Trans>
+                    Contributors will redeem from the project's treasury with
+                    their NFTs as opposed to standard project tokens.
+                  </Trans>
+                }
+              />
+            }
+          />
+        </Form.Item>
+      </AdvancedDropdown>
+    </div>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/NftsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/NftsTable.tsx
@@ -1,0 +1,3 @@
+export function NftsTable() {
+  return <>NFTs table</>
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/AdvancedDropdown.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/AdvancedDropdown.tsx
@@ -6,8 +6,17 @@ import { twMerge } from 'tailwind-merge'
 export function AdvancedDropdown({
   children,
   hideDivider,
+  className,
+  headerClassName,
+  contentContainerClass,
   title = <Trans>Advanced</Trans>,
-}: React.PropsWithChildren<{ hideDivider?: boolean; title?: ReactNode }>) {
+}: React.PropsWithChildren<{
+  hideDivider?: boolean
+  title?: ReactNode
+  className?: string
+  headerClassName?: string
+  contentContainerClass?: string
+}>) {
   const [isOpen, setIsOpen] = useState(false)
   const iconClass = 'h-4 w-4'
   return (
@@ -15,10 +24,14 @@ export function AdvancedDropdown({
       className={twMerge(
         'border-t border-grey-300 pt-4 dark:border-grey-600',
         hideDivider ? 'border-0' : null,
+        className,
       )}
     >
       <div
-        className="flex cursor-pointer justify-between"
+        className={twMerge(
+          'flex cursor-pointer items-center justify-between',
+          headerClassName,
+        )}
         onClick={() => setIsOpen(!isOpen)}
       >
         <span className="text-primary font-medium">{title}</span>
@@ -28,7 +41,13 @@ export function AdvancedDropdown({
           <ChevronDownIcon className={iconClass} />
         )}
       </div>
-      {isOpen && <div className="flex flex-col gap-2 pt-8">{children}</div>}
+      {isOpen && (
+        <div
+          className={twMerge('flex flex-col gap-2 pt-8', contentContainerClass)}
+        >
+          {children}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/DetailsSection/DetailsSectionAdvanced.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/DetailsSection/DetailsSectionAdvanced.tsx
@@ -16,7 +16,7 @@ export function DetailsSectionAdvanced() {
           label={
             <TooltipLabel
               tip={TERMINAL_CONFIG_EXPLANATION}
-              label={<Trans>Enable payment terminal configuration</Trans>}
+              label={<Trans>Enable set payment terminal</Trans>}
             />
           }
         />
@@ -26,7 +26,7 @@ export function DetailsSectionAdvanced() {
           label={
             <TooltipLabel
               tip={CONTROLLER_CONFIG_EXPLANATION}
-              label={<Trans>Enable controller configuration</Trans>}
+              label={<Trans>Enable set controller</Trans>}
             />
           }
         />

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCycleFormFields.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCycleFormFields.ts
@@ -31,6 +31,7 @@ export type TokenSectionFields = {
 
 export type NftSectionFields = {
   nftRewards: NftRewardsData | undefined
+  useDataSourceForRedeem: boolean
 }
 
 export type EditCycleFormFields = DetailsSectionFields &

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCycleFormFields.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCycleFormFields.ts
@@ -37,4 +37,6 @@ export type NftSectionFields = {
 export type EditCycleFormFields = DetailsSectionFields &
   PayoutsSectionFields &
   TokenSectionFields &
-  NftSectionFields
+  NftSectionFields & {
+    memo: string | undefined
+  }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -5,15 +5,18 @@ import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import Link from 'next/link'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { helpPagePath, settingsPagePath } from 'utils/routes'
 import { DetailsSection } from './DetailsSection'
 import { useEditCycleFormContext } from './EditCycleFormContext'
 import { EditCycleFormSection } from './EditCycleFormSection'
 import { PayoutsSection } from './PayoutsSection'
+import { ReviewConfirmModal } from './ReviewConfirmModal'
 import { TokensSection } from './TokensSection'
 
 export function EditCyclePage() {
+  const [confirmModalOpen, setConfirmModalOpen] = useState<boolean>(false)
+
   const { projectId } = useContext(ProjectMetadataContext)
   const { handle } = useContext(V2V3ProjectContext)
 
@@ -66,6 +69,7 @@ export function EditCyclePage() {
             description={
               <Trans>Manage how your projects tokens should work.</Trans>
             }
+            className="border-b-0"
           >
             <TokensSection />
           </EditCycleFormSection>
@@ -81,16 +85,14 @@ export function EditCyclePage() {
           </Link>
         ) : null}
 
-        <Button
-          type="primary"
-          onClick={
-            () => null
-            // TODO: make it open modal which will then call hooks/SaveEditCycleForm.tsx
-          }
-        >
+        <Button type="primary" onClick={() => setConfirmModalOpen(true)}>
           <Trans>Save changes</Trans>
         </Button>
       </div>
+      <ReviewConfirmModal
+        open={confirmModalOpen}
+        onClose={() => setConfirmModalOpen(false)}
+      />
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -69,18 +69,6 @@ export function EditCyclePage() {
           >
             <TokensSection />
           </EditCycleFormSection>
-
-          <EditCycleFormSection
-            title={<Trans>NFTs</Trans>}
-            description={
-              <Trans>
-                Manage how you reward supporters when they support your project.
-              </Trans>
-            }
-            className="border-b-0"
-          >
-            <div>Todo</div>
-          </EditCycleFormSection>
         </Form>
       </div>
 

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -21,6 +21,12 @@ export function HeaderRows() {
   const handleAddRecipientModalOk = (
     newSplit: AddEditAllocationModalEntity,
   ) => {
+    if (newSplit.projectOwner) {
+      console.error(
+        'Not supporting manually adding project owner splits in Edit cycle form',
+      )
+      return
+    }
     handleNewPayoutSplit({ newSplit })
     setAddRecipientModalOpen(false)
   }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRow.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRow.tsx
@@ -68,6 +68,12 @@ export function PayoutSplitRow({
   }
 
   const handleEditModalOk = (allocation: AddEditAllocationModalEntity) => {
+    if (allocation.projectOwner) {
+      console.error(
+        'Not supporting manually adding project owner splits in Edit cycle form',
+      )
+      return
+    }
     handlePayoutSplitChanged({
       editedPayoutSplit: payoutSplit,
       newPayoutSplit: allocation,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DetailsSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DetailsSectionDiff.tsx
@@ -1,0 +1,110 @@
+import { t } from '@lingui/macro'
+import { FundingCycleListItem } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem'
+import { DurationValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItems/DurationValue'
+
+import {
+  CONTROLLER_CONFIG_EXPLANATION,
+  RECONFIG_RULES_EXPLANATION,
+  TERMINAL_CONFIG_EXPLANATION,
+} from 'components/strings'
+import { AllowedValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/AllowedValue'
+import { BallotStrategyValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/BallotStrategyValue'
+import { DiffSection } from './DiffSection'
+import { useDetailsSectionValues } from './hooks/useDetailsSectionValues'
+
+export function DetailsSectionDiff() {
+  const {
+    currentDuration,
+    newDuration,
+    durationHasDiff,
+
+    currentBallot,
+    newBallot,
+    ballotHasDiff,
+
+    newPausePay,
+    currentPausePay,
+    pausePayHasDiff,
+
+    newSetTerminals,
+    currentSetTerminals,
+    allowSetTerminalsHasDiff,
+
+    newSetController,
+    currentSetController,
+    allowSetControllerHasDiff,
+  } = useDetailsSectionValues()
+
+  const content = (
+    <>
+      <FundingCycleListItem
+        name={t`Duration`}
+        value={<DurationValue duration={newDuration} />}
+        oldValue={
+          durationHasDiff ? (
+            <DurationValue duration={currentDuration} />
+          ) : undefined
+        }
+        // className='text-xs'
+      />
+      <FundingCycleListItem
+        name={t`Edit deadline`}
+        value={
+          <BallotStrategyValue
+            ballotStrategy={newBallot}
+            warningText={undefined}
+          />
+        }
+        oldValue={
+          currentBallot && ballotHasDiff ? (
+            <BallotStrategyValue
+              ballotStrategy={currentBallot}
+              warningText={undefined}
+            />
+          ) : undefined
+        }
+        helperText={RECONFIG_RULES_EXPLANATION}
+        // className='text-xs'
+      />
+    </>
+  )
+
+  const advancedOptions = (
+    <>
+      <FundingCycleListItem
+        name={t`Payments disabled`}
+        value={<span className="capitalize">{newPausePay.toString()}</span>}
+        oldValue={
+          pausePayHasDiff ? (
+            <span className="capitalize">{currentPausePay.toString()}</span>
+          ) : undefined
+        }
+        className="text-xs"
+      />
+      <FundingCycleListItem
+        name={t`Enable set payment terminal`}
+        value={<AllowedValue value={newSetTerminals} />}
+        oldValue={
+          allowSetTerminalsHasDiff ? (
+            <AllowedValue value={currentSetTerminals} />
+          ) : undefined
+        }
+        helperText={TERMINAL_CONFIG_EXPLANATION}
+        className="text-xs"
+      />
+      <FundingCycleListItem
+        name={t`Enable set controller`}
+        value={<AllowedValue value={newSetController} />}
+        oldValue={
+          allowSetControllerHasDiff ? (
+            <AllowedValue value={currentSetController} />
+          ) : undefined
+        }
+        helperText={CONTROLLER_CONFIG_EXPLANATION}
+        className="text-xs"
+      />
+    </>
+  )
+
+  return <DiffSection content={content} advancedOptions={advancedOptions} />
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DiffSection.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DiffSection.tsx
@@ -1,0 +1,24 @@
+import { t } from '@lingui/macro'
+import { AdvancedDropdown } from '../AdvancedDropdown'
+
+export function DiffSection({
+  content,
+  advancedOptions,
+}: {
+  content: React.ReactNode
+  advancedOptions: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      {content}
+      <AdvancedDropdown
+        title={t`Advanced options:`}
+        className="border-t-0 pb-3 pt-0"
+        headerClassName="flex-row-reverse justify-end gap-2 text-sm"
+        contentContainerClass="pt-2"
+      >
+        <div className="pl-10">{advancedOptions}</div>
+      </AdvancedDropdown>
+    </div>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/PayoutsSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/PayoutsSectionDiff.tsx
@@ -1,0 +1,76 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { t } from '@lingui/macro'
+import { DISTRIBUTION_LIMIT_EXPLANATION } from 'components/strings'
+import { FundingCycleListItem } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem'
+import { DistributionLimitValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItems/DistributionLimitValue'
+import DiffedSplitList from 'components/v2v3/shared/DiffedSplits/DiffedSplitList'
+import { getV2V3CurrencyOption } from 'utils/v2v3/currency'
+import { DiffSection } from './DiffSection'
+import { usePayoutsSectionValues } from './hooks/usePayoutsSectionValues'
+
+export function PayoutsSectionDiff() {
+  const {
+    newCurrency,
+    currentCurrency,
+
+    currentDistributionLimit,
+    newDistributionLimit,
+    distributionLimitHasDiff,
+    distributionLimitIsInfinite,
+
+    currentPayoutSplits,
+    newPayoutSplits,
+
+    newHoldFees,
+    currentHoldFees,
+    holdFeesHasDiff,
+  } = usePayoutsSectionValues()
+
+  const roundingPrecision = newCurrency === 'ETH' ? 4 : 2
+
+  const content = (
+    <div className="mb-5 flex flex-col gap-3 text-sm">
+      <FundingCycleListItem
+        name={t`Total payouts`}
+        value={
+          <DistributionLimitValue
+            distributionLimit={newDistributionLimit}
+            currency={newCurrency}
+          />
+        }
+        oldValue={
+          distributionLimitHasDiff ? (
+            <DistributionLimitValue
+              distributionLimit={currentDistributionLimit}
+              currency={currentCurrency}
+            />
+          ) : undefined
+        }
+        helperText={DISTRIBUTION_LIMIT_EXPLANATION}
+      />
+      <DiffedSplitList
+        splits={newPayoutSplits}
+        diffSplits={currentPayoutSplits}
+        currency={BigNumber.from(getV2V3CurrencyOption(newCurrency))}
+        projectOwnerAddress={undefined}
+        totalValue={newDistributionLimit}
+        showAmounts={!distributionLimitIsInfinite}
+        valueFormatProps={{ precision: roundingPrecision }}
+        showDiffs
+      />
+    </div>
+  )
+  const advancedOptions = (
+    <FundingCycleListItem
+      name={t`Hold fees`}
+      value={<span className="capitalize">{newHoldFees.toString()}</span>}
+      oldValue={
+        holdFeesHasDiff ? (
+          <span className="capitalize">{currentHoldFees.toString()}</span>
+        ) : undefined
+      }
+      className="text-xs"
+    />
+  )
+  return <DiffSection content={content} advancedOptions={advancedOptions} />
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/ReviewConfirmModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/ReviewConfirmModal.tsx
@@ -1,0 +1,58 @@
+import { Trans, t } from '@lingui/macro'
+import { Form } from 'antd'
+import { CreateCollapse } from 'components/Create/components/CreateCollapse'
+import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
+import TransactionModal from 'components/modals/TransactionModal'
+import { useSaveEditCycleData } from '../hooks/SaveEditCycleData'
+import { DetailsSectionDiff } from './DetailsSectionDiff'
+import { PayoutsSectionDiff } from './PayoutsSectionDiff'
+
+export function ReviewConfirmModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const { saveEditCycleLoading, saveEditCycle } = useSaveEditCycleData()
+
+  const onOk = () => {
+    saveEditCycle()
+  }
+  const panelProps = { className: 'text-lg' }
+  return (
+    <TransactionModal
+      open={open}
+      title={<Trans>Review & confirm</Trans>}
+      destroyOnClose
+      onOk={onOk}
+      okText={<Trans>Deploy changes</Trans>}
+      onCancel={onClose}
+      confirmLoading={saveEditCycleLoading}
+    >
+      <p className="text-secondary text-sm">
+        <Trans>
+          Please check your details carefully. Each change will incur a gas fee.
+        </Trans>
+      </p>
+      <CreateCollapse>
+        <CreateCollapse.Panel key={0} header={t`Cycle details`} {...panelProps}>
+          <DetailsSectionDiff />
+        </CreateCollapse.Panel>
+        <CreateCollapse.Panel key={1} header={t`Payouts`} {...panelProps}>
+          <PayoutsSectionDiff />
+        </CreateCollapse.Panel>
+        <CreateCollapse.Panel key={2} header={t`Tokens`} {...panelProps}>
+          <>Details diff</>
+        </CreateCollapse.Panel>
+      </CreateCollapse>
+      <Form.Item name="memo" className="mt-10">
+        <JuiceTextArea
+          rows={4}
+          placeholder={t`Add an on-chain note about this cycle.`}
+          maxLength={256}
+        />
+      </Form.Item>
+    </TransactionModal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useDetailsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useDetailsSectionValues.ts
@@ -1,0 +1,73 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
+import { useContext } from 'react'
+import { otherUnitToSeconds } from 'utils/format/formatTime'
+import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
+import { useEditCycleFormContext } from '../../EditCycleFormContext'
+
+export const useDetailsSectionValues = () => {
+  const { editCycleForm } = useEditCycleFormContext()
+
+  const {
+    fundingCycle: currentFundingCycle,
+    fundingCycleMetadata: currentFundingCycleMetadata,
+  } = useContext(V2V3ProjectContext)
+
+  const currentDuration = currentFundingCycle?.duration
+  const newDurationSeconds = otherUnitToSeconds({
+    duration: editCycleForm?.getFieldValue('duration'),
+    unit: editCycleForm?.getFieldValue('durationUnit').value,
+  })
+  const newDuration = BigNumber.from(newDurationSeconds)
+  const durationHasDiff = !newDuration.eq(currentDuration ?? 0)
+
+  const newBallot = getBallotStrategyByAddress(
+    editCycleForm?.getFieldValue('ballot'),
+  )
+  const currentBallot = currentFundingCycle
+    ? getBallotStrategyByAddress(currentFundingCycle.ballot)
+    : undefined
+  const ballotHasDiff = newBallot?.address !== currentBallot?.address
+
+  const newPausePay = Boolean(editCycleForm?.getFieldValue('pausePay'))
+  const currentPausePay = Boolean(currentFundingCycleMetadata?.pausePay)
+  const pausePayHasDiff = currentPausePay !== newPausePay
+
+  const newSetTerminals = Boolean(
+    editCycleForm?.getFieldValue('allowSetTerminals'),
+  )
+  const currentSetTerminals = Boolean(
+    currentFundingCycleMetadata?.global.allowSetTerminals,
+  )
+  const allowSetTerminalsHasDiff = currentSetTerminals !== newSetTerminals
+
+  const newSetController = Boolean(
+    editCycleForm?.getFieldValue('allowSetController'),
+  )
+  const currentSetController = Boolean(
+    currentFundingCycleMetadata?.global.allowSetController,
+  )
+  const allowSetControllerHasDiff = currentSetController !== newSetController
+
+  return {
+    currentDuration,
+    newDuration,
+    durationHasDiff,
+
+    currentBallot,
+    newBallot,
+    ballotHasDiff,
+
+    newPausePay,
+    currentPausePay,
+    pausePayHasDiff,
+
+    newSetTerminals,
+    currentSetTerminals,
+    allowSetTerminalsHasDiff,
+
+    newSetController,
+    currentSetController,
+    allowSetControllerHasDiff,
+  }
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
@@ -1,0 +1,62 @@
+import { CurrencyName } from 'constants/currency'
+import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
+import { Split } from 'models/splits'
+import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
+import { useContext } from 'react'
+import { parseWad } from 'utils/format/formatNumber'
+import { V2V3CurrencyName, V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
+import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
+import { useEditCycleFormContext } from '../../EditCycleFormContext'
+
+export const usePayoutsSectionValues = () => {
+  const { editCycleForm } = useEditCycleFormContext()
+
+  const {
+    distributionLimit: currentDistributionLimit,
+    distributionLimitCurrency: currentCurrencyOption,
+    fundingCycleMetadata: currentFundingCycleMetadata,
+    payoutSplits: currentPayoutSplits,
+  } = useContext(V2V3ProjectContext)
+
+  const newPayoutSplits: Split[] = editCycleForm?.getFieldValue('payoutSplits')
+
+  const newCurrency: CurrencyName = editCycleForm?.getFieldValue(
+    'distributionLimitCurrency',
+  )
+  const currentCurrency = V2V3CurrencyName(
+    (currentCurrencyOption?.toNumber() ??
+      V2V3_CURRENCY_ETH) as V2V3CurrencyOption,
+  )
+  const currencyHasDiff = currentCurrency !== newCurrency
+
+  const newDistributionLimit = parseWad(
+    editCycleForm?.getFieldValue('distributionLimit') as number,
+  )
+  const distributionLimitHasDiff =
+    (currentDistributionLimit &&
+      !newDistributionLimit?.eq(currentDistributionLimit)) ||
+    currencyHasDiff
+  const distributionLimitIsInfinite =
+    !newDistributionLimit || newDistributionLimit.eq(MAX_DISTRIBUTION_LIMIT)
+
+  const newHoldFees = Boolean(editCycleForm?.getFieldValue('holdFees'))
+  const currentHoldFees = Boolean(currentFundingCycleMetadata?.holdFees)
+  const holdFeesHasDiff = newHoldFees !== currentHoldFees
+
+  return {
+    newCurrency,
+    currentCurrency,
+
+    currentDistributionLimit,
+    newDistributionLimit,
+    distributionLimitHasDiff,
+    distributionLimitIsInfinite,
+
+    currentPayoutSplits,
+    newPayoutSplits,
+
+    newHoldFees,
+    currentHoldFees,
+    holdFeesHasDiff,
+  }
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/index.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/index.tsx
@@ -1,0 +1,1 @@
+export * from './ReviewConfirmModal'

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/IssuanceRateReductionField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/IssuanceRateReductionField.tsx
@@ -18,7 +18,7 @@ export function IssuanceRateReductionField() {
     setIssuanceReductionRateSwitchEnabled,
   ] = useState<boolean>(issuanceReductionRate > 0)
   return (
-    <div>
+    <div className="flex flex-col gap-5">
       <JuiceSwitch
         label={<Trans>Enable issuance reduction rate</Trans>}
         description={

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/MintRateField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/MintRateField.tsx
@@ -7,7 +7,7 @@ export function MintRateField() {
   return (
     <Form.Item name="mintRate">
       <FormattedNumberInput
-        className="py-1 pr-4"
+        className="h-10 py-1 pr-4"
         min={0}
         max={MAX_MINT_RATE}
         accessory={

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/RedemptionRateField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/RedemptionRateField.tsx
@@ -16,7 +16,7 @@ export function RedemptionRateField() {
 
   const [redemptionRateSwitchEnabled, setRedemptionRateSwitchEnabled] =
     useState<boolean>(
-      editCycleForm?.getFieldValue('redemptionRate') ?? 100 < 100,
+      (editCycleForm?.getFieldValue('redemptionRate') ?? 100) < 100,
     )
   return (
     <div className="flex flex-col gap-5">

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/ReservedTokensField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/ReservedTokensField.tsx
@@ -72,7 +72,6 @@ export function ReservedTokensField() {
       ) : null}
       {/* Empty inputs to keep AntD useWatch happy */}
       <ItemNoInput name="reservedSplits" className="hidden" />
-      <ItemNoInput name="reservedTokens" className="hidden" />
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
@@ -90,6 +90,8 @@ export const useLoadEditCycleData = () => {
         allowTokenMinting,
         pauseTransfers: pauseTransfers,
         nftRewards: initialEditingData.nftRewards,
+        useDataSourceForRedeem:
+          initialEditingData.fundingCycleMetadata.useDataSourceForRedeem,
       }
 
       setInitialFormData(formData)

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
@@ -19,6 +19,7 @@ import {
 import { useInitialEditingData } from '../../ReconfigureFundingCycleSettingsPage/hooks/useInitialEditingData'
 import { EditCycleFormFields } from '../EditCycleFormFields'
 
+/** Loads project FC data from redux into an Ant D form instance */
 export const useLoadEditCycleData = () => {
   const [initialFormData, setInitialFormData] = useState<
     EditCycleFormFields | undefined
@@ -92,6 +93,7 @@ export const useLoadEditCycleData = () => {
         nftRewards: initialEditingData.nftRewards,
         useDataSourceForRedeem:
           initialEditingData.fundingCycleMetadata.useDataSourceForRedeem,
+        memo: '',
       }
 
       setInitialFormData(formData)

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/SaveEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/SaveEditCycleData.tsx
@@ -1,0 +1,190 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { ETH_TOKEN_ADDRESS } from 'constants/v2v3/juiceboxTokens'
+import { V2V3ProjectContractsContext } from 'contexts/v2v3/ProjectContracts/V2V3ProjectContractsContext'
+import {
+  ETHPayoutGroupedSplits,
+  ReservedTokensGroupedSplits,
+} from 'models/splits'
+import {
+  V2V3FundAccessConstraint,
+  V2V3FundingCycleData,
+  V2V3FundingCycleMetadata,
+} from 'models/v2v3/fundingCycle'
+import { BaseV3FundingCycleMetadataGlobal } from 'models/v3/fundingCycle'
+import { useContext } from 'react'
+import { DEFAULT_MUST_START_AT_OR_AFTER } from 'redux/slices/editingV2Project'
+import { NftRewardsData } from 'redux/slices/editingV2Project/types'
+import { isZeroAddress } from 'utils/address'
+import { parseWad } from 'utils/format/formatNumber'
+import { otherUnitToSeconds } from 'utils/format/formatTime'
+import { getV2V3CurrencyOption } from 'utils/v2v3/currency'
+import {
+  MAX_DISTRIBUTION_LIMIT,
+  discountRateFrom,
+  issuanceRateFrom,
+  redemptionRateFrom,
+  reservedRateFrom,
+} from 'utils/v2v3/math'
+import {
+  EditingFundingCycleConfig,
+  useEditingFundingCycleConfig,
+} from '../../ReconfigureFundingCycleSettingsPage/hooks/useEditingFundingCycleConfig'
+import { useReconfigureFundingCycle } from '../../ReconfigureFundingCycleSettingsPage/hooks/useReconfigureFundingCycle'
+import { useEditCycleFormContext } from '../EditCycleFormContext'
+import { EditCycleFormFields } from '../EditCycleFormFields'
+// EditingFundingCycleConfig {
+//   editingPayoutGroupedSplits: ETHPayoutGroupedSplits
+//   editingReservedTokensGroupedSplits: ReservedTokensGroupedSplits
+//   editingFundingCycleMetadata: Omit<V2V3FundingCycleMetadata, 'version'>
+//   editingFundingCycleData: V2V3FundingCycleData
+//   editingFundAccessConstraints: V2V3FundAccessConstraint[]
+//   editingNftRewards: NftRewardsData | undefined
+//   editingMustStartAtOrAfter: string
+// }
+
+// export type V2V3FundingCycleData = {
+//   duration: BigNumber
+//   weight: BigNumber
+//   discountRate: BigNumber
+//   ballot: string // hex, contract address
+// }
+
+/* export type V2V3FundingCycleMetadata =
+  | V2FundingCycleMetadata
+   | V3FundingCycleMetadata
+ BaseV2V3FundingCycleMetadata = {
+  version?: number
+  global: BaseV3FundingCycleMetadataGlobal
+  reservedRate: BigNumber
+  redemptionRate: BigNumber
+  ballotRedemptionRate: BigNumber
+  pausePay: boolean
+  pauseDistributions: boolean
+  pauseRedeem: boolean
+  pauseBurn: boolean
+  allowMinting: boolean
+  allowTerminalMigration: boolean
+  allowControllerMigration: boolean
+  holdFees: boolean
+  useTotalOverflowForRedemptions: boolean
+  useDataSourceForPay: boolean // undefined for outgoing NFT args
+  useDataSourceForRedeem: boolean
+  dataSource: string // hex, contract address. undefined for outgoing NFT args
+}
+
+BaseV3FundingCycleMetadataGlobal = {
+  allowSetController: boolean
+  allowSetTerminals: boolean
+  pauseTransfers?: boolean
+}
+
+ V3: preferClaimedTokenOverride?: boolean
+  metadata?: BigNumber
+
+V2: allowChangeToken: boolean
+**}
+
+//** Converts EditCycleForm data to EditingFundingCycleConfig and calls useReconfigureFundingCycle tx */
+
+export const useSaveEditCycleData = () => {
+  // Use Redux to get current (pre-edit) project state since it's not changed by edit
+  // Only using this to get values of FC parameters not supported in the FC form (e.g. allowTerminalMigration, etc.)
+  const reduxConfig = useEditingFundingCycleConfig()
+
+  const { editCycleForm } = useEditCycleFormContext()
+  const {
+    contracts: { JBETHPaymentTerminal },
+  } = useContext(V2V3ProjectContractsContext)
+
+  if (!editCycleForm)
+    return {
+      saveEditCycleLoading: false,
+      saveEditCycle: () => null,
+    }
+
+  const fundingCycleMetadata = reduxConfig.editingFundingCycleMetadata
+
+  const formValues = editCycleForm.getFieldsValue(true) as EditCycleFormFields
+
+  const durationSeconds = otherUnitToSeconds({
+    duration: formValues.duration,
+    unit: formValues.durationUnit.value,
+  })
+
+  const editingPayoutGroupedSplits: ETHPayoutGroupedSplits = {
+    group: 1,
+    splits: formValues.payoutSplits,
+  }
+
+  const editingReservedTokensGroupedSplits: ReservedTokensGroupedSplits = {
+    group: 2,
+    splits: formValues.reservedSplits,
+  }
+
+  const editingFundingCycleMetadata: Omit<V2V3FundingCycleMetadata, 'version'> =
+    {
+      ...fundingCycleMetadata,
+      global: {
+        allowSetController: formValues.allowSetController,
+        allowSetTerminals: formValues.allowSetTerminals,
+        pauseTransfers: formValues.pauseTransfers,
+      } as BaseV3FundingCycleMetadataGlobal,
+      reservedRate: reservedRateFrom(formValues.reservedTokens),
+      redemptionRate: redemptionRateFrom(formValues.redemptionRate),
+      pausePay: formValues.pausePay,
+      allowMinting: formValues.allowTokenMinting,
+      holdFees: formValues.holdFees,
+      useDataSourceForPay: isZeroAddress(fundingCycleMetadata?.dataSource)
+        ? false
+        : true,
+      useDataSourceForRedeem: formValues.useDataSourceForRedeem,
+    }
+
+  const editingFundingCycleData: V2V3FundingCycleData = {
+    duration: BigNumber.from(durationSeconds),
+    weight: BigNumber.from(issuanceRateFrom(formValues.mintRate.toString())),
+    discountRate: discountRateFrom(formValues.discountRate),
+    ballot: formValues.ballot,
+  }
+  const distributionLimit =
+    formValues.distributionLimit === undefined
+      ? MAX_DISTRIBUTION_LIMIT
+      : parseWad(formValues.distributionLimit)
+  const editingFundAccessConstraints: V2V3FundAccessConstraint[] = [
+    {
+      terminal: JBETHPaymentTerminal?.address ?? '',
+      token: ETH_TOKEN_ADDRESS,
+      distributionLimit,
+      distributionLimitCurrency: BigNumber.from(
+        getV2V3CurrencyOption(formValues.distributionLimitCurrency),
+      ),
+      overflowAllowance: BigNumber.from(0),
+      overflowAllowanceCurrency: BigNumber.from(0),
+    },
+  ]
+
+  const editingNftRewards: NftRewardsData | undefined = undefined // TODO: isLaunchingNewCollection ? formData : undefined
+
+  const editingFundingCycleConfig: EditingFundingCycleConfig = {
+    editingPayoutGroupedSplits,
+    editingReservedTokensGroupedSplits,
+    editingFundingCycleMetadata,
+    editingFundingCycleData,
+    editingFundAccessConstraints,
+    editingNftRewards,
+    editingMustStartAtOrAfter: DEFAULT_MUST_START_AT_OR_AFTER,
+  }
+  const {
+    reconfigureLoading: saveEditCycleLoading,
+    reconfigureFundingCycle: saveEditCycle,
+  } = useReconfigureFundingCycle({
+    editingFundingCycleConfig,
+    memo: formValues.memo ?? '',
+    launchedNewNfts: false, // TODO: isLaunchingNewCollection,
+  })
+
+  return {
+    saveEditCycleLoading,
+    saveEditCycle,
+  }
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/V2V3EditReservedTokens.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReservedTokensSettingsPage/V2V3EditReservedTokens.tsx
@@ -3,9 +3,8 @@ import { Callout } from 'components/Callout'
 import { ReservedTokensList } from 'components/Create/components/pages/ProjectToken/components/CustomTokenSettings/components/ReservedTokensList'
 import { CsvUpload } from 'components/inputs/CsvUpload'
 import { AllocationSplit } from 'components/v2v3/shared/Allocation'
-import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
 import { Split } from 'models/splits'
-import { useCallback, useContext, useEffect } from 'react'
+import { useCallback } from 'react'
 import { parseV2SplitsCsv } from 'utils/csv'
 import { allocationToSplit, splitToAllocation } from 'utils/splitToAllocation'
 
@@ -20,13 +19,6 @@ export function V2V3EditReservedTokens({
   showInstantChangesCallout?: boolean
   hideTitle?: boolean
 }) {
-  const { reservedTokensSplits } = useContext(V2V3ProjectContext)
-
-  useEffect(() => {
-    if (!reservedTokensSplits) return
-    setEditingReservedTokensSplits(reservedTokensSplits)
-  }, [reservedTokensSplits, setEditingReservedTokensSplits])
-
   const onSplitsChanged = useCallback(
     (newSplits: Split[]) => {
       setEditingReservedTokensSplits(newSplits)

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -2,9 +2,11 @@ export type FeatureFlag =
   | 'SIMULATE_TXS'
   | 'NEW_PROJECT_PAGE'
   | 'NEW_CYCLE_CONFIG_PAGE'
+  | 'NEW_EDIT_NFTS'
 
 export const FEATURE_FLAGS: { [k in FeatureFlag]: string } = {
   SIMULATE_TXS: 'simulateTxs',
   NEW_PROJECT_PAGE: 'newProjectPage',
   NEW_CYCLE_CONFIG_PAGE: 'newCycleConfigPage',
+  NEW_EDIT_NFTS: 'newEditNfts',
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -146,6 +146,9 @@ msgstr ""
 msgid "Data from current cycle"
 msgstr ""
 
+msgid "Contributors will redeem from the project's treasury with their NFTs as opposed to standard project tokens."
+msgstr ""
+
 msgid "You're about to add NFTs to your cycle. You'll need to <0>grant NFT permissions</0> before deploying the new cycle"
 msgstr ""
 
@@ -291,6 +294,9 @@ msgid "Deploy Snapshot space"
 msgstr ""
 
 msgid "Contributions"
+msgstr ""
+
+msgid "Enable NFTs for your project"
 msgstr ""
 
 msgid "Attach an image"
@@ -2111,6 +2117,9 @@ msgstr ""
 msgid "This project's rules may pose risks for contributors:"
 msgstr ""
 
+msgid "Enable NFTs"
+msgstr ""
+
 msgid "Save token recipients"
 msgstr ""
 
@@ -2960,6 +2969,9 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
+msgid "Juicebox mints and provides extended functionality for you to sell or reward contributors with NFTs for your project. <0>Learn more about NFTs</0>"
+msgstr ""
+
 msgid "Create an ERC-20 token (optional)"
 msgstr ""
 
@@ -3141,9 +3153,6 @@ msgid "Request a feature."
 msgstr ""
 
 msgid "Fees held"
-msgstr ""
-
-msgid "Manage how you reward supporters when they support your project."
 msgstr ""
 
 msgid "Issuance reduction rate"
@@ -3473,6 +3482,9 @@ msgstr ""
 msgid "Prevent NFT overspending"
 msgstr ""
 
+msgid "To add NFTs to your cycle. You'll need to <0>grant NFT permissions</0> before launching your new cycle."
+msgstr ""
+
 msgid "Pay this project to receive NFTs."
 msgstr ""
 
@@ -3510,6 +3522,9 @@ msgid "Amount required"
 msgstr ""
 
 msgid "Burn your {tokensLabel}. You won't receive ETH in return because this project has no ETH, or is using all of its ETH for payouts."
+msgstr ""
+
+msgid "Use NFTs for redemption"
 msgstr ""
 
 msgid "JB vs. Kickstarter"

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -50,6 +50,9 @@ msgstr ""
 msgid "Art"
 msgstr ""
 
+msgid "Deploy changes"
+msgstr ""
+
 msgid "How should I set up my project?"
 msgstr ""
 
@@ -270,6 +273,9 @@ msgid "Try it now"
 msgstr ""
 
 msgid "<0>Issuance reduction rate</0>. This allows you to predictably reduce your project token's issuance rate (tokens per ETH) over time without needing to manually edit your cycle."
+msgstr ""
+
+msgid "Review & confirm"
 msgstr ""
 
 msgid "Cycles:"
@@ -711,6 +717,9 @@ msgid "Heads up"
 msgstr ""
 
 msgid "No deadline"
+msgstr ""
+
+msgid "Enable set payment terminal"
 msgstr ""
 
 msgid "Your project is up to date!"
@@ -1484,9 +1493,6 @@ msgstr ""
 msgid "Next cycle, the project will issue {0} tokens per 1 ETH. The cycle after that, the project will issue {1} tokens per 1 ETH."
 msgstr ""
 
-msgid "Enable payment terminal configuration"
-msgstr ""
-
 msgid "Days"
 msgstr ""
 
@@ -2099,6 +2105,9 @@ msgstr ""
 msgid "Project ID must be a number."
 msgstr ""
 
+msgid "Payments disabled"
+msgstr ""
+
 msgid "Add image"
 msgstr ""
 
@@ -2571,9 +2580,6 @@ msgid "Subject"
 msgstr ""
 
 msgid "You must confirm your compliance."
-msgstr ""
-
-msgid "Enable controller configuration"
 msgstr ""
 
 msgid "{pageTitle}"
@@ -3194,6 +3200,9 @@ msgstr ""
 msgid "<0/> fee"
 msgstr ""
 
+msgid "Advanced options:"
+msgstr ""
+
 msgid "Payments to this project are paused in this cycle."
 msgstr ""
 
@@ -3644,6 +3653,9 @@ msgstr ""
 msgid "Contract permissions"
 msgstr ""
 
+msgid "Enable set controller"
+msgstr ""
+
 msgid "Project configurations cannot be changed to the duration of locked cycles."
 msgstr ""
 
@@ -3813,6 +3825,9 @@ msgid "Upgrade"
 msgstr ""
 
 msgid "After {0} (your first cycle), your project will not issue any tokens unless you edit the issuance rate."
+msgstr ""
+
+msgid "Please check your details carefully. Each change will incur a gas fee."
 msgstr ""
 
 msgid "Unknown extension"
@@ -4572,6 +4587,9 @@ msgid "<0>If you're looking for help planning or deploying your project, you can
 msgstr ""
 
 msgid "Open source"
+msgstr ""
+
+msgid "Total payouts"
 msgstr ""
 
 msgid "Following the launch of their token $MOONEY, the next goal on MoonDAO's roadmap was to buy two tickets to space on a Blue Origin rocket. They set the project's Payouts to Infinite in order to raise as much as possible during their campaign and be able to distribute all of the funds. Using a reserved rate of 50%, the MoonDAO multi-sig received half of all newly minted tokens to build up a treasury of both ETH and $MOONEY that could later be used for bounties and compensation."


### PR DESCRIPTION
- First part of the NFT flow - setting operator permissions. Has to be done before adding any NFTs to non-NFT projects

- This was originally supposed to be in Edit cycle, so there's still stuff related to Edit cycle in this new NFT page - will fix that when I finish Edit cycle and start building the rest of the new NFTs

- Also includes a few small misc. fixes throughout the edit cycle form

For project's without operator permission:

https://github.com/jbx-protocol/juice-interface/assets/96150256/7936e8e0-22b1-438e-8c6b-9c5694504368

