### PR TITLE
Fix project page i18n

### DIFF
--- a/src/contexts/Language/LanguageProvider.tsx
+++ b/src/contexts/Language/LanguageProvider.tsx
@@ -9,6 +9,7 @@ export type I18nProviderProps = {
 }
 
 let i18nSingleton: { messages: Messages; locale: string } | undefined
+export const defaultI18n = { messages: {}, locale: 'en' }
 
 export const LanguageProvider: React.FC<I18nProviderProps> = ({
   children,
@@ -17,7 +18,7 @@ export const LanguageProvider: React.FC<I18nProviderProps> = ({
   if (_i18n) {
     i18nSingleton = _i18n
   } else {
-    _i18n = i18nSingleton || { messages: {}, locale: 'en' }
+    _i18n = i18nSingleton || defaultI18n
   }
 
   if (!_i18n)

--- a/src/pages/v2/p/[projectId]/index.tsx
+++ b/src/pages/v2/p/[projectId]/index.tsx
@@ -4,6 +4,7 @@ import { V2V3Dashboard } from 'components/v2v3/V2V3Project/V2V3Dashboard'
 import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { PV_V2 } from 'constants/pv'
 import { AnnouncementsProvider } from 'contexts/Announcements/AnnouncementsProvider'
+import { defaultI18n } from 'contexts/Language/LanguageProvider'
 import { V2V3ProjectPageProvider } from 'contexts/v2v3/V2V3ProjectPageProvider'
 import { paginateDepleteProjectsQueryCall } from 'lib/apollo/paginateDepleteProjectsQuery'
 import { loadCatalog } from 'locales/utils'
@@ -51,6 +52,11 @@ export const getStaticProps: GetStaticProps<
   const props = (await getProjectStaticProps(projectId)) as any
   if (props?.props?.i18n) {
     props.props.i18n = i18n
+  } else {
+    props.props = {
+      ...props.props,
+      i18n: defaultI18n,
+    }
   }
 
   return {


### PR DESCRIPTION
Currently on prod (not local), the whole project page is rendering the weird encodings. This should fix by ensuring projectPage props always has an i18n object 