### PR TITLE
Enable buyback delegate metadata for pay() txs to juicebox

### DIFF
--- a/src/components/AMMPrices/hooks/useERC20UniswapPrice.ts
+++ b/src/components/AMMPrices/hooks/useERC20UniswapPrice.ts
@@ -35,8 +35,8 @@ interface State {
 }
 
 type Props = {
-  tokenSymbol: string
-  tokenAddress: string
+  tokenSymbol: string | undefined
+  tokenAddress: string | undefined
 }
 
 /**
@@ -126,6 +126,8 @@ export function useUniswapPriceQuery({ tokenSymbol, tokenAddress }: Props) {
   return useQuery(
     [`${tokenSymbol}-uniswap-price`],
     async () => {
+      if (!tokenAddress || !tokenSymbol) return null
+
       try {
         const poolAddress = await getPoolAddress()
         if (!poolAddress) {
@@ -179,6 +181,7 @@ export function useUniswapPriceQuery({ tokenSymbol, tokenAddress }: Props) {
     },
     {
       refetchInterval: 30000, // refetch every 30 seconds
+      enabled: !!(tokenAddress && tokenSymbol),
     },
   )
 }

--- a/src/components/AMMPrices/hooks/useERC20UniswapPrice.ts
+++ b/src/components/AMMPrices/hooks/useERC20UniswapPrice.ts
@@ -2,6 +2,7 @@ import { Token } from '@uniswap/sdk-core'
 import IUniswapV3FactoryABI from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Factory.sol/IUniswapV3Factory.json'
 import IUniswapV3PoolABI from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 import {
+  FeeAmount,
   Pool,
   FACTORY_ADDRESS as UNISWAP_V3_FACTORY_ADDRESS,
 } from '@uniswap/v3-sdk'
@@ -43,7 +44,12 @@ type Props = {
  * Pools are created at a specific fee tier.
  * https://docs.uniswap.org/protocol/concepts/V3-overview/fees#pool-fees-tiers
  */
