### PR TITLE
fix: payouts table in distribute payouts modal 

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/modals/DistributePayoutsModal.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3FundingCycleSection/modals/DistributePayoutsModal.tsx
@@ -166,7 +166,7 @@ export default function DistributePayoutsModal({
             <PayoutsTable
               payoutSplits={payoutSplits ?? []}
               currency={currencyName}
-              distributionLimit={parseFloat(distributionAmount ?? '0')}
+              distributionLimit={parseFloat(distributionAmount ?? '0')} // distributionLimit is the amount to distribute in the instance.
               hideHeader
               showAvatars
             />

--- a/src/components/v2v3/shared/PayoutsTable/PayoutsTableBody.tsx
+++ b/src/components/v2v3/shared/PayoutsTable/PayoutsTableBody.tsx
@@ -26,6 +26,8 @@ export function PayoutsTableBody() {
   } = usePayoutsTable()
   const emptyState = distributionLimit === 0 && !payoutSplits?.length
 
+  const hasDistributionLimit = distributionLimit && distributionLimit > 0
+
   return (
     <>
       {topAccessory}
@@ -45,7 +47,8 @@ export function PayoutsTableBody() {
                 </Row>
               ) : (
                 <>
-                  {payoutSplits.length > 0 ? (
+                  {/* `|| hasDistributionLimit` to account for old projects whose payout is only the "remaining project owner" split, but still have a distributionLimit.  */}
+                  {payoutSplits.length > 0 || hasDistributionLimit ? (
                     <Row
                       className={twMerge(
                         'font-medium',

--- a/src/components/v2v3/shared/PayoutsTable/hooks/usePayoutsTable.tsx
+++ b/src/components/v2v3/shared/PayoutsTable/hooks/usePayoutsTable.tsx
@@ -21,6 +21,7 @@ import {
 import {
   JB_FEE,
   adjustedSplitPercents,
+  deriveAmountAfterFee,
   deriveAmountBeforeFee,
   derivePayoutAmount,
   ensureSplitsSumTo100Percent,
@@ -82,7 +83,9 @@ export const usePayoutsTable = () => {
     SPLITS_TOTAL_PERCENT - totalSplitsPercent(payoutSplits) // parts-per-billion
   const ownerRemainingAmount =
     distributionLimit && !distributionLimitIsInfinite
-      ? (ownerRemainingPercentPPB / ONE_BILLION) * distributionLimit
+      ? deriveAmountAfterFee(
+          (ownerRemainingPercentPPB / ONE_BILLION) * distributionLimit,
+        )
       : undefined
 
   const ownerRemainderValue = round(


### PR DESCRIPTION
Some minor fixes to the payouts table in "distribute payouts" modal when only owner split the owner split is present. 

### **Before:**
<img width="438" alt="Screen Shot 2024-01-18 at 3 02 53 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/c166d64e-098d-41ba-8abe-b204e00a6ff7">

### **Implemented:**

- [x] When there are no payouts and an owner split (like above):
- [x] remove sub-total row
- [x] change “Remaining…” to the owner wallet address
- [x] make owner row amount account for fee

- [x] Check all other instances of the payouts table to check they are behaving as usual. 

### **After:**
<img width="646" alt="Screen Shot 2024-01-18 at 2 47 02 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/b63b9587-ba06-45a7-b0d0-d9b71b0a4e71">

