### PR TITLE
fix: upcoming tab fixes

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/components/CurrentUpcomingSubPanel.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/components/CurrentUpcomingSubPanel.tsx
@@ -63,7 +63,16 @@ export const CurrentUpcomingSubPanel = ({
     </Trans>
   )
 
-  if (info.type === 'upcoming' && info.cycleUnlocked) {
+  if (
+    info.type === 'upcoming' &&
+    info.cycleUnlocked &&
+    /**
+     * Always show 'upcoming' tab if it's FC 1
+     * (which happens when Scheduled Launch is used,
+     * mustStartAtOrAfter is in the future)
+     */
+    info.cycleNumber !== 1
+  ) {
     return (
       <div>
         <div

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationExtensionSection.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationExtensionSection.ts
@@ -90,7 +90,10 @@ export const useFormatConfigurationExtensionSection = ({
     }
   }, [contractDatum, useForPaymentsDatum, useForRedemptionsDatum])
 
-  if (isZeroAddress(fundingCycleMetadata?.dataSource)) {
+  if (
+    isZeroAddress(fundingCycleMetadata?.dataSource) &&
+    !upcomingFundingCycleMetadata
+  ) {
     return null
   }
 

--- a/src/hooks/v2v3/contractReader/useProjectUpcomingFundingCycle.ts
+++ b/src/hooks/v2v3/contractReader/useProjectUpcomingFundingCycle.ts
@@ -14,7 +14,7 @@ type UpcomingFundingCycleDataType = [
 ]
 
 /**
- * If the latestConfiguredFundingCycleOf has an active ballot, return latestConfiguredFundingCycleOf.
+ * If the latestConfiguredFundingCycleOf's ballot state is ACTIVE, return latestConfiguredFundingCycleOf.
  * Else, return queuedFundingCycleOf.
  */
 export function useProjectUpcomingFundingCycle({
@@ -42,7 +42,7 @@ export function useProjectUpcomingFundingCycle({
     latestConfiguredFundingCycleBallotState === BallotState.active
 
   /**
-   * Get Queued Configured Funding Cycle, only if latestConfiguredFundingCycle isn't active.
+   * Get Queued Configured Funding Cycle, *only if* latestConfiguredFundingCycle isn't active.
    */
   const {
     data: queuedFundingCycleResponse,
@@ -56,6 +56,9 @@ export function useProjectUpcomingFundingCycle({
   const loading =
     queuedFundingCycleLoading || latestConfiguredFundingCycleLoading
 
+  /**
+   * Return latest configured cycle if it exists and is active
+   */
   if (isLatestConfiguredActive) {
     return {
       data: [
@@ -68,6 +71,9 @@ export function useProjectUpcomingFundingCycle({
     }
   }
 
+  /**
+   * Else, return the queued cycle.
+   */
   return {
     data: [queuedFundingCycle, queuedFundingCycleMetadata],
     loading,


### PR DESCRIPTION
- always show 'upcoming' tab when its the first cycle (i.e. Scheduled Launch)
- always show "extension" section on upcoming tab
