### PR TITLE
Give the callout cards a 1px stroke to help bring them out of the design.

### DIFF
--- a/src/components/ProjectDashboard/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard/ProjectDashboard.tsx
@@ -35,7 +35,13 @@ export const ProjectDashboard = () => {
                   <div className="flex w-full justify-center md:px-6">
                     <div className="flex w-full max-w-6xl flex-col">
                       <ProjectHeader className="mt-12 px-4 md:mt-4 md:px-0" />
-                      <div className="mt-10 flex w-full flex-col gap-4 px-4 md:flex-row md:px-0">
+                      <div
+                        className={twMerge(
+                          'mt-10 flex w-full flex-col gap-4 px-4 md:flex-row md:px-0',
+                          // Styles applied to children
+                          '[&>*]:border [&>*]:border-smoke-100 [&>*]:dark:border-slate-600',
+                        )}
+                      >
                         <PayProjectCard className="flex-1" />
                         {shouldShowNftCard ? <NftRewardsCard /> : null}
                         <CurrentCycleCard


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-725 : Give the callout cards a 1px stroke \(smoke-100\) to help bring them out of the design.](https://linear.app/peel/issue/JB-725/give-the-callout-cards-a-1px-stroke-smoke-100-to-help-bring-them-out)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
