### PR TITLE
feat: add start date to project dashboard cycle tab

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationDisplayCard.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/components/ConfigurationDisplayCard.tsx
@@ -24,7 +24,7 @@ export const ConfigurationDisplayCard = ({
             <div className="flex flex-col gap-2 text-sm font-medium text-grey-600 dark:text-slate-200">
               {title}
               <div className="font-heading text-xl font-medium text-grey-900 dark:text-slate-50">
-                <Trans>Configuration</Trans>
+                <Trans>Rules</Trans>
               </div>
             </div>
             <ChevronDownIcon

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/components/__snapshots__/ConfigurationDisplayCard.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`ConfigurationDisplayCard renders 1`] = `
           <div
             class="font-heading text-xl font-medium text-grey-900 dark:text-slate-50"
           >
-            Configuration
+            Rules
           </div>
         </div>
         <svg

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
@@ -55,7 +55,7 @@ describe('useFormatConfigurationCyclesSection', () => {
     }
     const expectedStartTime = {
       name: 'Start time',
-      new: '1970-01-01, Wednesday, 07:00:00 PM EST',
+      new: '1970-01-01, Wednesday, 09:46:40 PM EST',
       easyCopy: true,
     }
     const expectedPayouts = { name: 'Payouts', old: 'Ξ100', new: 'US$200' }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
@@ -55,8 +55,8 @@ describe('useFormatConfigurationCyclesSection', () => {
     }
     const expectedStartTime = {
       name: 'Start time',
-      old: '1970-01-01, Wednesday, 07:00:00 PM EST',
-      new: '1970-01-01, Wednesday, 09:46:40 PM EST',
+      new: '1970-01-01, Wednesday, 07:00:00 PM EST',
+      easyCopy: true,
     }
     const expectedPayouts = { name: 'Payouts', old: 'Ξ100', new: 'US$200' }
     const expectedEditDeadline = {

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
@@ -7,8 +7,17 @@ import { BigNumber } from 'ethers'
 import { parseWad } from 'utils/format/formatNumber'
 import { useFormatConfigurationCyclesSection } from './useFormatConfigurationCyclesSection'
 
+// Use EST timezone for start time tests
+beforeAll(() => {
+  process.env.TZ = 'America/New_York'
+})
+afterAll(() => {
+  delete process.env.TZ
+})
+
 describe('useFormatConfigurationCyclesSection', () => {
   const mockFundingCycle = {
+    start: BigNumber.from(0),
     duration: BigNumber.from(10000),
     ballot: '0x0000000000000000000000000000000000000000',
   }
@@ -44,6 +53,11 @@ describe('useFormatConfigurationCyclesSection', () => {
       old: '2 hours',
       new: '5 hours',
     }
+    const expectedStartTime = {
+      name: 'Start time',
+      old: '1970-01-01, Wednesday, 07:00:00 PM EST',
+      new: '1970-01-01, Wednesday, 09:46:40 PM EST',
+    }
     const expectedPayouts = { name: 'Payouts', old: 'Ξ100', new: 'US$200' }
     const expectedEditDeadline = {
       name: 'Edit deadline',
@@ -52,6 +66,7 @@ describe('useFormatConfigurationCyclesSection', () => {
     }
 
     expect(result.current.duration).toEqual(expectedDuration)
+    expect(result.current.startTime).toEqual(expectedStartTime)
     expect(result.current.payouts).toEqual(expectedPayouts)
     expect(result.current.editDeadline).toEqual(expectedEditDeadline)
   })

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.test.ts
@@ -9,7 +9,7 @@ import { useFormatConfigurationCyclesSection } from './useFormatConfigurationCyc
 
 // Use EST timezone for start time tests
 beforeAll(() => {
-  process.env.TZ = 'America/New_York'
+  process.env.TZ = 'UTC'
 })
 afterAll(() => {
   delete process.env.TZ
@@ -55,7 +55,8 @@ describe('useFormatConfigurationCyclesSection', () => {
     }
     const expectedStartTime = {
       name: 'Start time',
-      new: '1970-01-01, Wednesday, 09:46:40 PM EST',
+      new: '1970-01-01, Thursday, 02:46:40 AM UTC',
+      // new: '1970-01-01, Wednesday, 09:46:40 PM EST',
       easyCopy: true,
     }
     const expectedPayouts = { name: 'Payouts', old: 'Ξ100', new: 'US$200' }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
@@ -45,6 +45,33 @@ export const useFormatConfigurationCyclesSection = ({
     return pairToDatum(t`Duration`, currentDuration, upcomingDuration)
   }, [fundingCycle?.duration, upcomingFundingCycle])
 
+  const startTimeDatum: ConfigurationPanelDatum = useMemo(() => {
+    const formatTime = (timestamp: BigNumber | undefined) => {
+      if (timestamp === undefined) return undefined
+      const timeDate = new Date(timestamp.toNumber() * 1000)
+      const isoDateString = timeDate.toISOString().split('T')[0]
+      const formatOptions: Intl.DateTimeFormatOptions = {
+        weekday: 'long',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: true,
+        timeZoneName: 'short',
+      }
+      const timeWeekdayString = timeDate.toLocaleString('en-US', formatOptions)
+      return isoDateString + ', ' + timeWeekdayString
+    }
+
+    const currentStartTime = formatTime(fundingCycle?.start)
+    if (!fundingCycle?.duration) {
+      return pairToDatum(t`Start time`, currentStartTime, t`Any time`)
+    }
+    const upcomingStartTime = formatTime(
+      fundingCycle?.start.add(fundingCycle?.duration),
+    )
+    return pairToDatum(t`Start time`, currentStartTime, upcomingStartTime)
+  }, [fundingCycle?.start, fundingCycle?.duration])
+
   const payoutsDatum: ConfigurationPanelDatum = useMemo(() => {
     const formatCurrency = (currency: BigNumber | undefined) => {
       if (currency === undefined) return undefined
@@ -108,8 +135,9 @@ export const useFormatConfigurationCyclesSection = ({
   return useMemo(() => {
     return {
       duration: durationDatum,
+      startTime: startTimeDatum,
       payouts: payoutsDatum,
       editDeadline: editDeadlineDatum,
     }
-  }, [durationDatum, editDeadlineDatum, payoutsDatum])
+  }, [durationDatum, startTimeDatum, editDeadlineDatum, payoutsDatum])
 }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
@@ -5,6 +5,7 @@ import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { V2V3FundingCycle } from 'models/v2v3/fundingCycle'
 import { useMemo } from 'react'
 import { fromWad } from 'utils/format/formatNumber'
+import { formatTime } from 'utils/format/formatTime'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { getBallotStrategyByAddress } from 'utils/v2v3/ballotStrategies'
 import { MAX_DISTRIBUTION_LIMIT } from 'utils/v2v3/math'
@@ -46,22 +47,6 @@ export const useFormatConfigurationCyclesSection = ({
   }, [fundingCycle?.duration, upcomingFundingCycle])
 
   const startTimeDatum: ConfigurationPanelDatum = useMemo(() => {
-    const formatTime = (timestamp: BigNumber | undefined) => {
-      if (timestamp === undefined) return undefined
-      const timeDate = new Date(timestamp.toNumber() * 1000)
-      const isoDateString = timeDate.toISOString().split('T')[0]
-      const formatOptions: Intl.DateTimeFormatOptions = {
-        weekday: 'long',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: true,
-        timeZoneName: 'short',
-      }
-      const timeWeekdayString = timeDate.toLocaleString('en-US', formatOptions)
-      return isoDateString + ', ' + timeWeekdayString
-    }
-
     const formattedTime =
       upcomingFundingCycle === null
         ? formatTime(fundingCycle?.start)

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
@@ -61,13 +61,19 @@ export const useFormatConfigurationCyclesSection = ({
       const timeWeekdayString = timeDate.toLocaleString('en-US', formatOptions)
       return isoDateString + ', ' + timeWeekdayString
     }
-    const timeDatum: ConfigurationPanelDatum = {
+
+    const formattedTime =
+      upcomingFundingCycle === null
+        ? formatTime(fundingCycle?.start)
+        : formatTime(fundingCycle?.start.add(fundingCycle?.duration))
+
+    const formatTimeDatum: ConfigurationPanelDatum = {
       name: t`Start time`,
-      new: formatTime(fundingCycle?.start),
+      new: formattedTime,
       easyCopy: true,
     }
-    return timeDatum
-  }, [fundingCycle?.start])
+    return formatTimeDatum
+  }, [fundingCycle?.start, fundingCycle?.duration, upcomingFundingCycle])
 
   const payoutsDatum: ConfigurationPanelDatum = useMemo(() => {
     const formatCurrency = (currency: BigNumber | undefined) => {

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
@@ -65,6 +65,8 @@ export const useFormatConfigurationCyclesSection = ({
     const formattedTime =
       upcomingFundingCycle === null
         ? formatTime(fundingCycle?.start)
+        : fundingCycle?.duration.isZero()
+        ? t`Any time`
         : formatTime(fundingCycle?.start.add(fundingCycle?.duration))
 
     const formatTimeDatum: ConfigurationPanelDatum = {

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/CyclesPayoutsPanel/hooks/useConfigurationPanel/useFormatConfigurationCyclesSection.ts
@@ -61,16 +61,13 @@ export const useFormatConfigurationCyclesSection = ({
       const timeWeekdayString = timeDate.toLocaleString('en-US', formatOptions)
       return isoDateString + ', ' + timeWeekdayString
     }
-
-    const currentStartTime = formatTime(fundingCycle?.start)
-    if (!fundingCycle?.duration) {
-      return pairToDatum(t`Start time`, currentStartTime, t`Any time`)
+    const timeDatum: ConfigurationPanelDatum = {
+      name: t`Start time`,
+      new: formatTime(fundingCycle?.start),
+      easyCopy: true,
     }
-    const upcomingStartTime = formatTime(
-      fundingCycle?.start.add(fundingCycle?.duration),
-    )
-    return pairToDatum(t`Start time`, currentStartTime, upcomingStartTime)
-  }, [fundingCycle?.start, fundingCycle?.duration])
+    return timeDatum
+  }, [fundingCycle?.start])
 
   const payoutsDatum: ConfigurationPanelDatum = useMemo(() => {
     const formatCurrency = (currency: BigNumber | undefined) => {

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -644,6 +644,9 @@ msgstr ""
 msgid "To: <0/>"
 msgstr ""
 
+msgid "Any time"
+msgstr ""
+
 msgid "Join 1,000+ projects growing with Juicebox"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -644,9 +644,6 @@ msgstr ""
 msgid "To: <0/>"
 msgstr ""
 
-msgid "Any time"
-msgstr ""
-
 msgid "Join 1,000+ projects growing with Juicebox"
 msgstr ""
 

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -644,6 +644,9 @@ msgstr ""
 msgid "To: <0/>"
 msgstr ""
 
+msgid "Any time"
+msgstr ""
+
 msgid "Join 1,000+ projects growing with Juicebox"
 msgstr ""
 
@@ -4812,9 +4815,6 @@ msgid "project"
 msgstr ""
 
 msgid "Something went wrong!"
-msgstr ""
-
-msgid "Configuration"
 msgstr ""
 
 msgid "Reserved {0}"

--- a/src/utils/format/formatTime.ts
+++ b/src/utils/format/formatTime.ts
@@ -124,3 +124,20 @@ export const deriveDurationOption = (
     ) ?? _durationOptions[0]
   )
 }
+
+export const formatTime = (timestamp: BigNumber | undefined) => {
+  if (timestamp === undefined) return undefined
+  const timeDate = new Date(timestamp.toNumber() * 1000)
+  const isoDateString = timeDate.toISOString().split('T')[0]
+  const formatOptions: Intl.DateTimeFormatOptions = {
+    weekday: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
+    timeZone: 'UTC',
+  }
+  const timeWeekdayString = timeDate.toLocaleString('en-US', formatOptions)
+  return isoDateString + ', ' + timeWeekdayString
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8252,20 +8252,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001406:
-  version "1.0.30001489"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz#ca82ee2d4e4dbf2bd2589c9360d3fcc2c7ba3bd8"
-  integrity sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==
-
-caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449:
-  version "1.0.30001488"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz#d19d7b6e913afae3e98f023db97c19e9ddc5e91f"
-  integrity sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==
-
-caniuse-lite@^1.0.30001503:
-  version "1.0.30001514"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz#e2a7e184a23affc9367b7c8d734e7ec4628c1309"
-  integrity sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==
+caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001503:
+  version "1.0.30001561"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz"
+  integrity sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- Add cycle start date to dropdown Rules tab on project dashboard in this format: `1970-01-01, Wednesday, 07:00:00 PM EST`
- Change word "Configuration" to "Rules" in dropdown (should we go with "Details" instead?)
- Tests.

NOTE: All tests on CI fail because of the same error: `Cannot find module './src/locales/en/messages.js' from '../jest.setup.ts'`. Works locally, not sure how to debug this.

![image](https://github.com/jbx-protocol/juice-interface/assets/96905094/552abb0b-5cbe-487d-8987-b58afa66dfea)
![image](https://github.com/jbx-protocol/juice-interface/assets/96905094/00b126fe-49b7-4231-ae5b-3267dcfa412d)
