### PR TITLE
Only show version appropriate ballots in listings

### DIFF
--- a/src/components/Create/hooks/useAvailableReconfigurationStrategies.ts
+++ b/src/components/Create/hooks/useAvailableReconfigurationStrategies.ts
@@ -3,7 +3,7 @@ import { NetworkName } from 'models/networkName'
 import { ArrayElement } from 'utils/arrayElement'
 
 export const useAvailableReconfigurationStrategies = (network: NetworkName) => {
-  const strategies = ballotStrategiesFn(network).map(s =>
+  const strategies = ballotStrategiesFn({ network }).map(s =>
     s.id === 'threeDay'
       ? { ...s, isDefault: true }
       : { ...s, isDefault: false },

--- a/src/components/Create/hooks/useLoadInitialStateFromQuery.ts
+++ b/src/components/Create/hooks/useLoadInitialStateFromQuery.ts
@@ -73,7 +73,7 @@ const parseCreateFlowStateFromInitialState = (
   }
 
   const reconfigurationRuleSelection =
-    ballotStrategiesFn().find(s =>
+    ballotStrategiesFn({}).find(s =>
       isEqualAddress(s.address, initialState.fundingCycleData.ballot),
     )?.id ?? 'threeDay'
 

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/DetailsSection/CycleDeadlineDropdown.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/NewEditCyclePage/DetailsSection/CycleDeadlineDropdown.tsx
@@ -1,14 +1,17 @@
 import { Trans } from '@lingui/macro'
 import { Form, Select } from 'antd'
 import { ballotStrategiesFn } from 'constants/v2v3/ballotStrategies'
+import { V2V3ContractsContext } from 'contexts/v2v3/Contracts/V2V3ContractsContext'
 import { BallotStrategy } from 'models/ballot'
+import { useContext } from 'react'
 
 export default function CycleDeadlineDropdown({
   className,
 }: {
   className?: string
 }) {
-  const ballotStrategies = ballotStrategiesFn()
+  const { cv } = useContext(V2V3ContractsContext)
+  const ballotStrategies = ballotStrategiesFn({ cv })
   return (
     <Form.Item name="ballot" required>
       <Select className={className}>

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/RulesForm.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/RulesDrawer/RulesForm/RulesForm.tsx
@@ -13,10 +13,11 @@ import {
   USE_DATASOURCE_FOR_REDEEM_EXPLANATION,
 } from 'components/strings'
 import { ballotStrategiesFn } from 'constants/v2v3/ballotStrategies'
+import { V2V3ContractsContext } from 'contexts/v2v3/Contracts/V2V3ContractsContext'
 import { isAddress } from 'ethers/lib/utils'
 import isEqual from 'lodash/isEqual'
 import { BallotStrategy } from 'models/ballot'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useAppDispatch } from 'redux/hooks/useAppDispatch'
 import { useAppSelector } from 'redux/hooks/useAppSelector'
 import { editingV2ProjectActions } from 'redux/slices/editingV2Project'
@@ -30,10 +31,13 @@ export default function RulesForm({
   onFormUpdated?: (updated: boolean) => void
   onFinish: VoidFunction
 }) {
+  const { cv } = useContext(V2V3ContractsContext)
   const dispatch = useAppDispatch()
   const { fundingCycleMetadata, fundingCycleData } = useAppSelector(
     state => state.editingV2Project,
   )
+
+  const ballotStrategies = ballotStrategiesFn({ cv })
 
   // Form initial values set by default
   const initialValues = useMemo(
@@ -41,7 +45,7 @@ export default function RulesForm({
       pausePay: fundingCycleMetadata.pausePay,
       allowMinting: fundingCycleMetadata.allowMinting,
       ballotStrategy: getBallotStrategyByAddress(
-        fundingCycleData.ballot ?? ballotStrategiesFn()[0].address,
+        fundingCycleData.ballot ?? ballotStrategies[0].address,
       ),
       allowSetTerminals: fundingCycleMetadata.global.allowSetTerminals,
       allowSetController: fundingCycleMetadata.global.allowSetController,
@@ -51,7 +55,7 @@ export default function RulesForm({
       holdFees: fundingCycleMetadata.holdFees,
       useDataSourceForRedeem: fundingCycleMetadata.useDataSourceForRedeem,
     }),
-    [fundingCycleData, fundingCycleMetadata],
+    [fundingCycleData, fundingCycleMetadata, ballotStrategies],
   )
 
   const [showMintingWarning, setShowMintingWarning] = useState<boolean>(false)
@@ -297,7 +301,7 @@ export default function RulesForm({
           }
         >
           <ReconfigurationStrategySelector
-            ballotStrategies={ballotStrategiesFn()}
+            ballotStrategies={ballotStrategies}
             selectedStrategy={ballotStrategy}
             onChange={setBallotStrategy}
           />

--- a/src/constants/v2v3/ballotStrategies/index.ts
+++ b/src/constants/v2v3/ballotStrategies/index.ts
@@ -2,7 +2,9 @@ import { plural, t } from '@lingui/macro'
 import { readNetwork } from 'constants/networks'
 import { SECONDS_IN_DAY } from 'constants/numbers'
 import { constants } from 'ethers'
+import { CV2V3 } from 'models/v2v3/cv'
 
+import { CV_V2 } from 'constants/cv'
 import { NetworkName } from 'models/networkName'
 import { ReconfigurationStrategy } from 'models/reconfigurationStrategy'
 
@@ -69,8 +71,14 @@ const durationBallotStrategyDescription = (days: number) =>
       'Edits to an upcoming cycle must be submitted at least # days before that cycle starts.',
   })
 
-export function ballotStrategiesFn(network?: NetworkName): BallotStrategy[] {
-  return [
+export function ballotStrategiesFn({
+  network,
+  cv,
+}: {
+  network?: NetworkName
+  cv?: CV2V3
+} = {}): BallotStrategy[] {
+  const ballotStrategies: BallotStrategy[] = [
     {
       id: 'none',
       name: t`No deadline`,
@@ -78,41 +86,48 @@ export function ballotStrategiesFn(network?: NetworkName): BallotStrategy[] {
       address: constants.AddressZero,
       durationSeconds: 0,
     },
-    {
-      id: 'oneDay',
-      name: t`1-day deadline`,
-      description: durationBallotStrategyDescription(1),
-      address: BALLOT_ADDRESSES.ONE_DAY[network ?? readNetwork.name]!,
-      durationSeconds: SECONDS_IN_DAY,
-    },
-    {
-      id: 'threeDay',
-      name: t`3-day deadline`,
-      description: durationBallotStrategyDescription(3),
-      address: BALLOT_ADDRESSES.THREE_DAY[network ?? readNetwork.name]!,
-      durationSeconds: SECONDS_IN_DAY * 3,
-    },
-    {
-      id: 'sevenDay',
-      name: t`7-day deadline`,
-      description: durationBallotStrategyDescription(7),
-      address: BALLOT_ADDRESSES.SEVEN_DAY[network ?? readNetwork.name]!,
-      durationSeconds: SECONDS_IN_DAY * 7,
-    },
-    // v2, hacky, sorry
-    {
-      id: 'threeDayV2',
-      name: t`V2 3-day deadline`,
-      description: durationBallotStrategyDescription(3),
-      address: V2_BALLOT_ADDRESSES.THREE_DAY[network ?? readNetwork.name]!,
-      durationSeconds: SECONDS_IN_DAY * 3,
-    },
-    {
-      id: 'sevenDayV2',
-      name: t`V2 7-day deadline`,
-      description: durationBallotStrategyDescription(7),
-      address: V2_BALLOT_ADDRESSES.SEVEN_DAY[network ?? readNetwork.name]!,
-      durationSeconds: SECONDS_IN_DAY * 7,
-    },
   ]
+  if (cv === CV_V2) {
+    ballotStrategies.push(
+      {
+        id: 'threeDayV2',
+        name: t`V2 3-day deadline`,
+        description: durationBallotStrategyDescription(3),
+        address: V2_BALLOT_ADDRESSES.THREE_DAY[network ?? readNetwork.name]!,
+        durationSeconds: SECONDS_IN_DAY * 3,
+      },
+      {
+        id: 'sevenDayV2',
+        name: t`V2 7-day deadline`,
+        description: durationBallotStrategyDescription(7),
+        address: V2_BALLOT_ADDRESSES.SEVEN_DAY[network ?? readNetwork.name]!,
+        durationSeconds: SECONDS_IN_DAY * 7,
+      },
+    )
+  } else {
+    ballotStrategies.push(
+      {
+        id: 'oneDay',
+        name: t`1-day deadline`,
+        description: durationBallotStrategyDescription(1),
+        address: BALLOT_ADDRESSES.ONE_DAY[network ?? readNetwork.name]!,
+        durationSeconds: SECONDS_IN_DAY,
+      },
+      {
+        id: 'threeDay',
+        name: t`3-day deadline`,
+        description: durationBallotStrategyDescription(3),
+        address: BALLOT_ADDRESSES.THREE_DAY[network ?? readNetwork.name]!,
+        durationSeconds: SECONDS_IN_DAY * 3,
+      },
+      {
+        id: 'sevenDay',
+        name: t`7-day deadline`,
+        description: durationBallotStrategyDescription(7),
+        address: BALLOT_ADDRESSES.SEVEN_DAY[network ?? readNetwork.name]!,
+        durationSeconds: SECONDS_IN_DAY * 7,
+      },
+    )
+  }
+  return ballotStrategies
 }


### PR DESCRIPTION
- We're currently showing all the sets of ballots for both V2 and V3 projects in any ballot listing (BEFORE):
<img width="737" alt="Screen Shot 2023-08-30 at 6 19 22 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/64df4f24-2d8f-4199-9de8-808698a493ec">

- This PR filters out the V2 ballots for the listings on V3 projects and vice-versa (AFTER):
<img width="1139" alt="Screen Shot 2023-08-30 at 6 14 07 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/a7bcb1a7-1759-4865-bd46-056b2a07015d">


