### PR TITLE
Dist payouts modal makeover

### DIFF
--- a/src/components/v2v3/shared/SplitItem/JuiceboxProjectBeneficiary.tsx
+++ b/src/components/v2v3/shared/SplitItem/JuiceboxProjectBeneficiary.tsx
@@ -17,7 +17,10 @@ export function JuiceboxProjectBeneficiary({
   return (
     <div>
       <div className="flex gap-2">
-        <V2V3ProjectHandleLink projectId={parseInt(split.projectId)} />
+        <V2V3ProjectHandleLink
+          projectId={parseInt(split.projectId)}
+          withProjectAvatar
+        />
         <AllocatorBadge allocator={split.allocator} />
       </div>
       {split.allocator === NULL_ALLOCATOR_ADDRESS ? (

--- a/src/components/v2v3/shared/SplitList.tsx
+++ b/src/components/v2v3/shared/SplitList.tsx
@@ -45,7 +45,7 @@ export default function SplitList({
   }
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-3">
       {sortSplits(splits).map(split => {
         return (
           <SplitItem


### PR DESCRIPTION
- Originally, ETH addresses recipients show ETH address but projects don't. This adds project logos
- Increases space between the list items