### PR TITLE
Filter out blocklisted projects at api level

### DIFF
--- a/src/constants/blocklist.ts
+++ b/src/constants/blocklist.ts
@@ -1,5 +1,7 @@
 import { NetworkName } from 'models/networkName'
+import { getSubgraphIdForProject } from 'utils/graph'
 import { readNetwork } from './networks'
+import { PV_V2 } from './pv'
 
 const PROJECT_IDS = {
   METAKEYS_COPYCAT: 564, // copycat of 563
@@ -14,3 +16,7 @@ const V2_BLOCKLISTED_PROJECT_IDS_BY_NETWORK: Partial<
 
 export const V2_BLOCKLISTED_PROJECT_IDS =
   V2_BLOCKLISTED_PROJECT_IDS_BY_NETWORK[readNetwork.name] ?? []
+
+export const V2_BLOCKLISTED_PROJECTS = V2_BLOCKLISTED_PROJECT_IDS.map(
+  projectId => getSubgraphIdForProject(PV_V2, projectId),
+)

--- a/src/lib/api/supabase/projects/api.ts
+++ b/src/lib/api/supabase/projects/api.ts
@@ -1,4 +1,5 @@
 import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { V2_BLOCKLISTED_PROJECTS } from 'constants/blocklist'
 import { DbProjectsDocument, DbProjectsQuery, Project } from 'generated/graphql'
 import { paginateDepleteQuery } from 'lib/apollo/paginateDepleteQuery'
 import { serverClient } from 'lib/apollo/serverClient'
@@ -98,6 +99,9 @@ export async function queryDBProjects(
     .select('*')
     .order(orderBy, { ascending })
     .range(page * pageSize, (page + 1) * pageSize - 1)
+
+  // Filter out blocklisted projects
+  query = query.not('id', 'in', `(${V2_BLOCKLISTED_PROJECTS.join(',')})`)
 
   if (opts.archived) query = query.is('archived', true)
   else query = query.not('archived', 'is', true)


### PR DESCRIPTION
We previously implemented a filter on the client side to avoid showing blocklisted projects in the UI. This created a convoluted bug where:
1. Items were filtered out of project DB responses, _after_ the response was received
2. The client may receive a smaller-than-expected pageSize of results
3. The client would assume there were no more objects to query, breaking infinite paging

This filter has been moved to the API level, so that blocklisted projects will be filtered in the query to the projects DB.