### PR TITLE
Edit cycle [5/n]: Small payouts table bugs

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -77,6 +77,7 @@ export function HeaderRows() {
         open={addRecipientModalOpen}
         onOk={handleAddRecipientModalOk}
         onCancel={() => setAddRecipientModalOpen(false)}
+        hideProjectOwnerOption
       />
     </>
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRowMenu.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRowMenu.tsx
@@ -1,0 +1,39 @@
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { Trans } from '@lingui/macro'
+import { PopupMenu } from 'components/ui/PopupMenu'
+
+export function PayoutSplitRowMenu({
+  onEditClick,
+  onDeleteClick,
+}: {
+  onEditClick: VoidFunction
+  onDeleteClick: VoidFunction
+}) {
+  const menuItemsLabelClass = 'flex gap-2 items-center'
+  const menuItemsIconClass = 'h-5 w-5'
+
+  const menuItems = [
+    {
+      id: 'edit',
+      label: (
+        <div className={menuItemsLabelClass}>
+          <PencilIcon className={menuItemsIconClass} />
+          <Trans>Edit</Trans>
+        </div>
+      ),
+      onClick: onEditClick,
+    },
+    {
+      id: 'delete',
+      label: (
+        <div className={menuItemsLabelClass}>
+          <TrashIcon className={menuItemsIconClass} />
+          <Trans>Delete</Trans>
+        </div>
+      ),
+      onClick: onDeleteClick,
+    },
+  ]
+
+  return <PopupMenu items={menuItems} />
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -18,6 +18,7 @@ import {
 } from 'utils/v2v3/currency'
 import {
   adjustedSplitPercents,
+  ensureSplitsSumTo100Percent,
   getNewDistributionLimit,
 } from 'utils/v2v3/distributions'
 import { MAX_DISTRIBUTION_LIMIT, SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
@@ -237,7 +238,9 @@ export const usePayoutsTable = () => {
     editingPayoutSplit: Split
     newAmount: number
   }) {
-    const _amount = isProjectSplit(editingPayoutSplit)
+    const _amount = Number.isNaN(newAmount)
+      ? 0
+      : isProjectSplit(editingPayoutSplit)
       ? newAmount
       : deriveAmountBeforeFee(newAmount)
     // Convert the newAmount to its percentage of the new DL in parts-per-bill
@@ -280,7 +283,7 @@ export const usePayoutsTable = () => {
     )
 
     setDistributionLimit(newDistributionLimit)
-    setPayoutSplits(newPayoutSplits)
+    setPayoutSplits(ensureSplitsSumTo100Percent({ splits: newPayoutSplits }))
   }
 
   /**

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
@@ -66,7 +66,7 @@ export function TokensSectionDiff() {
         <div className="mb-5 flex flex-col gap-3 text-sm">
           {mintRateHasDiff && currentMintRate && (
             <FundingCycleListItem
-              name={t`Total issuance rate`}
+              name={t`Total issuance`}
               value={
                 <MintRateValue
                   value={newMintRate}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/usePayoutsSectionValues.ts
@@ -5,7 +5,7 @@ import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useContext } from 'react'
 import { parseWad } from 'utils/format/formatNumber'
 import { splitsListsHaveDiff } from 'utils/splits'
-import { V2V3CurrencyName, V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
+import { V2V3CurrencyName } from 'utils/v2v3/currency'
 import { distributionLimitsEqual } from 'utils/v2v3/distributions'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 import { useEditCycleFormContext } from '../../EditCycleFormContext'
@@ -29,17 +29,17 @@ export const usePayoutsSectionValues = () => {
   const newCurrency: CurrencyName = editCycleForm?.getFieldValue(
     'distributionLimitCurrency',
   )
-  const currentCurrency = V2V3CurrencyName(
-    (currentCurrencyOption?.toNumber() ??
-      V2V3_CURRENCY_ETH) as V2V3CurrencyOption,
-  )
+  const currentCurrency =
+    V2V3CurrencyName(currentCurrencyOption?.toNumber() as V2V3CurrencyOption) ??
+    'ETH'
   const currencyHasDiff = currentCurrency !== newCurrency
 
   const newDistributionLimitNum =
     editCycleForm?.getFieldValue('distributionLimit')
-  const newDistributionLimit = newDistributionLimitNum
-    ? parseWad(newDistributionLimitNum)
-    : undefined
+  const newDistributionLimit =
+    newDistributionLimitNum !== undefined
+      ? parseWad(newDistributionLimitNum)
+      : undefined
   const distributionLimitHasDiff =
     !distributionLimitsEqual(currentDistributionLimit, newDistributionLimit) ||
     currencyHasDiff

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
@@ -9,6 +9,7 @@ import {
 } from 'utils/v2v3/fundingCycle'
 import {
   discountRateFrom,
+  formatIssuanceRate,
   issuanceRateFrom,
   reservedRateFrom,
 } from 'utils/v2v3/math'
@@ -39,7 +40,11 @@ export const useTokensSectionValues = () => {
     plural: true,
   })
 
-  const newMintRate = BigNumber.from(issuanceRateFrom(formValues.mintRate))
+  const newMintRateNum = parseFloat(formValues.mintRate)
+  const newMintRate = BigNumber.from(
+    issuanceRateFrom(newMintRateNum.toString()),
+  )
+
   const newReservedRate = reservedRateFrom(formValues.reservedTokens)
   const newReservedSplits = formValues.reservedSplits
   const newDiscountRate = discountRateFrom(formValues.discountRate)
@@ -48,6 +53,10 @@ export const useTokensSectionValues = () => {
   const newPauseTransfers = formValues.pauseTransfers
 
   const currentMintRate = currentFundingCycle?.weight
+  const currentMintRateNum = currentMintRate
+    ? parseFloat(formatIssuanceRate(currentMintRate.toString()))
+    : undefined
+
   const currentReservedRate = currentFundingCycleMetadata?.reservedRate
   const currentDiscountRate = currentFundingCycle?.discountRate
   const currentRedemptionRate = currentFundingCycleMetadata?.redemptionRate
@@ -67,9 +76,7 @@ export const useTokensSectionValues = () => {
     )
 
   const mintRateHasDiff = Boolean(
-    currentMintRate &&
-      !newMintRate.eq(currentMintRate) &&
-      !onlyDiscountRateApplied,
+    currentMintRateNum !== newMintRateNum && !onlyDiscountRateApplied,
   )
 
   const reservedRateHasDiff = Boolean(

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/LoadEditCycleData.tsx
@@ -95,7 +95,6 @@ export const useLoadEditCycleData = () => {
           initialEditingData.fundingCycleMetadata.useDataSourceForRedeem,
         memo: '',
       }
-
       setInitialFormData(formData)
       editCycleForm.setFieldsValue(formData)
     }

--- a/src/components/v2v3/shared/Allocation/AddEditAllocationModal.tsx
+++ b/src/components/v2v3/shared/Allocation/AddEditAllocationModal.tsx
@@ -54,6 +54,7 @@ export const AddEditAllocationModal = ({
   open,
   onOk,
   onCancel,
+  hideProjectOwnerOption,
 }: {
   className?: string
   allocationName: string
@@ -62,6 +63,7 @@ export const AddEditAllocationModal = ({
   open?: boolean
   onOk: (split: AddEditAllocationModalEntity) => void
   onCancel: VoidFunction
+  hideProjectOwnerOption?: boolean
 }) => {
   const { primaryETHTerminalFee } = useContext(V2V3ProjectContext)
 
@@ -190,7 +192,8 @@ export const AddEditAllocationModal = ({
   const showProjectOwnerRecipientOption =
     amountType !== 'percentage' &&
     (!allocations.length ||
-      ceilIfCloseToNextInteger(totalAllocationPercent) === 100)
+      ceilIfCloseToNextInteger(totalAllocationPercent) === 100) &&
+    !hideProjectOwnerOption
 
   const projectId = Form.useWatch('juiceboxProjectId', form)
 

--- a/src/utils/v2v3/distributions.ts
+++ b/src/utils/v2v3/distributions.ts
@@ -5,12 +5,13 @@ import { fromWad, parseWad } from 'utils/format/formatNumber'
 import { isInfiniteDistributionLimit } from './fundingCycle'
 import {
   MAX_DISTRIBUTION_LIMIT,
+  SPLITS_TOTAL_PERCENT,
   preciseFormatSplitPercent,
   splitPercentFrom,
 } from './math'
 
 /**
- * Gets amount from percent of a bigger amount (rounded to 4dp)
+ * Gets amount from percent of a bigger amount
  * @param percent {float} - value as a percentage.
  * @param amount string (hexString)
  * @returns {number} distribution amount
@@ -27,7 +28,7 @@ export function amountFromPercent({
 
 /**
  * Gets split percent from split amount and the distribution limit
- * @param percent {float} - value as a percentage.
+ * @param amount {float} - value as a percentage.
  * @param distributionLimit number
  * @returns {number} percent as an actual percentage of distribution limit (/100)
  */
@@ -51,6 +52,52 @@ export function getTotalSplitsPercentage(splits: Split[]) {
     (acc, curr) => acc + preciseFormatSplitPercent(curr.percent),
     0,
   )
+}
+
+/**
+ * Due to limitations of rounding errors, it's possible that adjustedSplitPercents causes
+ * the splits to sum to 99.99999999% or 100.0000001% (causes error) instead of 100%.
+ * This function does one final pass of the percents to ensure they sum to 100%.
+ * @param splits {Split[]} - list of current splits to possibly have their percents adjusted
+ * @returns {Split[]} splits with their percents adjusted
+ */
+export function ensureSplitsSumTo100Percent({
+  splits,
+}: {
+  splits: Split[]
+}): Split[] {
+  // Calculate the percent total of the splits
+  const currentTotal = splits.reduce((sum, split) => sum + split.percent, 0)
+  // If the current total is already equal to SPLITS_TOTAL_PERCENT, no adjustment needed
+  if (currentTotal === SPLITS_TOTAL_PERCENT) {
+    return splits
+  }
+
+  // Calculate the ratio to adjust each split by
+  const ratio = SPLITS_TOTAL_PERCENT / currentTotal
+
+  // Adjust each split
+  const adjustedSplits = splits.map(split => ({
+    ...split,
+    percent: Math.round(split.percent * ratio),
+  }))
+
+  // Calculate the total after adjustment
+  const adjustedTotal = adjustedSplits.reduce(
+    (sum, split) => sum + split.percent,
+    0,
+  )
+  if (adjustedTotal === SPLITS_TOTAL_PERCENT) {
+    return adjustedSplits
+  }
+
+  // If there's STILL a difference due to rounding errors, adjust the largest split
+  const difference = SPLITS_TOTAL_PERCENT - adjustedTotal
+  const largestSplitIndex = adjustedSplits.findIndex(
+    split => split.percent === Math.max(...adjustedSplits.map(s => s.percent)),
+  )
+  adjustedSplits[largestSplitIndex].percent += difference
+  return adjustedSplits
 }
 
 /**

--- a/src/utils/v2v3/distributions.ts
+++ b/src/utils/v2v3/distributions.ts
@@ -203,11 +203,10 @@ export function distributionLimitsEqual(
   distributionLimit1: BigNumber | undefined,
   distributionLimit2: BigNumber | undefined,
 ) {
-  const distributionLimit1IsInfinite =
-    !distributionLimit1 || isInfiniteDistributionLimit(distributionLimit1)
-  const distributionLimit2IsInfinite =
-    !distributionLimit2 || isInfiniteDistributionLimit(distributionLimit2)
-  if (distributionLimit1IsInfinite && distributionLimit2IsInfinite) {
+  if (
+    isInfiniteDistributionLimit(distributionLimit1) &&
+    isInfiniteDistributionLimit(distributionLimit2)
+  ) {
     return true
   }
   return distributionLimit1?.eq(distributionLimit2 ?? 0)

--- a/src/utils/v2v3/fundingCycle.ts
+++ b/src/utils/v2v3/fundingCycle.ts
@@ -177,8 +177,13 @@ export function hasDataSourceForPay(
   )
 }
 
-export function isInfiniteDistributionLimit(distributionLimit: BigNumber) {
-  return distributionLimit.eq(MAX_DISTRIBUTION_LIMIT)
+export function isInfiniteDistributionLimit(
+  distributionLimit: BigNumber | undefined,
+) {
+  return (
+    distributionLimit === undefined ||
+    distributionLimit.eq(MAX_DISTRIBUTION_LIMIT)
+  )
 }
 
 // Not zero and not infinite


### PR DESCRIPTION
1. Fixes bug where clearing a field causes NaN value and breaks
2. Writes a new function to ensure that when we want the percents to add to 100, they really do equal exactly 100. Previously, rounding errors were causing very slight (~0.00001%) discrepancies in the total percent. Nothing we can do about those rounding errors btw, they're reaching the limit of the percent fidelity in the contracts. Doesn't seem like a big deal, but if it's over 100, i.e. 100.000001, the reconfig tx breaks. Here's an example of logging that algo in action:

![Screen Shot 2023-08-22 at 12 20 20 pm](https://github.com/jbx-protocol/juice-interface/assets/96150256/88d761ea-9009-4df4-93b4-0f9047a15a6f)

<img width="284" alt="Screen Shot 2023-08-22 at 12 19 54 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/88aa280d-8d74-43fd-b9bc-9c16ed46dbc2">

