### PR TITLE
Activity from/beneficiary redesign

### DIFF
--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -35,12 +35,11 @@ const FromBeneficiary = ({
             </div>
           )}
           {distributionFromProjectId && (
-            <div className="flex gap-1">
+            <div className="flex items-baseline gap-1">
               Paid from:{' '}
               <V2V3ProjectHandleLink
                 projectId={distributionFromProjectId}
-                className="leading-3 dark:text-grey-900"
-                containerClassName="p-0"
+                className="leading-5 dark:text-grey-900"
               />
             </div>
           )}

--- a/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
+++ b/src/components/activityEventElems/ActivityElement/ActivityElement.tsx
@@ -1,34 +1,65 @@
-import { ArrowRightOutlined } from '@ant-design/icons'
-import EthereumAddress from 'components/EthereumAddress'
 import EtherscanLink from 'components/EtherscanLink'
 import { JuiceboxAccountLink } from 'components/JuiceboxAccountLink'
 import V1ProjectHandle from 'components/v1/shared/V1ProjectHandle'
 import V2V3ProjectHandleLink from 'components/v2v3/shared/V2V3ProjectHandleLink'
 import { PV_V2 } from 'constants/pv'
 import { PV } from 'models/pv'
-import { isEqualAddress } from 'utils/address'
 import { formatHistoricalDate } from 'utils/format/formatDate'
 
+import { Tooltip } from 'antd'
+import EthereumAddress from 'components/EthereumAddress'
 import { ActivityElementEvent } from './activityElementEvent'
 
 const FromBeneficiary = ({
   from,
   beneficiary,
+  distributionFromProjectId,
 }: {
   from?: string
   beneficiary?: string
+  distributionFromProjectId?: number // projectId only defined for v2 events
 }) => {
-  if (!(beneficiary || from)) return null
+  if (!(beneficiary || from || distributionFromProjectId)) return null
 
-  return beneficiary && from && !isEqualAddress(beneficiary, from) ? (
-    <div className="text-xs">
-      <EthereumAddress address={from} /> <ArrowRightOutlined />{' '}
-      <EthereumAddress address={beneficiary} />
-    </div>
-  ) : (
-    <div className="flex items-center self-start text-sm">
-      <JuiceboxAccountLink address={from} withEnsAvatar />
-    </div>
+  return (
+    <Tooltip
+      trigger={['hover', 'click']}
+      title={
+        <div>
+          <div>
+            Called by: <JuiceboxAccountLink address={from} />
+          </div>
+          {beneficiary && (
+            <div>
+              Beneficiary: <JuiceboxAccountLink address={beneficiary} />
+            </div>
+          )}
+          {distributionFromProjectId && (
+            <div className="flex gap-1">
+              Paid from:{' '}
+              <V2V3ProjectHandleLink
+                projectId={distributionFromProjectId}
+                className="leading-3 dark:text-grey-900"
+                containerClassName="p-0"
+              />
+            </div>
+          )}
+        </div>
+      }
+    >
+      <div>
+        {distributionFromProjectId ? (
+          <V2V3ProjectHandleLink
+            projectId={distributionFromProjectId}
+            className="leading-3 dark:text-grey-100"
+            containerClassName="gap-2"
+            withProjectAvatar
+          />
+        ) : (
+          <EthereumAddress address={from} tooltipDisabled linkDisabled />
+        )}
+      </div>
+    </Tooltip>
   )
 }
 

--- a/src/graphql/projectEvents/projectEvents.graphql
+++ b/src/graphql/projectEvents/projectEvents.graphql
@@ -159,6 +159,7 @@ query ProjectEvents(
       project {
         handle
       }
+      distributionFromProjectId
     }
     printReservesEvent {
       id


### PR DESCRIPTION
Redesigns the display of from/beneficiary on project activity element

Support for new `PayEvent.distributionFromProjectId` in the case of a payment being a distribution from another project.

<img width="685" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/95b9a1bf-b069-4bd7-b364-a05f413f8b08">

<img width="688" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/6911a875-1959-4379-9fcd-d6771decf903">

<img width="710" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/79433522/7d8d1974-020a-4f97-a2c6-122cca9eb3b3">
