### PR TITLE
JB-736 - Pay field 'Receive X tokens per ETH'

### DIFF
--- a/src/components/AMMPrices/TokenAMMPriceRow.tsx
+++ b/src/components/AMMPrices/TokenAMMPriceRow.tsx
@@ -81,7 +81,7 @@ export default function TokenAMMPriceRow({
             title={t`${tokenSymbol}/ETH exchange rate on ${exchangeName}.`}
           >
             <ExternalLink className="font-normal" href={exchangeLink}>
-              {`${formatPrice(WETHPrice)} ${tokenSymbol}/1 ETH`}
+              {`${formatPrice(WETHPrice)} ${tokenSymbol} per ETH`}
             </ExternalLink>
           </Tooltip>
         ) : (

--- a/src/components/ProjectDashboard/components/PayProjectCard/components/TokensPerEth.test.tsx
+++ b/src/components/ProjectDashboard/components/PayProjectCard/components/TokensPerEth.test.tsx
@@ -34,12 +34,6 @@ describe('TokensPerEth', () => {
     expect(screen.getByText('Receive 100 TKN')).toBeInTheDocument()
   })
 
-  it('renders when `currencyAmount` is undefined', () => {
-    const { container } = render(<TokensPerEth currencyAmount={undefined} />)
-    expect(container).toMatchSnapshot()
-    expect(screen.getByText('Receive 100 TKN/1 ETH')).toBeInTheDocument()
-  })
-
   it('calls useTokensPerEth with correct arguments', () => {
     render(
       <TokensPerEth

--- a/src/components/ProjectDashboard/components/PayProjectCard/components/TokensPerEth.tsx
+++ b/src/components/ProjectDashboard/components/PayProjectCard/components/TokensPerEth.tsx
@@ -16,11 +16,14 @@ export const TokensPerEth = ({
     useTokensPerEth(currencyAmount)
 
   const suffix =
-    !currencyAmount || !currencyAmount.amount ? `/1 ${currencyText}` : ''
+    !currencyAmount || !currencyAmount.amount ? (
+      <Trans>per {currencyText} paid</Trans>
+    ) : (
+      ''
+    )
   return (
     <Trans>
-      Receive {receivedTickets} {receivedTokenSymbolText}
-      {suffix}
+      Receive {receivedTickets} {receivedTokenSymbolText} {suffix}
     </Trans>
   )
 }

--- a/src/components/ProjectDashboard/components/PayProjectCard/components/__snapshots__/TokensPerEth.test.tsx.snap
+++ b/src/components/ProjectDashboard/components/PayProjectCard/components/__snapshots__/TokensPerEth.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`TokensPerEth renders when \`currencyAmount\` is 1 1`] = `
 <div>
-  Receive 100 TKN
+  Receive 100 TKN 
 </div>
 `;
 
 exports[`TokensPerEth renders when \`currencyAmount\` is undefined 1`] = `
 <div>
-  Receive 100 TKN/1 ETH
+  Receive 100 TKN [object Object]
 </div>
 `;

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -80,6 +80,9 @@ msgstr ""
 msgid "Contract address: {0}"
 msgstr ""
 
+msgid "per {currencyText} paid"
+msgstr ""
+
 msgid "Trust"
 msgstr ""
 
@@ -540,6 +543,9 @@ msgid "If locked, this percentage can't be edited or removed until the lock expi
 msgstr ""
 
 msgid "Claiming {tokenSymbol} tokens will convert your {tokenSymbol} balance to ERC-20 tokens and mint them to your wallet."
+msgstr ""
+
+msgid "Receive {receivedTickets} {receivedTokenSymbolText} {suffix}"
 msgstr ""
 
 msgid "Amount to pay out"
@@ -3156,9 +3162,6 @@ msgid "To connect 1,000,000 creators to 100,000,000 contributors to raise ${0}, 
 msgstr ""
 
 msgid "Paying this project is currently disabled."
-msgstr ""
-
-msgid "Receive {receivedTickets} {receivedTokenSymbolText}{suffix}"
 msgstr ""
 
 msgid "Your project can't receive payments through the juicebox.money app."


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-736 : Pay field 'Receive X tokens per ETH'](https://linear.app/peel/issue/JB-736/pay-field-receive-x-tokens-per-eth)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
