### PR TITLE
Edit cycle bugs [4/n]: Better error state for payouts and reserved splits overflow

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/EditCyclePage.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { Button, Form } from 'antd'
+import { Button, Form, Tooltip } from 'antd'
 import Loading from 'components/Loading'
 import { ExternalLinkWithIcon } from 'components/ProjectDashboard/components/ui/ExternalLinkWithIcon'
 import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
@@ -13,6 +13,7 @@ import { EditCycleFormSection } from './EditCycleFormSection'
 import { PayoutsSection } from './PayoutsSection'
 import { ReviewConfirmModal } from './ReviewConfirmModal'
 import { TokensSection } from './TokensSection'
+import { useEditCycleFormHasError } from './hooks/useEditCycleFormHasError'
 
 export function EditCyclePage() {
   const [confirmModalOpen, setConfirmModalOpen] = useState<boolean>(false)
@@ -23,12 +24,15 @@ export function EditCyclePage() {
   const { editCycleForm, initialFormData, formHasUpdated, setFormHasUpdated } =
     useEditCycleFormContext()
 
+  const { error } = useEditCycleFormHasError()
+
   const handleFormValuesChange = () => {
     if (!formHasUpdated) {
       setFormHasUpdated(true)
     }
   }
   if (!initialFormData) return <Loading className="h-70" />
+
   return (
     <div>
       <p>
@@ -95,14 +99,15 @@ export function EditCyclePage() {
             </Button>
           </Link>
         ) : null}
-
-        <Button
-          type="primary"
-          onClick={() => setConfirmModalOpen(true)}
-          disabled={!formHasUpdated}
-        >
-          <Trans>Save changes</Trans>
-        </Button>
+        <Tooltip title={error}>
+          <Button
+            type="primary"
+            onClick={() => setConfirmModalOpen(true)}
+            disabled={!formHasUpdated || Boolean(error)}
+          >
+            <Trans>Save changes</Trans>
+          </Button>
+        </Tooltip>
       </div>
     </div>
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
@@ -26,14 +26,16 @@ export function TotalRows() {
       ? round(distributionLimit, roundingPrecision)
       : t`Unlimited`
 
+  const subTotalExceedsMax = distributionLimitIsInfinite && subTotal > 100
+
   return (
     <>
       <Row>
         <Cell>Sub-total</Cell>
-        <Cell className={ownerRemainderValue < 0 ? 'text-error-500' : ''}>
+        <Cell className={subTotalExceedsMax ? 'text-error-500' : ''}>
           <Tooltip
             title={
-              ownerRemainderValue < 0 ? (
+              subTotalExceedsMax ? (
                 <Trans>Sub-total cannot exceed 100%</Trans>
               ) : undefined
             }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
@@ -9,6 +9,8 @@ import { PayoutsTableRow } from './PayoutsTableRow'
 const Row = PayoutsTableRow
 const Cell = PayoutsTableCell
 
+const SMALL_FEE_PRECISION_BUFFER = 2
+
 /* Bottom few rows of the payouts table which show total amounts and fees */
 export function TotalRows() {
   const {
@@ -27,6 +29,12 @@ export function TotalRows() {
       : t`Unlimited`
 
   const subTotalExceedsMax = distributionLimitIsInfinite && subTotal > 100
+
+  // Make fee more precise when it is very small
+  const feeRoundingPrecision =
+    totalFeeAmount >= 1
+      ? roundingPrecision
+      : roundingPrecision + SMALL_FEE_PRECISION_BUFFER
 
   return (
     <>
@@ -60,7 +68,8 @@ export function TotalRows() {
       <Row>
         <Cell>Fees</Cell>
         <Cell>
-          {currencyOrPercentSymbol} {round(totalFeeAmount, roundingPrecision)}
+          {currencyOrPercentSymbol}{' '}
+          {round(totalFeeAmount, feeRoundingPrecision)}
         </Cell>
       </Row>
       <Row className="rounded-b-lg font-medium" highlighted>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
@@ -1,4 +1,5 @@
 import { Trans, t } from '@lingui/macro'
+import { Tooltip } from 'antd'
 import TooltipLabel from 'components/TooltipLabel'
 import round from 'lodash/round'
 import { usePayoutsTable } from '../hooks/usePayoutsTable'
@@ -29,11 +30,19 @@ export function TotalRows() {
     <>
       <Row>
         <Cell>Sub-total</Cell>
-        <Cell>
-          {currencyOrPercentSymbol} {round(subTotal, roundingPrecision)}
+        <Cell className={ownerRemainderValue < 0 ? 'text-error-500' : ''}>
+          <Tooltip
+            title={
+              ownerRemainderValue < 0 ? (
+                <Trans>Sub-total cannot exceed 100%</Trans>
+              ) : undefined
+            }
+          >
+            {currencyOrPercentSymbol} {round(subTotal, roundingPrecision)}
+          </Tooltip>
         </Cell>
       </Row>
-      {ownerRemainderValue ? (
+      {ownerRemainderValue > 0 ? (
         <Row>
           <Cell>
             <TooltipLabel
@@ -41,7 +50,7 @@ export function TotalRows() {
               label={<Trans>Remaining balance</Trans>}
             />
           </Cell>
-          <Cell className={ownerRemainderValue < 0 ? 'text-error-500' : ''}>
+          <Cell>
             {currencyOrPercentSymbol} {ownerRemainderValue}
           </Cell>
         </Row>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -1,6 +1,6 @@
 import { AddEditAllocationModalEntity } from 'components/v2v3/shared/Allocation/AddEditAllocationModal'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
-import { ONE_BILLION } from 'constants/numbers'
+import { ONE_BILLION, WAD_DECIMALS } from 'constants/numbers'
 import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
@@ -39,7 +39,6 @@ export const usePayoutsTable = () => {
     setCurrency: _setCurrency,
   } = usePayoutsTableContext()
   const { setFormHasUpdated } = useEditCycleFormContext()
-
   const distributionLimitIsInfinite = useMemo(
     () =>
       distributionLimit === undefined ||
@@ -131,6 +130,14 @@ export const usePayoutsTable = () => {
       setPayoutSplits(ensureSplitsSumTo100Percent({ splits }))
     }
     setFormHasUpdated(true)
+  }
+
+  function _setDistributionLimit(distributionLimit: number | undefined) {
+    const _distributionLimit =
+      distributionLimit !== undefined
+        ? round(distributionLimit, WAD_DECIMALS)
+        : undefined
+    setDistributionLimit(_distributionLimit)
   }
 
   /**
@@ -232,7 +239,7 @@ export const usePayoutsTable = () => {
           newDistributionLimit: newDistributionLimit.toString(),
         })
       }
-      setDistributionLimit(newDistributionLimit)
+      _setDistributionLimit(newDistributionLimit)
     }
 
     const newPayoutSplit = {
@@ -353,7 +360,7 @@ export const usePayoutsTable = () => {
           }
         : m
     })
-    setDistributionLimit(newDistributionLimit)
+    _setDistributionLimit(newDistributionLimit)
     _setPayoutSplits(newPayoutSplits)
   }
 
@@ -381,7 +388,7 @@ export const usePayoutsTable = () => {
       })
     }
 
-    setDistributionLimit(newDistributionLimit)
+    _setDistributionLimit(newDistributionLimit)
     _setPayoutSplits(adjustedSplits)
   }
 

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -1,6 +1,7 @@
 import { AddEditAllocationModalEntity } from 'components/v2v3/shared/Allocation/AddEditAllocationModal'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
 import { ONE_BILLION } from 'constants/numbers'
+import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
@@ -310,9 +311,7 @@ export const usePayoutsTable = () => {
    * @param split - Split to be deleted
    */
   function handleDeletePayoutSplit({ payoutSplit }: { payoutSplit: Split }) {
-    const newSplits = payoutSplits.filter(
-      m => !hasEqualRecipient(m, payoutSplit),
-    )
+    const newSplits = payoutSplits.filter(m => !isEqual(m, payoutSplit))
 
     let adjustedSplits: Split[] = newSplits
     let newDistributionLimit = distributionLimit

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/ReservedTokensField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/TokensSection/ReservedTokensField.tsx
@@ -7,6 +7,8 @@ import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
 import { Split } from 'models/splits'
 import { useState } from 'react'
 import { helpPagePath } from 'utils/routes'
+import { totalSplitsPercent } from 'utils/splits'
+import { SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
 import { V2V3EditReservedTokens } from '../../ReservedTokensSettingsPage/V2V3EditReservedTokens'
 import { AdvancedDropdown } from '../AdvancedDropdown'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
@@ -17,6 +19,9 @@ export function ReservedTokensField() {
   const reservedTokens = useWatch('reservedTokens', editCycleForm) ?? 0
   const reservedSplits = useWatch('reservedSplits', editCycleForm) ?? []
   const totalIssuanceRate = useWatch('mintRate', editCycleForm) ?? 0
+
+  const reservedSplitsPercentExceedsMax =
+    totalSplitsPercent(reservedSplits) > SPLITS_TOTAL_PERCENT
 
   const [reservedTokensSwitchEnabled, setReservedTokensSwitchEnabled] =
     useState<boolean>(editCycleForm?.getFieldValue('reservedTokens') > 0)
@@ -70,6 +75,11 @@ export function ReservedTokensField() {
             />
           </AdvancedDropdown>
         </div>
+      ) : null}
+      {reservedSplitsPercentExceedsMax ? (
+        <span className="font-medium text-error-500">
+          <Trans>Reserved recipients cannot exceed 100%</Trans>
+        </span>
       ) : null}
       {/* Empty inputs to keep AntD useWatch happy */}
       <ItemNoInput name="reservedSplits" className="hidden" />

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/useEditCycleFormHasError.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/hooks/useEditCycleFormHasError.tsx
@@ -1,0 +1,33 @@
+import { Trans } from '@lingui/macro'
+import { useWatch } from 'antd/lib/form/Form'
+import { totalSplitsPercent } from 'utils/splits'
+import { SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
+import { useEditCycleFormContext } from '../EditCycleFormContext'
+
+export function useEditCycleFormHasError() {
+  const { editCycleForm } = useEditCycleFormContext()
+
+  const payoutSplits = useWatch('payoutSplits', editCycleForm) ?? []
+  const reservedSplits = useWatch('reservedSplits', editCycleForm) ?? []
+
+  const payoutSplitsPercentExceedsMax =
+    totalSplitsPercent(payoutSplits) > SPLITS_TOTAL_PERCENT
+  const reservedSplitsPercentExceedsMax =
+    totalSplitsPercent(reservedSplits) > SPLITS_TOTAL_PERCENT
+
+  let error: JSX.Element | undefined
+
+  if (payoutSplitsPercentExceedsMax && reservedSplitsPercentExceedsMax) {
+    error = (
+      <Trans>Payout and reserved token recipients cannot exceed 100%</Trans>
+    )
+  } else if (payoutSplitsPercentExceedsMax) {
+    error = <Trans>Payouts cannot exceed 100%</Trans>
+  } else if (reservedSplitsPercentExceedsMax) {
+    error = <Trans>Reserved token recipients cannot exceed 100%</Trans>
+  }
+
+  return {
+    error,
+  }
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1037,6 +1037,9 @@ msgstr ""
 msgid "Using crowdfunding platforms for films has been around for a while, but Juicebox adds an extra layer of transparency to the process, allowing fans to see where funds are going. Unlike traditional models where money is controlled behind the scenes, StudioDAO members source, vote, fund, and distribute movies transparently using the treasury while creators retain 100% of their creative control and ownership. With the entertainment market currently valued at two trillion dollars, StudioDAO founder Kenny Miller can see a “clear scenario for a decentralized studio to do one billion dollars of production 2-3 years from now.” To learn more about Kenny's vision for StudioDAO, listen to episode 9 of the Juicecast: <0>https://podcast.juicebox.money</0>."
 msgstr ""
 
+msgid "Reserved token recipients cannot exceed 100%"
+msgstr ""
+
 msgid "Contributors will receive this NFT when they contribute at least this amount."
 msgstr ""
 
@@ -2798,6 +2801,9 @@ msgstr ""
 msgid "Update basic project details"
 msgstr ""
 
+msgid "Reserved recipients cannot exceed 100%"
+msgstr ""
+
 msgid "Available: {0}"
 msgstr ""
 
@@ -4457,6 +4463,9 @@ msgstr ""
 msgid "Other rules"
 msgstr ""
 
+msgid "Sub-total cannot exceed 100%"
+msgstr ""
+
 msgid "{0} holders"
 msgstr ""
 
@@ -4613,6 +4622,9 @@ msgstr ""
 msgid "You will receive {0}<0/>"
 msgstr ""
 
+msgid "Payouts cannot exceed 100%"
+msgstr ""
+
 msgid "Data from upcoming cycle"
 msgstr ""
 
@@ -4713,6 +4725,9 @@ msgid "Max Supply"
 msgstr ""
 
 msgid "The maximum supply of this NFT in circulation."
+msgstr ""
+
+msgid "Payout and reserved token recipients cannot exceed 100%"
 msgstr ""
 
 msgid "Payouts to Ethereum addresses incur a {feePercentage}% fee. Your project will receive JBX in return. <0>Learn more</0>."

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -41,7 +41,7 @@
   @apply h-full;
 }
 
-.formatted-number-input .ant-input-number-input-wrap input {
+.formatted-number-input .ant-input-number-input-wrap input, .ant-input-number-input {
   @apply py-1;
 }
 

--- a/src/utils/splits.ts
+++ b/src/utils/splits.ts
@@ -218,8 +218,12 @@ export const isProjectSplit = (split: Split): boolean => {
 export const projectIdToHex = (projectIdString: string | undefined) =>
   BigNumber.from(projectIdString ?? 0).toHexString()
 
-// Returns the sum of each split's percent in a list of splits
-export const totalSplitsPercent = (splits: Split[]) =>
+/**
+ * Returns the sum of each split's percent in a list of splits
+ * @param splits {Split[]} - list of splits to sum percents
+ * @returns {number} - sum of percents in part-per-billion (max = SPLITS_TOTAL_PERCENT)
+ */
+export const totalSplitsPercent = (splits: Split[]): number =>
   splits?.reduce((sum, split) => sum + split.percent, 0) ?? 0
 
 /**


### PR DESCRIPTION
### **- Shows better error states for payouts and reserved splits exceed 100%:**

<img width="764" alt="Screen Shot 2023-08-29 at 10 32 06 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/88454a13-e712-4666-9239-1f7cd09be474">

<img width="748" alt="Screen Shot 2023-08-29 at 10 31 34 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/4c342a68-7b58-45fb-8550-ac0225d533a0">

### **- Prevents form from being submitted when the errors exist:**##

<img width="756" alt="Screen Shot 2023-08-29 at 10 33 04 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/2a293ef2-6fe8-4d46-81d1-d0e210204592">
<img width="796" alt="Screen Shot 2023-08-29 at 10 33 36 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/2db9e9bc-034a-445e-b6ca-eae5d73ee4d7">
<img width="831" alt="Screen Shot 2023-08-29 at 10 32 12 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/20d4ee07-2bad-4a1d-a302-eb3688d249eb">
