### PR TITLE
Remove custom edit pay button field from create flow

### DIFF
--- a/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
+++ b/src/components/Create/components/pages/ProjectDetails/ProjectDetailsPage.tsx
@@ -171,18 +171,6 @@ export const ProjectDetailsPage: React.FC<
               <FormImageUploader text={t`Upload`} maxSizeKBs={10000} />
             </Form.Item>
 
-            <Row className="pb-8 pt-5" gutter={32}>
-              <Col span={12}>
-                <Form.Item
-                  name="payButtonText"
-                  label={<Trans>Pay button text</Trans>}
-                  tooltip={t`The text on the button supporters will click to pay your project`}
-                  extra={t`Use a simple term like 'Pay' or 'Donate'.`}
-                >
-                  <JuiceInput placeholder={t`Pay`} />
-                </Form.Item>
-              </Col>
-            </Row>
             <Form.Item
               name="payDisclosure"
               label={<Trans>Payment notice</Trans>}

--- a/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
+++ b/src/components/Create/components/pages/ReviewDeploy/components/ProjectDetailsReview/ProjectDetailsReview.tsx
@@ -17,7 +17,6 @@ export const ProjectDetailsReview = () => {
       logoUri,
       infoUri,
       name,
-      payButton,
       payDisclosure,
       twitter,
       projectTagline,
@@ -110,16 +109,6 @@ export const ProjectDetailsReview = () => {
       <ReviewDescription
         title={t`Tags`}
         desc={tags?.length ? <ProjectTagsList tags={tags} /> : t`No tags`}
-      />
-      <ReviewDescription
-        title={t`Pay button text`}
-        desc={
-          payButton ? (
-            <div className="overflow-hidden text-ellipsis text-base font-medium">
-              {payButton}
-            </div>
-          ) : null
-        }
       />
       <ReviewDescription
         title={t`Payment notice`}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -176,9 +176,6 @@ msgstr ""
 msgid "Twitter"
 msgstr ""
 
-msgid "The text on the button supporters will click to pay your project"
-msgstr ""
-
 msgid "Issue tokens or NFTs to your supporters and use them for governance, token-gated websites, or redemptions. With flexible token issuance and redemption, your project automatically scales to meet your supporters' demand."
 msgstr ""
 
@@ -2556,9 +2553,6 @@ msgid "Unlimited payouts."
 msgstr ""
 
 msgid "<0>View transactions.</0>"
-msgstr ""
-
-msgid "Use a simple term like 'Pay' or 'Donate'."
 msgstr ""
 
 msgid "to close"


### PR DESCRIPTION
Fixes JB-779 (https://linear.app/peel/issue/JB-779/pay-button-text-missing-from-project-page)