### PR TITLE
Consolidate subgraph URL env vars

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -7,10 +7,7 @@ NEXT_PUBLIC_INFURA_NETWORK=
 NEXT_PUBLIC_SUBGRAPH_URL=
 
 # Query URL for Juicebox subgraph used by server
-NEXT_SUBGRAPH_URL=
-
-# Query URL for Juicebox subgraph used to load schema for graphql generation
-GRAPHQL_SCHEMA_SUBGRAPH_URL=
+SUBGRAPH_URL=
 
 # Base URL of site - for dev, just use http://localhost:3000/
 NEXT_PUBLIC_BASE_URL=

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -19,7 +19,7 @@ on:
 env:
   NEXT_PUBLIC_INFURA_NETWORK: mainnet
   PRE_RENDER_INFURA_ID: ${{ secrets.PRE_RENDER_INFURA_ID }}
-  GRAPHQL_SCHEMA_SUBGRAPH_URL: ${{ secrets.GRAPHQL_SCHEMA_SUBGRAPH_URL }}
+  SUBGRAPH_URL: ${{ secrets.SUBGRAPH_URL }}
 
 jobs:
   jest:

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: ${GRAPHQL_SCHEMA_SUBGRAPH_URL}
+schema: ${SUBGRAPH_URL}
 documents: 'src/graphql/**/*.graphql'
 generates:
   src/generated/graphql.tsx:

--- a/doc/devops.md
+++ b/doc/devops.md
@@ -25,15 +25,15 @@ We need to update the following configurations for new subgraph versions:
 #### Vercel
 
 - [ ] Update **juice-interface-goerli** project
-  - [ ] `GRAPHQL_SCHEMA_SUBGRAPH_URL`
+  - [ ] `SUBGRAPH_URL`
   - [ ] `NEXT_PUBLIC_SUBGRAPH_URL`
 - [ ] Update **juice-interface**
-  - [ ] `GRAPHQL_SCHEMA_SUBGRAPH_URL`
+  - [ ] `SUBGRAPH_URL`
   - [ ] `NEXT_PUBLIC_SUBGRAPH_URL`
 
 #### GitHub
 
-- [ ] `GRAPHQL_SCHEMA_SUBGRAPH_URL`
+- [ ] `SUBGRAPH_URL`
   1.  Select **Secrets** > **Actions**.
   2.  Locate the **Repository secrets** section.
   3.  Edit the secret variable

--- a/src/lib/apollo/subgraphUri.ts
+++ b/src/lib/apollo/subgraphUri.ts
@@ -10,11 +10,9 @@ export const subgraphUri = () => {
       )
     }
   } else {
-    uri = process.env.GRAPHQL_SCHEMA_SUBGRAPH_URL
+    uri = process.env.SUBGRAPH_URL
     if (!uri) {
-      throw new Error(
-        'GRAPHQL_SCHEMA_SUBGRAPH_URL environment variable not defined',
-      )
+      throw new Error('SUBGRAPH_URL environment variable not defined')
     }
   }
 

--- a/src/types/environment.d.ts
+++ b/src/types/environment.d.ts
@@ -19,7 +19,7 @@ declare global {
       // Ask in Discord for the goerli subgraph url
       // for both SCHEMA and SUBGRAPH_URL
       NEXT_PUBLIC_SUBGRAPH_URL: string
-      GRAPHQL_SCHEMA_SUBGRAPH_URL: string
+      SUBGRAPH_URL: string
 
       NEXT_PUBLIC_BASE_URL: PublicBaseURLS
 


### PR DESCRIPTION
Removes redundant subgraph URL vars, consolidates into 2: 
- `env.SUBGRAPH_URL` for server
- `env.NEXT_PUBLIC_SUBGRAPH_URL` for UI

**DO NOT MERGE:** Vercel + Github CI need to be updated first. CI will be broken for this PR