### PR TITLE
Edit cycle: Payouts table mobile, lockedUntil bug

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -15,8 +15,12 @@ import { PayoutsTableCell } from './PayoutsTableCell'
 
 export function HeaderRows() {
   const [addRecipientModalOpen, setAddRecipientModalOpen] = useState<boolean>()
-  const { distributionLimitIsInfinite, handleNewPayoutSplit, payoutSplits } =
-    usePayoutsTable()
+  const {
+    distributionLimit,
+    distributionLimitIsInfinite,
+    handleNewPayoutSplit,
+    payoutSplits,
+  } = usePayoutsTable()
 
   const handleAddRecipientModalOk = (
     newSplit: AddEditAllocationModalEntity,
@@ -33,7 +37,7 @@ export function HeaderRows() {
 
   return (
     <>
-      <PayoutsTableCell className="flex gap-10">
+      <PayoutsTableCell className="flex flex-col items-start gap-0 md:flex-row md:gap-10">
         <div className="py-5">
           <div className="mb-2 text-lg font-medium">
             <Trans>Payout recipients</Trans>
@@ -61,7 +65,7 @@ export function HeaderRows() {
                 <Trans>Add recipient</Trans>
               </span>
             </Button>
-            <PayoutTableSettings />
+            {distributionLimit === 0 ? null : <PayoutTableSettings />}
           </div>
         </div>
       </PayoutsTableCell>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRow.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutSplitRow.tsx
@@ -114,7 +114,7 @@ export function PayoutSplitRow({
                 amountPercentFieldHasEndingDecimal ? '.' : ''
               }`}
               onChange={onAmountPercentageInputChange}
-              className="h-10"
+              className="md:unset h-10 w-28"
             />
             <PayoutSplitRowMenu
               onEditClick={() => setEditModalOpen(true)}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTableRow.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/PayoutsTableRow.tsx
@@ -8,7 +8,7 @@ export function PayoutsTableRow({
   return (
     <div
       className={twMerge(
-        'text-secondary grid grid-cols-[3fr,2fr] items-center border-t border-smoke-200 text-xs dark:border-grey-600',
+        'text-secondary grid grid-cols-2 items-center border-t border-smoke-200 text-xs dark:border-grey-600 md:grid-cols-[3fr,2fr]',
         highlighted ? 'bg-grey-50 dark:bg-grey-900' : null,
         className,
       )}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -7,6 +7,7 @@ import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { useMemo } from 'react'
 import { parseWad } from 'utils/format/formatNumber'
 import {
+  getProjectOwnerRemainderSplit,
   hasEqualRecipient,
   isProjectSplit,
   totalSplitsPercent,
@@ -168,8 +169,8 @@ export const usePayoutsTable = () => {
       beneficiary: newSplit.beneficiary,
       percent: newSplitPercentPPB,
       preferClaimed: false,
-      lockedUntil: newSplit.lockedUntil,
-      projectId: newSplit.projectId,
+      lockedUntil: newSplit.lockedUntil ?? 0,
+      projectId: newSplit.projectId ?? '0x00',
       allocator: NULL_ALLOCATOR_ADDRESS,
     } as Split
 
@@ -339,9 +340,14 @@ export const usePayoutsTable = () => {
   }, 0)
 
   /* Payouts that don't go to Juicebox projects incur 2.5% fee */
-  const nonJuiceboxProjectPayoutSplits = payoutSplits.filter(
-    payoutSplit => !isProjectSplit(payoutSplit),
-  )
+  const nonJuiceboxProjectPayoutSplits = [
+    ...payoutSplits.filter(payoutSplit => !isProjectSplit(payoutSplit)),
+    getProjectOwnerRemainderSplit(
+      // remaining owner split also incurs fee
+      '',
+      payoutSplits,
+    ) as Split,
+  ]
 
   /* Count the total fee amount. If % of payouts sums > 100, just set fees to 2.5% (maximum)*/
   const totalFeeAmount =


### PR DESCRIPTION
- Fixes payouts table mobile styles:
<img width="257" alt="Screen Shot 2023-08-22 at 6 22 43 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/ecf71a3e-17b2-4ace-ad7c-5b0d2f373cc4">

- Fixes % fee total wrong when owner split exists
- Fixes adding a new payout split from no payouts causing tx not to work
- Fixes lockedUntil bug