-const UNISWAP_FEES_BPS = [10000, 3000, 500]
+const UNISWAP_FEES_BPS = [
+  FeeAmount.LOWEST,
+  FeeAmount.LOW,
+  FeeAmount.MEDIUM,
+  FeeAmount.HIGH,
+]
 const networkId = readNetwork.chainId
 
 /**

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -21,7 +21,7 @@ import {
   encodeJB721DelegateV3_2RedeemMetadata,
   encodeJB721DelegateV3_4RedeemMetadata,
   encodeJB721DelegateV3RedeemMetadata,
-} from 'utils/encodeJb721DelegateMetadata/encodeJb721DelegateMetadata'
+} from 'utils/delegateMetadata/encodeJb721DelegateMetadata'
 import { emitErrorNotification } from 'utils/notifications'
 import { formatRedemptionRate } from 'utils/v2v3/math'
 import { RedeemNftCard } from './RedeemNftCard'

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/ReceiveTokensItem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/ReceiveTokensItem.tsx
@@ -1,11 +1,16 @@
 import { Trans } from '@lingui/macro'
+import TooltipIcon from 'components/TooltipIcon'
 import { useProjectHasErc20Token } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectHasErc20Token'
 import { useProjectPaymentTokens } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectPaymentTokens'
+import { BUYBACK_DELEGATE_ENABLED_PROJECT_IDS } from 'constants/buybackDelegateEnabledProjectIds'
+import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
+import { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { CartItemBadge } from '../../Cart/components/CartItem/CartItemBadge'
 import { ProjectHeaderLogo } from '../../ProjectHeader/components/ProjectHeaderLogo'
 
 export const ReceiveTokensItem = ({ className }: { className?: string }) => {
+  const { projectId } = useContext(ProjectMetadataContext)
   const { receivedTickets, receivedTokenSymbolText } = useProjectPaymentTokens()
   const projectHasErc20Token = useProjectHasErc20Token()
 
@@ -19,6 +24,9 @@ export const ReceiveTokensItem = ({ className }: { className?: string }) => {
     return null
   }
 
+  const buybackDelegateEnabled =
+    projectId && BUYBACK_DELEGATE_ENABLED_PROJECT_IDS.includes(projectId)
+
   return (
     <div className={twMerge('flex flex-col gap-4', className)}>
       <div className="flex items-center justify-between gap-3">
@@ -31,7 +39,18 @@ export const ReceiveTokensItem = ({ className }: { className?: string }) => {
             <Trans>{badgeTitle} Token</Trans>
           </CartItemBadge>
         </div>
-        <div>{receivedTickets}</div>
+        {buybackDelegateEnabled ? (
+          <div>
+            ≥ {receivedTickets}
+            <TooltipIcon
+              tip={
+                'This project may purchase tokens from a secondary market instead of minting new tokens, which may result in more tokens distributed depending on the swap price.'
+              }
+            />
+          </div>
+        ) : (
+          <div>{receivedTickets}</div>
+        )}
       </div>
     </div>
   )

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/ReceiveTokensItem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/ReceiveTokensItem.tsx
@@ -44,7 +44,7 @@ export const ReceiveTokensItem = ({ className }: { className?: string }) => {
             ≥ {receivedTickets}
             <TooltipIcon
               tip={
-                'This project may purchase tokens from a secondary market instead of minting new tokens, which may result in more tokens distributed depending on the swap price.'
+                'Your payment may purchase tokens from a secondary market instead of minting new tokens. You might receive more tokens depending on the swap price.'
               }
             />
           </div>

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/ReceiveTokensItem.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/ReceiveTokensItem.tsx
@@ -1,4 +1,4 @@
-import { Trans } from '@lingui/macro'
+import { Trans, t } from '@lingui/macro'
 import TooltipIcon from 'components/TooltipIcon'
 import { useProjectHasErc20Token } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectHasErc20Token'
 import { useProjectPaymentTokens } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectPaymentTokens'
@@ -41,11 +41,9 @@ export const ReceiveTokensItem = ({ className }: { className?: string }) => {
         </div>
         {buybackDelegateEnabled ? (
           <div>
-            ≥ {receivedTickets}
+            ≥ {receivedTickets}{' '}
             <TooltipIcon
-              tip={
-                'Your payment may purchase tokens from a secondary market instead of minting new tokens. You might receive more tokens depending on the swap price.'
-              }
+              tip={t`Your payment may purchase tokens from a secondary market instead of minting new tokens. You might receive more tokens depending on the swap price.`}
             />
           </div>
         ) : (

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectModal.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectModal.test.ts
@@ -2,6 +2,9 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react'
+import { Price, Token } from '@uniswap/sdk-core'
+import { ADDRESS_ZERO } from '@uniswap/v3-sdk'
+import { useUniswapPriceQuery } from 'components/AMMPrices/hooks/useERC20UniswapPrice'
 import { useWallet } from 'hooks/Wallet'
 import { useCurrencyConverter } from 'hooks/useCurrencyConverter'
 import { CurrencyUtils } from 'utils/format/formatCurrency'
@@ -14,6 +17,7 @@ jest.mock('hooks/Wallet')
 jest.mock('hooks/useCurrencyConverter')
 jest.mock('../useProjectCart')
 jest.mock('../useProjectPageQueries')
+jest.mock('components/AMMPrices/hooks/useERC20UniswapPrice')
 
 describe('usePayProjectModal', () => {
   const DefaultuseProjectCart = {
@@ -31,12 +35,24 @@ describe('usePayProjectModal', () => {
     userAddress: '0x1234567890',
   }
   const mockCurrencyUtils = new CurrencyUtils(2000)
+  const mockPriceQuery = {
+    data: {
+      liquidity: '1000000',
+      projectTokenPrice: new Price(
+        new Token(1, ADDRESS_ZERO, 18),
+        new Token(1, ADDRESS_ZERO, 18),
+        1000,
+        1000,
+      ),
+    },
+  }
   beforeEach(() => {
     DefaultuseProjectCart.dispatch.mockClear()
     DefaultUseProjectPageQueries.setProjectPayReceipt.mockClear()
     ;(useProjectCart as jest.Mock).mockReturnValue(DefaultuseProjectCart)
     ;(useWallet as jest.Mock).mockReturnValue(DefaultUseWallet)
     ;(useCurrencyConverter as jest.Mock).mockReturnValue(mockCurrencyUtils)
+    ;(useUniswapPriceQuery as jest.Mock).mockReturnValue(mockPriceQuery)
     ;(useProjectPageQueries as jest.Mock).mockReturnValue(
       DefaultUseProjectPageQueries,
     )

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -94,11 +94,14 @@ export const usePayProjectTx = ({
         priceQuery?.projectTokenPrice.numerator.toString()
       const priceQueryDenominator =
         priceQuery?.projectTokenPrice.denominator.toString()
-      const priceQueryFactor = BigNumber.from(priceQueryNumerator ?? 0).div(
-        BigNumber.from(priceQueryDenominator ?? 0),
-      )
+      const priceQueryFactor =
+        priceQueryNumerator && priceQueryDenominator
+          ? BigNumber.from(priceQueryNumerator).div(
+              BigNumber.from(priceQueryDenominator),
+            )
+          : undefined
 
-      const expectedTokensFromSwap = priceQueryFactor.gt(0)
+      const expectedTokensFromSwap = priceQueryFactor?.gt(0)
         ? weiAmount.div(priceQueryFactor)
         : undefined
 

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -94,15 +94,16 @@ export const usePayProjectTx = ({
         priceQuery?.projectTokenPrice.numerator.toString()
       const priceQueryDenominator =
         priceQuery?.projectTokenPrice.denominator.toString()
-      const priceQueryFactor =
+      const inversePriceQueryFactor =
         priceQueryNumerator && priceQueryDenominator
-          ? BigNumber.from(priceQueryNumerator).div(
-              BigNumber.from(priceQueryDenominator),
+          ? BigNumber.from(priceQueryDenominator).div(
+              BigNumber.from(priceQueryNumerator),
             )
           : undefined
 
-      const expectedTokensFromSwap = priceQueryFactor?.gt(0)
-        ? weiAmount.div(priceQueryFactor)
+      // Using inverse price query helps avoid dividing by zero. This assumes the token price is < 1ETH
+      const expectedTokensFromSwap = inversePriceQueryFactor?.gt(0)
+        ? weiAmount.mul(inversePriceQueryFactor)
         : undefined
 
       /**

--- a/src/constants/buybackDelegate.ts
+++ b/src/constants/buybackDelegate.ts
@@ -1,0 +1,1 @@
+export const IJBBuybackDelegate_INTERFACE_ID = '0x42555942' // bytes4('BUYB')

--- a/src/constants/buybackDelegateEnabledProjectIds.ts
+++ b/src/constants/buybackDelegateEnabledProjectIds.ts
@@ -1,0 +1,2 @@
+// v2 projects with buyback delegate metadata enabled for pay
+export const BUYBACK_DELEGATE_ENABLED_PROJECT_IDS = [1]

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -3713,6 +3713,9 @@ msgstr ""
 msgid "Detach NFTs from cycle"
 msgstr ""
 
+msgid "Your payment may purchase tokens from a secondary market instead of minting new tokens. You might receive more tokens depending on the swap price."
+msgstr ""
+
 msgid "Mint tokens"
 msgstr ""
 

--- a/src/utils/delegateMetadata/encodeDelegateMetadata.ts
+++ b/src/utils/delegateMetadata/encodeDelegateMetadata.ts
@@ -1,0 +1,98 @@
+import { IJBBuybackDelegate_INTERFACE_ID } from 'constants/buybackDelegate'
+import { IJBTiered721Delegate_V3_4_PAY_ID } from 'constants/nftRewards'
+import { BigNumber, BigNumberish, utils } from 'ethers'
+import { createMetadata } from 'juicebox-metadata-helper'
+import { JB721DelegateVersion } from 'models/v2v3/contracts'
+import {
+  JB721DelegatePayMetadata,
+  encodeJb721DelegateMetadata,
+} from 'utils/delegateMetadata/encodeJb721DelegateMetadata'
+
+/**
+ * Encode pay metadata for project delegate contracts.
+ *
+ * Supports delegate contracts:
+ *  - jb721Delegate
+ *  - jbBuybackDelegate
+ *
+ * Note: jbBuybackDelegate metadata uses the Metadata Lib pattern (https://github.com/jbx-protocol/juice-delegate-metadata-lib) and CANNOT be encoded with jb721Delegate contracts older than version 3.4.
+ *
+ * @param jbBuyBackDelegate.amountToSwap The amount of ETH to use to buy project tokens. "0" will use full pay() amount
+ * @param jbBuyBackDelegate.minExpectedTokens Minimum expected received tokens from swap
+ * @param jb721Delegate.metadata Metadata for jb721Delegate
+ * @param jb721Delegate.version Version of jb721Delegate
+ * @returns Encoded metadata string for buyback delegate https://github.com/jbx-protocol/juice-buyback
+ */
+export function encodeDelegateMetadata({
+  jbBuybackDelegate,
+  jb721Delegate,
+}: {
+  jbBuybackDelegate?: {
+    amountToSwap: BigNumberish
+    minExpectedTokens: BigNumberish
+  }
+  jb721Delegate?: {
+    metadata: JB721DelegatePayMetadata
+    version: JB721DelegateVersion | undefined
+  }
+}) {
+  if (
+    jb721Delegate &&
+    jb721Delegate.version &&
+    !jb721DelegateVersionSupportsMetadataLib(jb721Delegate.version)
+  ) {
+    // Encode without using metadata lib pattern
+
+    if (jbBuybackDelegate) {
+      throw new Error(
+        'Metadata encoding for JBBuybackDelegate incompatible with encoding for JB721Delegate',
+      )
+    }
+
+    return encodeJb721DelegateMetadata(
+      jb721Delegate.metadata,
+      jb721Delegate.version,
+    )
+  }
+
+  const ids: string[] = []
+  const metadatas: string[] = []
+
+  if (jbBuybackDelegate) {
+    ids.push(IJBBuybackDelegate_INTERFACE_ID)
+    metadatas.push(
+      utils.defaultAbiCoder.encode(
+        ['uint256', 'uint256'],
+        [
+          BigNumber.from(jbBuybackDelegate.amountToSwap).toHexString(),
+          BigNumber.from(jbBuybackDelegate.minExpectedTokens).toHexString(),
+        ],
+      ),
+    )
+  }
+
+  if (jb721Delegate?.version) {
+    const encoded = encodeJb721DelegateMetadata(
+      jb721Delegate.metadata,
+      jb721Delegate.version,
+    )
+
+    if (encoded) {
+      ids.push(IJBTiered721Delegate_V3_4_PAY_ID)
+      metadatas.push(encoded)
+    }
+  }
+
+  return createMetadata(ids, metadatas)
+}
+
+/**
+ * <JB721Delegate3_4 supports JB Metadata Lib pattern and should be handled differently (https://github.com/jbx-protocol/juice-delegate-metadata-lib)
+ */
+function jb721DelegateVersionSupportsMetadataLib(
+  version: JB721DelegateVersion | undefined,
+): version is JB721DelegateVersion.JB721DELEGATE_V3_4 {
+  if (!version) return false
+
+  return version === JB721DelegateVersion.JB721DELEGATE_V3_4
+}

