### PR TITLE
fix: project settings mint rate changes to original bug

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
@@ -1,8 +1,12 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { Trans, t } from '@lingui/macro'
 import { FundingCycleListItem } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/FundingCycleListItem'
 import { MintRateValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/TokenListItems/MintRateValue'
 import { ReservedRateValue } from 'components/v2v3/V2V3Project/V2V3FundingCycleSection/FundingCycleDetails/TokenListItems/ReservedRateValue'
 import DiffedSplitList from 'components/v2v3/shared/DiffedSplits/DiffedSplitList'
+import { V2V3ProjectContext } from 'contexts/v2v3/Project/V2V3ProjectContext'
+import { useContext } from 'react'
+import { deriveNextIssuanceRate } from 'utils/v2v3/fundingCycle'
 import {
   formatDiscountRate,
   formatRedemptionRate,
@@ -17,7 +21,6 @@ export function TokensSectionDiff() {
     sectionHasDiff,
 
     newMintRate,
-    currentMintRate,
     mintRateHasDiff,
 
     newReservedRate,
@@ -48,6 +51,8 @@ export function TokensSectionDiff() {
     tokenSymbolPlural,
   } = useTokensSectionValues()
 
+  const { fundingCycle: currentFundingCycle } = useContext(V2V3ProjectContext)
+
   if (!sectionHasDiff) {
     return (
       <div className={emptySectionClasses}>
@@ -58,11 +63,16 @@ export function TokensSectionDiff() {
 
   const formattedReservedRate = parseFloat(formatReservedRate(newReservedRate))
 
+  const currentMintRateAfterDiscountRateApplied = deriveNextIssuanceRate({
+    weight: BigNumber.from(0),
+    previousFC: currentFundingCycle,
+  })
+
   return (
     <DiffSection
       content={
         <div className="mb-5 flex flex-col gap-3 text-sm">
-          {mintRateHasDiff && currentMintRate && (
+          {mintRateHasDiff && currentMintRateAfterDiscountRateApplied && (
             <FundingCycleListItem
               name={t`Total issuance`}
               value={
@@ -73,7 +83,7 @@ export function TokensSectionDiff() {
               }
               oldValue={
                 <MintRateValue
-                  value={currentMintRate}
+                  value={currentMintRateAfterDiscountRateApplied}
                   tokenSymbol={tokenSymbolPlural}
                 />
               }

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/hooks/useTokensSectionValues.ts
@@ -9,7 +9,6 @@ import {
 } from 'utils/v2v3/fundingCycle'
 import {
   discountRateFrom,
-  formatIssuanceRate,
   issuanceRateFrom,
   reservedRateFrom,
 } from 'utils/v2v3/math'
@@ -52,9 +51,6 @@ export const useTokensSectionValues = () => {
   const newPauseTransfers = formValues.pauseTransfers
 
   const currentMintRate = currentFundingCycle?.weight
-  const currentMintRateNum = currentMintRate
-    ? parseFloat(formatIssuanceRate(currentMintRate.toString()))
-    : undefined
 
   const currentReservedRate = currentFundingCycleMetadata?.reservedRate
   const currentDiscountRate = currentFundingCycle?.discountRate
@@ -74,9 +70,7 @@ export const useTokensSectionValues = () => {
       }),
     )
 
-  const mintRateHasDiff = Boolean(
-    currentMintRateNum !== newMintRateNum && !onlyDiscountRateApplied,
-  )
+  const mintRateHasDiff = !onlyDiscountRateApplied
 
   const reservedRateHasDiff = Boolean(
     currentReservedRate &&

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
@@ -37,7 +37,7 @@ export const usePrepareSaveEditCycleData = () => {
   // Only using this to get values of FC parameters not supported in the FC form (e.g. allowTerminalMigration, etc.)
   const reduxConfig = useEditingFundingCycleConfig()
 
-  const { newMintRate, mintRateHasDiff } = useTokensSectionValues()
+  const { newMintRate } = useTokensSectionValues()
 
   const { editCycleForm } = useEditCycleFormContext()
   const {
@@ -90,9 +90,7 @@ export const usePrepareSaveEditCycleData = () => {
 
   const editingFundingCycleData: V2V3FundingCycleData = {
     duration: BigNumber.from(durationSeconds),
-    weight: mintRateHasDiff
-      ? newMintRate
-      : reduxConfig.editingFundingCycleData.weight,
+    weight: newMintRate,
     discountRate: discountRateFrom(formValues.discountRate),
     ballot: formValues.ballot,
   }


### PR DESCRIPTION
Fixes #4246  (refer to **Case 2** below):

### Case 1: Mint rate unchanged
i.e. Inputted mint rate is the same as what would be applied by the discount rate.
-> Sends 0 to contracts:

<img width="713" alt="Screen Shot 2024-02-07 at 11 52 50 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/d105e418-4061-4503-bcd5-09fb9f1e2adb">

### Case 2: Mint rate changes to anything else (including to current FC's mint rate):
-> Sends the value inputted to the contracts

Artizen's issue is that they set the mint rate back to current FC's mint rate, which was mistakenly also giving 0 to the contracts. The video below shows me executing the same process with JB's cycle with success:

https://github.com/jbx-protocol/juice-interface/assets/96150256/71409821-4a2a-4ecf-a92d-8862f51b18ce

### Case 3: User sets mint rate to 0:
-> As before, contracts need to see a value of `1`. This is unchanged:
<img width="711" alt="Screen Shot 2024-02-07 at 12 06 05 pm" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/451b6239-52d6-4214-b7bf-474f1d8261f0">
