### PR TITLE
Edit cycle bugs [3/n]: Changing networks resets form + mintRate field bug

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { Button, Form } from 'antd'
+import { Button, Form, Tooltip } from 'antd'
 import Loading from 'components/Loading'
 import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
@@ -13,6 +13,7 @@ import { EditCycleFormSection } from './EditCycleFormSection'
 import { PayoutsSection } from './PayoutsSection'
 import { ReviewConfirmModal } from './ReviewConfirmModal'
 import { TokensSection } from './TokensSection'
+import { useEditCycleFormHasError } from './hooks/useEditCycleFormHasError'
 
 export function EditCyclePage() {
   const [confirmModalOpen, setConfirmModalOpen] = useState<boolean>(false)
@@ -23,12 +24,15 @@ export function EditCyclePage() {
   const { editCycleForm, initialFormData, formHasUpdated, setFormHasUpdated } =
     useEditCycleFormContext()
 
+  const { error } = useEditCycleFormHasError()
+
   const handleFormValuesChange = () => {
     if (!formHasUpdated) {
       setFormHasUpdated(true)
     }
   }
   if (!initialFormData) return <Loading className="h-70" />
+
   return (
     <div>
       <p>
@@ -95,14 +99,15 @@ export function EditCyclePage() {
             </Button>
           </Link>
         ) : null}
-
-        <Button
-          type="primary"
-          onClick={() => setConfirmModalOpen(true)}
-          disabled={!formHasUpdated}
-        >
-          <Trans>Save changes</Trans>
-        </Button>
+        <Tooltip title={error}>
+          <Button
+            type="primary"
+            onClick={() => setConfirmModalOpen(true)}
+            disabled={!formHasUpdated || Boolean(error)}
+          >
+            <Trans>Save changes</Trans>
+          </Button>
+        </Tooltip>
       </div>
     </div>
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -1,6 +1,7 @@
 import { AddEditAllocationModalEntity } from 'components/v2v3/shared/Allocation/AddEditAllocationModal'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
-import { ONE_BILLION } from 'constants/numbers'
+import { ONE_BILLION, WAD_DECIMALS } from 'constants/numbers'
+import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
@@ -38,15 +39,43 @@ export const usePayoutsTable = () => {
     setCurrency: _setCurrency,
   } = usePayoutsTableContext()
   const { setFormHasUpdated } = useEditCycleFormContext()
-
-  const roundingPrecision = currency === 'ETH' ? 4 : 2
-
   const distributionLimitIsInfinite = useMemo(
     () =>
       distributionLimit === undefined ||
       parseWad(distributionLimit).eq(MAX_DISTRIBUTION_LIMIT),
     [distributionLimit],
   )
+
+  const amountOrPercentValue = ({
+    payoutSplit,
+    dontApplyFee,
+  }: {
+    payoutSplit: Split
+    dontApplyFee?: boolean
+  }) =>
+    distributionLimitIsInfinite
+      ? (payoutSplit.percent / ONE_BILLION) * 100
+      : derivePayoutAmount({ payoutSplit, dontApplyFee })
+
+  /* Total amount that leaves the treasury minus fees */
+  const subTotal = payoutSplits.reduce((acc, payoutSplit) => {
+    const reducer = amountOrPercentValue({ payoutSplit })
+    return acc + reducer
+  }, 0)
+
+  let roundingPrecision = currency === 'ETH' ? 4 : 2
+  // If subTotal exceeds 100%, set rounding precision to exceeding decimal amount
+  // e.g. subTotal = 100.00001, roundingPrecision = 5
+  if (distributionLimitIsInfinite && subTotal > 100) {
+    const decimalPart = subTotal - Math.floor(subTotal)
+    if (decimalPart > 0) {
+      const decimalStr = decimalPart.toString()
+      const decimalPrecision = decimalStr.slice(
+        decimalStr.indexOf('.') + 1,
+      ).length
+      roundingPrecision = Math.max(roundingPrecision, decimalPrecision)
+    }
+  }
 
   const ownerRemainingPercentPPB =
     SPLITS_TOTAL_PERCENT - totalSplitsPercent(payoutSplits) // parts-per-billion
@@ -64,6 +93,27 @@ export const usePayoutsTable = () => {
     ? '%'
     : V2V3_CURRENCY_METADATA[getV2V3CurrencyOption(currency)].symbol
 
+  /* Payouts that don't go to Juicebox projects incur 2.5% fee */
+  const nonJuiceboxProjectPayoutSplits = [
+    ...payoutSplits.filter(payoutSplit => !isProjectSplit(payoutSplit)),
+    getProjectOwnerRemainderSplit(
+      // remaining owner split also incurs fee
+      '',
+      payoutSplits,
+    ) as Split,
+  ]
+
+  /* Count the total fee amount. If % of payouts sums > 100, just set fees to 2.5% (maximum)*/
+  const totalFeeAmount =
+    distributionLimitIsInfinite && round(subTotal, roundingPrecision) > 100
+      ? 2.5
+      : nonJuiceboxProjectPayoutSplits.reduce((acc, payoutSplit) => {
+          return (
+            acc +
+            amountOrPercentValue({ payoutSplit, dontApplyFee: true }) * JB_FEE
+          )
+        }, 0)
+
   /**
    * Sets the currency for the distributionLimit
    * @param currency - Currency as a V2V3CurrencyOption (1 | 2)
@@ -80,6 +130,14 @@ export const usePayoutsTable = () => {
       setPayoutSplits(ensureSplitsSumTo100Percent({ splits }))
     }
     setFormHasUpdated(true)
+  }
+
+  function _setDistributionLimit(distributionLimit: number | undefined) {
+    const _distributionLimit =
+      distributionLimit !== undefined
+        ? round(distributionLimit, WAD_DECIMALS)
+        : undefined
+    setDistributionLimit(_distributionLimit)
   }
 
   /**
@@ -129,7 +187,10 @@ export const usePayoutsTable = () => {
   }: {
     payoutSplitPercent: number
   }) {
-    return round((payoutSplitPercent / ONE_BILLION) * 100, 2).toString()
+    return round(
+      (payoutSplitPercent / ONE_BILLION) * 100,
+      roundingPrecision,
+    ).toString()
   }
 
   /**
@@ -178,7 +239,7 @@ export const usePayoutsTable = () => {
           newDistributionLimit: newDistributionLimit.toString(),
         })
       }
-      setDistributionLimit(newDistributionLimit)
+      _setDistributionLimit(newDistributionLimit)
     }
 
     const newPayoutSplit = {
@@ -299,7 +360,7 @@ export const usePayoutsTable = () => {
           }
         : m
     })
-    setDistributionLimit(newDistributionLimit)
+    _setDistributionLimit(newDistributionLimit)
     _setPayoutSplits(newPayoutSplits)
   }
 
@@ -310,9 +371,7 @@ export const usePayoutsTable = () => {
    * @param split - Split to be deleted
    */
   function handleDeletePayoutSplit({ payoutSplit }: { payoutSplit: Split }) {
-    const newSplits = payoutSplits.filter(
-      m => !hasEqualRecipient(m, payoutSplit),
-    )
+    const newSplits = payoutSplits.filter(m => !isEqual(m, payoutSplit))
 
     let adjustedSplits: Split[] = newSplits
     let newDistributionLimit = distributionLimit
@@ -329,7 +388,7 @@ export const usePayoutsTable = () => {
       })
     }
 
-    setDistributionLimit(newDistributionLimit)
+    _setDistributionLimit(newDistributionLimit)
     _setPayoutSplits(adjustedSplits)
   }
 
@@ -337,44 +396,6 @@ export const usePayoutsTable = () => {
     setDistributionLimit(0)
     setPayoutSplits([])
   }
-
-  const amountOrPercentValue = ({
-    payoutSplit,
-    dontApplyFee,
-  }: {
-    payoutSplit: Split
-    dontApplyFee?: boolean
-  }) =>
-    distributionLimitIsInfinite
-      ? (payoutSplit.percent / ONE_BILLION) * 100
-      : derivePayoutAmount({ payoutSplit, dontApplyFee })
-
-  /* Total amount that leaves the treasury minus fees */
-  const subTotal = payoutSplits.reduce((acc, payoutSplit) => {
-    const reducer = amountOrPercentValue({ payoutSplit })
-    return acc + reducer
-  }, 0)
-
-  /* Payouts that don't go to Juicebox projects incur 2.5% fee */
-  const nonJuiceboxProjectPayoutSplits = [
-    ...payoutSplits.filter(payoutSplit => !isProjectSplit(payoutSplit)),
-    getProjectOwnerRemainderSplit(
-      // remaining owner split also incurs fee
-      '',
-      payoutSplits,
-    ) as Split,
-  ]
-
-  /* Count the total fee amount. If % of payouts sums > 100, just set fees to 2.5% (maximum)*/
-  const totalFeeAmount =
-    distributionLimitIsInfinite && round(subTotal, roundingPrecision) > 100
-      ? 2.5
-      : nonJuiceboxProjectPayoutSplits.reduce((acc, payoutSplit) => {
-          return (
-            acc +
-            amountOrPercentValue({ payoutSplit, dontApplyFee: true }) * JB_FEE
-          )
-        }, 0)
 
   return {
     distributionLimit,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
@@ -39,8 +39,7 @@ export const useTokensSectionValues = () => {
     capitalize: false,
     plural: true,
   })
-
-  const newMintRateNum = parseFloat(formValues.mintRate)
+  const newMintRateNum = parseFloat(formValues.mintRate ?? '0')
   const newMintRate = BigNumber.from(
     issuanceRateFrom(newMintRateNum.toString()),
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/MintRateField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/MintRateField.tsx
@@ -9,6 +9,7 @@ export function MintRateField() {
       <FormattedNumberInput
         className="h-10 py-1 pr-4"
         min={0}
+        defaultValue={0}
         max={MAX_MINT_RATE}
         accessory={
           <span className="mr-5 text-sm text-black dark:text-slate-100">

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/ReservedTokensField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/ReservedTokensField.tsx
@@ -7,6 +7,8 @@ import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
 import { Split } from 'models/splits'
 import { useState } from 'react'
 import { helpPagePath } from 'utils/routes'
+import { totalSplitsPercent } from 'utils/splits'
+import { SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
 import { V2V3EditReservedTokens } from '../../ReservedTokensSettingsPage/V2V3EditReservedTokens'
 import { AdvancedDropdown } from '../AdvancedDropdown'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
@@ -17,6 +19,9 @@ export function ReservedTokensField() {
   const reservedTokens = useWatch('reservedTokens', editCycleForm) ?? 0
   const reservedSplits = useWatch('reservedSplits', editCycleForm) ?? []
   const totalIssuanceRate = useWatch('mintRate', editCycleForm) ?? 0
+
+  const reservedSplitsPercentExceedsMax =
+    totalSplitsPercent(reservedSplits) > SPLITS_TOTAL_PERCENT
 
   const [reservedTokensSwitchEnabled, setReservedTokensSwitchEnabled] =
     useState<boolean>(editCycleForm?.getFieldValue('reservedTokens') > 0)
@@ -70,6 +75,11 @@ export function ReservedTokensField() {
             />
           </AdvancedDropdown>
         </div>
+      ) : null}
+      {reservedSplitsPercentExceedsMax ? (
+        <span className="font-medium text-error-500">
+          <Trans>Reserved recipients cannot exceed 100%</Trans>
+        </span>
       ) : null}
       {/* Empty inputs to keep AntD useWatch happy */}
       <ItemNoInput name="reservedSplits" className="hidden" />

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/useEditCycleFormHasError.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/useEditCycleFormHasError.tsx
@@ -1,0 +1,33 @@
+import { Trans } from '@lingui/macro'
+import { useWatch } from 'antd/lib/form/Form'
+import { totalSplitsPercent } from 'utils/splits'
+import { SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
+import { useEditCycleFormContext } from '../EditCycleFormContext'
+
+export function useEditCycleFormHasError() {
+  const { editCycleForm } = useEditCycleFormContext()
+
+  const payoutSplits = useWatch('payoutSplits', editCycleForm) ?? []
+  const reservedSplits = useWatch('reservedSplits', editCycleForm) ?? []
+
+  const payoutSplitsPercentExceedsMax =
+    totalSplitsPercent(payoutSplits) > SPLITS_TOTAL_PERCENT
+  const reservedSplitsPercentExceedsMax =
+    totalSplitsPercent(reservedSplits) > SPLITS_TOTAL_PERCENT
+
+  let error: JSX.Element | undefined
+
+  if (payoutSplitsPercentExceedsMax && reservedSplitsPercentExceedsMax) {
+    error = (
+      <Trans>Payout and reserved token recipients cannot exceed 100%</Trans>
+    )
+  } else if (payoutSplitsPercentExceedsMax) {
+    error = <Trans>Payouts cannot exceed 100%</Trans>
+  } else if (reservedSplitsPercentExceedsMax) {
+    error = <Trans>Reserved token recipients cannot exceed 100%</Trans>
+  }
+
+  return {
+    error,
+  }
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
@@ -87,7 +87,9 @@ export const usePrepareSaveEditCycleData = () => {
 
   const editingFundingCycleData: V2V3FundingCycleData = {
     duration: BigNumber.from(durationSeconds),
-    weight: BigNumber.from(issuanceRateFrom(formValues.mintRate.toString())),
+    weight: BigNumber.from(
+      issuanceRateFrom(formValues.mintRate?.toString() ?? '0'),
+    ),
     discountRate: discountRateFrom(formValues.discountRate),
     ballot: formValues.ballot,
   }

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1037,6 +1037,9 @@ msgstr ""
 msgid "Using crowdfunding platforms for films has been around for a while, but Juicebox adds an extra layer of transparency to the process, allowing fans to see where funds are going. Unlike traditional models where money is controlled behind the scenes, StudioDAO members source, vote, fund, and distribute movies transparently using the treasury while creators retain 100% of their creative control and ownership. With the entertainment market currently valued at two trillion dollars, StudioDAO founder Kenny Miller can see a “clear scenario for a decentralized studio to do one billion dollars of production 2-3 years from now.” To learn more about Kenny's vision for StudioDAO, listen to episode 9 of the Juicecast: <0>https://podcast.juicebox.money</0>."
 msgstr ""
 
+msgid "Reserved token recipients cannot exceed 100%"
+msgstr ""
+
 msgid "Contributors will receive this NFT when they contribute at least this amount."
 msgstr ""
 
@@ -2798,6 +2801,9 @@ msgstr ""
 msgid "Update basic project details"
 msgstr ""
 
+msgid "Reserved recipients cannot exceed 100%"
+msgstr ""
+
 msgid "Available: {0}"
 msgstr ""
 
@@ -4457,6 +4463,9 @@ msgstr ""
 msgid "Other rules"
 msgstr ""
 
+msgid "Sub-total cannot exceed 100%"
+msgstr ""
+
 msgid "{0} holders"
 msgstr ""
 
@@ -4613,6 +4622,9 @@ msgstr ""
 msgid "You will receive {0}<0/>"
 msgstr ""
 
+msgid "Payouts cannot exceed 100%"
+msgstr ""
+
 msgid "Data from upcoming cycle"
 msgstr ""
 
@@ -4713,6 +4725,9 @@ msgid "Max Supply"
 msgstr ""
 
 msgid "The maximum supply of this NFT in circulation."
+msgstr ""
+
+msgid "Payout and reserved token recipients cannot exceed 100%"
 msgstr ""
 
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return. <0>Learn more</0>."

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -41,7 +41,7 @@
   @apply h-full;
 }
 
-.formatted-number-input .ant-input-number-input-wrap input {
+.formatted-number-input .ant-input-number-input-wrap input, .ant-input-number-input {
   @apply py-1;
 }
 

--- a/src/utils/splits.ts
+++ b/src/utils/splits.ts
@@ -218,8 +218,12 @@ export const isProjectSplit = (split: Split): boolean => {
 export const projectIdToHex = (projectIdString: string | undefined) =>
   BigNumber.from(projectIdString ?? 0).toHexString()
 
-// Returns the sum of each split's percent in a list of splits
-export const totalSplitsPercent = (splits: Split[]) =>
+/**
+ * Returns the sum of each split's percent in a list of splits
+ * @param splits {Split[]} - list of splits to sum percents
+ * @returns {number} - sum of percents in part-per-billion (max = SPLITS_TOTAL_PERCENT)
+ */
+export const totalSplitsPercent = (splits: Split[]): number =>
   splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
 
 /**


### PR DESCRIPTION
**Fixes changing networks resetting form bug:**
- `useEffect` was being called when page re-renders from network change
- Change the name of `initialEditingData` (from `useInitialEditingData`) to `currentProjectData`
- Create a new ref, `initialEditingData`, to compare `currentProjectData` to on subsequent re-renders
- Only call the body of useEffect when `currentProjectData` has changed (`currentProjectData` !== `initialEditingData`)

https://github.com/jbx-protocol/juice-interface/assets/96150256/133a14c6-0ec9-402e-a214-ae3f6a3f43c8

- Also fixes a bug when clearing the mintRate field (similar to the duration bug)

