### PR TITLE
Edit cycle bugs [5/n]: Delete payouts bug

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -1,6 +1,7 @@
 import { AddEditAllocationModalEntity } from 'components/v2v3/shared/Allocation/AddEditAllocationModal'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
 import { ONE_BILLION } from 'constants/numbers'
+import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
@@ -310,9 +311,7 @@ export const usePayoutsTable = () => {
    * @param split - Split to be deleted
    */
   function handleDeletePayoutSplit({ payoutSplit }: { payoutSplit: Split }) {
-    const newSplits = payoutSplits.filter(
-      m => !hasEqualRecipient(m, payoutSplit),
-    )
+    const newSplits = payoutSplits.filter(m => !isEqual(m, payoutSplit))
 
     let adjustedSplits: Split[] = newSplits
     let newDistributionLimit = distributionLimit

--- a/src/styles/antd-overrides/input.scss
+++ b/src/styles/antd-overrides/input.scss
@@ -41,7 +41,7 @@
   @apply h-full;
 }
 
-.formatted-number-input .ant-input-number-input-wrap input {
+.formatted-number-input .ant-input-number-input-wrap input, .ant-input-number-input {
   @apply py-1;
 }
 


### PR DESCRIPTION
- Deletes bug where deleting a project will also delete the payout with the same address as the project's token beneficiary:

https://github.com/jbx-protocol/juice-interface/assets/96150256/b52a295a-9190-43f1-8724-54e300d87362

- Also sneaks in widening the number input:
BEFORE:
<img width="599" alt="Screen Shot 2023-08-29 at 11 09 05 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/203233c2-d042-4a5b-b30d-4f2c04c6df6d">

AFTER:
<img width="636" alt="Screen Shot 2023-08-29 at 11 05 41 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/8ea38304-3104-4686-b8c1-a6b86ffe7b10">
