### PR TITLE
fix: break words in project description

### DIFF
--- a/src/components/RichPreview/RichPreview.tsx
+++ b/src/components/RichPreview/RichPreview.tsx
@@ -6,6 +6,7 @@ export const RichPreview = ({ source }: { source: string }) => {
   return (
     <div
       id="rich-text"
+      className="break-words"
       dangerouslySetInnerHTML={{
         __html: purified,
       }}


### PR DESCRIPTION
Fixes #4221 

<img width="383" alt="Screen Shot 2024-01-22 at 12 31 17 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/57f12e20-653b-4e12-9cba-4054ab3f38d0">

<img width="696" alt="Screen Shot 2024-01-22 at 12 30 48 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/097bdeb1-11c0-483c-a297-1fde3ad33e4e">
