### PR TITLE
[2/3] Create flow payouts table: "Review section"

### DIFF
--- a/src/components/Create/components/pages/PayoutsPage/NewPayoutsPage.tsx
+++ b/src/components/Create/components/pages/PayoutsPage/NewPayoutsPage.tsx
@@ -1,80 +1,21 @@
-import { Form } from 'antd'
-import PayoutsTable from 'components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable'
-import { CURRENCY_METADATA, CurrencyName } from 'constants/currency'
-import { Split } from 'models/splits'
 import { useContext } from 'react'
 import { useSetCreateFurthestPageReached } from 'redux/hooks/useEditingCreateFurthestPageReached'
-import { useEditingDistributionLimit } from 'redux/hooks/useEditingDistributionLimit'
-import { fromWad, parseWad } from 'utils/format/formatNumber'
-import { allocationToSplit, splitToAllocation } from 'utils/splitToAllocation'
-import { V2V3CurrencyName, getV2V3CurrencyOption } from 'utils/v2v3/currency'
-import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
 import { Wizard } from '../../Wizard'
 import { PageContext } from '../../Wizard/contexts/PageContext'
+import { CreateFlowPayoutsTable } from './components/CreateFlowPayoutsTable'
 import { TreasuryOptionsRadio } from './components/TreasuryOptionsRadio'
-import { usePayoutsForm } from './hooks'
-
-const DEFAULT_CURRENCY_NAME = CURRENCY_METADATA.ETH.name
 
 export const NewPayoutsPage = () => {
   useSetCreateFurthestPageReached('payouts')
   const { goToNextPage } = useContext(PageContext)
 
-  const [
-    editingDistributionLimit,
-    ,
-    setDistributionLimitAmount,
-    setDistributionLimitCurrency,
-  ] = useEditingDistributionLimit()
-
-  const { form, initialValues } = usePayoutsForm()
-  const distributionLimit = !editingDistributionLimit
-    ? 0
-    : editingDistributionLimit.amount.eq(MAX_DISTRIBUTION_LIMIT)
-    ? undefined
-    : parseFloat(fromWad(editingDistributionLimit?.amount))
-
-  const splits: Split[] =
-    form.getFieldValue('payoutsList')?.map(allocationToSplit) ?? []
-
-  const setDistributionLimit = (amount: number | undefined) => {
-    setDistributionLimitAmount(
-      amount === undefined ? MAX_DISTRIBUTION_LIMIT : parseWad(amount),
-    )
-  }
-  const setCurrency = (currency: CurrencyName) => {
-    setDistributionLimitCurrency(getV2V3CurrencyOption(currency))
-  }
-
-  const setSplits = (splits: Split[]) => {
-    form.setFieldsValue({ payoutsList: splits.map(splitToAllocation) })
-  }
-
   return (
-    <Form
-      form={form}
-      initialValues={initialValues}
+    <CreateFlowPayoutsTable
       onFinish={() => {
         goToNextPage?.()
       }}
-    >
-      <PayoutsTable
-        payoutSplits={splits}
-        setPayoutSplits={setSplits}
-        currency={
-          V2V3CurrencyName(editingDistributionLimit?.currency) ??
-          DEFAULT_CURRENCY_NAME
-        }
-        setCurrency={setCurrency}
-        distributionLimit={distributionLimit}
-        setDistributionLimit={setDistributionLimit}
-        topAccessory={<TreasuryOptionsRadio />}
-        hideExplaination
-        hideSettings
-      />
-      {/* Empty form item just to keep AntD useWatch happy */}
-      <Form.Item shouldUpdate name="payoutsList" className="mb-0" />
-      <Wizard.Page.ButtonControl />
-    </Form>
+      okButton={<Wizard.Page.ButtonControl />}
+      topAccessory={<TreasuryOptionsRadio />}
+    />
   )
 }

