### PR TITLE
Add Juicecrowd banner to homepage

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -2,20 +2,23 @@ import Icon, {
   ExclamationCircleOutlined,
   WarningOutlined,
 } from '@ant-design/icons'
-import { classNames } from 'utils/classNames'
+import { twMerge } from 'tailwind-merge'
 
-type BannerVariant = 'warning' | 'info'
+type BannerVariant = 'warning' | 'info' | 'blue'
+type TextAlignOption = 'left' | 'center' | 'right'
 
 export default function Banner({
   title,
   body,
   actions,
   variant = 'info',
+  textAlign = 'left',
 }: {
-  title: string | JSX.Element
+  title?: string | JSX.Element
   body: string | JSX.Element
   actions?: JSX.Element
   variant?: BannerVariant
+  textAlign?: TextAlignOption
 }) {
   const variantClasses: {
     [k in BannerVariant]: { textClasses: string; backgroundClasses: string }
@@ -29,13 +32,19 @@ export default function Banner({
       textClasses: '',
       backgroundClasses: 'bg-smoke-75 dark:bg-slate-400',
     },
+    blue: {
+      textClasses: 'text-bluebs-700 dark:text-bluebs-200',
+      backgroundClasses: 'bg-bluebs-50 dark:bg-bluebs-900',
+    },
   }
+  const textAlignmentClass = `text-${textAlign}`
 
   const variantIcon: {
     [k in BannerVariant]: typeof Icon
   } = {
     warning: WarningOutlined,
     info: ExclamationCircleOutlined,
+    blue: ExclamationCircleOutlined,
   }
 
   const IconComponent = variantIcon[variant]
@@ -43,13 +52,22 @@ export default function Banner({
   const { textClasses, backgroundClasses } = variantClasses[variant]
 
   return (
-    <div className={classNames('py-4 px-12', textClasses, backgroundClasses)}>
-      <span className="mb-2 flex items-center gap-2">
-        <IconComponent />
-        <h2 className={classNames('m-0 text-sm font-medium', textClasses)}>
-          {title}
-        </h2>
-      </span>
+    <div
+      className={twMerge(
+        'py-4 px-12',
+        textClasses,
+        backgroundClasses,
+        textAlignmentClass,
+      )}
+    >
+      {title ? (
+        <span className="mb-2 flex items-center gap-2">
+          <IconComponent />
+          <h2 className={twMerge('m-0 text-sm font-medium', textClasses)}>
+            {title}
+          </h2>
+        </span>
+      ) : null}
       <div>{body}</div>
 
       {actions && <div>{actions}</div>}

--- a/src/components/Home/HomePage.tsx
+++ b/src/components/Home/HomePage.tsx
@@ -10,11 +10,13 @@ import { TopSection } from 'components/Home/TopSection/TopSection'
 import { WhyJuiceboxSection } from 'components/Home/WhyJuiceboxSection'
 import { readNetwork } from 'constants/networks'
 import { NetworkName } from 'models/networkName'
+import { JuicecrowdBanner } from './JuicecrowdBanner'
 
 export function HomePage() {
   return (
     <>
       <div className="[&>*:nth-child(even)]:bg-smoke-50 dark:[&>*:nth-child(even)]:bg-slate-700">
+        <JuicecrowdBanner />
         <TopSection />
 
         <StatsSection />

--- a/src/components/Home/JuicecrowdBanner.tsx
+++ b/src/components/Home/JuicecrowdBanner.tsx
@@ -1,0 +1,19 @@
+import { Trans } from '@lingui/macro'
+import Banner from 'components/Banner'
+import ExternalLink from 'components/ExternalLink'
+
+export function JuicecrowdBanner() {
+  return (
+    <Banner
+      body={
+        <Trans>
+          Juicecrowd submissions are now open.{' '}
+          <strong className="font-semibold">3 ETH</strong> prize pool.{' '}
+          <ExternalLink href="https://juicecrowd.gg">Learn more</ExternalLink>
+        </Trans>
+      }
+      variant="blue"
+      textAlign="center"
+    />
+  )
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -149,6 +149,9 @@ msgstr ""
 msgid "Data from current cycle"
 msgstr ""
 
+msgid "Juicecrowd submissions are now open. <0>3 ETH</0> prize pool. <1>Learn more</1>"
+msgstr ""
+
 msgid "Add NFT"
 msgstr ""
 


### PR DESCRIPTION
- Adds Juicecrowd banner to homepage
- Makes `title` prop optional in `<Banner>`
- Adds `textAlign` prop to `<Banner>`
- Adds color variant `blue` to `<Banner>`

### DESKTOP (light):
<img width="1221" alt="Screen Shot 2023-10-21 at 2 52 23 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/a0365ecd-529d-4092-b1e6-0bc3363a180b">

### DESKTOP (dark):
<img width="1225" alt="Screen Shot 2023-10-21 at 2 52 30 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/c7c12113-f800-4a3a-8fe5-fe31a38dad72">

### MOBILE:
<img width="380" alt="Screen Shot 2023-10-21 at 2 52 14 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/760db9b8-a888-43af-9c68-f474627b4892">


