### PR TITLE
refactor: delegate metadata

### DIFF
--- a/src/components/AMMPrices/hooks/useERC20UniswapPrice.ts
+++ b/src/components/AMMPrices/hooks/useERC20UniswapPrice.ts
@@ -187,7 +187,7 @@ export function useUniswapPriceQuery({ tokenSymbol, tokenAddress }: Props) {
     },
     {
       refetchInterval: 30000, // refetch every 30 seconds
-      enabled: !!(tokenAddress && tokenSymbol),
+      enabled: Boolean(tokenAddress && tokenSymbol),
     },
   )
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -144,7 +144,7 @@ export function Footer() {
   const gitCommit = process.env.NEXT_PUBLIC_VERSION
 
   return (
-    <footer className="bg-slate-900 px-5 pt-12 text-sm text-slate-100 md:px-12">
+    <footer className="border-t border-t-slate-500 bg-slate-900 px-5 pt-12 text-sm text-slate-100 md:px-12">
       <div className="m-auto max-w-6xl">
         <div className="flex flex-col gap-y-10 md:grid md:grid-cols-6 md:items-start md:gap-x-10">
           <div className="flex flex-col gap-y-5 text-slate-200 md:col-span-2 md:items-start">

--- a/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
+++ b/src/components/v2v3/V2V3Project/ManageNftsSection/RedeemNftsModal/RedeemNftsModal.tsx
@@ -15,13 +15,8 @@ import { useNftAccountBalance } from 'hooks/JB721Delegate/useNftAccountBalance'
 import { useETHReceivedFromNftRedeem } from 'hooks/v2v3/contractReader/useETHReceivedFromNftRedeem'
 import { useRedeemTokensTx } from 'hooks/v2v3/transactor/useRedeemTokensTx'
 import { useWallet } from 'hooks/Wallet'
-import { JB721DelegateVersion } from 'models/v2v3/contracts'
 import { useContext, useState } from 'react'
-import {
-  encodeJB721DelegateV3_2RedeemMetadata,
-  encodeJB721DelegateV3_4RedeemMetadata,
-  encodeJB721DelegateV3RedeemMetadata,
-} from 'utils/delegateMetadata/encodeJb721DelegateMetadata'
+import { encodeJb721DelegateRedeemMetadata } from 'utils/delegateMetadata/encodeJb721DelegateMetadata'
 import { emitErrorNotification } from 'utils/notifications'
 import { formatRedemptionRate } from 'utils/v2v3/math'
 import { RedeemNftCard } from './RedeemNftCard'
@@ -80,15 +75,10 @@ export function RedeemNftsModal({
         redeemAmount: BigNumber.from(0),
         minReturnedTokens: BigNumber.from(0),
         memo,
-        metadata:
-          jb721DelegateVersion === JB721DelegateVersion.JB721DELEGATE_V3 ||
-          jb721DelegateVersion === JB721DelegateVersion.JB721DELEGATE_V3_1
-            ? encodeJB721DelegateV3RedeemMetadata(tokenIdsToRedeem)
-            : jb721DelegateVersion ===
-                JB721DelegateVersion.JB721DELEGATE_V3_2 ||
-              jb721DelegateVersion === JB721DelegateVersion.JB721DELEGATE_V3_3
-            ? encodeJB721DelegateV3_2RedeemMetadata(tokenIdsToRedeem)
-            : encodeJB721DelegateV3_4RedeemMetadata(tokenIdsToRedeem),
+        metadata: encodeJb721DelegateRedeemMetadata(
+          tokenIdsToRedeem,
+          jb721DelegateVersion,
+        ),
       },
       {
         // step 1

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectModal.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectModal.test.ts
@@ -23,6 +23,7 @@ describe('usePayProjectModal', () => {
   const DefaultuseProjectCart = {
     dispatch: jest.fn(),
     payModalOpen: false,
+    nftRewards: [],
     totalAmount: {
       amount: 0,
       currency: V2V3_CURRENCY_ETH,

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -1,11 +1,11 @@
 import { NftRewardsContext } from 'contexts/NftRewards/NftRewardsContext'
-import { BigNumber, Transaction } from 'ethers'
+import { Transaction } from 'ethers'
 import { FormikHelpers } from 'formik'
 import { useWallet } from 'hooks/Wallet'
 import { useCurrencyConverter } from 'hooks/useCurrencyConverter'
 import { usePayETHPaymentTerminalTx } from 'hooks/v2v3/transactor/usePayETHPaymentTerminalTx'
 import { useProjectHasErc20 } from 'hooks/v2v3/useProjectHasErc20'
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { buildPaymentMemo } from 'utils/buildPaymentMemo'
 import { parseWad } from 'utils/format/formatNumber'
 import { V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
@@ -59,14 +59,16 @@ export const usePayProjectTx = ({
     [nftRewards, receivedTickets, totalAmount, userAddress],
   )
 
-  let weiAmount: BigNumber
-  if (!totalAmount) {
-    weiAmount = parseWad(0)
-  } else if (totalAmount.currency === V2V3_CURRENCY_ETH) {
-    weiAmount = parseWad(totalAmount.amount)
-  } else {
-    weiAmount = converter.usdToWei(totalAmount.amount)
-  }
+  const weiAmount = useMemo(() => {
+    if (!totalAmount) {
+      return parseWad(0)
+    } else if (totalAmount.currency === V2V3_CURRENCY_ETH) {
+      return parseWad(totalAmount.amount)
+    } else {
+      return converter.usdToWei(totalAmount.amount)
+    }
+  }, [totalAmount, converter])
+
   const delegateMetadata = usePreparePayDelegateMetadata(weiAmount, {
     nftRewards,
     receivedTickets,

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -69,7 +69,7 @@ export const usePayProjectTx = ({
     }
   }, [totalAmount, converter])
 
-  const delegateMetadata = usePrepareDelegatePayMetadata(weiAmount, {
+  const prepareDelegateMetadata = usePrepareDelegatePayMetadata(weiAmount, {
     nftRewards,
     receivedTickets,
   })
@@ -101,7 +101,7 @@ export const usePayProjectTx = ({
           {
             memo,
             beneficiary,
-            delegateMetadata,
+            delegateMetadata: prepareDelegateMetadata(),
             value: weiAmount,
             // always claim tokens if the project has an ERC20.
             // if project has no erc20, then nothing to claim!
@@ -144,7 +144,7 @@ export const usePayProjectTx = ({
       rewardTiers,
       weiAmount,
       userAddress,
-      delegateMetadata,
+      prepareDelegateMetadata,
     ],
   )
 }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -1,9 +1,4 @@
-import { useUniswapPriceQuery } from 'components/AMMPrices/hooks/useERC20UniswapPrice'
-import { BUYBACK_DELEGATE_ENABLED_PROJECT_IDS } from 'constants/buybackDelegateEnabledProjectIds'
-import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
-import { JB721DelegateContractsContext } from 'contexts/NftRewards/JB721DelegateContracts/JB721DelegateContractsContext'
 import { NftRewardsContext } from 'contexts/NftRewards/NftRewardsContext'
-import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
 import { BigNumber, Transaction } from 'ethers'
 import { FormikHelpers } from 'formik'
 import { useWallet } from 'hooks/Wallet'
@@ -12,15 +7,13 @@ import { usePayETHPaymentTerminalTx } from 'hooks/v2v3/transactor/usePayETHPayme
 import { useProjectHasErc20 } from 'hooks/v2v3/useProjectHasErc20'
 import { useCallback, useContext } from 'react'
 import { buildPaymentMemo } from 'utils/buildPaymentMemo'
-import { encodeDelegateMetadata } from 'utils/delegateMetadata/encodeDelegateMetadata'
 import { parseWad } from 'utils/format/formatNumber'
 import { V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
-import { MAX_RESERVED_RATE } from 'utils/v2v3/math'
 import { useProjectCart } from '../useProjectCart'
-import { useProjectContext } from '../useProjectContext'
 import { ProjectPayReceipt } from '../useProjectPageQueries'
 import { useProjectPaymentTokens } from '../useProjectPaymentTokens'
 import { PayProjectModalFormValues } from './usePayProjectModal'
+import { usePreparePayDelegateMetadata } from './usePrepareDelegatePayMetadata'
 
 export const usePayProjectTx = ({
   onTransactionPending: onTransactionPendingCallback,
@@ -41,12 +34,6 @@ export const usePayProjectTx = ({
 }) => {
   const { userAddress } = useWallet()
   const { totalAmount, nftRewards } = useProjectCart()
-  const { version: JB721DelegateVersion } = useContext(
-    JB721DelegateContractsContext,
-  )
-  const { projectId } = useContext(ProjectMetadataContext)
-  const { tokenAddress, tokenSymbol, fundingCycleMetadata } =
-    useProjectContext()
   const {
     nftRewards: { rewardTiers },
   } = useContext(NftRewardsContext)
@@ -54,11 +41,6 @@ export const usePayProjectTx = ({
   const payProjectTx = usePayETHPaymentTerminalTx()
   const { receivedTickets } = useProjectPaymentTokens()
   const projectHasErc20 = useProjectHasErc20()
-
-  const { data: priceQuery } = useUniswapPriceQuery({
-    tokenAddress,
-    tokenSymbol,
-  })
 
   const buildPayReceipt = useCallback(
     (e: Transaction | undefined): ProjectPayReceipt => {
@@ -77,107 +59,18 @@ export const usePayProjectTx = ({
     [nftRewards, receivedTickets, totalAmount, userAddress],
   )
 
-  const buildPayDelegateMetadata = useCallback(
-    (weiAmount: BigNumber) => {
-      const tierIdsToMint = nftRewards
-        .map(({ id, quantity }) => Array<number>(quantity).fill(id))
-        .flat()
-
-      const receivedTicketsWei = parseWad(receivedTickets?.replace(',', ''))
-
-      // Total tokens that should be minted by pay() tx, including reserved tokens
-      const requiredTokens =
-        fundingCycleMetadata && fundingCycleMetadata.reservedRate.gt(0)
-          ? receivedTicketsWei
-              .mul(MAX_RESERVED_RATE)
-              .div(fundingCycleMetadata.reservedRate)
-          : receivedTicketsWei
-
-      const priceQueryNumeratorRaw =
-        priceQuery?.projectTokenPrice.numerator.toString()
-      const priceQueryDenominatorRaw =
-        priceQuery?.projectTokenPrice.denominator.toString()
-      const priceQueryNumerator = priceQueryNumeratorRaw
-        ? BigNumber.from(priceQueryNumeratorRaw)
-        : undefined
-      const priceQueryDenominator = priceQueryNumeratorRaw
-        ? BigNumber.from(priceQueryDenominatorRaw)
-        : undefined
-      const inversePriceQueryFactor =
-        priceQueryNumerator?.gt(0) && priceQueryDenominator?.gt(0)
-          ? priceQueryDenominator.div(priceQueryNumerator)
-          : undefined
-
-      // Using inverse price query helps avoid dividing by zero. This assumes the token price is < 1ETH
-      const expectedTokensFromSwap = inversePriceQueryFactor?.gt(0)
-        ? weiAmount.mul(inversePriceQueryFactor)
-        : undefined
-
-      /**
-       * Expect whichever is greater: 95% of expected tokens from swap, or minimum amount of tokens required to be minted.
-       * We don't really care if less tokens are returned from the swap than what we've estimated (as long as we're getting at least the minimum amount that would otherwise be minted).
-       * The main concern is sending as high a minimum as possible to limit arbitrage possibility.
-       */
-      const minExpectedTokens =
-        requiredTokens &&
-        expectedTokensFromSwap &&
-        expectedTokensFromSwap.mul(95).div(100).gt(requiredTokens)
-          ? expectedTokensFromSwap.mul(95).div(100)
-          : requiredTokens
-
-      const shouldUseBuybackDelegate =
-        Boolean(
-          projectId &&
-            priceQuery &&
-            BUYBACK_DELEGATE_ENABLED_PROJECT_IDS.includes(projectId) &&
-            requiredTokens &&
-            expectedTokensFromSwap?.gte(requiredTokens) &&
-            // total token amount must be less than half of available liquidity (arbitrary) to avoid slippage
-            BigNumber.from(requiredTokens).mul(2).lt(priceQuery.liquidity),
-        ) && minExpectedTokens !== undefined
-
-      console.info(
-        '🧃 useProjectPayTx::use buy back delegate::',
-        shouldUseBuybackDelegate,
-        {
-          weiAmount: weiAmount.toString(),
-          priceQueryNumerator,
-          priceQueryDenominator,
-          requiredTokens: requiredTokens?.toString(),
-          expectedTokensFromSwap: expectedTokensFromSwap?.toString(),
-          minExpectedTokens: minExpectedTokens?.toString(),
-        },
-      )
-
-      // Encode metadata for jb721Delegate AND/OR jbBuybackDelegate
-      const delegateMetadata = encodeDelegateMetadata({
-        jb721Delegate: {
-          metadata: {
-            tierIdsToMint,
-            allowOverspending:
-              nftRewards.length > 0 ? DEFAULT_ALLOW_OVERSPENDING : undefined,
-          },
-          version: JB721DelegateVersion,
-        },
-        jbBuybackDelegate: shouldUseBuybackDelegate
-          ? {
-              amountToSwap: 0, // use all ETH
-              minExpectedTokens,
-            }
-          : undefined,
-      })
-
-      return delegateMetadata
-    },
-    [
-      JB721DelegateVersion,
-      fundingCycleMetadata,
-      nftRewards,
-      priceQuery,
-      projectId,
-      receivedTickets,
-    ],
-  )
+  let weiAmount: BigNumber
+  if (!totalAmount) {
+    weiAmount = parseWad(0)
+  } else if (totalAmount.currency === V2V3_CURRENCY_ETH) {
+    weiAmount = parseWad(totalAmount.amount)
+  } else {
+    weiAmount = converter.usdToWei(totalAmount.amount)
+  }
+  const delegateMetadata = usePreparePayDelegateMetadata(weiAmount, {
+    nftRewards,
+    receivedTickets,
+  })
 
   return useCallback(
     async (
@@ -200,19 +93,8 @@ export const usePayProjectTx = ({
       })
       const beneficiary = values.beneficiaryAddress ?? userAddress
 
-      let weiAmount: BigNumber
-      if (!totalAmount) {
-        weiAmount = parseWad(0)
-      } else if (totalAmount.currency === V2V3_CURRENCY_ETH) {
-        weiAmount = parseWad(totalAmount.amount)
-      } else {
-        weiAmount = converter.usdToWei(totalAmount.amount)
-      }
-
       let onError = undefined
       try {
-        const delegateMetadata = buildPayDelegateMetadata(weiAmount)
-
         const success = await payProjectTx(
           {
             memo,
@@ -252,16 +134,15 @@ export const usePayProjectTx = ({
     [
       projectHasErc20,
       buildPayReceipt,
-      converter,
       nftRewards,
       onTransactionConfirmedCallback,
       onTransactionErrorCallback,
       onTransactionPendingCallback,
       payProjectTx,
       rewardTiers,
-      totalAmount,
+      weiAmount,
       userAddress,
-      buildPayDelegateMetadata,
+      delegateMetadata,
     ],
   )
 }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -13,7 +13,7 @@ import { useProjectCart } from '../useProjectCart'
 import { ProjectPayReceipt } from '../useProjectPageQueries'
 import { useProjectPaymentTokens } from '../useProjectPaymentTokens'
 import { PayProjectModalFormValues } from './usePayProjectModal'
-import { usePreparePayDelegateMetadata } from './usePrepareDelegatePayMetadata'
+import { usePrepareDelegatePayMetadata } from './usePrepareDelegatePayMetadata'
 
 export const usePayProjectTx = ({
   onTransactionPending: onTransactionPendingCallback,
@@ -69,7 +69,7 @@ export const usePayProjectTx = ({
     }
   }, [totalAmount, converter])
 
-  const delegateMetadata = usePreparePayDelegateMetadata(weiAmount, {
+  const delegateMetadata = usePrepareDelegatePayMetadata(weiAmount, {
     nftRewards,
     receivedTickets,
   })

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePrepareDelegatePayMetadata.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectModal/usePrepareDelegatePayMetadata.ts
@@ -1,0 +1,117 @@
+import { useUniswapPriceQuery } from 'components/AMMPrices/hooks/useERC20UniswapPrice'
+import { BUYBACK_DELEGATE_ENABLED_PROJECT_IDS } from 'constants/buybackDelegateEnabledProjectIds'
+import { DEFAULT_ALLOW_OVERSPENDING } from 'constants/transactionDefaults'
+import { JB721DelegateContractsContext } from 'contexts/NftRewards/JB721DelegateContracts/JB721DelegateContractsContext'
+import { ProjectMetadataContext } from 'contexts/shared/ProjectMetadataContext'
+import { BigNumber } from 'ethers'
+import { useContext } from 'react'
+import { encodeDelegatePayMetadata } from 'utils/delegateMetadata/encodeDelegateMetadata'
+import { parseWad } from 'utils/format/formatNumber'
+import { MAX_RESERVED_RATE } from 'utils/v2v3/math'
+import { ProjectCartNftReward } from '../../components/ProjectCartProvider'
+import { useProjectContext } from '../useProjectContext'
+
+export function usePreparePayDelegateMetadata(
+  weiAmount: BigNumber,
+  {
+    nftRewards,
+    receivedTickets,
+  }: {
+    nftRewards: ProjectCartNftReward[]
+    receivedTickets: string | undefined
+  },
+) {
+  const { tokenAddress, tokenSymbol, fundingCycleMetadata } =
+    useProjectContext()
+  const { projectId } = useContext(ProjectMetadataContext)
+
+  const { data: priceQuery } = useUniswapPriceQuery({
+    tokenAddress,
+    tokenSymbol,
+  })
+
+  const { version: JB721DelegateVersion } = useContext(
+    JB721DelegateContractsContext,
+  )
+  const tierIdsToMint = nftRewards
+    .map(({ id, quantity }) => Array<number>(quantity).fill(id))
+    .flat()
+
+  // Total tokens that should be minted by pay() tx, including reserved tokens
+  const requiredTokens = fundingCycleMetadata
+    ? parseWad(receivedTickets?.replace(',', ''))
+        .mul(MAX_RESERVED_RATE)
+        .div(fundingCycleMetadata.reservedRate)
+    : undefined
+
+  const priceQueryNumerator = priceQuery?.projectTokenPrice.numerator.toString()
+  const priceQueryDenominator =
+    priceQuery?.projectTokenPrice.denominator.toString()
+  const inversePriceQueryFactor =
+    priceQueryNumerator && priceQueryDenominator
+      ? BigNumber.from(priceQueryDenominator).div(
+          BigNumber.from(priceQueryNumerator),
+        )
+      : undefined
+
+  // Using inverse price query helps avoid dividing by zero. This assumes the token price is < 1ETH
+  const expectedTokensFromSwap = inversePriceQueryFactor?.gt(0)
+    ? weiAmount.mul(inversePriceQueryFactor)
+    : undefined
+
+  /**
+   * Expect whichever is greater: 95% of expected tokens from swap, or minimum amount of tokens required to be minted.
+   * We don't really care if less tokens are returned from the swap than what we've estimated (as long as we're getting at least the minimum amount that would otherwise be minted).
+   * The main concern is sending as high a minimum as possible to limit arbitrage possibility.
+   */
+  const minExpectedTokens =
+    requiredTokens &&
+    expectedTokensFromSwap &&
+    expectedTokensFromSwap.mul(95).div(100).gt(requiredTokens)
+      ? expectedTokensFromSwap.mul(95).div(100)
+      : requiredTokens
+
+  const shouldUseBuybackDelegate =
+    Boolean(
+      projectId &&
+        priceQuery &&
+        BUYBACK_DELEGATE_ENABLED_PROJECT_IDS.includes(projectId) &&
+        requiredTokens &&
+        expectedTokensFromSwap?.gte(requiredTokens) &&
+        // total token amount must be less than half of available liquidity (arbitrary) to avoid slippage
+        BigNumber.from(requiredTokens).mul(2).lt(priceQuery.liquidity),
+    ) && minExpectedTokens !== undefined
+
+  console.info(
+    '🧃 useProjectPayTx::use buy back delegate::',
+    shouldUseBuybackDelegate,
+    {
+      weiAmount: weiAmount.toString(),
+      priceQueryNumerator,
+      priceQueryDenominator,
+      requiredTokens: requiredTokens?.toString(),
+      expectedTokensFromSwap: expectedTokensFromSwap?.toString(),
+      minExpectedTokens: minExpectedTokens?.toString(),
+    },
+  )
+
+  // Encode metadata for jb721Delegate AND/OR jbBuybackDelegate
+  const delegateMetadata = encodeDelegatePayMetadata({
+    jb721Delegate: {
+      metadata: {
+        tierIdsToMint,
+        allowOverspending:
+          nftRewards.length > 0 ? DEFAULT_ALLOW_OVERSPENDING : undefined,
+      },
+      version: JB721DelegateVersion,
+    },
+    jbBuybackDelegate: shouldUseBuybackDelegate
+      ? {
+          amountToSwap: 0, // use all ETH
+          minExpectedTokens,
+        }
+      : undefined,
+  })
+
+  return delegateMetadata
+}

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectPaymentTokens.test.ts
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectPaymentTokens.test.ts
@@ -17,6 +17,7 @@ describe('useProjectPaymentTokens', () => {
       amount: 100,
       currency: V2V3_CURRENCY_ETH,
     },
+    nftRewards: [],
     dispatch: jest.fn(),
   }
   const DefaultUseTokensPerEth = {

--- a/src/components/v2v3/shared/FundingCycleConfigurationDrawers/FundingDrawer/FundingForm/DistributionSplitsSection/SpecificLimitModal.tsx
+++ b/src/components/v2v3/shared/FundingCycleConfigurationDrawers/FundingDrawer/FundingForm/DistributionSplitsSection/SpecificLimitModal.tsx
@@ -6,6 +6,7 @@ import FormattedNumberInput from 'components/inputs/FormattedNumberInput'
 import TooltipLabel from 'components/TooltipLabel'
 
 import { CurrencyName } from 'constants/currency'
+import { stripCommas } from 'utils/format/formatNumber'
 
 export default function SpecificLimitModal({
   open,
@@ -24,11 +25,10 @@ export default function SpecificLimitModal({
 
   function setNewSplitsFromLimit() {
     form.validateFields()
-
-    const distributionLimit = form
-      .getFieldValue('distributionLimit')
-      // Remove all commas from distribution limit
-      .replace(/,/g, '')
+    // Remove all commas from distribution limit
+    const distributionLimit = stripCommas(
+      form.getFieldValue('distributionLimit'),
+    )
     setDistributionLimit(distributionLimit)
     onClose()
   }

--- a/src/utils/delegateMetadata/encodeDelegateMetadata.ts
+++ b/src/utils/delegateMetadata/encodeDelegateMetadata.ts
@@ -30,11 +30,11 @@ export function encodeDelegatePayMetadata({
   jbBuybackDelegate?: {
     amountToSwap: BigNumberish
     minExpectedTokens: BigNumberish
-  }
+  } | null
   jb721Delegate?: {
     metadata: JB721DelegatePayMetadata
     version: JB721DelegateVersion | undefined
-  }
+  } | null
 }) {
   if (
     jb721Delegate?.version &&

--- a/src/utils/delegateMetadata/encodeDelegateMetadata.ts
+++ b/src/utils/delegateMetadata/encodeDelegateMetadata.ts
@@ -5,8 +5,8 @@ import { createMetadata } from 'juicebox-metadata-helper'
 import { JB721DelegateVersion } from 'models/v2v3/contracts'
 import {
   JB721DelegatePayMetadata,
-  encodeJb721DelegateMetadata,
-} from 'utils/delegateMetadata/encodeJb721DelegateMetadata'
+  encodeJb721DelegatePayMetadata,
+} from './encodeJb721DelegateMetadata'
 
 /**
  * Encode pay metadata for project delegate contracts.
@@ -23,7 +23,7 @@ import {
  * @param jb721Delegate.version Version of jb721Delegate
  * @returns Encoded metadata string for buyback delegate https://github.com/jbx-protocol/juice-buyback
  */
-export function encodeDelegateMetadata({
+export function encodeDelegatePayMetadata({
   jbBuybackDelegate,
   jb721Delegate,
 }: {
@@ -37,19 +37,17 @@ export function encodeDelegateMetadata({
   }
 }) {
   if (
-    jb721Delegate &&
-    jb721Delegate.version &&
+    jb721Delegate?.version &&
     !jb721DelegateVersionSupportsMetadataLib(jb721Delegate.version)
   ) {
-    // Encode without using metadata lib pattern
-
     if (jbBuybackDelegate) {
       throw new Error(
         'Metadata encoding for JBBuybackDelegate incompatible with encoding for JB721Delegate',
       )
     }
 
-    return encodeJb721DelegateMetadata(
+    // Encode without using metadata lib pattern
+    return encodeJb721DelegatePayMetadata(
       jb721Delegate.metadata,
       jb721Delegate.version,
     )
@@ -72,7 +70,7 @@ export function encodeDelegateMetadata({
   }
 
   if (jb721Delegate?.version) {
-    const encoded = encodeJb721DelegateMetadata(
+    const encoded = encodeJb721DelegatePayMetadata(
       jb721Delegate.metadata,
       jb721Delegate.version,
     )
@@ -89,7 +87,8 @@ export function encodeDelegateMetadata({
 }
 
 /**
- * <JB721Delegate3_4 supports JB Metadata Lib pattern and should be handled differently (https://github.com/jbx-protocol/juice-delegate-metadata-lib)
+ * JB721Delegate3_4 supports JB Metadata Lib pattern and should be handled differently
+ * @link https://github.com/jbx-protocol/juice-delegate-metadata-lib
  */
 function jb721DelegateVersionSupportsMetadataLib(
   version: JB721DelegateVersion | undefined,

--- a/src/utils/delegateMetadata/encodeJb721DelegateMetadata.ts
+++ b/src/utils/delegateMetadata/encodeJb721DelegateMetadata.ts
@@ -28,7 +28,7 @@ export type JB721DelegatePayMetadata =
   | JB721DELAGATE_V3_1_PAY_METADATA
   | JB721DELAGATE_V3_2_PAY_METADATA // in future, maybe more
 
-export function encodeJb721DelegateMetadata(
+export function encodeJb721DelegatePayMetadata(
   metadata: JB721DelegatePayMetadata,
   version: JB721DelegateVersion | undefined,
 ) {
@@ -51,6 +51,25 @@ export function encodeJb721DelegateMetadata(
       return encodeJB721DelegateV3_4PayMetadata(
         metadata as JB721DELAGATE_V3_2_PAY_METADATA,
       )
+    default:
+      throw new Error(`Invalid delegate version: ${version}`)
+  }
+}
+
+export function encodeJb721DelegateRedeemMetadata(
+  tokenIdsToRedeem: string[],
+  version: JB721DelegateVersion | undefined,
+) {
+  if (!version) return undefined
+  switch (version) {
+    case JB721DelegateVersion.JB721DELEGATE_V3:
+    case JB721DelegateVersion.JB721DELEGATE_V3_1:
+      return encodeJB721DelegateV3RedeemMetadata(tokenIdsToRedeem)
+    case JB721DelegateVersion.JB721DELEGATE_V3_2:
+    case JB721DelegateVersion.JB721DELEGATE_V3_3:
+      return encodeJB721DelegateV3_2RedeemMetadata(tokenIdsToRedeem)
+    case JB721DelegateVersion.JB721DELEGATE_V3_4:
+      return encodeJB721DelegateV3_4RedeemMetadata(tokenIdsToRedeem)
     default:
       throw new Error(`Invalid delegate version: ${version}`)
   }
@@ -134,9 +153,7 @@ function encodeJB721DelegateV3_4PayMetadata(
   return encoded
 }
 
-export function encodeJB721DelegateV3RedeemMetadata(
-  tokenIdsToRedeem: string[],
-) {
+function encodeJB721DelegateV3RedeemMetadata(tokenIdsToRedeem: string[]) {
   const args = [
     constants.HashZero,
     IJB721Delegate_V3_INTERFACE_ID,
@@ -151,9 +168,7 @@ export function encodeJB721DelegateV3RedeemMetadata(
   return encoded
 }
 
-export function encodeJB721DelegateV3_2RedeemMetadata(
-  tokenIdsToRedeem: string[],
-) {
+function encodeJB721DelegateV3_2RedeemMetadata(tokenIdsToRedeem: string[]) {
   const args = [
     constants.HashZero,
     IJB721Delegate_V3_2_INTERFACE_ID,
@@ -168,9 +183,7 @@ export function encodeJB721DelegateV3_2RedeemMetadata(
   return encoded
 }
 
-export function encodeJB721DelegateV3_4RedeemMetadata(
-  tokenIdsToRedeem: string[],
-) {
+function encodeJB721DelegateV3_4RedeemMetadata(tokenIdsToRedeem: string[]) {
   const args = [tokenIdsToRedeem]
   const encoded = utils.defaultAbiCoder.encode(['uint256[]'], args)
   const result = createMetadata(


### PR DESCRIPTION
## What does this PR do and why?

Motivated by the need to move delegate metadata prep code to juice-hooks. This PR pulls out the delegate prep code into its own hook. No functinality should change.

It also adds a function to prep redeem delegate metadata that is version-aware.