--- a/src/components/Create/components/pages/PayoutsPage/components/CreateFlowPayoutsTable.tsx
+++ b/src/components/Create/components/pages/PayoutsPage/components/CreateFlowPayoutsTable.tsx
@@ -1,0 +1,78 @@
+import { Form } from 'antd'
+import PayoutsTable from 'components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable'
+import { CURRENCY_METADATA, CurrencyName } from 'constants/currency'
+import { Split } from 'models/splits'
+import { ReactNode } from 'react'
+import { useEditingDistributionLimit } from 'redux/hooks/useEditingDistributionLimit'
+import { fromWad, parseWad } from 'utils/format/formatNumber'
+import { allocationToSplit, splitToAllocation } from 'utils/splitToAllocation'
+import { V2V3CurrencyName, getV2V3CurrencyOption } from 'utils/v2v3/currency'
+import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
+import { usePayoutsForm } from '../hooks'
+
+export const DEFAULT_CURRENCY_NAME = CURRENCY_METADATA.ETH.name
+
+export function CreateFlowPayoutsTable({
+  onFinish,
+  topAccessory,
+  okButton,
+  addPayoutsDisabled,
+}: {
+  onFinish?: VoidFunction
+  okButton?: ReactNode
+  topAccessory?: ReactNode
+  addPayoutsDisabled?: boolean
+}) {
+  const [
+    editingDistributionLimit,
+    ,
+    setDistributionLimitAmount,
+    setDistributionLimitCurrency,
+  ] = useEditingDistributionLimit()
+
+  const { form, initialValues } = usePayoutsForm()
+  const distributionLimit = !editingDistributionLimit
+    ? 0
+    : editingDistributionLimit.amount.eq(MAX_DISTRIBUTION_LIMIT)
+    ? undefined
+    : parseFloat(fromWad(editingDistributionLimit?.amount))
+
+  const splits: Split[] =
+    form.getFieldValue('payoutsList')?.map(allocationToSplit) ?? []
+
+  const setDistributionLimit = (amount: number | undefined) => {
+    setDistributionLimitAmount(
+      amount === undefined ? MAX_DISTRIBUTION_LIMIT : parseWad(amount),
+    )
+  }
+  const setCurrency = (currency: CurrencyName) => {
+    setDistributionLimitCurrency(getV2V3CurrencyOption(currency))
+  }
+
+  const setSplits = (splits: Split[]) => {
+    form.setFieldsValue({ payoutsList: splits.map(splitToAllocation) })
+  }
+
+  return (
+    <Form form={form} initialValues={initialValues} onFinish={onFinish}>
+      <PayoutsTable
+        payoutSplits={splits}
+        setPayoutSplits={setSplits}
+        currency={
+          V2V3CurrencyName(editingDistributionLimit?.currency) ??
+          DEFAULT_CURRENCY_NAME
+        }
+        setCurrency={setCurrency}
+        distributionLimit={distributionLimit}
+        setDistributionLimit={setDistributionLimit}
+        topAccessory={topAccessory}
+        hideExplaination
+        hideSettings
+        addPayoutsDisabled={addPayoutsDisabled}
+      />
+      {/* Empty form item just to keep AntD useWatch happy */}
+      <Form.Item shouldUpdate name="payoutsList" className="mb-0" />
+      {okButton}
+    </Form>
+  )
+}

--- a/src/components/Create/components/pages/ReviewDeploy/components/FundingConfigurationReview/FundingConfigurationReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/FundingConfigurationReview/FundingConfigurationReview.tsx
@@ -1,6 +1,9 @@
 import { t, Trans } from '@lingui/macro'
 import { Tooltip } from 'antd'
+import { FEATURE_FLAGS } from 'constants/featureFlags'
 import { twMerge } from 'tailwind-merge'
+import { featureFlagEnabled } from 'utils/featureFlags'
+import { CreateFlowPayoutsTable } from '../../../PayoutsPage/components/CreateFlowPayoutsTable'
 import { PayoutsList } from '../../../PayoutsPage/components/PayoutsList'
 import { ReviewDescription } from '../ReviewDescription'
 import { useFundingConfigurationReview } from './hooks/useFundingConfigurationReview'
@@ -16,60 +19,78 @@ export const FundingConfigurationReview = () => {
     launchDate,
   } = useFundingConfigurationReview()
 
