### PR TITLE
Fix safe payouts' old values showing ETH symbol

### DIFF
--- a/src/components/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/ReconfigurationRichPreview.tsx
+++ b/src/components/ProjectSafeDashboard/juiceboxTransactions/reconfigureFundingCyclesOf/ReconfigurationRichPreview.tsx
@@ -24,6 +24,7 @@ export function ReconfigureRichPreview({
     fundingCycle: previousFC,
     payoutSplits: diffPayoutSplits,
     distributionLimit: previousDistributionLimit,
+    distributionLimitCurrency: previousCurrency,
     reservedTokensSplits: diffReservedSplits,
   } = useContext(V2V3ProjectContext)
 
@@ -100,6 +101,7 @@ export function ReconfigureRichPreview({
                 splits={toSplit(payoutSplits)}
                 diffSplits={diffPayoutSplits}
                 currency={distributionLimitCurrency}
+                oldCurrency={previousCurrency}
                 totalValue={distributionLimit}
                 previousTotalValue={previousDistributionLimit}
                 valueFormatProps={{ precision: 4 }}


### PR DESCRIPTION
Fixes JB-758 (https://linear.app/peel/issue/JB-785/old-values-show-eth-symbol-on-safe-preview-payouts-update)

<img width="882" alt="Screen Shot 2023-10-17 at 7 07 20 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/c9605094-d021-4ae4-af91-37c9f74a6bbc">
