### PR TITLE
Edit cycle bugs [6/n]: Fix extremely small distribution limit bug

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/PayoutsTable/TotalRows.tsx
@@ -9,6 +9,8 @@ import { PayoutsTableRow } from './PayoutsTableRow'
 const Row = PayoutsTableRow
 const Cell = PayoutsTableCell
 
+const SMALL_FEE_PRECISION_BUFFER = 2
+
 /* Bottom few rows of the payouts table which show total amounts and fees */
 export function TotalRows() {
   const {
@@ -27,6 +29,12 @@ export function TotalRows() {
       : t`Unlimited`
 
   const subTotalExceedsMax = distributionLimitIsInfinite && subTotal > 100
+
+  // Make fee more precise when it is very small
+  const feeRoundingPrecision =
+    totalFeeAmount >= 1
+      ? roundingPrecision
+      : roundingPrecision + SMALL_FEE_PRECISION_BUFFER
 
   return (
     <>
@@ -60,7 +68,8 @@ export function TotalRows() {
       <Row>
         <Cell>Fees</Cell>
         <Cell>
-          {currencyOrPercentSymbol} {round(totalFeeAmount, roundingPrecision)}
+          {currencyOrPercentSymbol}{' '}
+          {round(totalFeeAmount, feeRoundingPrecision)}
         </Cell>
       </Row>
       <Row className="rounded-b-lg font-medium" highlighted>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/PayoutsSection/hooks/usePayoutsTable.tsx
@@ -1,6 +1,6 @@
 import { AddEditAllocationModalEntity } from 'components/v2v3/shared/Allocation/AddEditAllocationModal'
 import { NULL_ALLOCATOR_ADDRESS } from 'constants/contracts/mainnet/Allocators'
-import { ONE_BILLION } from 'constants/numbers'
+import { ONE_BILLION, WAD_DECIMALS } from 'constants/numbers'
 import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import { Split } from 'models/splits'
@@ -39,7 +39,6 @@ export const usePayoutsTable = () => {
     setCurrency: _setCurrency,
   } = usePayoutsTableContext()
   const { setFormHasUpdated } = useEditCycleFormContext()
-
   const distributionLimitIsInfinite = useMemo(
     () =>
       distributionLimit === undefined ||
@@ -131,6 +130,14 @@ export const usePayoutsTable = () => {
       setPayoutSplits(ensureSplitsSumTo100Percent({ splits }))
     }
     setFormHasUpdated(true)
+  }
+
+  function _setDistributionLimit(distributionLimit: number | undefined) {
+    const _distributionLimit =
+      distributionLimit !== undefined
+        ? round(distributionLimit, WAD_DECIMALS)
+        : undefined
+    setDistributionLimit(_distributionLimit)
   }
 
   /**
@@ -232,7 +239,7 @@ export const usePayoutsTable = () => {
           newDistributionLimit: newDistributionLimit.toString(),
         })
       }
-      setDistributionLimit(newDistributionLimit)
+      _setDistributionLimit(newDistributionLimit)
     }
 
     const newPayoutSplit = {
@@ -353,7 +360,7 @@ export const usePayoutsTable = () => {
           }
         : m
     })
-    setDistributionLimit(newDistributionLimit)
+    _setDistributionLimit(newDistributionLimit)
     _setPayoutSplits(newPayoutSplits)
   }
 
@@ -381,7 +388,7 @@ export const usePayoutsTable = () => {
       })
     }
 
-    setDistributionLimit(newDistributionLimit)
+    _setDistributionLimit(newDistributionLimit)
     _setPayoutSplits(adjustedSplits)
   }
 


### PR DESCRIPTION
- There was a bug when the user made one payout of `0.001`, because the DL (once the fee amount added) was being set to a value with greater than `WAD_DECIMALS` (more than 18 decimals):

<img width="309" alt="Screen Shot 2023-08-30 at 4 16 29 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/ad64ee53-2ffd-4905-a77a-d7865938d460">

- Set a rounding limit of `WAD_DECIMALS` wherever the DL is set 
- Also change the fee rounding amount to account for very small ETH amounts when it is necessary

https://github.com/jbx-protocol/juice-interface/assets/96150256/eff4d0e8-53f0-4176-a303-e05940ca08b9

