### PR TITLE
fix: make lottie import dynamic

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/SuccessPayView/SuccessPayView.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/SuccessPayView/SuccessPayView.tsx
@@ -3,13 +3,14 @@ import { Trans } from '@lingui/macro'
 import { SubscribeButton } from 'components/buttons/SubscribeButton'
 import { useSuccessPayView } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useSuccessPayView'
 import confettiAnimationJuicebox from 'data/lottie/confetti-animation-juicebox.json'
-import Lottie from 'lottie-react'
+import dynamic from 'next/dynamic'
 import {
   SuccessButton,
   SuccessNftItem,
   SuccessPayCard,
   SuccessTokensItem,
 } from './components'
+const Lottie = dynamic(() => import('lottie-react'), { ssr: false })
 
 export const SuccessPayView = () => {
   const {


### PR DESCRIPTION
Local dev server would break for certain projects because the Lottie library tried to reference the `document` object in node contexts. I fixed this with:

```js
const Lottie = dynamic(() => import('lottie-react'), { ssr: false })
```

See discussion here: https://discord.com/channels/939317843059679252/939705688563810304/1172296215027781675

NOTE: This is only a problem on my machine. Doesn't seem to affect prod.

Steps to reproduce:
1. yarn dev
2. Navigate to `localhost:3000/v2/p/421`
3. bong