### PR TITLE
New edit cycle [1/3]: Review modal updates (general styles)

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem.tsx
@@ -32,7 +32,7 @@ export function FundingCycleListItem({
     return (
       <div
         className={twMerge(
-          'mb-2 flex cursor-default flex-wrap items-center',
+          'mb-2 flex cursor-default flex-wrap items-center justify-between',
           subItem ? 'ml-5 text-xs' : 'text-sm',
           className,
         )}
@@ -50,7 +50,7 @@ export function FundingCycleListItem({
             :
           </div>{' '}
         </Tooltip>
-        {_value}
+        <div className="flex">{_value}</div>
       </div>
     )
   }
@@ -58,12 +58,13 @@ export function FundingCycleListItem({
   return (
     <div
       className={classNames(
-        'mb-2 flex flex-wrap items-center',
+        'mb-2 flex flex-wrap items-center justify-between',
         subItem ? 'ml-5 text-xs' : 'text-sm',
         className,
       )}
     >
-      <div className="font-medium">{name}:</div> {_value}
+      <div className="font-medium">{name}:</div>
+      <div className="flex">{_value}</div>
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItems/DistributionLimitValue.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItems/DistributionLimitValue.tsx
@@ -7,9 +7,11 @@ import { BigNumber } from 'ethers'
 export function DistributionLimitValue({
   distributionLimit,
   currency,
+  shortName,
 }: {
   distributionLimit: BigNumber | undefined
   currency: CurrencyName | undefined
+  shortName?: boolean
 }) {
   return (
     <span className="whitespace-nowrap">
@@ -24,6 +26,7 @@ export function DistributionLimitValue({
           distributionLimit={distributionLimit}
           currencyName={currency}
           className="text-grey-900 dark:text-slate-100"
+          shortName={shortName}
         />
       </Tooltip>
     </span>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DetailsSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DetailsSectionDiff.tsx
@@ -1,19 +1,19 @@
-import { t } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { FundingCycleListItem } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem'
 import { DurationValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItems/DurationValue'
 
-import {
-  CONTROLLER_CONFIG_EXPLANATION,
-  RECONFIG_RULES_EXPLANATION,
-  TERMINAL_CONFIG_EXPLANATION,
-} from 'components/strings'
 import { AllowedValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/AllowedValue'
 import { BallotStrategyValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/BallotStrategyValue'
 import { DiffSection } from './DiffSection'
 import { useDetailsSectionValues } from './hooks/useDetailsSectionValues'
 
+export const emptySectionClasses = 'text-sm text-secondary pt-2 pb-3'
+
 export function DetailsSectionDiff() {
   const {
+    advancedOptionsHasDiff,
+    sectionHasDiff,
+
     currentDuration,
     newDuration,
     durationHasDiff,
@@ -35,6 +35,14 @@ export function DetailsSectionDiff() {
     allowSetControllerHasDiff,
   } = useDetailsSectionValues()
 
+  if (!sectionHasDiff) {
+    return (
+      <div className={emptySectionClasses}>
+        <Trans>No edits were made to cycle details for this cycle.</Trans>
+      </div>
+    )
+  }
+
   const content = (
     <>
       <FundingCycleListItem
@@ -45,7 +53,6 @@ export function DetailsSectionDiff() {
             <DurationValue duration={currentDuration} />
           ) : undefined
         }
-        // className='text-xs'
       />
       <FundingCycleListItem
         name={t`Edit deadline`}
@@ -63,13 +70,11 @@ export function DetailsSectionDiff() {
             />
           ) : undefined
         }
-        helperText={RECONFIG_RULES_EXPLANATION}
-        // className='text-xs'
       />
     </>
   )
 
-  const advancedOptions = (
+  const advancedOptions = advancedOptionsHasDiff ? (
     <>
       <FundingCycleListItem
         name={t`Payments disabled`}
@@ -79,7 +84,6 @@ export function DetailsSectionDiff() {
             <span className="capitalize">{currentPausePay.toString()}</span>
           ) : undefined
         }
-        className="text-xs"
       />
       <FundingCycleListItem
         name={t`Enable set payment terminal`}
@@ -89,8 +93,6 @@ export function DetailsSectionDiff() {
             <AllowedValue value={currentSetTerminals} />
           ) : undefined
         }
-        helperText={TERMINAL_CONFIG_EXPLANATION}
-        className="text-xs"
       />
       <FundingCycleListItem
         name={t`Enable set controller`}
@@ -100,11 +102,9 @@ export function DetailsSectionDiff() {
             <AllowedValue value={currentSetController} />
           ) : undefined
         }
-        helperText={CONTROLLER_CONFIG_EXPLANATION}
-        className="text-xs"
       />
     </>
-  )
+  ) : undefined
 
   return <DiffSection content={content} advancedOptions={advancedOptions} />
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DiffSection.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/DiffSection.tsx
@@ -1,24 +1,23 @@
-import { t } from '@lingui/macro'
-import { AdvancedDropdown } from '../AdvancedDropdown'
+import { Trans } from '@lingui/macro'
 
 export function DiffSection({
   content,
   advancedOptions,
 }: {
   content: React.ReactNode
-  advancedOptions: React.ReactNode
+  advancedOptions?: React.ReactNode
 }) {
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-1 text-sm">
       {content}
-      <AdvancedDropdown
-        title={t`Advanced options:`}
-        className="border-t-0 pb-3 pt-0"
-        headerClassName="flex-row-reverse justify-end gap-2 text-sm"
-        contentContainerClass="pt-2"
-      >
-        <div className="pl-10 text-xs">{advancedOptions}</div>
-      </AdvancedDropdown>
+      {advancedOptions ? (
+        <>
+          <div className="py-3 font-semibold">
+            <Trans>Advanced options:</Trans>
+          </div>
+          {advancedOptions}
+        </>
+      ) : null}
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/PayoutsSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/PayoutsSectionDiff.tsx
@@ -1,15 +1,18 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { t } from '@lingui/macro'
-import { DISTRIBUTION_LIMIT_EXPLANATION } from 'components/strings'
+import { Trans, t } from '@lingui/macro'
 import { FundingCycleListItem } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem'
 import { DistributionLimitValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItems/DistributionLimitValue'
 import DiffedSplitList from 'components/v2v3/shared/DiffedSplits/DiffedSplitList'
 import { getV2V3CurrencyOption } from 'utils/v2v3/currency'
+import { emptySectionClasses } from './DetailsSectionDiff'
 import { DiffSection } from './DiffSection'
 import { usePayoutsSectionValues } from './hooks/usePayoutsSectionValues'
 
 export function PayoutsSectionDiff() {
   const {
+    sectionHasDiff,
+    advancedOptionsHasDiff,
+
     newCurrency,
     currentCurrency,
 
@@ -26,6 +29,14 @@ export function PayoutsSectionDiff() {
     holdFeesHasDiff,
   } = usePayoutsSectionValues()
 
+  if (!sectionHasDiff) {
+    return (
+      <div className={emptySectionClasses}>
+        <Trans>No edits were made to payouts for this cycle.</Trans>
+      </div>
+    )
+  }
+
   const roundingPrecision = newCurrency === 'ETH' ? 4 : 2
 
   const content = (
@@ -36,6 +47,7 @@ export function PayoutsSectionDiff() {
           <DistributionLimitValue
             distributionLimit={newDistributionLimit}
             currency={newCurrency}
+            shortName
           />
         }
         oldValue={
@@ -43,24 +55,30 @@ export function PayoutsSectionDiff() {
             <DistributionLimitValue
               distributionLimit={currentDistributionLimit}
               currency={currentCurrency}
+              shortName
             />
           ) : undefined
         }
-        helperText={DISTRIBUTION_LIMIT_EXPLANATION}
       />
-      <DiffedSplitList
-        splits={newPayoutSplits}
-        diffSplits={currentPayoutSplits}
-        currency={BigNumber.from(getV2V3CurrencyOption(newCurrency))}
-        projectOwnerAddress={undefined}
-        totalValue={newDistributionLimit}
-        showAmounts={!distributionLimitIsInfinite}
-        valueFormatProps={{ precision: roundingPrecision }}
-        showDiffs
-      />
+      <div className="pb-4">
+        <div className="mb-3 text-sm font-semibold">
+          <Trans>Payout recipients:</Trans>
+        </div>
+        <DiffedSplitList
+          splits={newPayoutSplits}
+          diffSplits={currentPayoutSplits}
+          currency={BigNumber.from(getV2V3CurrencyOption(newCurrency))}
+          projectOwnerAddress={undefined}
+          totalValue={newDistributionLimit}
+          showAmounts={!distributionLimitIsInfinite}
+          valueFormatProps={{ precision: roundingPrecision }}
+          showDiffs
+        />
+      </div>
     </div>
   )
-  const advancedOptions = (
+
+  const advancedOptions = advancedOptionsHasDiff ? (
     <FundingCycleListItem
       name={t`Hold fees`}
       value={<span className="capitalize">{newHoldFees.toString()}</span>}
@@ -69,8 +87,8 @@ export function PayoutsSectionDiff() {
           <span className="capitalize">{currentHoldFees.toString()}</span>
         ) : undefined
       }
-      className="text-xs"
     />
-  )
+  ) : undefined
+
   return <DiffSection content={content} advancedOptions={advancedOptions} />
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/ReviewConfirmModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/ReviewConfirmModal.tsx
@@ -6,7 +6,11 @@ import TransactionModal from 'components/modals/TransactionModal'
 import { useSaveEditCycleData } from '../hooks/SaveEditCycleData'
 import { DetailsSectionDiff } from './DetailsSectionDiff'
 import { PayoutsSectionDiff } from './PayoutsSectionDiff'
+import { SectionCollapseHeader } from './SectionCollapseHeader'
 import { TokensSectionDiff } from './TokensSectionDiff'
+import { useDetailsSectionValues } from './hooks/useDetailsSectionValues'
+import { usePayoutsSectionValues } from './hooks/usePayoutsSectionValues'
+import { useTokensSectionValues } from './hooks/useTokensSectionValues'
 
 export function ReviewConfirmModal({
   open,
@@ -16,11 +20,15 @@ export function ReviewConfirmModal({
   onClose: VoidFunction
 }) {
   const { saveEditCycleLoading, saveEditCycle } = useSaveEditCycleData()
+  const { sectionHasDiff: detailsSectionHasDiff } = useDetailsSectionValues()
+  const { sectionHasDiff: payoutsSectionHasDiff } = usePayoutsSectionValues()
+  const { sectionHasDiff: tokensSectionHasDiff } = useTokensSectionValues()
 
   const onOk = () => {
     saveEditCycle()
   }
   const panelProps = { className: 'text-lg' }
+
   return (
     <TransactionModal
       open={open}
@@ -37,13 +45,40 @@ export function ReviewConfirmModal({
         </Trans>
       </p>
       <CreateCollapse>
-        <CreateCollapse.Panel key={0} header={t`Cycle details`} {...panelProps}>
+        <CreateCollapse.Panel
+          key={0}
+          header={
+            <SectionCollapseHeader
+              title={<Trans>Cycle details</Trans>}
+              hasDiff={detailsSectionHasDiff}
+            />
+          }
+          {...panelProps}
+        >
           <DetailsSectionDiff />
         </CreateCollapse.Panel>
-        <CreateCollapse.Panel key={1} header={t`Payouts`} {...panelProps}>
+        <CreateCollapse.Panel
+          key={1}
+          header={
+            <SectionCollapseHeader
+              title={<Trans>Payouts</Trans>}
+              hasDiff={payoutsSectionHasDiff}
+            />
+          }
+          {...panelProps}
+        >
           <PayoutsSectionDiff />
         </CreateCollapse.Panel>
-        <CreateCollapse.Panel key={2} header={t`Tokens`} {...panelProps}>
+        <CreateCollapse.Panel
+          key={2}
+          header={
+            <SectionCollapseHeader
+              title={<Trans>Tokens</Trans>}
+              hasDiff={tokensSectionHasDiff}
+            />
+          }
+          {...panelProps}
+        >
           <TokensSectionDiff />
         </CreateCollapse.Panel>
       </CreateCollapse>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/SectionCollapseHeader.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/SectionCollapseHeader.tsx
@@ -1,0 +1,28 @@
+import { Trans } from '@lingui/macro'
+import { Badge } from 'components/Badge'
+
+export function SectionCollapseHeader({
+  title,
+  hasDiff,
+}: {
+  title: React.ReactNode
+  hasDiff: boolean
+}) {
+  const sectionHasEditsCard = (
+    <Badge variant="warning">
+      <Trans>Edited</Trans>
+    </Badge>
+  )
+
+  const sectionNoEditsCard = (
+    <Badge variant="info">
+      <Trans>No changes</Trans>
+    </Badge>
+  )
+  return (
+    <div className="flex items-center gap-2">
+      {title}
+      {hasDiff ? sectionHasEditsCard : sectionNoEditsCard}
+    </div>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
@@ -1,13 +1,5 @@
-import { t } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import { useProjectContext } from 'components/ProjectDashboard/hooks'
-import {
-  DISCOUNT_RATE_EXPLANATION,
-  MINT_RATE_EXPLANATION,
-  OWNER_MINTING_EXPLANATION,
-  PAUSE_TRANSFERS_EXPLANATION,
-  REDEMPTION_RATE_EXPLANATION,
-  RESERVED_RATE_EXPLANATION,
-} from 'components/strings'
 import { FundingCycleListItem } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem'
 import { AllowMintingValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/AllowMintingValue'
 import { PauseTransfersValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/RulesListItems/PauseTransfersValue'
@@ -19,12 +11,15 @@ import {
   formatRedemptionRate,
   formatReservedRate,
 } from 'utils/v2v3/math'
+import { emptySectionClasses } from './DetailsSectionDiff'
 import { DiffSection } from './DiffSection'
 import { useTokensSectionValues } from './hooks/useTokensSectionValues'
 
 export function TokensSectionDiff() {
   const { projectOwnerAddress } = useProjectContext()
   const {
+    sectionHasDiff,
+
     newMintRate,
     currentMintRate,
     mintRateHasDiff,
@@ -57,6 +52,14 @@ export function TokensSectionDiff() {
     tokenSymbolPlural,
   } = useTokensSectionValues()
 
+  if (!sectionHasDiff) {
+    return (
+      <div className={emptySectionClasses}>
+        <Trans>No edits were made to tokens for this cycle.</Trans>
+      </div>
+    )
+  }
+
   const formattedReservedRate = parseFloat(formatReservedRate(newReservedRate))
 
   const content = (
@@ -78,13 +81,7 @@ export function TokensSectionDiff() {
             />
           ) : undefined
         }
-        helperText={MINT_RATE_EXPLANATION}
       />
-    </div>
-  )
-
-  const advancedOptions = (
-    <>
       <FundingCycleListItem
         name={t`Reserved tokens`}
         value={
@@ -98,17 +95,21 @@ export function TokensSectionDiff() {
             <ReservedRateValue value={currentReservedRate} />
           ) : undefined
         }
-        helperText={RESERVED_RATE_EXPLANATION}
       />
       {newReservedRate?.gt(0) ? (
-        <DiffedSplitList
-          splits={newReservedSplits}
-          diffSplits={currentReservedSplits}
-          projectOwnerAddress={projectOwnerAddress}
-          totalValue={undefined}
-          reservedRate={formattedReservedRate}
-          showDiffs
-        />
+        <div className="pb-4">
+          <div className="mb-3 text-sm font-semibold">
+            <Trans>Reserved recipients:</Trans>
+          </div>
+          <DiffedSplitList
+            splits={newReservedSplits}
+            diffSplits={currentReservedSplits}
+            projectOwnerAddress={projectOwnerAddress}
+            totalValue={undefined}
+            reservedRate={formattedReservedRate}
+            showDiffs
+          />
+        </div>
       ) : null}
 
       <FundingCycleListItem
@@ -119,7 +120,6 @@ export function TokensSectionDiff() {
             ? `${formatDiscountRate(currentDiscountRate)}%`
             : undefined
         }
-        helperText={DISCOUNT_RATE_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Redemption rate`}
@@ -129,7 +129,6 @@ export function TokensSectionDiff() {
             ? `${formatRedemptionRate(currentRedemptionRate)}%`
             : undefined
         }
-        helperText={REDEMPTION_RATE_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Project owner token minting`}
@@ -139,7 +138,6 @@ export function TokensSectionDiff() {
             <AllowMintingValue allowMinting={currentAllowMinting} />
           ) : undefined
         }
-        helperText={OWNER_MINTING_EXPLANATION}
       />
       <FundingCycleListItem
         name={t`Token transfers`}
@@ -149,10 +147,9 @@ export function TokensSectionDiff() {
             <PauseTransfersValue pauseTransfers={currentPauseTransfers} />
           ) : undefined
         }
-        helperText={PAUSE_TRANSFERS_EXPLANATION}
       />
-    </>
+    </div>
   )
 
-  return <DiffSection content={content} advancedOptions={advancedOptions} />
+  return <DiffSection content={content} />
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useDetailsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useDetailsSectionValues.ts
@@ -49,6 +49,12 @@ export const useDetailsSectionValues = () => {
   )
   const allowSetControllerHasDiff = currentSetController !== newSetController
 
+  const advancedOptionsHasDiff =
+    pausePayHasDiff || allowSetTerminalsHasDiff || allowSetControllerHasDiff
+
+  const sectionHasDiff =
+    durationHasDiff || ballotHasDiff || advancedOptionsHasDiff
+
   return {
     currentDuration,
     newDuration,
@@ -69,5 +75,8 @@ export const useDetailsSectionValues = () => {
     newSetController,
     currentSetController,
     allowSetControllerHasDiff,
+
+    advancedOptionsHasDiff,
+    sectionHasDiff,
   }
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
@@ -43,6 +43,9 @@ export const usePayoutsSectionValues = () => {
   const currentHoldFees = Boolean(currentFundingCycleMetadata?.holdFees)
   const holdFeesHasDiff = newHoldFees !== currentHoldFees
 
+  const advancedOptionsHasDiff = holdFeesHasDiff
+  const sectionHasDiff = distributionLimitHasDiff || advancedOptionsHasDiff // TODO: || payoutSplitsHasDiff
+
   return {
     newCurrency,
     currentCurrency,
@@ -54,9 +57,13 @@ export const usePayoutsSectionValues = () => {
 
     currentPayoutSplits,
     newPayoutSplits,
+    // TODO: payoutSplitsHasDiff,
 
     newHoldFees,
     currentHoldFees,
     holdFeesHasDiff,
+
+    advancedOptionsHasDiff,
+    sectionHasDiff,
   }
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
@@ -91,6 +91,14 @@ export const useTokensSectionValues = () => {
     newPauseTransfers !== currentPauseTransfers,
   )
 
+  const advancedOptionsHasDiff =
+    reservedRateHasDiff ||
+    discountRateHasDiff ||
+    redemptionHasDiff ||
+    allowMintingHasDiff ||
+    pauseTransfersHasDiff
+  const sectionHasDiff = mintRateHasDiff || advancedOptionsHasDiff
+
   return {
     newMintRate,
     currentMintRate,
@@ -102,7 +110,7 @@ export const useTokensSectionValues = () => {
 
     newReservedSplits,
     currentReservedSplits,
-    // reservedSplitsHasDiff,
+    //TODO: reservedSplitsHasDiff,
 
     newDiscountRate,
     currentDiscountRate,
@@ -122,5 +130,8 @@ export const useTokensSectionValues = () => {
 
     tokenSymbolPlural,
     unsafeFundingCycleProperties,
+
+    advancedOptionsHasDiff,
+    sectionHasDiff,
   }
 }

--- a/src/components/v2v3/shared/DiffedItem.tsx
+++ b/src/components/v2v3/shared/DiffedItem.tsx
@@ -1,13 +1,16 @@
 import { MinusCircleIcon, PlusCircleIcon } from '@heroicons/react/24/outline'
+import { Trans } from '@lingui/macro'
+import { Tooltip } from 'antd'
 import { twJoin } from 'tailwind-merge'
 
-export const DIFF_OLD_BACKGROUND = 'bg-error-100 dark:bg-error-900 rounded-sm'
-export const DIFF_NEW_BACKGROUND = 'bg-melon-100 dark:bg-melon-900 rounded-sm'
+export const DIFF_OLD_BACKGROUND = 'bg-error-100 dark:bg-error-900'
+export const DIFF_NEW_BACKGROUND = 'bg-melon-100 dark:bg-melon-900'
 
 // whether this value the old value or a new (updated) value
 type DiffStatus = 'new' | 'old'
 
-const diffIconsMargins = 'ml-1 mr-2'
+const diffIconsMargins = 'mr-2'
+const iconsStrokeWidth = 2
 
 export function DiffPlus() {
   const className = twJoin(
@@ -16,7 +19,7 @@ export function DiffPlus() {
   )
   return (
     <span className={className}>
-      <PlusCircleIcon className="h-5 w-5" />
+      <PlusCircleIcon className="h-4 w-4" strokeWidth={iconsStrokeWidth} />
     </span>
   )
 }
@@ -28,7 +31,7 @@ export function DiffMinus() {
   )
   return (
     <span className={className}>
-      <MinusCircleIcon className="h-5 w-5" />
+      <MinusCircleIcon className="h-4 w-4" strokeWidth={iconsStrokeWidth} />
     </span>
   )
 }
@@ -50,22 +53,32 @@ export function DiffedItem({
       : undefined
 
   return (
-    <div
-      className={twJoin(
-        'text-primary ml-2 flex items-center whitespace-nowrap pr-1',
-        highlight,
-      )}
+    <Tooltip
+      title={
+        diffStatus === 'old' ? (
+          <Trans>Previous value</Trans>
+        ) : (
+          <Trans>New value</Trans>
+        )
+      }
     >
-      {hideIcon ? null : (
-        <>
-          {diffStatus === 'new' ? (
-            <DiffPlus />
-          ) : diffStatus === 'old' ? (
-            <DiffMinus />
-          ) : null}
-        </>
-      )}
-      {value}
-    </div>
+      <div
+        className={twJoin(
+          'text-primary ml-2 flex items-center whitespace-nowrap rounded-md py-1 pl-3 pr-4',
+          highlight,
+        )}
+      >
+        {hideIcon ? null : (
+          <>
+            {diffStatus === 'new' ? (
+              <DiffPlus />
+            ) : diffStatus === 'old' ? (
+              <DiffMinus />
+            ) : null}
+          </>
+        )}
+        {value}
+      </div>
+    </Tooltip>
   )
 }

--- a/src/components/v2v3/shared/DistributionLimit.tsx
+++ b/src/components/v2v3/shared/DistributionLimit.tsx
@@ -12,11 +12,13 @@ export default function DistributionLimit({
   distributionLimit,
   currencyName,
   showTooltip,
+  shortName,
 }: {
   className?: string
   distributionLimit: BigNumber | undefined
   currencyName: CurrencyName | undefined
   showTooltip?: boolean
+  shortName?: boolean
 }) {
   const distributionLimitIsInfinite =
     distributionLimit && isInfiniteDistributionLimit(distributionLimit)
@@ -51,9 +53,15 @@ export default function DistributionLimit({
   ) : null
 
   const _text = distributionLimitIsInfinite ? (
-    <Trans>No limit (all available ETH)</Trans>
+    <>
+      {shortName ? (
+        <Trans>No limit</Trans>
+      ) : (
+        <Trans>No limit (all available ETH)</Trans>
+      )}
+    </>
   ) : distributionLimitIsZero ? (
-    <Trans>Zero (no payouts)</Trans>
+    <>{shortName ? <Trans>Zero</Trans> : <Trans>Zero (no payouts)</Trans>}</>
   ) : (
     <>
       {formatFundingTarget({

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -200,6 +200,9 @@ msgstr ""
 msgid "Project owner token minting"
 msgstr ""
 
+msgid "Payout recipients:"
+msgstr ""
+
 msgid "Project launch successful"
 msgstr ""
 
@@ -1673,6 +1676,9 @@ msgstr ""
 msgid "Payments made"
 msgstr ""
 
+msgid "Reserved recipients:"
+msgstr ""
+
 msgid "Transfer ownership"
 msgstr ""
 
@@ -1854,6 +1860,9 @@ msgid "Treasury balance"
 msgstr ""
 
 msgid "DAO"
+msgstr ""
+
+msgid "Edited"
 msgstr ""
 
 msgid "Send {tokensText}"
@@ -2346,6 +2355,9 @@ msgid "Send reserved tokens"
 msgstr ""
 
 msgid "Sent reserved tokens"
+msgstr ""
+
+msgid "No edits were made to cycle details for this cycle."
 msgstr ""
 
 msgid "{nftBalanceFormatted, plural, one {NFT} other {NFTs}}"
@@ -3146,6 +3158,9 @@ msgstr ""
 msgid "1. Grant permission"
 msgstr ""
 
+msgid "No edits were made to payouts for this cycle."
+msgstr ""
+
 msgid "V1 Project handle"
 msgstr ""
 
@@ -3294,6 +3309,9 @@ msgid "This transaction edits the project's cycle."
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "New value"
 msgstr ""
 
 msgid "Find a project"
@@ -3560,6 +3578,9 @@ msgstr ""
 msgid "Display ERC-20 tokens and other Juicebox project tokens that are in this project's owner's wallet."
 msgstr ""
 
+msgid "Previous value"
+msgstr ""
+
 msgid "Owner token minting:"
 msgstr ""
 
@@ -3810,6 +3831,9 @@ msgid "Something went wrong."
 msgstr ""
 
 msgid "Avatar"
+msgstr ""
+
+msgid "No changes"
 msgstr ""
 
 msgid "Project ENS name"
@@ -4233,6 +4257,9 @@ msgid "Has Juicebox been audited? What are the risks?"
 msgstr ""
 
 msgid "Customization"
+msgstr ""
+
+msgid "No limit"
 msgstr ""
 
 msgid "Block number"
@@ -4968,6 +4995,9 @@ msgid "Unlocked Cycles"
 msgstr ""
 
 msgid "Add token"
+msgstr ""
+
+msgid "No edits were made to tokens for this cycle."
 msgstr ""
 
 msgid "Your rules are locked during a cycle. With no duration, edits can be made at any time."


### PR DESCRIPTION
- Updates "Review and confirm" modal according to latest Strath design updates:

- [x] Adds badge to big collapses
- [x] Tidies up styles for diffed items (spacing, padding, rounding)
- [x] Changes the advanced options 
- [x] If section has no diff, shows different state

<img width="1405" alt="Screen Shot 2023-08-21 at 4 19 53 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/77257e56-a415-4417-b3ca-42248a189b49">

<img width="553" alt="Screen Shot 2023-08-21 at 4 33 00 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/b8edf217-1bcf-4693-9498-afd00ea34875">

<img width="543" alt="Screen Shot 2023-08-21 at 4 34 00 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/1f00e136-334f-4b56-ba62-cef0e4198ba9">