-  return (
-    <div className="flex flex-col gap-y-10 pt-5 pb-12 md:grid md:grid-cols-4">
-      <ReviewDescription
-        title={t`Cycles`}
-        desc={<div className="text-base font-medium">{fundingCycles}</div>}
-      />
-      <ReviewDescription
-        title={t`Duration`}
-        desc={
-          duration ? (
-            <div className="text-base font-medium">{duration}</div>
-          ) : null
-        }
-      />
-      <ReviewDescription
-        className="col-span-2"
-        title={t`Scheduled launch time`}
-        desc={
-          <div className="text-base font-medium">
-            {launchDate ? (
-              <Tooltip
-                title={launchDate.clone().utc().format('MMMM Do YYYY, h:mma z')}
-              >
-                {launchDate.clone().format('MMMM Do YYYY, h:mma z')}
-              </Tooltip>
-            ) : (
-              <Trans>Immediately</Trans>
-            )}
-          </div>
-        }
-      />
-      <ReviewDescription
-        title={t`Payouts`}
-        desc={<div className="text-base font-medium">{fundingTarget}</div>}
-      />
+  const newPayoutsTableEnabled = featureFlagEnabled(
+    FEATURE_FLAGS.PAYOUTS_TABLE_CREATE_FLOW,
+  )
 
-      <ReviewDescription
-        className={twMerge(allocationSplits.length ? 'col-span-4' : '')}
-        title={t`Payout recipients`}
-        desc={
-          allocationSplits.length > 0 ? (
-            <PayoutsList
-              value={allocationSplits}
-              onChange={setAllocationSplits}
-              payoutsSelection={selection ?? 'amounts'}
-              isEditable={false}
-            />
-          ) : (
+  return (
+    <>
+      <div className="flex flex-col gap-y-10 pt-5 pb-12 md:grid md:grid-cols-4">
+        <ReviewDescription
+          title={t`Cycles`}
+          desc={<div className="text-base font-medium">{fundingCycles}</div>}
+        />
+        <ReviewDescription
+          title={t`Duration`}
+          desc={
+            duration ? (
+              <div className="text-base font-medium">{duration}</div>
+            ) : null
+          }
+        />
+        <ReviewDescription
+          className="col-span-2"
+          title={t`Scheduled launch time`}
+          desc={
             <div className="text-base font-medium">
-              <Trans>None</Trans>
+              {launchDate ? (
+                <Tooltip
+                  title={launchDate
+                    .clone()
+                    .utc()
+                    .format('MMMM Do YYYY, h:mma z')}
+                >
+                  {launchDate.clone().format('MMMM Do YYYY, h:mma z')}
+                </Tooltip>
+              ) : (
+                <Trans>Immediately</Trans>
+              )}
             </div>
-          )
-        }
-      />
-    </div>
+          }
+        />
+        {newPayoutsTableEnabled ? null : (
+          <>
+            <ReviewDescription
+              title={t`Payouts`}
+              desc={
+                <div className="text-base font-medium">{fundingTarget}</div>
+              }
+            />
+
+            <ReviewDescription
+              className={twMerge(allocationSplits.length ? 'col-span-4' : '')}
+              title={t`Payout recipients`}
+              desc={
+                allocationSplits.length > 0 ? (
+                  <PayoutsList
+                    value={allocationSplits}
+                    onChange={setAllocationSplits}
+                    payoutsSelection={selection ?? 'amounts'}
+                    isEditable={false}
+                  />
+                ) : (
+                  <div className="text-base font-medium">
+                    <Trans>None</Trans>
+                  </div>
+                )
+              }
+            />
+          </>
+        )}
+      </div>
+      {newPayoutsTableEnabled ? (
+        <CreateFlowPayoutsTable addPayoutsDisabled />
+      ) : null}
+    </>
   )
 }

