### PR TITLE
feat: enable cors on jb-721-delegate

### DIFF
--- a/src/lib/api/nextjs.ts
+++ b/src/lib/api/nextjs.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { PV1, PV2 } from 'models/pv'
+import { NextApiResponse } from 'next'
 
 /**
  * Calls to the NextJS API `/api/nextjs/revalidate-project` to revalidate the
@@ -15,4 +16,18 @@ export function revalidateProject(
   project: { pv: PV1; handle: string } | { pv: PV2; projectId: string },
 ) {
   return axios.post('/api/nextjs/revalidate-project', { project })
+}
+
+/**
+ * Enables CORS for a NextJS API endpoint response.
+ * @link https://vercel.com/guides/how-to-enable-cors#enabling-cors-in-a-next.js-app
+ */
+export function enableCors(res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET')
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+  )
 }

--- a/src/pages/api/juicebox/jb-721-delegate/[dataSourceAddress].ts
+++ b/src/pages/api/juicebox/jb-721-delegate/[dataSourceAddress].ts
@@ -5,6 +5,7 @@ import { Contract } from 'ethers'
 import { ForgeDeploy, addressFor } from 'forge-run-parser'
 import { loadJB721DelegateJson } from 'hooks/JB721Delegate/contracts/useJB721DelegateAbi'
 import { loadJB721DelegateAddress } from 'hooks/JB721Delegate/contracts/useJB721DelegateContractAddress'
+import { enableCors } from 'lib/api/nextjs'
 import { getLogger } from 'lib/logger'
 import { JB721DelegateVersion } from 'models/v2v3/contracts'
 import { NextApiRequest, NextApiResponse } from 'next'
@@ -145,6 +146,8 @@ async function fetchJB721DelegateVersion(dataSourceAddress: string) {
 }
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  enableCors(res)
+
   if (req.method !== 'GET') {
     return res.status(404)
   }

--- a/src/pages/api/juicebox/prices/ethusd.ts
+++ b/src/pages/api/juicebox/prices/ethusd.ts
@@ -1,6 +1,7 @@
 import { CV_V3 } from 'constants/cv'
 import { WAD_DECIMALS } from 'constants/numbers'
 import { loadJBPrices } from 'hooks/JBPrices/loadJBPrices'
+import { enableCors } from 'lib/api/nextjs'
 import { getLogger } from 'lib/logger'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { fromWad } from 'utils/format/formatNumber'
@@ -11,6 +12,8 @@ const PRICE_REFRESH_INTERVAL_SECONDS = 60 * 5 // 5 minutes
 const logger = getLogger('api/juicebox/prices/ethusd')
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  enableCors(res)
+
   if (req.method !== 'GET') {
     return res.status(404)
   }
@@ -30,7 +33,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       'Cache-Control',
       `s-maxage=${PRICE_REFRESH_INTERVAL_SECONDS}, stale-while-revalidate`,
     )
-    res.setHeader('Access-Control-Allow-Origin', '*')
     return res.status(200).json({ price })
   } catch (err) {
     logger.error({ error: err })

--- a/src/pages/api/projects/index.ts
+++ b/src/pages/api/projects/index.ts
@@ -1,3 +1,4 @@
+import { enableCors } from 'lib/api/nextjs'
 import { queryDBProjects } from 'lib/api/supabase/projects'
 import { DBProjectQueryOpts } from 'models/dbProject'
 import { ProjectTagName } from 'models/project-tags'
@@ -8,6 +9,8 @@ import { NextApiHandler } from 'next'
  * @returns Raw SQL query response
  */
 const handler: NextApiHandler = async (req, res) => {
+  enableCors(res)
+
   const {
     text,
     tags,
@@ -22,15 +25,6 @@ const handler: NextApiHandler = async (req, res) => {
     projectId,
     ids,
   } = req.query
-
-  // https://vercel.com/guides/how-to-enable-cors#enabling-cors-in-a-next.js-app
-  res.setHeader('Access-Control-Allow-Credentials', 'true')
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET')
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
-  )
 
   if (text && typeof text !== 'string') {
     res.status(400).send('Text is not a string')


### PR DESCRIPTION
Lets us call the "which 721 delegate version is this" api endpoint from other origins (e.g. juicecrowd)