--- a/src/utils/delegateMetadata/encodeDelegateMetadata.ts
+++ b/src/utils/delegateMetadata/encodeDelegateMetadata.ts
@@ -55,11 +55,11 @@ export function encodeDelegateMetadata({
     )
   }
 
-  const ids: string[] = []
+  const delegateIds: string[] = []
   const metadatas: string[] = []
 
   if (jbBuybackDelegate) {
-    ids.push(IJBBuybackDelegate_INTERFACE_ID)
+    delegateIds.push(IJBBuybackDelegate_INTERFACE_ID)
     metadatas.push(
       utils.defaultAbiCoder.encode(
         ['uint256', 'uint256'],
@@ -78,12 +78,14 @@ export function encodeDelegateMetadata({
     )
 
     if (encoded) {
-      ids.push(IJBTiered721Delegate_V3_4_PAY_ID)
+      delegateIds.push(IJBTiered721Delegate_V3_4_PAY_ID)
       metadatas.push(encoded)
     }
   }
 
-  return createMetadata(ids, metadatas)
+  if (!delegateIds.length || !metadatas.length) return
+
+  return createMetadata(delegateIds, metadatas)
 }
 
 /**

--- a/src/utils/delegateMetadata/encodeJb721DelegateMetadata.ts
+++ b/src/utils/delegateMetadata/encodeJb721DelegateMetadata.ts
@@ -2,7 +2,6 @@ import {
   IJB721Delegate_V3_2_INTERFACE_ID,
   IJB721Delegate_V3_INTERFACE_ID,
   IJBTiered721Delegate_V3_2_INTERFACE_ID,
-  IJBTiered721Delegate_V3_4_PAY_ID,
   IJBTiered721Delegate_V3_4_REDEEM_ID,
 } from 'constants/nftRewards'
 import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
@@ -24,13 +23,13 @@ interface JB721DELAGATE_V3_1_PAY_METADATA {
 
 type JB721DELAGATE_V3_2_PAY_METADATA = JB721DELAGATE_V3_1_PAY_METADATA
 
-export type PayMetadata =
+export type JB721DelegatePayMetadata =
   | JB721DELAGATE_V3_PAY_METADATA
   | JB721DELAGATE_V3_1_PAY_METADATA
   | JB721DELAGATE_V3_2_PAY_METADATA // in future, maybe more
 
 export function encodeJb721DelegateMetadata(
-  metadata: PayMetadata,
+  metadata: JB721DelegatePayMetadata,
   version: JB721DelegateVersion | undefined,
 ) {
   if (!version) return undefined
@@ -123,19 +122,16 @@ function encodeJB721DelegateV3_2PayMetadata(
 }
 
 function encodeJB721DelegateV3_4PayMetadata(
-  metadata: JB721DELAGATE_V3_2_PAY_METADATA | undefined,
+  metadata: JB721DELAGATE_V3_2_PAY_METADATA,
 ) {
-  if (!metadata) return undefined
-
   const args = [
     metadata.allowOverspending ?? DEFAULT_ALLOW_OVERSPENDING,
     metadata.tierIdsToMint,
   ]
 
   const encoded = utils.defaultAbiCoder.encode(['bool', 'uint16[]'], args)
-  const result = createMetadata([IJBTiered721Delegate_V3_4_PAY_ID], [encoded])
 
-  return result
+  return encoded
 }
 
 export function encodeJB721DelegateV3RedeemMetadata(


### PR DESCRIPTION
**Changes**
- New `encodeDelegateMetadata()` pattern as a new catch-all metadata encoding util for all delegate types
  - Encodes metadata for multiple delegates, using the new [metadata-lib pattern](https://github.com/jbx-protocol/juice-delegate-metadata-lib/tree/main), and the [juicebox-metadata-helper](https://www.npmjs.com/package/juicebox-metadata-helper) package
  - Also supports legacy encoding of jb721Delegate metadata where version < 3.4 (not compatible with buyback delegate)
  - Will be extensible for any future cases where any project makes use of multiple metadata-lib-compatible delegates
- Enables buyback delegate metadata encoding for Juicebox
  - Minted tokens count must not exceed half of available AMM liquidity (arbitrary) to avoid slippage. If condition is not met, buyback delegate metadata will be omitted
  - If included, buyback delegate metadata will instruct protocol to use ALL ETH in pay amount to purchase tokens on AMM. In order to reduce arbitrage opportunities, the client will estimate the output of the swap based on the market price, and encode a minimum of 95% of that estimate in the delegate metadata. This is arbitrary—we only care about getting a minimum of the number of tokens that would otherwise be minted by the protocol, but we don't want to _request_ a minimum that is significantly smaller than the actual swap output, as it would increase the likelihood of the tx being front run.
  - Support for buyback delegate with Juicebox project is hard coded to projectId. We could determine this dynamically, but since there's no expectation of any other project using the buyback delegate this is prolly fine for now
- Adds a notice in Juicebox Pay > TokensReceived section that indicate a payer may receive more tokens than what are estimated. 
<img width="676" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/38ea35e8-ee4f-4e47-9dd1-e15ed127eaa0">
