### PR TITLE
wraethdao/jb-724-change-the-7-days-to-a-small-green-badge-to-add-visual

### DIFF
--- a/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStats.test.tsx
+++ b/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStats.test.tsx
@@ -41,7 +41,7 @@ describe('ProjectHeaderStats', () => {
   })
   it.each`
     last7DaysPercent | shouldRender
-    ${0}             | ${false}
+    ${0}             | ${true}
     ${Infinity}      | ${false}
     ${69}            | ${true}
   `(

--- a/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStats.tsx
+++ b/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStats.tsx
@@ -1,9 +1,12 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { ArrowTrendingUpIcon } from '@heroicons/react/24/outline'
 import { t, Trans } from '@lingui/macro'
 import ETHAmount from 'components/currency/ETHAmount'
 import { useProjectHeader } from 'components/ProjectDashboard/hooks'
 import { useProjectPageQueries } from 'components/ProjectDashboard/hooks/useProjectPageQueries'
 import { TRENDING_WINDOW_DAYS } from 'components/Projects/RankingExplanation'
-import { useCallback } from 'react'
+import { PropsWithChildren, useCallback } from 'react'
+import { twMerge } from 'tailwind-merge'
 import { ProjectHeaderStat } from './ProjectHeaderStat'
 
 export function ProjectHeaderStats() {
@@ -18,19 +21,48 @@ export function ProjectHeaderStats() {
   return (
     <div className="flex min-w-0 gap-12 md:shrink-0">
       <a role="button" onClick={openActivityTab}>
-        <ProjectHeaderStat label={t`Payments`} stat={payments} />
+        <ProjectHeaderStat label={t`Payments`} stat={payments ?? 0} />
       </a>
       <ProjectHeaderStat
         label={t`Total volume`}
-        stat={<ETHAmount amount={totalVolume} precision={2} />}
+        stat={
+          <ETHAmount amount={totalVolume ?? BigNumber.from(0)} precision={2} />
+        }
       />
-      {last7DaysPercent !== 0 && last7DaysPercent !== Infinity ? (
+      {last7DaysPercent !== Infinity ? (
         <ProjectHeaderStat
           label={<Trans>last {TRENDING_WINDOW_DAYS} days</Trans>}
-          stat={`+${last7DaysPercent}%`}
+          stat={
+            <StatBadge type={last7DaysPercent > 0 ? 'trending' : 'stagnant'}>
+              {last7DaysPercent}%
+            </StatBadge>
+          }
           data-testid="project-header-trending-perc"
         />
       ) : null}
+    </div>
+  )
+}
+
+type StatBadgeProps = {
+  type: 'trending' | 'stagnant'
+}
+
+const StatBadge: React.FC<PropsWithChildren<StatBadgeProps>> = ({
+  type,
+  children,
+}) => {
+  return (
+    <div
+      className={twMerge(
+        'ml-auto flex w-fit items-center gap-0.5 rounded-2xl border py-1.5 pl-2.5 pr-3 text-base font-medium leading-none',
+        type === 'trending'
+          ? 'border-melon-100 bg-melon-50 text-melon-700 dark:border-melon-800 dark:bg-melon-950 dark:text-melon-400'
+          : 'border-split-100 bg-split-50 text-split-800 dark:border-split-800 dark:bg-split-950 dark:text-split-400',
+      )}
+    >
+      <ArrowTrendingUpIcon className="h-4 w-4 stroke-2" />
+      {children}
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-724 : Change the 7 days % to a small green badge to add visual interest.](https://linear.app/peel/issue/JB-724/change-the-7-days-percent-to-a-small-green-badge-to-add-visual)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
