### PR TITLE
Tidy up v1 payout reconfig

### DIFF
--- a/src/components/v1/V1Project/modals/ReconfigureFCModal/ReconfigureFCModal.tsx
+++ b/src/components/v1/V1Project/modals/ReconfigureFCModal/ReconfigureFCModal.tsx
@@ -388,9 +388,11 @@ export default function ReconfigureFCModal({
         <h4 className="mb-0">
           <Trans>Edit upcoming cycles</Trans>
         </h4>
-        <Callout.Info>
-          <V1ReconfigureUpcomingMessage currentFC={currentFC} />
-        </Callout.Info>
+        <div className="my-6">
+          <Callout.Info>
+            <V1ReconfigureUpcomingMessage currentFC={currentFC} />
+          </Callout.Info>
+        </div>
 
         <Space direction="vertical" size="large" className="w-full">
           <div>
@@ -530,18 +532,19 @@ export default function ReconfigureFCModal({
               />
             </Space>
           )}
-
-          <div>
-            <h4>
-              <Trans>Payouts</Trans>
-            </h4>
-            <PayoutModsList
-              mods={editingPayoutMods}
-              projectId={undefined}
-              fundingCycle={editingFC}
-              feePerbicent={terminalFee}
-            />
-          </div>
+          {editingFC.target.gt(0) ? (
+            <div>
+              <h4>
+                <Trans>Payouts</Trans>
+              </h4>
+              <PayoutModsList
+                mods={editingPayoutMods}
+                projectId={undefined}
+                fundingCycle={editingFC}
+                feePerbicent={terminalFee}
+              />
+            </div>
+          ) : null}
 
           <div>
             <h4>

--- a/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
+++ b/src/components/v1/shared/FundingCycle/FundingCycleDetails.tsx
@@ -129,7 +129,7 @@ export default function FundingCycleDetails({
               {formatWad(fundingCycle.target)}
             </>
           ) : (
-            <Trans>No payouts</Trans>
+            <Trans>Unlimited payouts</Trans>
           )}
         </Descriptions.Item>
 

--- a/src/components/v1/shared/forms/BudgetForm.tsx
+++ b/src/components/v1/shared/forms/BudgetForm.tsx
@@ -12,10 +12,10 @@ import { useContext, useLayoutEffect, useMemo, useState } from 'react'
 import { useAppDispatch } from 'redux/hooks/useAppDispatch'
 import { useEditingV1FundingCycleSelector } from 'redux/hooks/useAppSelector'
 import { editingProjectActions } from 'redux/slices/editingProject'
-import { fromWad, parseWad } from 'utils/format/formatNumber'
+import { fromWad } from 'utils/format/formatNumber'
 import { helpPagePath } from 'utils/routes'
 import { V1CurrencyName, getV1CurrencyOption } from 'utils/v1/currency'
-import { hasFundingTarget, isRecurring } from 'utils/v1/fundingCycle'
+import { isRecurring } from 'utils/v1/fundingCycle'
 import {
   targetSubFeeToTargetFormatted,
   targetToTargetSubFeeFormatted,
@@ -45,7 +45,6 @@ export default function BudgetForm({
   const [target, setTarget] = useState<string>('0')
   const [targetSubFee, setTargetSubFee] = useState<string>('0')
   const [duration, setDuration] = useState<string>('0')
-  const [showFundingFields, setShowFundingFields] = useState<boolean>()
 
   const dispatch = useAppDispatch()
   const { terminal } = useContext(V1ProjectContext)
@@ -58,11 +57,6 @@ export default function BudgetForm({
     setTarget(initialTarget)
     setTargetSubFee(targetToTargetSubFeeFormatted(initialTarget, terminalFee))
     setDuration(initialDuration)
-    setShowFundingFields(
-      hasFundingTarget({
-        target: parseWad(initialTarget),
-      }),
-    )
   }, [initialCurrency, initialDuration, initialTarget, terminalFee])
 
   const maxIntStr = fromWad(constants.MaxUint256)
@@ -86,67 +80,66 @@ export default function BudgetForm({
           <p>{DISTRIBUTION_LIMIT_EXPLANATION}</p>
         </div>
 
-        <Form.Item>
+        <Space direction="vertical" size="middle">
           <Space>
             <Switch
-              checked={showFundingFields}
+              checked={target === maxIntStr}
               onChange={checked => {
                 const targetSubFee = checked
-                  ? DEFAULT_TARGET_AFTER_FEE
-                  : maxIntStr || '0'
+                  ? maxIntStr
+                  : DEFAULT_TARGET_AFTER_FEE
                 setTargetSubFee(targetSubFee)
                 setTarget(
                   targetSubFeeToTargetFormatted(targetSubFee, terminalFee),
                 )
                 setCurrency('USD')
-                setShowFundingFields(checked)
               }}
             />
             <label>
-              <Trans>Set up payouts</Trans>
+              <Trans>Unlimited payouts</Trans>
             </label>
           </Space>
-        </Form.Item>
+          {hasTarget ? (
+            <FormItems.ProjectTarget
+              formItemProps={{
+                rules: [{ required: true }],
+                extra: null,
+              }}
+              target={target}
+              targetSubFee={targetSubFee}
+              onTargetChange={target => {
+                setTarget(target ?? '0')
+                setTargetSubFee(
+                  targetToTargetSubFeeFormatted(target ?? '0', terminalFee),
+                )
+              }}
+              onTargetSubFeeChange={targetSubFee => {
+                setTargetSubFee(targetSubFee ?? '0')
+                setTarget(
+                  targetSubFeeToTargetFormatted(
+                    targetSubFee ?? '0',
+                    terminalFee,
+                  ),
+                )
+              }}
+              currency={currency}
+              onCurrencyChange={setCurrency}
+              feePerbicent={terminalFee}
+            />
+          ) : (
+            <p className="text-black dark:text-slate-100">
+              <span className="font-medium">
+                <Trans>Unlimited payouts.</Trans>{' '}
+              </span>
+              <Trans>
+                All ETH can be paid out from the project. No ETH will be
+                available for redemptions.
+              </Trans>
+            </p>
+          )}
+        </Space>
 
-        {!hasTarget && (
-          <p className="text-black dark:text-slate-100">
-            <span className="font-medium">
-              <Trans>Unlimited payouts.</Trans>{' '}
-            </span>
-            <Trans>
-              All ETH can be paid out from the project. No ETH will be available
-              for redemptions.
-            </Trans>
-          </p>
-        )}
-
-        {showFundingFields && (
-          <FormItems.ProjectTarget
-            formItemProps={{
-              rules: [{ required: true }],
-              extra: null,
-            }}
-            target={target}
-            targetSubFee={targetSubFee}
-            onTargetChange={target => {
-              setTarget(target ?? '0')
-              setTargetSubFee(
-                targetToTargetSubFeeFormatted(target ?? '0', terminalFee),
-              )
-            }}
-            onTargetSubFeeChange={targetSubFee => {
-              setTargetSubFee(targetSubFee ?? '0')
-              setTarget(
-                targetSubFeeToTargetFormatted(targetSubFee ?? '0', terminalFee),
-              )
-            }}
-            currency={currency}
-            onCurrencyChange={setCurrency}
-            feePerbicent={terminalFee}
-          />
-        )}
-
-        {showFundingFields && target === '0' && (
+        {target === '0' && (
           <p className="text-black dark:text-slate-100">
             <Trans>
               <span className="font-medium">No payouts.</span> All of the

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2192,6 +2192,9 @@ msgstr ""
 msgid "Juicebox is an open-source protocol that is transparent, community-owned, and built on the Ethereum blockchain."
 msgstr ""
 
+msgid "Unlimited payouts"
+msgstr ""
+
 msgid "Configuration rules"
 msgstr ""
 
@@ -2538,9 +2541,6 @@ msgid "We are here"
 msgstr ""
 
 msgid "Redeem NFTs"
-msgstr ""
-
-msgid "Set up payouts"
 msgstr ""
 
 msgid "Docs"


### PR DESCRIPTION
- Changes switch text from "Has payouts" to "Unlimited payouts"
- Prevents bug where it randomly switches back
- Hides payouts from reconfig preview when payouts are 0 
- When unlimited payouts, changes "Payouts" text in FC config listing to "Unlimited payouts" from "No payouts"


BEFORE:

https://github.com/jbx-protocol/juice-interface/assets/96150256/3c4e753a-7fd8-40c7-85e8-f2e43c0bc0b6


AFTER:

https://github.com/jbx-protocol/juice-interface/assets/96150256/f8bbd2f2-f3d4-431a-8a72-57362c235370

