### PR TITLE
Edit cycle [4/n]: Tx success modal + fix memo

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/ProjectSettingsLayout.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/ProjectSettingsLayout.tsx
@@ -14,7 +14,7 @@ export const ProjectSettingsLayout: React.FC<React.PropsWithChildren> = ({
 
   return (
     <>
-      <header className="sticky top-0 right-0 z-50 mb-8 border-b border-solid border-b-grey-100 bg-white dark:border-b-slate-500 dark:bg-slate-900">
+      <header className="sticky top-0 right-0 z-10 mb-8 border-b border-solid border-b-grey-100 bg-white dark:border-b-slate-500 dark:bg-slate-900">
         <div className="mx-auto flex max-w-5xl items-center justify-between p-5">
           <h1 className="m-0 flex items-center gap-2 font-heading text-xl font-medium">
             <Cog6ToothIcon className="h-6 w-6" />

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -73,6 +73,10 @@ export function EditCyclePage() {
           >
             <TokensSection />
           </EditCycleFormSection>
+          <ReviewConfirmModal
+            open={confirmModalOpen}
+            onClose={() => setConfirmModalOpen(false)}
+          />
         </Form>
       </div>
 
@@ -89,10 +93,6 @@ export function EditCyclePage() {
           <Trans>Save changes</Trans>
         </Button>
       </div>
-      <ReviewConfirmModal
-        open={confirmModalOpen}
-        onClose={() => setConfirmModalOpen(false)}
-      />
     </div>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -77,6 +77,7 @@ export function HeaderRows() {
         open={addRecipientModalOpen}
         onOk={handleAddRecipientModalOk}
         onCancel={() => setAddRecipientModalOpen(false)}
+        hideProjectOwnerOption
       />
     </>
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRowMenu.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRowMenu.tsx
@@ -1,0 +1,39 @@
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { Trans } from '@lingui/macro'
+import { PopupMenu } from 'components/ui/PopupMenu'
+
+export function PayoutSplitRowMenu({
+  onEditClick,
+  onDeleteClick,
+}: {
+  onEditClick: VoidFunction
+  onDeleteClick: VoidFunction
+}) {
+  const menuItemsLabelClass = 'flex gap-2 items-center'
+  const menuItemsIconClass = 'h-5 w-5'
+
+  const menuItems = [
+    {
+      id: 'edit',
+      label: (
+        <div className={menuItemsLabelClass}>
+          <PencilIcon className={menuItemsIconClass} />
+          <Trans>Edit</Trans>
+        </div>
+      ),
+      onClick: onEditClick,
+    },
+    {
+      id: 'delete',
+      label: (
+        <div className={menuItemsLabelClass}>
+          <TrashIcon className={menuItemsIconClass} />
+          <Trans>Delete</Trans>
+        </div>
+      ),
+      onClick: onDeleteClick,
+    },
+  ]
+
+  return <PopupMenu items={menuItems} />
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -18,6 +18,7 @@ import {
 } from 'utils/v2v3/currency'
 import {
   adjustedSplitPercents,
+  ensureSplitsSumTo100Percent,
   getNewDistributionLimit,
 } from 'utils/v2v3/distributions'
 import { MAX_DISTRIBUTION_LIMIT, SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
@@ -237,7 +238,9 @@ export const usePayoutsTable = () => {
     editingPayoutSplit: Split
     newAmount: number
   }) {
-    const _amount = isProjectSplit(editingPayoutSplit)
+    const _amount = Number.isNaN(newAmount)
+      ? 0
+      : isProjectSplit(editingPayoutSplit)
       ? newAmount
       : deriveAmountBeforeFee(newAmount)
     // Convert the newAmount to its percentage of the new DL in parts-per-bill
@@ -280,7 +283,7 @@ export const usePayoutsTable = () => {
     )
 
     setDistributionLimit(newDistributionLimit)
-    setPayoutSplits(newPayoutSplits)
+    setPayoutSplits(ensureSplitsSumTo100Percent({ splits: newPayoutSplits }))
   }
 
   /**

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/EditCycleSuccessModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/EditCycleSuccessModal.tsx
@@ -1,0 +1,59 @@
+import { CheckCircleIcon } from '@heroicons/react/24/outline'
+import { Trans } from '@lingui/macro'
+import { Button, Modal } from 'antd'
+import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
+import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
+import Link from 'next/link'
+import { useContext } from 'react'
+import { settingsPagePath, v2v3ProjectRoute } from 'utils/routes'
+
+export function EditCycleSuccessModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: VoidFunction
+}) {
+  const { projectId } = useContext(ProjectMetadataContext)
+  const { handle } = useContext(V2V3ProjectContext)
+
+  const checkIconWithBackground = (
+    <div className="flex h-20 w-20 items-center justify-center rounded-full bg-melon-100 dark:bg-melon-950">
+      <div className="flex h-[60px] w-[60px] items-center justify-center rounded-full bg-melon-200 dark:bg-melon-900">
+        <CheckCircleIcon className="h-10 w-10 text-melon-700 dark:text-melon-500" />
+      </div>
+    </div>
+  )
+
+  const buttonClasses = 'w-[185px] h-12'
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      okButtonProps={{ hidden: true }}
+      cancelButtonProps={{ hidden: true }}
+    >
+      <div className="flex w-full flex-col items-center gap-4 pt-2 text-center">
+        {checkIconWithBackground}
+        <div className="w-80 pt-1 text-2xl font-medium">
+          <Trans>Your updated cycle has been deployed</Trans>
+        </div>
+        <div className="text-secondary pb-6">
+          <Trans>Changes will take effect when your next cycle starts.</Trans>
+        </div>
+        <div className="flex gap-2.5">
+          <Link href={settingsPagePath(undefined, { projectId, handle })}>
+            <Button type="ghost" className={buttonClasses}>
+              <Trans>Back to settings</Trans>
+            </Button>
+          </Link>
+          <Link href={v2v3ProjectRoute({ projectId, handle })}>
+            <Button type="primary" className={buttonClasses}>
+              <Trans>Go to project</Trans>
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/ReviewConfirmModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/ReviewConfirmModal.tsx
@@ -1,10 +1,15 @@
 import { Trans, t } from '@lingui/macro'
 import { Form } from 'antd'
+import { useWatch } from 'antd/lib/form/Form'
 import { CreateCollapse } from 'components/Create/components/CreateCollapse'
 import { JuiceTextArea } from 'components/inputs/JuiceTextArea'
 import TransactionModal from 'components/modals/TransactionModal'
-import { useSaveEditCycleData } from '../hooks/SaveEditCycleData'
+import { useState } from 'react'
+import { useReconfigureFundingCycle } from '../../ReconfigureFundingCycleSettingsPage/hooks/useReconfigureFundingCycle'
+import { useEditCycleFormContext } from '../EditCycleFormContext'
+import { usePrepareSaveEditCycleData } from '../hooks/PrepareSaveEditCycleData'
 import { DetailsSectionDiff } from './DetailsSectionDiff'
+import { EditCycleSuccessModal } from './EditCycleSuccessModal'
 import { PayoutsSectionDiff } from './PayoutsSectionDiff'
 import { SectionCollapseHeader } from './SectionCollapseHeader'
 import { TokensSectionDiff } from './TokensSectionDiff'
@@ -19,76 +24,105 @@ export function ReviewConfirmModal({
   open: boolean
   onClose: VoidFunction
 }) {
-  const { saveEditCycleLoading, saveEditCycle } = useSaveEditCycleData()
+  const [editCycleSuccessModalOpen, setEditCycleSuccessModalOpen] =
+    useState<boolean>(false)
+
+  const { editCycleForm } = useEditCycleFormContext()
+
   const { sectionHasDiff: detailsSectionHasDiff } = useDetailsSectionValues()
   const { sectionHasDiff: payoutsSectionHasDiff } = usePayoutsSectionValues()
   const { sectionHasDiff: tokensSectionHasDiff } = useTokensSectionValues()
 
-  const onOk = () => {
-    saveEditCycle()
-  }
+  const memo = useWatch('memo', editCycleForm)
+  const { editingFundingCycleConfig } = usePrepareSaveEditCycleData()
+
+  const { reconfigureLoading, reconfigureFundingCycle } =
+    useReconfigureFundingCycle({
+      editingFundingCycleConfig,
+      memo: memo ?? '',
+      onComplete: () => {
+        setEditCycleSuccessModalOpen(true)
+        onClose()
+      },
+    })
+
   const panelProps = { className: 'text-lg' }
 
   return (
-    <TransactionModal
-      open={open}
-      title={<Trans>Review & confirm</Trans>}
-      destroyOnClose
-      onOk={onOk}
-      okText={<Trans>Deploy changes</Trans>}
-      onCancel={onClose}
-      confirmLoading={saveEditCycleLoading}
-    >
-      <p className="text-secondary text-sm">
-        <Trans>
-          Please check your details carefully. Each change will incur a gas fee.
-        </Trans>
-      </p>
-      <CreateCollapse>
-        <CreateCollapse.Panel
-          key={0}
-          header={
-            <SectionCollapseHeader
-              title={<Trans>Cycle details</Trans>}
-              hasDiff={detailsSectionHasDiff}
-            />
-          }
-          {...panelProps}
-        >
-          <DetailsSectionDiff />
-        </CreateCollapse.Panel>
-        <CreateCollapse.Panel
-          key={1}
-          header={
-            <SectionCollapseHeader
-              title={<Trans>Payouts</Trans>}
-              hasDiff={payoutsSectionHasDiff}
-            />
-          }
-          {...panelProps}
-        >
-          <PayoutsSectionDiff />
-        </CreateCollapse.Panel>
-        <CreateCollapse.Panel
-          key={2}
-          header={
-            <SectionCollapseHeader
-              title={<Trans>Tokens</Trans>}
-              hasDiff={tokensSectionHasDiff}
-            />
-          }
-          {...panelProps}
-        >
-          <TokensSectionDiff />
-        </CreateCollapse.Panel>
-      </CreateCollapse>
-      <Form.Item name="memo" className="mt-10">
-        <JuiceTextArea
-          rows={4}
-          placeholder={t`Add an on-chain note about this cycle.`}
-          maxLength={256}
-        />
-      </Form.Item>
-    </TransactionModal>
+    <>
+      <TransactionModal
+        open={open}
+        title={<Trans>Review & confirm</Trans>}
+        destroyOnClose
+        onOk={reconfigureFundingCycle}
+        okText={<Trans>Deploy changes</Trans>}
+        cancelButtonProps={{ hidden: true }}
+        onCancel={onClose}
+        confirmLoading={reconfigureLoading}
+      >
+        <p className="text-secondary text-sm">
+          <Trans>
+            Please check your details carefully. Each change will incur a gas
+            fee.
+          </Trans>
+        </p>
+        <CreateCollapse>
+          <CreateCollapse.Panel
+            key={0}
+            header={
+              <SectionCollapseHeader
+                title={<Trans>Cycle details</Trans>}
+                hasDiff={detailsSectionHasDiff}
+              />
+            }
+            {...panelProps}
+          >
+            <DetailsSectionDiff />
+          </CreateCollapse.Panel>
+          <CreateCollapse.Panel
+            key={1}
+            header={
+              <SectionCollapseHeader
+                title={<Trans>Payouts</Trans>}
+                hasDiff={payoutsSectionHasDiff}
+              />
+            }
+            {...panelProps}
+          >
+            <PayoutsSectionDiff />
+          </CreateCollapse.Panel>
+          <CreateCollapse.Panel
+            key={2}
+            header={
+              <SectionCollapseHeader
+                title={<Trans>Tokens</Trans>}
+                hasDiff={tokensSectionHasDiff}
+              />
+            }
+            {...panelProps}
+          >
+            <TokensSectionDiff />
+          </CreateCollapse.Panel>
+        </CreateCollapse>
+        <div className="mt-8 mb-1 font-medium">
+          <Trans>
+            Memo <span className="text-secondary font-normal">(optional)</span>
+          </Trans>
+        </div>
+        <Form.Item name="memo">
+          <JuiceTextArea
+            rows={4}
+            name="memo"
+            placeholder={t`Add an on-chain note about this cycle.`}
+            maxLength={256}
+            showCount={true}
+          />
+        </Form.Item>
+      </TransactionModal>
+      <EditCycleSuccessModal
+        open={editCycleSuccessModalOpen}
+        onClose={() => setEditCycleSuccessModalOpen(false)}
+      />
+    </>
   )
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
@@ -66,7 +66,7 @@ export function TokensSectionDiff() {
         <div className="mb-5 flex flex-col gap-3 text-sm">
           {mintRateHasDiff && currentMintRate && (
             <FundingCycleListItem
-              name={t`Total issuance rate`}
+              name={t`Total issuance`}
               value={
                 <MintRateValue
                   value={newMintRate}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
@@ -5,7 +5,7 @@ import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useContext } from 'react'
 import { parseWad } from 'utils/format/formatNumber'
 import { splitsListsHaveDiff } from 'utils/splits'
-import { V2V3CurrencyName, V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
+import { V2V3CurrencyName } from 'utils/v2v3/currency'
 import { distributionLimitsEqual } from 'utils/v2v3/distributions'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 import { useEditCycleFormContext } from '../../EditCycleFormContext'
@@ -29,17 +29,17 @@ export const usePayoutsSectionValues = () => {
   const newCurrency: CurrencyName = editCycleForm?.getFieldValue(
     'distributionLimitCurrency',
   )
-  const currentCurrency = V2V3CurrencyName(
-    (currentCurrencyOption?.toNumber() ??
-      V2V3_CURRENCY_ETH) as V2V3CurrencyOption,
-  )
+  const currentCurrency =
+    V2V3CurrencyName(currentCurrencyOption?.toNumber() as V2V3CurrencyOption) ??
+    'ETH'
   const currencyHasDiff = currentCurrency !== newCurrency
 
   const newDistributionLimitNum =
     editCycleForm?.getFieldValue('distributionLimit')
-  const newDistributionLimit = newDistributionLimitNum
-    ? parseWad(newDistributionLimitNum)
-    : undefined
+  const newDistributionLimit =
+    newDistributionLimitNum !== undefined
+      ? parseWad(newDistributionLimitNum)
+      : undefined
   const distributionLimitHasDiff =
     !distributionLimitsEqual(currentDistributionLimit, newDistributionLimit) ||
     currencyHasDiff

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
@@ -9,6 +9,7 @@ import {
 } from 'utils/v2v3/fundingCycle'
 import {
   discountRateFrom,
+  formatIssuanceRate,
   issuanceRateFrom,
   reservedRateFrom,
 } from 'utils/v2v3/math'
@@ -39,7 +40,11 @@ export const useTokensSectionValues = () => {
     plural: true,
   })
 
-  const newMintRate = BigNumber.from(issuanceRateFrom(formValues.mintRate))
+  const newMintRateNum = parseFloat(formValues.mintRate)
+  const newMintRate = BigNumber.from(
+    issuanceRateFrom(newMintRateNum.toString()),
+  )
+
   const newReservedRate = reservedRateFrom(formValues.reservedTokens)
   const newReservedSplits = formValues.reservedSplits
   const newDiscountRate = discountRateFrom(formValues.discountRate)
@@ -48,6 +53,10 @@ export const useTokensSectionValues = () => {
   const newPauseTransfers = formValues.pauseTransfers
 
   const currentMintRate = currentFundingCycle?.weight
+  const currentMintRateNum = currentMintRate
+    ? parseFloat(formatIssuanceRate(currentMintRate.toString()))
+    : undefined
+
   const currentReservedRate = currentFundingCycleMetadata?.reservedRate
   const currentDiscountRate = currentFundingCycle?.discountRate
   const currentRedemptionRate = currentFundingCycleMetadata?.redemptionRate
@@ -67,9 +76,7 @@ export const useTokensSectionValues = () => {
     )
 
   const mintRateHasDiff = Boolean(
-    currentMintRate &&
-      !newMintRate.eq(currentMintRate) &&
-      !onlyDiscountRateApplied,
+    currentMintRateNum !== newMintRateNum && !onlyDiscountRateApplied,
   )
 
   const reservedRateHasDiff = Boolean(

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
@@ -95,7 +95,6 @@ export const useLoadEditCycleData = () => {
           initialEditingData.fundingCycleMetadata.useDataSourceForRedeem,
         memo: '',
       }
-
       setInitialFormData(formData)
       editCycleForm.setFieldsValue(formData)
     }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/PrepareSaveEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/PrepareSaveEditCycleData.tsx
@@ -29,11 +29,10 @@ import {
   EditingFundingCycleConfig,
   useEditingFundingCycleConfig,
 } from '../../ReconfigureFundingCycleSettingsPage/hooks/useEditingFundingCycleConfig'
-import { useReconfigureFundingCycle } from '../../ReconfigureFundingCycleSettingsPage/hooks/useReconfigureFundingCycle'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
 import { EditCycleFormFields } from '../EditCycleFormFields'
 
-export const useSaveEditCycleData = () => {
+export const usePrepareSaveEditCycleData = () => {
   // Use Redux to get current (pre-edit) project state since it's not changed by edit
   // Only using this to get values of FC parameters not supported in the FC form (e.g. allowTerminalMigration, etc.)
   const reduxConfig = useEditingFundingCycleConfig()
@@ -45,8 +44,7 @@ export const useSaveEditCycleData = () => {
 
   if (!editCycleForm)
     return {
-      saveEditCycleLoading: false,
-      saveEditCycle: () => null,
+      editingFundingCycleConfig: reduxConfig,
     }
 
   const fundingCycleMetadata = reduxConfig.editingFundingCycleMetadata
@@ -121,17 +119,8 @@ export const useSaveEditCycleData = () => {
     editingNftRewards,
     editingMustStartAtOrAfter: DEFAULT_MUST_START_AT_OR_AFTER,
   }
-  const {
-    reconfigureLoading: saveEditCycleLoading,
-    reconfigureFundingCycle: saveEditCycle,
-  } = useReconfigureFundingCycle({
-    editingFundingCycleConfig,
-    memo: formValues.memo ?? '',
-    launchedNewNfts: false, // TODO: isLaunchingNewCollection,
-  })
 
   return {
-    saveEditCycleLoading,
-    saveEditCycle,
+    editingFundingCycleConfig,
   }
 }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/useReconfigureFundingCycle.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ReconfigureFundingCycleSettingsPage/hooks/useReconfigureFundingCycle.ts
@@ -45,10 +45,12 @@ export const useReconfigureFundingCycle = ({
   editingFundingCycleConfig,
   memo,
   launchedNewNfts,
+  onComplete,
 }: {
   editingFundingCycleConfig: EditingFundingCycleConfig
   memo: string
   launchedNewNfts?: boolean
+  onComplete?: VoidFunction
 }) => {
   const { fundingCycle } = useContext(V2V3ProjectContext)
   const { projectId } = useContext(ProjectMetadataContext)
@@ -124,7 +126,11 @@ export const useReconfigureFundingCycle = ({
           })
         }
         setReconfigureTxLoading(false)
-        reloadWindow()
+        if (onComplete) {
+          onComplete()
+        } else {
+          reloadWindow()
+        }
       },
     }
 
@@ -161,6 +167,7 @@ export const useReconfigureFundingCycle = ({
     nftRewardsCids,
     fundingCycle,
     memo,
+    onComplete,
     projectId,
   ])
 

--- a/src/components/v2v3/shared/Allocation/AddEditAllocationModal.tsx
+++ b/src/components/v2v3/shared/Allocation/AddEditAllocationModal.tsx
@@ -54,6 +54,7 @@ export const AddEditAllocationModal = ({
   open,
   onOk,
   onCancel,
+  hideProjectOwnerOption,
 }: {
   className?: string
   allocationName: string
@@ -62,6 +63,7 @@ export const AddEditAllocationModal = ({
   open?: boolean
   onOk: (split: AddEditAllocationModalEntity) => void
   onCancel: VoidFunction
+  hideProjectOwnerOption?: boolean
 }) => {
   const { primaryETHTerminalFee } = useContext(V2V3ProjectContext)
 
@@ -190,7 +192,8 @@ export const AddEditAllocationModal = ({
   const showProjectOwnerRecipientOption =
     amountType !== 'percentage' &&
     (!allocations.length ||
-      ceilIfCloseToNextInteger(totalAllocationPercent) === 100)
+      ceilIfCloseToNextInteger(totalAllocationPercent) === 100) &&
+    !hideProjectOwnerOption
 
   const projectId = Form.useWatch('juiceboxProjectId', form)
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -326,6 +326,9 @@ msgstr ""
 msgid "<0>Snapshot</0> is an off-chain voting system. You can use your Juicebox project tokens in a Snapshot voting strategy. <1>Learn more</1>."
 msgstr ""
 
+msgid "Changes will take effect when your next cycle starts."
+msgstr ""
+
 msgid "See example"
 msgstr ""
 
@@ -939,6 +942,9 @@ msgid "Automated"
 msgstr ""
 
 msgid "Design how your tokens should work."
+msgstr ""
+
+msgid "Back to settings"
 msgstr ""
 
 msgid "Project {projectId} not found"
@@ -2159,6 +2165,9 @@ msgstr ""
 msgid "{count} total"
 msgstr ""
 
+msgid "Your updated cycle has been deployed"
+msgstr ""
+
 msgid "Edit NFTs"
 msgstr ""
 
@@ -2343,6 +2352,9 @@ msgid "Project balance"
 msgstr ""
 
 msgid "Available to pay out"
+msgstr ""
+
+msgid "Memo <0>(optional)</0>"
 msgstr ""
 
 msgid "Max. supply reached"

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -2,6 +2,7 @@
 .ant-input-affix-wrapper .ant-input,
 .ant-input-textarea textarea {
   @apply text-primary;
+  @apply py-1.5;
 }
 
 .ant-input-number,

--- a/src/utils/v2v3/distributions.ts
+++ b/src/utils/v2v3/distributions.ts
@@ -5,12 +5,13 @@ import { fromWad, parseWad } from 'utils/format/formatNumber'
 import { isInfiniteDistributionLimit } from './fundingCycle'
 import {
   MAX_DISTRIBUTION_LIMIT,
+  SPLITS_TOTAL_PERCENT,
   preciseFormatSplitPercent,
   splitPercentFrom,
 } from './math'
 
 /**
- * Gets amount from percent of a bigger amount (rounded to 4dp)
+ * Gets amount from percent of a bigger amount
  * @param percent {float} - value as a percentage.
  * @param amount string (hexString)
  * @returns {number} distribution amount
@@ -27,7 +28,7 @@ export function amountFromPercent({
 
 /**
  * Gets split percent from split amount and the distribution limit
- * @param percent {float} - value as a percentage.
+ * @param amount {float} - value as a percentage.
  * @param distributionLimit number
  * @returns {number} percent as an actual percentage of distribution limit (/100)
  */
@@ -51,6 +52,52 @@ export function getTotalSplitsPercentage(splits: Split[]) {
     (acc, curr) => acc + preciseFormatSplitPercent(curr.percent),
     0,
   )
+}
+
+/**
+ * Due to limitations of rounding errors, it's possible that adjustedSplitPercents causes
+ * the splits to sum to 99.99999999% or 100.0000001% (causes error) instead of 100%.
+ * This function does one final pass of the percents to ensure they sum to 100%.
+ * @param splits {Split[]} - list of current splits to possibly have their percents adjusted
+ * @returns {Split[]} splits with their percents adjusted
+ */
+export function ensureSplitsSumTo100Percent({
+  splits,
+}: {
+  splits: Split[]
+}): Split[] {
+  // Calculate the percent total of the splits
+  const currentTotal = splits.reduce((sum, split) => sum + split.percent, 0)
+  // If the current total is already equal to SPLITS_TOTAL_PERCENT, no adjustment needed
+  if (currentTotal === SPLITS_TOTAL_PERCENT) {
+    return splits
+  }
+
+  // Calculate the ratio to adjust each split by
+  const ratio = SPLITS_TOTAL_PERCENT / currentTotal
+
+  // Adjust each split
+  const adjustedSplits = splits.map(split => ({
+    ...split,
+    percent: Math.round(split.percent * ratio),
+  }))
+
+  // Calculate the total after adjustment
+  const adjustedTotal = adjustedSplits.reduce(
+    (sum, split) => sum + split.percent,
+    0,
+  )
+  if (adjustedTotal === SPLITS_TOTAL_PERCENT) {
+    return adjustedSplits
+  }
+
+  // If there's STILL a difference due to rounding errors, adjust the largest split
+  const difference = SPLITS_TOTAL_PERCENT - adjustedTotal
+  const largestSplitIndex = adjustedSplits.findIndex(
+    split => split.percent === Math.max(...adjustedSplits.map(s => s.percent)),
+  )
+  adjustedSplits[largestSplitIndex].percent += difference
+  return adjustedSplits
 }
 
 /**
@@ -156,11 +203,10 @@ export function distributionLimitsEqual(
   distributionLimit1: BigNumber | undefined,
   distributionLimit2: BigNumber | undefined,
 ) {
-  const distributionLimit1IsInfinite =
-    !distributionLimit1 || isInfiniteDistributionLimit(distributionLimit1)
-  const distributionLimit2IsInfinite =
-    !distributionLimit2 || isInfiniteDistributionLimit(distributionLimit2)
-  if (distributionLimit1IsInfinite && distributionLimit2IsInfinite) {
+  if (
+    isInfiniteDistributionLimit(distributionLimit1) &&
+    isInfiniteDistributionLimit(distributionLimit2)
+  ) {
     return true
   }
   return distributionLimit1?.eq(distributionLimit2 ?? 0)

--- a/src/utils/v2v3/fundingCycle.ts
+++ b/src/utils/v2v3/fundingCycle.ts
@@ -177,8 +177,13 @@ export function hasDataSourceForPay(
   )
 }
 
-export function isInfiniteDistributionLimit(distributionLimit: BigNumber) {
-  return distributionLimit.eq(MAX_DISTRIBUTION_LIMIT)
+export function isInfiniteDistributionLimit(
+  distributionLimit: BigNumber | undefined,
+) {
+  return (
+    distributionLimit === undefined ||
+    distributionLimit.eq(MAX_DISTRIBUTION_LIMIT)
+  )
 }
 
 // Not zero and not infinite


### PR DESCRIPTION
- Adds a modal after config tx successful:

https://github.com/jbx-protocol/juice-interface/assets/96150256/8c55842c-d3d3-4c4d-afaf-e6e7fb6e4f00

- Fixes memo functionality (moves `<ReviewConfirmModal />` into the edit cycle `<Form>`

- Updates memo styles according to latest designs:
<img width="836" alt="Screen Shot 2023-08-22 at 1 08 27 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/d970ec84-fce0-478d-a1c3-fdfe916b6803">
