### PR TITLE
fix: redemption rate bug in reconfiguration

### DIFF
--- a/src/components/ProjectLogo.tsx
+++ b/src/components/ProjectLogo.tsx
@@ -28,9 +28,7 @@ export default function ProjectLogo({
   const [srcLoadError, setSrcLoadError] = useState(false)
 
   const imageSrc = useMemo(() => {
-    if (!projectId) return undefined
-
-    if (IMAGE_URI_OVERRIDES[projectId]) {
+    if (projectId && IMAGE_URI_OVERRIDES[projectId]) {
       return IMAGE_URI_OVERRIDES[projectId]
     }
 

--- a/src/components/inputs/JuiceSwitch.tsx
+++ b/src/components/inputs/JuiceSwitch.tsx
@@ -8,18 +8,26 @@ export const JuiceSwitch = ({
   description,
   value,
   onChange,
-}: FormItemInput<boolean> & { label?: ReactNode; description?: ReactNode }) => {
+  extra,
+}: FormItemInput<boolean> & {
+  label?: ReactNode
+  description?: ReactNode
+  extra?: ReactNode
+}) => {
   const switchId = `switch-${label}-${Math.random()}`
   return (
     <div className="flex items-start gap-2">
-      <Switch
-        className={classNames(
-          value ? 'bg-bluebs-500' : 'bg-smoke-200 dark:bg-slate-300',
-        )}
-        id={switchId}
-        checked={value}
-        onChange={onChange}
-      />
+      <div className="flex flex-col items-center gap-1">
+        <Switch
+          className={classNames(
+            value ? 'bg-bluebs-500' : 'bg-smoke-200 dark:bg-slate-300',
+          )}
+          id={switchId}
+          checked={value}
+          onChange={onChange}
+        />
+        {extra}
+      </div>
       {label && (
         <div>
           <label htmlFor={switchId} className="text-black dark:text-grey-200">

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/Cart/components/__snapshots__/SummaryExpandedView.test.tsx.snap
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/Cart/components/__snapshots__/SummaryExpandedView.test.tsx.snap
@@ -47,9 +47,12 @@ exports[`SummaryExpandedView should render correctly 1`] = `
               <div
                 class="flex items-center justify-center overflow-hidden text-4xl bg-smoke-100 dark:bg-slate-700 h-14 w-14 rounded-full"
               >
-                <span>
-                  🧃
-                </span>
+                <img
+                  alt="undefined logo"
+                  class="h-full w-full object-cover object-center"
+                  crossorigin="anonymous"
+                  src="/api/juicebox/pv/undefined/project/undefined/logo"
+                />
               </div>
               <span
                 class="ml-3 min-w-0 font-medium dark:text-slate-50"

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/EditCyclePage.tsx
@@ -135,7 +135,6 @@ export function EditCyclePage() {
           <Button
             type="primary"
             onClick={() => setConfirmModalOpen(true)}
-            // Removed the disabled state for now, as it was causing issues.
             disabled={Boolean(error)}
           >
             <Trans>Save changes</Trans>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/EditCyclePage.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/EditCyclePage.tsx
@@ -135,7 +135,8 @@ export function EditCyclePage() {
           <Button
             type="primary"
             onClick={() => setConfirmModalOpen(true)}
-            disabled={!formHasUpdated || Boolean(error)}
+            // Removed the disabled state for now, as it was causing issues.
+            disabled={Boolean(error)}
           >
             <Trans>Save changes</Trans>
           </Button>

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
@@ -79,34 +79,6 @@ export function TokensSectionDiff() {
               }
             />
           )}
-          {reservedRateHasDiff && currentReservedRate && (
-            <FundingCycleListItem
-              name={t`Reserved tokens`}
-              value={
-                <ReservedRateValue
-                  value={newReservedRate}
-                  showWarning={
-                    unsafeFundingCycleProperties?.metadataReservedRate
-                  }
-                />
-              }
-              oldValue={<ReservedRateValue value={currentReservedRate} />}
-            />
-          )}
-          {reservedSplitsHasDiff && (
-            <div className="pb-4">
-              <div className="mb-3 text-sm font-semibold">
-                <Trans>Reserved recipients:</Trans>
-              </div>
-              <DiffedSplitList
-                splits={newReservedSplits}
-                diffSplits={currentReservedSplits}
-                totalValue={undefined}
-                reservedRate={formattedReservedRate}
-                showDiffs
-              />
-            </div>
-          )}
           {discountRateHasDiff && currentDiscountRate && (
             <FundingCycleListItem
               name={t`Issuance reduction rate`}
@@ -148,6 +120,34 @@ export function TokensSectionDiff() {
                 </span>
               }
             />
+          )}
+          {reservedRateHasDiff && currentReservedRate && (
+            <FundingCycleListItem
+              name={t`Reserved tokens`}
+              value={
+                <ReservedRateValue
+                  value={newReservedRate}
+                  showWarning={
+                    unsafeFundingCycleProperties?.metadataReservedRate
+                  }
+                />
+              }
+              oldValue={<ReservedRateValue value={currentReservedRate} />}
+            />
+          )}
+          {reservedSplitsHasDiff && (
+            <div className="pb-4">
+              <div className="mb-3 text-sm font-semibold">
+                <Trans>Reserved recipients:</Trans>
+              </div>
+              <DiffedSplitList
+                splits={newReservedSplits}
+                diffSplits={currentReservedSplits}
+                totalValue={undefined}
+                reservedRate={formattedReservedRate}
+                showDiffs
+              />
+            </div>
           )}
         </div>
       }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/IssuanceRateReductionField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/IssuanceRateReductionField.tsx
@@ -5,6 +5,7 @@ import { ExternalLinkWithIcon } from 'components/v2v3/V2V3Project/ProjectDashboa
 import { useState } from 'react'
 import { helpPagePath } from 'utils/routes'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
+import { zeroPercentDisabledNoticed } from './RedemptionRateField'
 
 export function IssuanceRateReductionField() {
   const { editCycleForm, setFormHasUpdated } = useEditCycleFormContext()
@@ -32,6 +33,9 @@ export function IssuanceRateReductionField() {
           </Trans>
         }
         value={issuanceReductionRateSwitchEnabled}
+        extra={
+          issuanceReductionRateSwitchEnabled ? null : zeroPercentDisabledNoticed
+        }
         onChange={val => {
           setIssuanceReductionRateSwitchEnabled(val)
           setFormHasUpdated(true)

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/IssuanceRateReductionField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/IssuanceRateReductionField.tsx
@@ -7,7 +7,7 @@ import { helpPagePath } from 'utils/routes'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
 
 export function IssuanceRateReductionField() {
-  const { editCycleForm } = useEditCycleFormContext()
+  const { editCycleForm, setFormHasUpdated } = useEditCycleFormContext()
 
   // Issurance reduction rate %
   const issuanceReductionRate =
@@ -34,6 +34,7 @@ export function IssuanceRateReductionField() {
         value={issuanceReductionRateSwitchEnabled}
         onChange={val => {
           setIssuanceReductionRateSwitchEnabled(val)
+          setFormHasUpdated(true)
           if (!val) {
             editCycleForm?.setFieldsValue({ discountRate: 0 })
           }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/RedemptionRateField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/RedemptionRateField.tsx
@@ -9,7 +9,7 @@ import { helpPagePath } from 'utils/routes'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
 
 export function RedemptionRateField() {
-  const { editCycleForm } = useEditCycleFormContext()
+  const { editCycleForm, setFormHasUpdated } = useEditCycleFormContext()
 
   // Redemption rate %
   const redemptionReductionRate = useWatch('redemptionRate', editCycleForm)
@@ -35,6 +35,7 @@ export function RedemptionRateField() {
         value={redemptionRateSwitchEnabled}
         onChange={val => {
           setRedemptionRateSwitchEnabled(val)
+          setFormHasUpdated(true)
           if (!val) {
             editCycleForm?.setFieldsValue({
               redemptionRate: 0,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/RedemptionRateField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/RedemptionRateField.tsx
@@ -37,7 +37,7 @@ export function RedemptionRateField() {
           setRedemptionRateSwitchEnabled(val)
           if (!val) {
             editCycleForm?.setFieldsValue({
-              redemptionRate: 100,
+              redemptionRate: 0,
             })
           }
         }}

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/RedemptionRateField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/RedemptionRateField.tsx
@@ -8,6 +8,12 @@ import { useState } from 'react'
 import { helpPagePath } from 'utils/routes'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
 
+export const zeroPercentDisabledNoticed = (
+  <span className="text-tertiary text-xs">
+    <Trans>(0%)</Trans>
+  </span>
+)
+
 export function RedemptionRateField() {
   const { editCycleForm, setFormHasUpdated } = useEditCycleFormContext()
 
@@ -16,7 +22,7 @@ export function RedemptionRateField() {
 
   const [redemptionRateSwitchEnabled, setRedemptionRateSwitchEnabled] =
     useState<boolean>(
-      (editCycleForm?.getFieldValue('redemptionRate') ?? 100) < 100,
+      (editCycleForm?.getFieldValue('redemptionRate') ?? 100) > 0,
     )
   return (
     <div className="flex flex-col gap-5">
@@ -33,6 +39,7 @@ export function RedemptionRateField() {
           </Trans>
         }
         value={redemptionRateSwitchEnabled}
+        extra={redemptionRateSwitchEnabled ? null : zeroPercentDisabledNoticed}
         onChange={val => {
           setRedemptionRateSwitchEnabled(val)
           setFormHasUpdated(true)

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/ReservedTokensField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/ReservedTokensField.tsx
@@ -12,6 +12,7 @@ import { SPLITS_TOTAL_PERCENT } from 'utils/v2v3/math'
 import { V2V3EditReservedTokens } from '../../ReservedTokensSettingsPage/V2V3EditReservedTokens'
 import { AdvancedDropdown } from '../AdvancedDropdown'
 import { useEditCycleFormContext } from '../EditCycleFormContext'
+import { zeroPercentDisabledNoticed } from './RedemptionRateField'
 
 export function ReservedTokensField() {
   const { editCycleForm, setFormHasUpdated } = useEditCycleFormContext()
@@ -48,6 +49,7 @@ export function ReservedTokensField() {
             editCycleForm?.setFieldsValue({ reservedTokens: 0 })
           }
         }}
+        extra={reservedTokensSwitchEnabled ? null : zeroPercentDisabledNoticed}
       />
       {reservedTokensSwitchEnabled ? (
         <div className="pt-6 pb-5">

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/ReservedTokensField.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/TokensSection/ReservedTokensField.tsx
@@ -43,6 +43,7 @@ export function ReservedTokensField() {
         value={reservedTokensSwitchEnabled}
         onChange={val => {
           setReservedTokensSwitchEnabled(val)
+          setFormHasUpdated(true)
           if (!val) {
             editCycleForm?.setFieldsValue({ reservedTokens: 0 })
           }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
@@ -78,6 +78,7 @@ export const usePrepareSaveEditCycleData = () => {
       } as BaseV3FundingCycleMetadataGlobal,
       reservedRate: reservedRateFrom(formValues.reservedTokens),
       redemptionRate: redemptionRateFrom(formValues.redemptionRate),
+      ballotRedemptionRate: redemptionRateFrom(formValues.redemptionRate),
       pausePay: formValues.pausePay,
       allowMinting: formValues.allowTokenMinting,
       holdFees: formValues.holdFees,

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -4001,6 +4001,9 @@ msgstr ""
 msgid "Edit recipient"
 msgstr ""
 
+msgid "(0%)"
+msgstr ""
+
 msgid "Update preview"
 msgstr ""
 


### PR DESCRIPTION
## What does this PR do and why?

Fixes a bug in the reconfiguration settings where when a user disables the redemption rate, it sets it to 100; instead it now sets it to 0.

I have also removed disabling the save changes button when there is no changes as it is flaky, and may not behave as user expects. As the user can open this modal and then get feedback whether they can actually deploy or not, I think it is okay for now.

This also fixes the ballot redemption rate, by automatically setting it the same as the redemption rate.

## Steps to Repeat Initial Bug

1. Create a project with redemption rate set. For ease of testing, set to 0 < x < 100
1. Open settings and disable redemption rate with switch
1. Deploy
1. See error (redemption rate will be incorrectly set to 100)

It is **expected** that the redemption rate be set to 0.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

## Acceptance checklist

- [ ] I have evaluated the [Approval Guidelines](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#approval-guidelines) for this PR.
- [ ] (if relevant) I have tested this PR in [all supported browsers](https://github.com/jbx-protocol/juice-interface/blob/main/CONTRIBUTING.md#supported-browsers).
- [ ] (if relevant) I have tested this PR in dark mode and light mode (if applicable).
