### PR TITLE
Change the stats section text to Agrandir Medium 30px.

### DIFF
--- a/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStat.tsx
+++ b/src/components/ProjectDashboard/components/ProjectHeader/components/ProjectHeaderStat.tsx
@@ -13,7 +13,7 @@ export const ProjectHeaderStat = ({
       <span className="text-xs font-medium uppercase text-grey-500 dark:text-slate-200 md:text-sm">
         {label}
       </span>
-      <span className="text-medium font-display text-2xl text-grey-900  dark:text-slate-50 md:text-4xl">
+      <span className="text-medium font-heading text-2xl text-grey-900  dark:text-slate-50 md:text-3xl">
         {stat}
       </span>
     </div>


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-723 : Change the stats section text to Agrandir Medium 30px.](https://linear.app/peel/issue/JB-723/change-the-stats-section-text-to-agrandir-medium-30px)


## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
