### PR TITLE
:bug: Block payment for sanctioned address

### DIFF
--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/Cart/components/SummaryPayButton.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/Cart/components/SummaryPayButton.tsx
@@ -1,18 +1,44 @@
-import { Trans } from '@lingui/macro'
-import { Button } from 'antd'
+import { useMemo } from 'react'
+import { Button, Tooltip } from 'antd'
+import { t, Trans } from '@lingui/macro'
+
 import { useCartSummary } from '../hooks/useCartSummary'
+import { useProjectIsOFACListed } from '../../../hooks/useProjectIsOFACListed'
 
 export const SummaryPayButton = ({ className }: { className?: string }) => {
   const { payProject, walletConnected } = useCartSummary()
+  const { isAddressListedInOFAC, isLoading: isOFACChecking } =
+    useProjectIsOFACListed()
+
+  const isLoading = useMemo(() => {
+    return Boolean(walletConnected && isOFACChecking)
+  }, [walletConnected, isOFACChecking])
+
+  const isDisabled = useMemo(() => {
+    return Boolean(walletConnected && isAddressListedInOFAC)
+  }, [isAddressListedInOFAC, walletConnected])
+
   return (
-    <Button className={className} type="primary" onClick={payProject}>
-      <span>
-        {walletConnected ? (
-          <Trans>Pay project</Trans>
-        ) : (
-          <Trans>Connect wallet</Trans>
-        )}
-      </span>
-    </Button>
+    <Tooltip
+      title={t`You can't pay this project because your wallet address failed compliance check.`}
+      placement="top"
+      open={isDisabled ? undefined : false}
+    >
+      <Button
+        className={className}
+        type="primary"
+        onClick={payProject}
+        loading={isLoading}
+        disabled={isDisabled}
+      >
+        <span>
+          {walletConnected ? (
+            <Trans>Pay project</Trans>
+          ) : (
+            <Trans>Connect wallet</Trans>
+          )}
+        </span>
+      </Button>
+    </Tooltip>
   )
 }

--- a/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/MessageSection.tsx
+++ b/src/components/v2v3/V2V3Project/ProjectDashboard/components/PayProjectModal/components/MessageSection.tsx
@@ -37,7 +37,9 @@ export const MessageSection = () => {
             <div className="font-medium text-bluebs-700 dark:text-bluebs-300">
               <Trans>Notice from {projectName}</Trans>
             </div>
-            <p className="mt-2 mb-0">{projectPayDisclosure}</p>
+            <p className="mt-2 mb-0 whitespace-pre-wrap">
+              {projectPayDisclosure}
+            </p>
           </div>
         </Callout>
       )}

--- a/src/contexts/v2v3/V2V3ProjectOFACProvider.tsx
+++ b/src/contexts/v2v3/V2V3ProjectOFACProvider.tsx
@@ -7,10 +7,12 @@ import { useQuery } from 'react-query'
 const OFAC_API = 'https://api.wewantjusticedao.org/donation/validate'
 
 interface ProjectOFACContextType {
+  isLoading?: boolean
   isAddressListedInOFAC?: boolean
 }
 
 export const ProjectOFACContext = createContext<ProjectOFACContextType>({
+  isLoading: false,
   isAddressListedInOFAC: undefined,
 })
 
@@ -22,7 +24,7 @@ export default function V2V3ProjectOFACProvider({
   const { userAddress, isConnected } = useWallet()
   const { projectMetadata } = useProjectMetadata()
 
-  const { data: isAddressListedInOFAC } = useQuery(
+  const { data: isAddressListedInOFAC, isLoading } = useQuery(
     ['isAddressListedInOFAC', userAddress],
     async () => {
       if (!(projectMetadata?.projectRequiredOFACCheck && isConnected)) {
@@ -47,7 +49,7 @@ export default function V2V3ProjectOFACProvider({
   )
 
   return (
-    <ProjectOFACContext.Provider value={{ isAddressListedInOFAC }}>
+    <ProjectOFACContext.Provider value={{ isAddressListedInOFAC, isLoading }}>
       {children}
     </ProjectOFACContext.Provider>
   )


### PR DESCRIPTION
If users are not connected, they can add an NFT or donation to the cart. Once connected, the app does not check their OFAC status

DEFAULT
<img width="1043" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/147380121/faf99d1f-8799-4ac6-8441-ae9a7da85b3b">

IF BUTTON DISABLED AND BUTTON HOVERED
<img width="1048" alt="image" src="https://github.com/jbx-protocol/juice-interface/assets/147380121/f22a64a7-2d98-4dc1-82ed-8ba46d8005ac">