--- a/src/components/ui/PopupMenu.tsx
+++ b/src/components/ui/PopupMenu.tsx
@@ -26,6 +26,7 @@ type ButtonItem = {
 export type PopupMenuItem = ComponentItem | LinkItem | ButtonItem
 
 export type PopupMenuProps = {
+  customButton?: ReactNode
   className?: string
   popupClassName?: string
   menuButtonIconClassName?: string
@@ -41,6 +42,7 @@ function isButtonItem(item: PopupMenuItem): item is ButtonItem {
 }
 
 export const PopupMenu = ({
+  customButton,
   className,
   popupClassName,
   items,
@@ -53,12 +55,16 @@ export const PopupMenu = ({
           <>
             <Menu.Button
               className={twMerge(
-                open && 'rounded-lg bg-smoke-100 dark:bg-slate-600',
+                open &&
+                  !customButton &&
+                  'rounded-lg bg-smoke-100 dark:bg-slate-600',
               )}
             >
-              <EllipsisVerticalIcon
-                className={twMerge('h-6 w-6', menuButtonIconClassName)}
-              />
+              {customButton ?? (
+                <EllipsisVerticalIcon
+                  className={twMerge('h-6 w-6', menuButtonIconClassName)}
+                />
+              )}
             </Menu.Button>
 
             <Menu.Items

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/CurrencySwitcher.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/CurrencySwitcher.tsx
@@ -1,0 +1,83 @@
+import { ArrowPathIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
+import { Trans } from '@lingui/macro'
+import { PopupMenu } from 'components/ui/PopupMenu'
+import { useCurrencyConverter } from 'hooks/useCurrencyConverter'
+import round from 'lodash/round'
+import { fromWad, parseWad } from 'utils/format/formatNumber'
+import { V2V3_CURRENCY_ETH, V2V3_CURRENCY_USD } from 'utils/v2v3/currency'
+import { usePayoutsTable } from '../hooks/usePayoutsTable'
+import {
+  payoutsTableMenuItemsIconClass,
+  payoutsTableMenuItemsLabelClass,
+} from './PayoutTableSettings'
+
+export function CurrencySwitcher() {
+  const { currency, setCurrency, distributionLimit, setDistributionLimit } =
+    usePayoutsTable()
+  const converter = useCurrencyConverter()
+
+  const button = (
+    <div className="flex items-center gap-2">
+      {currency === 'ETH' ? (
+        <Trans>Amount (ETH)</Trans>
+      ) : (
+        <Trans>Amount (USD)</Trans>
+      )}
+      <ChevronDownIcon className="h-4 w-4" />
+    </div>
+  )
+
+  const itemsClassName = `${payoutsTableMenuItemsLabelClass} text-primary`
+  const items =
+    currency === 'ETH'
+      ? [
+          {
+            id: 'switchToUsd',
+            label: (
+              <div className={itemsClassName}>
+                <ArrowPathIcon className={payoutsTableMenuItemsIconClass} />
+                <Trans>Convert to USD</Trans>
+              </div>
+            ),
+            onClick: () => {
+              const usdAmount = converter.wadToCurrency(
+                parseWad(distributionLimit),
+                'USD',
+                'ETH',
+              )
+              const formattedUsdAmount = round(
+                parseFloat(fromWad(usdAmount)),
+                2,
+              )
+              setDistributionLimit(formattedUsdAmount)
+              setCurrency(V2V3_CURRENCY_USD)
+            },
+          },
+        ]
+      : [
+          {
+            id: 'switchToEth',
+            label: (
+              <div className={itemsClassName}>
+                <ArrowPathIcon className={payoutsTableMenuItemsIconClass} />
+                <Trans>Convert to ETH</Trans>
+              </div>
+            ),
+            onClick: () => {
+              const ethAmount = converter.wadToCurrency(
+                parseWad(distributionLimit),
+                'ETH',
+                'USD',
+              )
+              const formattedEthAmount = round(
+                parseFloat(fromWad(ethAmount)),
+                4,
+              )
+              setDistributionLimit(formattedEthAmount)
+              setCurrency(V2V3_CURRENCY_ETH)
+            },
+          },
+        ]
+
+  return <PopupMenu customButton={button} items={items} />
+}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/HeaderRows.tsx
@@ -17,7 +17,8 @@ import { usePayoutsTableContext } from './context/PayoutsTableContext'
 export function HeaderRows() {
   const [addRecipientModalOpen, setAddRecipientModalOpen] = useState<boolean>()
 
-  const { hideExplaination, hideSettings } = usePayoutsTableContext()
+  const { hideExplaination, hideSettings, addPayoutsDisabled } =
+    usePayoutsTableContext()
 
   const { distributionLimitIsInfinite, handleNewPayoutSplit, payoutSplits } =
     usePayoutsTable()
@@ -58,15 +59,17 @@ export function HeaderRows() {
         </div>
         <div className={`align-top ${hideExplaination ? 'pt-3' : 'pt-6'}`}>
           <div className="flex items-center justify-end gap-3">
-            <Button
-              type="ghost"
-              onClick={() => setAddRecipientModalOpen(true)}
-              icon={<PlusOutlined />}
-            >
-              <span>
-                <Trans>Add recipient</Trans>
-              </span>
-            </Button>
+            {addPayoutsDisabled ? null : (
+              <Button
+                type="ghost"
+                onClick={() => setAddRecipientModalOpen(true)}
+                icon={<PlusOutlined />}
+              >
+                <span>
+                  <Trans>Add recipient</Trans>
+                </span>
+              </Button>
+            )}
             {payoutSplits?.length === 0 || hideSettings ? null : (
               <PayoutTableSettings />
             )}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/PayoutTableSettings.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/PayoutTableSettings.tsx
@@ -9,6 +9,9 @@ import { fromWad } from 'utils/format/formatNumber'
 import { usePayoutsTable } from '../hooks/usePayoutsTable'
 import { SwitchToUnlimitedModal } from './modals/SwitchToUnlimitedModal'
 
+export const payoutsTableMenuItemsLabelClass = 'flex gap-2 items-center text-sm'
+export const payoutsTableMenuItemsIconClass = 'h-5 w-5'
+
 export function PayoutTableSettings() {
   const [switchToUnlimitedModalOpen, setSwitchToUnlimitedModalOpen] =
     useState<boolean>(false)
@@ -34,8 +37,6 @@ export function PayoutTableSettings() {
     setSwitchToUnlimitedModalOpen(false)
   }
 
-  const menuItemsLabelClass = 'flex gap-2 items-center text-sm'
-  const menuItemsIconClass = 'h-5 w-5'
   let menuItems: PopupMenuItem[] = []
 
   if (distributionLimitIsInfinite) {
@@ -44,8 +45,8 @@ export function PayoutTableSettings() {
       {
         id: 'limited',
         label: (
-          <div className={menuItemsLabelClass}>
-            <ReceiptPercentIcon className={menuItemsIconClass} />
+          <div className={payoutsTableMenuItemsLabelClass}>
+            <ReceiptPercentIcon className={payoutsTableMenuItemsIconClass} />
             <Trans>Switch to limited</Trans>
           </div>
         ),
@@ -58,8 +59,8 @@ export function PayoutTableSettings() {
       {
         id: 'unlimited',
         label: (
-          <div className={menuItemsLabelClass}>
-            <ReceiptPercentIcon className={menuItemsIconClass} />
+          <div className={payoutsTableMenuItemsLabelClass}>
+            <ReceiptPercentIcon className={payoutsTableMenuItemsIconClass} />
             <Trans>Switch to unlimited</Trans>
           </div>
         ),
@@ -74,8 +75,8 @@ export function PayoutTableSettings() {
       {
         id: 'delete',
         label: (
-          <div className={menuItemsLabelClass}>
-            <TrashIcon className={menuItemsIconClass} />
+          <div className={payoutsTableMenuItemsLabelClass}>
+            <TrashIcon className={payoutsTableMenuItemsIconClass} />
             <Trans>Delete all</Trans>
           </div>
         ),

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/PayoutsTableBody.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/PayoutsTableBody.tsx
@@ -3,6 +3,7 @@ import { Form } from 'antd'
 import { Allocation } from 'components/v2v3/shared/Allocation'
 import { getV2V3CurrencyOption } from 'utils/v2v3/currency'
 import { usePayoutsTable } from '../hooks/usePayoutsTable'
+import { CurrencySwitcher } from './CurrencySwitcher'
 import { HeaderRows } from './HeaderRows'
 import { PayoutSplitRow } from './PayoutSplitRow'
 import { PayoutsTableCell } from './PayoutsTableCell'
@@ -22,7 +23,7 @@ export function PayoutsTableBody() {
     setCurrency,
     distributionLimit,
   } = usePayoutsTable()
-  const emptyState = distributionLimit === 0
+  const emptyState = distributionLimit === 0 && !payoutSplits?.length
 
   return (
     <>
@@ -49,7 +50,7 @@ export function PayoutsTableBody() {
                         <Trans>Address or ID</Trans>
                       </Cell>
                       <Cell>
-                        <Trans>Amount</Trans>
+                        <CurrencySwitcher />
                       </Cell>
                     </Row>
                   ) : null}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/context/PayoutsTableContext.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/PayoutsSection/PayoutsTable/context/PayoutsTableContext.tsx
@@ -12,6 +12,7 @@ export interface PayoutsTableContextProps {
   hideExplaination?: boolean
   topAccessory?: ReactNode
   hideSettings?: boolean
+  addPayoutsDisabled?: boolean
 }
 
 export const PayoutsTableContext = createContext<

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -266,6 +266,9 @@ msgstr ""
 msgid "or <0><1>sell {tokenSymbol} on exchange.</1></0>"
 msgstr ""
 
+msgid "Amount (USD)"
+msgstr ""
+
 msgid "Payout recipients"
 msgstr ""
 
@@ -1416,6 +1419,9 @@ msgid "Check this to mint {tokenSymbol} ERC-20 to your wallet. Leave unchecked t
 msgstr ""
 
 msgid "minutes"
+msgstr ""
+
+msgid "Convert to USD"
 msgstr ""
 
 msgid "The project owner is the only payout recipient. Any ETH paid out this cycle will go to them."
@@ -4235,6 +4241,9 @@ msgstr ""
 msgid "{0} is not valid URL"
 msgstr ""
 
+msgid "Amount (ETH)"
+msgstr ""
+
 msgid "You haven't created any projects yet!"
 msgstr ""
 
@@ -4866,6 +4875,9 @@ msgid "Custom deadline contract"
 msgstr ""
 
 msgid "Unlocked Cycles"
+msgstr ""
+
+msgid "Convert to ETH"
 msgstr ""
 
 msgid "No edits were made to tokens for this cycle."

--- a/src/redux/hooks/useEditingDistributionLimit.ts
+++ b/src/redux/hooks/useEditingDistributionLimit.ts
@@ -76,10 +76,18 @@ export const useEditingDistributionLimit = (): [
   const setDistributionLimitAmount = useCallback(
     (input: BigNumber) => {
       if (!defaultJBETHPaymentTerminal) return
+
+      const currentFundAccessConstraint = fundAccessConstraints?.[0] ?? {
+        terminal: defaultJBETHPaymentTerminal?.address,
+        token: ETH_TOKEN_ADDRESS,
+        distributionLimitCurrency: V2V3_CURRENCY_ETH.toString(),
+        overflowAllowance: '0',
+        overflowAllowanceCurrency: '0',
+      }
       dispatch(
         editingV2ProjectActions.setFundAccessConstraints([
           {
-            ...fundAccessConstraints?.[0],
+            ...currentFundAccessConstraint,
             distributionLimit: fromWad(
               input === undefined ? MAX_DISTRIBUTION_LIMIT : input,
             ),

--- a/src/utils/format/formatCurrency.ts
+++ b/src/utils/format/formatCurrency.ts
@@ -1,6 +1,7 @@
 import { BigNumber, BigNumberish } from 'ethers'
 
 import { CurrencyName } from 'constants/currency'
+import round from 'lodash/round'
 import { parseWad } from './formatNumber'
 
 export class CurrencyUtils {
@@ -59,7 +60,7 @@ export class CurrencyUtils {
       return parseWad(this.weiToUsd(amount)?.toString())
     if (targetCurrency === 'ETH' && this.usdPerEth !== undefined)
       return BigNumber.from(amount)
-        .div(this.usdPerEth * 100)
+        .div(round(this.usdPerEth * 100))
         .mul(100)
   }
 }


### PR DESCRIPTION
- Creates a `CreateFlowPayoutsTable` component to reuse in the two places in the create flow: "Payouts" tab and "Review" tab 

https://github.com/jbx-protocol/juice-interface/assets/96150256/47ef540a-318b-4634-b3b9-8fcb42e68ae6

