### PR TITLE
Cycles with a duration of zero still show misleading information on the upcoming cycle tab.

### DIFF
--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/CurrentUpcomingSubPanel.tsx
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/components/CurrentUpcomingSubPanel.tsx
@@ -1,3 +1,4 @@
+import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import { Trans, t } from '@lingui/macro'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -61,6 +62,22 @@ export const CurrentUpcomingSubPanel = ({
       This project's rules will be locked in place for {cycleStatusValue} days.
     </Trans>
   )
+
+  if (info.type === 'upcoming' && info.cycleUnlocked) {
+    return (
+      <div>
+        <div
+          className={twMerge(
+            'flex items-center gap-2 rounded-lg py-2 px-3.5 text-sm font-medium shadow-sm',
+            'bg-smoke-75 text-smoke-700 dark:bg-slate-400 dark:text-slate-200',
+          )}
+        >
+          <InformationCircleIcon className="h-5 w-5" />
+          <Trans>This project has no upcoming cycle</Trans>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div>

--- a/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useCurrentUpcomingSubPanel.ts
+++ b/src/components/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useCurrentUpcomingSubPanel.ts
@@ -78,5 +78,6 @@ export const useCurrentUpcomingSubPanel = (type: 'current' | 'upcoming') => {
     cycleNumber,
     status,
     cycleLength: upcomingCycleLength,
+    cycleUnlocked,
   }
 }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -2282,6 +2282,9 @@ msgstr ""
 msgid "If enabled, project tokens will be minted to a custom beneficiary address. By default, project tokens will be minted to the wallet that pays this address."
 msgstr ""
 
+msgid "This project has no upcoming cycle"
+msgstr ""
+
 msgid "Highest paid"
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

Closes [JB-738 : Upcoming cycle redesign + fix](https://linear.app/peel/issue/JB-738/upcoming-cycle-redesign-fix)

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
