### PR TITLE
fix: formattednumberinput

### DIFF
--- a/src/components/inputs/JuiceInputNumber.tsx
+++ b/src/components/inputs/JuiceInputNumber.tsx
@@ -1,50 +1,14 @@
-import {
-  DetailedHTMLProps,
-  InputHTMLAttributes,
-  useEffect,
-  useState,
-} from 'react'
+import { InputNumber, InputNumberProps } from 'antd'
 import { twMerge } from 'tailwind-merge'
 
-export const JuiceInputNumber = ({
-  value,
-  formatter,
-  parser,
-  onChange,
-  className,
-  ...props
-}: {
-  value?: string
-  formatter?: (s?: string | undefined) => string
-  parser?: (s?: string | undefined) => string
-  onChange?: (s?: string) => void
-  className?: string
-} & Omit<
-  DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
-  'onChange'
->) => {
-  const [val, setVal] = useState<string>()
-
-  useEffect(() => {
-    setVal(formatter ? formatter(value) : value)
-  }, [value, formatter])
-
+export const JuiceInputNumber = (props: InputNumberProps) => {
   return (
-    <input
-      value={val}
-      className={twMerge(
-        'stroke-secondary rounded-lg border border-smoke-300 bg-smoke-50 px-4 py-2 text-black dark:border-slate-300 dark:bg-slate-600 dark:placeholder:text-slate-300',
-        props.disabled ? 'text-tertiary' : 'text-primary dark:text-slate-100',
-        className,
-      )}
-      onChange={e => {
-        if (!onChange) return
-
-        const _value = e.target.value
-        const parsedVal = parser ? parser(_value) : _value
-        onChange(parsedVal)
-      }}
+    <InputNumber
       {...props}
+      className={twMerge(
+        'border-smoke-300 bg-smoke-50 text-black dark:border-slate-300 dark:bg-slate-600 dark:text-slate-100 dark:placeholder:text-slate-300',
+        props.className,
+      )}
     />
   )
 }


### PR DESCRIPTION
Reverts the following components to commit `b2efe1ce90405c5a0dc66757409e03d90f24cda0`:
- FormattedNumberInput
- JuiceInputNumber

There have been a few reasonably bad bugs introduced, so thought it best to revert.

There may be some _features_ that have also been reverted.