### PR TITLE
feat: link to JC modal for JC projects

### DIFF
--- a/src/components/DomainBadge.tsx
+++ b/src/components/DomainBadge.tsx
@@ -1,20 +1,14 @@
-import { readNetwork } from 'constants/networks'
-import { NetworkName } from 'models/networkName'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { getJuicecrowdUrl } from 'utils/juicecrowd'
 import { Badge } from './Badge'
 
 export type DomainBadgeProps = {
   className?: string
   domain: string | undefined
   projectId?: number
-}
-
-export function getJuicecrowdUrl(projectId: number) {
-  const prefix = readNetwork.name === NetworkName.goerli ? 'goerli.' : ''
-  return `https://${prefix}juicecrowd.gg/p/${projectId}`
 }
 
 export const DomainBadge: React.FC<DomainBadgeProps> = ({

--- a/src/components/DomainBadge.tsx
+++ b/src/components/DomainBadge.tsx
@@ -12,7 +12,7 @@ export type DomainBadgeProps = {
   projectId?: number
 }
 
-function getJuicecrowdUrl(projectId: number) {
+export function getJuicecrowdUrl(projectId: number) {
   const prefix = readNetwork.name === NetworkName.goerli ? 'goerli.' : ''
   return `https://${prefix}juicecrowd.gg/p/${projectId}`
 }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/ProjectDashboard.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/ProjectDashboard.tsx
@@ -17,6 +17,7 @@ import { ProjectUpdatesProvider } from './components/ProjectUpdatesProvider/Proj
 import { SuccessPayView } from './components/SuccessPayView/SuccessPayView'
 import { useProjectMetadata } from './hooks/useProjectMetadata'
 import { useProjectPageQueries } from './hooks/useProjectPageQueries'
+import { JuiceCrowdRedirectModal } from './components/JuiceCrowdRedirectModal'
 
 export const ProjectDashboard = () => {
   const { projectPayReceipt } = useProjectPageQueries()
@@ -64,6 +65,7 @@ export const ProjectDashboard = () => {
                         />
                       </div>
                       <ProjectTabs className="mt-8" />
+                      <JuiceCrowdRedirectModal />
                     </div>
                   </div>
                 </>

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/ProjectDashboard.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/ProjectDashboard.tsx
@@ -1,6 +1,7 @@
 import { Footer } from 'components/Footer/Footer'
 import { TransactionProvider } from 'contexts/Transaction/TransactionProvider'
 import { useHasNftRewards } from 'hooks/JB721Delegate/useHasNftRewards'
+import { useIsJuicecrowd } from 'hooks/v2v3/useIsJuiceCrowd'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { BlockedProjectBanner } from './components/BlockedProjectBanner'
@@ -8,6 +9,7 @@ import { Cart } from './components/Cart/Cart'
 import { CoverPhoto } from './components/CoverPhoto/CoverPhoto'
 import { CurrentBalanceCard } from './components/CurrentBalanceCard/CurrentBalanceCard'
 import { FundingCycleCountdownProvider } from './components/FundingCycleCountdown/FundingCycleCountdownProvider'
+import { JuicecrowdRedirectModal } from './components/JuiceCrowdRedirectModal'
 import { NftRewardsCard } from './components/NftRewardsCard/NftRewardsCard'
 import { PayProjectCard } from './components/PayProjectCard/PayProjectCard'
 import { ProjectCartProvider } from './components/ProjectCartProvider/ProjectCartProvider'
@@ -15,23 +17,21 @@ import { ProjectHeader } from './components/ProjectHeader/ProjectHeader'
 import { ProjectTabs } from './components/ProjectTabs/ProjectTabs'
 import { ProjectUpdatesProvider } from './components/ProjectUpdatesProvider/ProjectUpdatesProvider'
 import { SuccessPayView } from './components/SuccessPayView/SuccessPayView'
-import { useProjectMetadata } from './hooks/useProjectMetadata'
 import { useProjectPageQueries } from './hooks/useProjectPageQueries'
-import { JuiceCrowdRedirectModal } from './components/JuiceCrowdRedirectModal'
 
 export const ProjectDashboard = () => {
   const { projectPayReceipt } = useProjectPageQueries()
-  const { projectMetadata } = useProjectMetadata()
 
   const { value: hasNftRewards } = useHasNftRewards()
+  const isJuicecrowd = useIsJuicecrowd()
   const shouldShowNftCard = useMemo(() => {
     // disable juicecrowd nft rewards
-    if (projectMetadata?.domain === 'juicecrowd') {
+    if (isJuicecrowd) {
       return false
     }
 
     return hasNftRewards
-  }, [hasNftRewards, projectMetadata?.domain])
+  }, [hasNftRewards, isJuicecrowd])
 
   return (
     <TransactionProvider>
@@ -65,7 +65,7 @@ export const ProjectDashboard = () => {
                         />
                       </div>
                       <ProjectTabs className="mt-8" />
-                      <JuiceCrowdRedirectModal />
+                      <JuicecrowdRedirectModal />
                     </div>
                   </div>
                 </>

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/JuiceCrowdRedirectModal.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/JuiceCrowdRedirectModal.tsx
@@ -1,16 +1,17 @@
 import { Trans } from '@lingui/macro'
 import { Button, Modal } from 'antd'
-import { getJuicecrowdUrl } from 'components/DomainBadge'
 import ExternalLink from 'components/ExternalLink'
+import { useIsJuicecrowd } from 'hooks/v2v3/useIsJuiceCrowd'
 import Image from 'next/image'
 import { useState } from 'react'
 import { useProjectMetadata } from '../hooks/useProjectMetadata'
+import { getJuicecrowdUrl } from 'utils/juicecrowd'
 
-export function JuiceCrowdRedirectModal() {
-  const { projectMetadata, projectId } = useProjectMetadata()
+export function JuicecrowdRedirectModal() {
+  const { projectId } = useProjectMetadata()
 
-  const isJuiceCrowd = projectMetadata?.domain === 'juicecrowd'
-  const [open, setOpen] = useState<boolean>(isJuiceCrowd)
+  const isJuicecrowd = useIsJuicecrowd()
+  const [open, setOpen] = useState<boolean>(isJuicecrowd)
 
   if (!projectId) return null
 
@@ -26,13 +27,13 @@ export function JuiceCrowdRedirectModal() {
         <div className="mb-3 flex h-20 w-20 items-center justify-center rounded-full bg-bluebs-50 dark:bg-bluebs-900">
           <Image
             src="/assets/images/juicecrowd-logo.webp"
-            alt="JuiceCrowd logo"
+            alt="Juicecrowd logo"
             height={35}
             width={35}
           />
         </div>
         <div className="text-xl font-medium">
-          <Trans>It looks like this is a JuiceCrowd project.</Trans>
+          <Trans>It looks like this is a Juicecrowd project.</Trans>
         </div>
         <p className="text-base">
           <Trans>
@@ -41,7 +42,7 @@ export function JuiceCrowdRedirectModal() {
           </Trans>
         </p>
       </div>
-      <div className="-mb-4 flex w-full flex-col gap-2 pt-4 md:flex-row">
+      <div className="-mb-5 flex w-full flex-col gap-2 pt-4 md:flex-row">
         <Button
           type="default"
           onClick={() => setOpen(false)}

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/JuiceCrowdRedirectModal.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/JuiceCrowdRedirectModal.tsx
@@ -10,7 +10,7 @@ export function JuiceCrowdRedirectModal() {
   const { projectMetadata, projectId } = useProjectMetadata()
 
   const isJuiceCrowd = projectMetadata?.domain === 'juicecrowd'
-  const [open, setOpen] = useState<boolean>(isJuiceCrowd || true)
+  const [open, setOpen] = useState<boolean>(isJuiceCrowd)
 
   if (!projectId) return null
 

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/JuiceCrowdRedirectModal.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/JuiceCrowdRedirectModal.tsx
@@ -1,0 +1,60 @@
+import { Trans } from '@lingui/macro'
+import { Button, Modal } from 'antd'
+import { getJuicecrowdUrl } from 'components/DomainBadge'
+import ExternalLink from 'components/ExternalLink'
+import Image from 'next/image'
+import { useState } from 'react'
+import { useProjectMetadata } from '../hooks/useProjectMetadata'
+
+export function JuiceCrowdRedirectModal() {
+  const { projectMetadata, projectId } = useProjectMetadata()
+
+  const isJuiceCrowd = projectMetadata?.domain === 'juicecrowd'
+  const [open, setOpen] = useState<boolean>(isJuiceCrowd || true)
+
+  if (!projectId) return null
+
+  return (
+    <Modal
+      open={open}
+      onCancel={() => setOpen(false)}
+      width={600}
+      okButtonProps={{ hidden: true }}
+      cancelButtonProps={{ hidden: true }}
+    >
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="mb-3 flex h-20 w-20 items-center justify-center rounded-full bg-bluebs-50 dark:bg-bluebs-900">
+          <Image
+            src="/assets/images/juicecrowd-logo.webp"
+            alt="JuiceCrowd logo"
+            height={35}
+            width={35}
+          />
+        </div>
+        <div className="text-xl font-medium">
+          <Trans>It looks like this is a JuiceCrowd project.</Trans>
+        </div>
+        <p className="text-base">
+          <Trans>
+            Some functionality may not work on juicebox.money, check it out on
+            Juicecrowd for the full experience.
+          </Trans>
+        </p>
+      </div>
+      <div className="-mb-4 flex w-full flex-col gap-2 pt-4 md:flex-row">
+        <Button
+          type="default"
+          onClick={() => setOpen(false)}
+          className="w-full grow"
+        >
+          <Trans>Cancel</Trans>
+        </Button>
+        <Button type="primary" className="w-full grow">
+          <ExternalLink href={getJuicecrowdUrl(projectId)} className="">
+            <Trans>Open on Juicecrowd</Trans>
+          </ExternalLink>
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/NftRewardsPanel/NftReward/NftReward.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/NftRewardsPanel/NftReward/NftReward.tsx
@@ -5,12 +5,12 @@ import { useProjectCart } from 'components/v2v3/V2V3Project/ProjectDashboard/hoo
 import { useProjectContext } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectContext'
 import { DEFAULT_NFT_MAX_SUPPLY } from 'constants/nftRewards'
 import { useNftRewardsEnabledForPay } from 'hooks/JB721Delegate/useNftRewardsEnabledForPay'
+import { useIsJuicecrowd } from 'hooks/v2v3/useIsJuiceCrowd'
 import { NftRewardTier } from 'models/nftRewards'
 import { useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { ipfsUriToGatewayUrl } from 'utils/ipfs'
 import { useProjectIsOFACListed } from '../../../hooks/useProjectIsOFACListed'
-import { useProjectMetadata } from '../../../hooks/useProjectMetadata'
 import { AddNftButton } from './AddNftButton'
 import { NftDetails } from './NftDetails'
 import { NftThumbnail } from './NftThumbnail'
@@ -40,7 +40,6 @@ export function NftReward({
   const cart = useProjectCart()
   const nftsEnabledForPay = useNftRewardsEnabledForPay()
 
-  const { projectMetadata } = useProjectMetadata()
   const { fundingCycleMetadata } = useProjectContext()
   const { isAddressListedInOFAC } = useProjectIsOFACListed()
 
@@ -69,9 +68,7 @@ export function NftReward({
     ? t`Unlimited`
     : t`${rewardTier?.remainingSupply} remaining`
 
-  const isJuicecrowdNft = useMemo(() => {
-    return projectMetadata?.domain === 'juicecrowd'
-  }, [projectMetadata?.domain])
+  const isJuicecrowdNft = useIsJuicecrowd()
 
   const disabled = useMemo(() => {
     return (

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectCard/PayProjectCard.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectCard/PayProjectCard.tsx
@@ -8,9 +8,9 @@ import { Trans, t } from '@lingui/macro'
 import { Button, Tooltip } from 'antd'
 import { usePayProjectCard } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/usePayProjectCard'
 import { useProjectIsOFACListed } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectIsOFACListed'
-import { useProjectMetadata } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectMetadata'
 import { Formik } from 'formik'
 import { useV2BlockedProject } from 'hooks/useBlockedProject'
+import { useIsJuicecrowd } from 'hooks/v2v3/useIsJuiceCrowd'
 import { V2V3CurrencyOption } from 'models/v2v3/currencyOption'
 import { twMerge } from 'tailwind-merge'
 import { V2V3_CURRENCY_ETH } from 'utils/v2v3/currency'
@@ -20,12 +20,11 @@ import { TokensPerEth } from './components/TokensPerEth'
 
 export const PayProjectCard = ({ className }: { className?: string }) => {
   const isBlockedProject = useV2BlockedProject()
-  const { projectMetadata } = useProjectMetadata()
   const { isAddressListedInOFAC } = useProjectIsOFACListed()
   const { validationSchema, paymentsPaused, addPay } = usePayProjectCard()
   const determiningIfProjectCanReceivePayments = paymentsPaused === undefined
 
-  const isJuicecrowdProject = projectMetadata?.domain === 'juicecrowd'
+  const isJuicecrowdProject = useIsJuicecrowd()
 
   const isPaymentDisabled = useMemo(() => {
     return (

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/ProjectTabs/ProjectTabs.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/ProjectTabs/ProjectTabs.tsx
@@ -1,10 +1,10 @@
 import { Tab } from '@headlessui/react'
 import { Trans, t } from '@lingui/macro'
-import { useProjectMetadata } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectMetadata'
 import { useProjectPageQueries } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectPageQueries'
 import { useHasNftRewards } from 'hooks/JB721Delegate/useHasNftRewards'
 import { useIsUserAddress } from 'hooks/useIsUserAddress'
 import { useOnScreen } from 'hooks/useOnScreen'
+import { useIsJuicecrowd } from 'hooks/v2v3/useIsJuiceCrowd'
 import {
   Fragment,
   useContext,
@@ -29,18 +29,18 @@ export const ProjectTabs = ({ className }: { className?: string }) => {
   const { projectPageTab, setProjectPageTab } = useProjectPageQueries()
   const { projectOwnerAddress } = useProjectContext()
   const isProjectOwner = useIsUserAddress(projectOwnerAddress)
-  const { projectMetadata } = useProjectMetadata()
+  const isJuicecrowd = useIsJuicecrowd()
 
   const { value: hasNftRewards } = useHasNftRewards()
 
   const showNftRewards = useMemo(() => {
     // disable juicecrowd nft rewards
-    if (projectMetadata?.domain === 'juicecrowd') {
+    if (isJuicecrowd) {
       return false
     }
 
     return hasNftRewards
-  }, [hasNftRewards, projectMetadata?.domain])
+  }, [hasNftRewards, isJuicecrowd])
 
   const containerRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/UpdateNftsPage/EditNftsSection.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/UpdateNftsPage/EditNftsSection.tsx
@@ -4,9 +4,9 @@ import { Callout } from 'components/Callout/Callout'
 import Loading from 'components/Loading'
 import TransactionModal from 'components/modals/TransactionModal'
 import { RewardsList } from 'components/NftRewards/RewardsList/RewardsList'
-import { useProjectMetadata } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectMetadata'
 import { useUpdateCurrentCollection } from 'components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditNftsPage/hooks/useUpdateCurrentCollection'
 import { useHasNftRewards } from 'hooks/JB721Delegate/useHasNftRewards'
+import { useIsJuicecrowd } from 'hooks/v2v3/useIsJuiceCrowd'
 import { useCallback, useMemo, useState } from 'react'
 import { TransactionSuccessModal } from '../../../TransactionSuccessModal'
 import { useEditingNfts } from '../hooks/useEditingNfts'
@@ -23,16 +23,15 @@ export function EditNftsSection() {
     rewardTiers,
     onConfirmed: () => setSuccessModalOpen(true),
   })
-  const { projectMetadata } = useProjectMetadata()
-
+  const isJuicecrowd = useIsJuicecrowd()
   const showNftRewards = useMemo(() => {
     // disable juicecrowd nft rewards
-    if (projectMetadata?.domain === 'juicecrowd') {
+    if (isJuicecrowd) {
       return false
     }
 
     return hasExistingNfts
-  }, [hasExistingNfts, projectMetadata?.domain])
+  }, [hasExistingNfts, isJuicecrowd])
 
   const onNftFormSaved = useCallback(async () => {
     if (!rewardTiers) return

--- a/src/hooks/v2v3/useIsJuiceCrowd.ts
+++ b/src/hooks/v2v3/useIsJuiceCrowd.ts
@@ -1,0 +1,19 @@
+import { useProjectMetadata } from 'components/v2v3/V2V3Project/ProjectDashboard/hooks/useProjectMetadata'
+import { readNetwork } from 'constants/networks'
+import { NetworkName } from 'models/networkName'
+
+export function useIsJuicecrowd() {
+  const { projectMetadata, projectId } = useProjectMetadata()
+
+  // Some project's metadata are broken, need to hardcode
+  const JCProjectsWithBrokenMetadata = [
+    600, // DreamDAO
+  ]
+  const isMainnet = readNetwork.name === NetworkName.mainnet
+  const isJCProjectWithBrokenMetadata =
+    isMainnet && JCProjectsWithBrokenMetadata.includes(projectId ?? 0)
+
+  return (
+    projectMetadata?.domain === 'juicecrowd' || isJCProjectWithBrokenMetadata
+  )
+}

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -998,6 +998,9 @@ msgstr ""
 msgid "Changes will take effect in your next cycle as long as it starts after your edit deadline."
 msgstr ""
 
+msgid "It looks like this is a Juicecrowd project."
+msgstr ""
+
 msgid "Reserved token recipients cannot exceed 100%"
 msgstr ""
 
@@ -1947,9 +1950,6 @@ msgid "Pay out ETH from your project to any Ethereum wallet or Juicebox project.
 msgstr ""
 
 msgid "Built for ideas like yours"
-msgstr ""
-
-msgid "It looks like this is a JuiceCrowd project."
 msgstr ""
 
 msgid "The <0>Juicebox protocol</0> could be vulnerable to bugs or hacks. All of the ETH moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses."

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -1949,6 +1949,9 @@ msgstr ""
 msgid "Built for ideas like yours"
 msgstr ""
 
+msgid "It looks like this is a JuiceCrowd project."
+msgstr ""
+
 msgid "The <0>Juicebox protocol</0> could be vulnerable to bugs or hacks. All of the ETH moved through Juicebox could be lost or stolen. JuiceboxDAO and Peel are not liable for any losses."
 msgstr ""
 
@@ -2769,6 +2772,9 @@ msgid "Current #1 trending"
 msgstr ""
 
 msgid "Attach a sticker"
+msgstr ""
+
+msgid "Open on Juicecrowd"
 msgstr ""
 
 msgid "Disclose any details to your contributors before they pay your project."
@@ -3654,6 +3660,9 @@ msgid "The unallocated portion of your total will go to the wallet that owns the
 msgstr ""
 
 msgid "New"
+msgstr ""
+
+msgid "Some functionality may not work on juicebox.money, check it out on Juicecrowd for the full experience."
 msgstr ""
 
 msgid "Select NFTs to redeem"

--- a/src/utils/juicecrowd.ts
+++ b/src/utils/juicecrowd.ts
@@ -1,0 +1,7 @@
+import { readNetwork } from 'constants/networks'
+import { NetworkName } from 'models/networkName'
+
+export function getJuicecrowdUrl(projectId: number) {
+  const prefix = readNetwork.name === NetworkName.goerli ? 'goerli.' : ''
+  return `https://${prefix}juicecrowd.gg/p/${projectId}`
+}


### PR DESCRIPTION
- Implements an `isJuicecrowd` hook and uses in 6 prior relevant cases
- Implements a modal which opens automatically when loading a Juicecrowd project

DEMO (note: "JuiceCrowd" casing has been fixed to show "Juicecrowd") 
<img width="303" alt="Screen Shot 2023-11-29 at 9 18 45 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/afdbb24a-40bc-4995-abe8-37b0aff72e34">

<img width="938" alt="Screen Shot 2023-11-29 at 9 18 35 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/351ed10c-aedd-4dfd-9669-6cba1746d027">
