### PR TITLE
fix: add controller and terminal migration settings to edit cycle

### DIFF
--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/DetailsSection/DetailsSectionAdvanced.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/DetailsSection/DetailsSectionAdvanced.tsx
@@ -4,19 +4,34 @@ import TooltipLabel from 'components/TooltipLabel'
 import { JuiceSwitch } from 'components/inputs/JuiceSwitch'
 import {
   CONTROLLER_CONFIG_EXPLANATION,
+  CONTROLLER_MIGRATION_EXPLANATION,
   TERMINAL_CONFIG_EXPLANATION,
+  TERMINAL_MIGRATION_EXPLANATION,
 } from 'components/strings'
 import { AdvancedDropdown } from '../AdvancedDropdown'
 
 export function DetailsSectionAdvanced() {
   return (
     <AdvancedDropdown>
+      <Form.Item name="pausePay">
+        <JuiceSwitch label={<Trans>Disable payments to this project</Trans>} />
+      </Form.Item>
       <Form.Item name="allowSetTerminals">
         <JuiceSwitch
           label={
             <TooltipLabel
               tip={TERMINAL_CONFIG_EXPLANATION}
-              label={<Trans>Enable set payment terminal</Trans>}
+              label={<Trans>Enable payment terminal configurations</Trans>}
+            />
+          }
+        />
+      </Form.Item>
+      <Form.Item name="allowTerminalMigration">
+        <JuiceSwitch
+          label={
+            <TooltipLabel
+              tip={TERMINAL_MIGRATION_EXPLANATION}
+              label={<Trans>Enable payment terminal migrations</Trans>}
             />
           }
         />
@@ -26,13 +41,20 @@ export function DetailsSectionAdvanced() {
           label={
             <TooltipLabel
               tip={CONTROLLER_CONFIG_EXPLANATION}
-              label={<Trans>Enable set controller</Trans>}
+              label={<Trans>Enable controller configurations</Trans>}
             />
           }
         />
       </Form.Item>
-      <Form.Item name="pausePay">
-        <JuiceSwitch label={<Trans>Disable payments to this project</Trans>} />
+      <Form.Item name="allowControllerMigration">
+        <JuiceSwitch
+          label={
+            <TooltipLabel
+              tip={CONTROLLER_MIGRATION_EXPLANATION}
+              label={<Trans>Enable controller migrations</Trans>}
+            />
+          }
+        />
       </Form.Item>
     </AdvancedDropdown>
   )

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/EditCycleFormFields.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/EditCycleFormFields.ts
@@ -9,6 +9,8 @@ type DetailsSectionFields = {
   ballot: string
   allowSetTerminals: boolean
   allowSetController: boolean
+  allowControllerMigration: boolean
+  allowTerminalMigration: boolean
   pausePay: boolean
 }
 

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/DetailsSectionDiff.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/DetailsSectionDiff.tsx
@@ -29,6 +29,14 @@ export function DetailsSectionDiff() {
     currentSetTerminals,
     allowSetTerminalsHasDiff,
 
+    newAllowTerminalMigration,
+    currentAllowTerminalMigration,
+    allowTerminalMigrationHasDiff,
+
+    newAllowControllerMigration,
+    currentAllowControllerMigration,
+    allowControllerMigrationHasDiff,
+
     newSetController,
     currentSetController,
     allowSetControllerHasDiff,
@@ -90,7 +98,7 @@ export function DetailsSectionDiff() {
             )}
             {allowSetTerminalsHasDiff && (
               <FundingCycleListItem
-                name={t`Enable set payment terminal`}
+                name={t`Enable payment terminal config`}
                 value={
                   <span className="capitalize">
                     {newSetTerminals.toString()}
@@ -103,9 +111,24 @@ export function DetailsSectionDiff() {
                 }
               />
             )}
+            {allowTerminalMigrationHasDiff && (
+              <FundingCycleListItem
+                name={t`Enable payment terminal migrations`}
+                value={
+                  <span className="capitalize">
+                    {newAllowTerminalMigration.toString()}
+                  </span>
+                }
+                oldValue={
+                  <span className="capitalize">
+                    {currentAllowTerminalMigration.toString()}
+                  </span>
+                }
+              />
+            )}
             {allowSetControllerHasDiff && (
               <FundingCycleListItem
-                name={t`Enable set controller`}
+                name={t`Enable controller config`}
                 value={
                   <span className="capitalize">
                     {newSetController.toString()}
@@ -114,6 +137,21 @@ export function DetailsSectionDiff() {
                 oldValue={
                   <span className="capitalize">
                     {currentSetController.toString()}
+                  </span>
+                }
+              />
+            )}
+            {allowControllerMigrationHasDiff && (
+              <FundingCycleListItem
+                name={t`Enable controller migrations`}
+                value={
+                  <span className="capitalize">
+                    {newAllowControllerMigration.toString()}
+                  </span>
+                }
+                oldValue={
+                  <span className="capitalize">
+                    {currentAllowControllerMigration.toString()}
                   </span>
                 }
               />

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/hooks/useDetailsSectionValues.ts
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/ReviewConfirmModal/hooks/useDetailsSectionValues.ts
@@ -41,6 +41,24 @@ export const useDetailsSectionValues = () => {
   )
   const allowSetTerminalsHasDiff = currentSetTerminals !== newSetTerminals
 
+  const newAllowTerminalMigration = Boolean(
+    editCycleForm?.getFieldValue('allowTerminalMigration'),
+  )
+  const currentAllowTerminalMigration = Boolean(
+    currentFundingCycleMetadata?.allowTerminalMigration,
+  )
+  const allowTerminalMigrationHasDiff =
+    currentAllowTerminalMigration !== newAllowTerminalMigration
+
+  const newAllowControllerMigration = Boolean(
+    editCycleForm?.getFieldValue('allowControllerMigration'),
+  )
+  const currentAllowControllerMigration = Boolean(
+    currentFundingCycleMetadata?.allowControllerMigration,
+  )
+  const allowControllerMigrationHasDiff =
+    currentAllowControllerMigration !== newAllowControllerMigration
+
   const newSetController = Boolean(
     editCycleForm?.getFieldValue('allowSetController'),
   )
@@ -50,7 +68,11 @@ export const useDetailsSectionValues = () => {
   const allowSetControllerHasDiff = currentSetController !== newSetController
 
   const advancedOptionsHasDiff =
-    pausePayHasDiff || allowSetTerminalsHasDiff || allowSetControllerHasDiff
+    pausePayHasDiff ||
+    allowSetTerminalsHasDiff ||
+    allowSetControllerHasDiff ||
+    allowControllerMigrationHasDiff ||
+    allowTerminalMigrationHasDiff
 
   const sectionHasDiff =
     durationHasDiff || ballotHasDiff || advancedOptionsHasDiff
@@ -71,6 +93,14 @@ export const useDetailsSectionValues = () => {
     newSetTerminals,
     currentSetTerminals,
     allowSetTerminalsHasDiff,
+
+    newAllowTerminalMigration,
+    currentAllowTerminalMigration,
+    allowTerminalMigrationHasDiff,
+
+    newAllowControllerMigration,
+    currentAllowControllerMigration,
+    allowControllerMigrationHasDiff,
 
     newSetController,
     currentSetController,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/useLoadEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/useLoadEditCycleData.tsx
@@ -88,6 +88,10 @@ export const useLoadEditCycleData = () => {
           currentProjectData.fundingCycleMetadata.global.allowSetTerminals,
         allowSetController:
           currentProjectData.fundingCycleMetadata.global.allowSetController,
+        allowControllerMigration:
+          currentProjectData.fundingCycleMetadata.allowControllerMigration,
+        allowTerminalMigration:
+          currentProjectData.fundingCycleMetadata.allowTerminalMigration,
         pausePay: currentProjectData.fundingCycleMetadata.pausePay,
         payoutSplits:
           currentProjectData.payoutGroupedSplits.payoutGroupedSplits,

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/EditCyclePage/hooks/usePrepareSaveEditCycleData.tsx
@@ -86,6 +86,8 @@ export const usePrepareSaveEditCycleData = () => {
         ? false
         : true,
       useDataSourceForRedeem: formValues.useDataSourceForRedeem,
+      allowControllerMigration: formValues.allowControllerMigration,
+      allowTerminalMigration: formValues.allowTerminalMigration,
     }
 
   const editingFundingCycleData: V2V3FundingCycleData = {

--- a/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectUpgradesPage/components/RequiredFlagsList.tsx
+++ b/src/components/v2v3/V2V3Project/V2V3ProjectSettings/pages/ProjectUpgradesPage/components/RequiredFlagsList.tsx
@@ -10,14 +10,14 @@ export function RequiredFlagsList() {
       <Trans>
         You must enable the following cycle rules:
         <ul className="list-disc pl-10">
-          {!fundingCycleMetadata?.allowControllerMigration ? (
-            <li>Allow Controller Migrations</li>
+          {!fundingCycleMetadata?.global.allowSetTerminals ? (
+            <li>Enable payment terminal configurations</li>
           ) : null}
           {!fundingCycleMetadata?.allowTerminalMigration ? (
-            <li>Allow Payment Terminal Migrations</li>
+            <li>Enable payment terminal migrations</li>
           ) : null}
-          {!fundingCycleMetadata?.global.allowSetTerminals ? (
-            <li>Allow Payment Terminal Configurations</li>
+          {!fundingCycleMetadata?.allowControllerMigration ? (
+            <li>Enable controller migrations</li>
           ) : null}
         </ul>
       </Trans>

--- a/src/locales/messages.pot
+++ b/src/locales/messages.pot
@@ -689,9 +689,6 @@ msgstr ""
 msgid "No deadline"
 msgstr ""
 
-msgid "Enable set payment terminal"
-msgstr ""
-
 msgid "Your project is up to date!"
 msgstr ""
 
@@ -2180,6 +2177,9 @@ msgstr ""
 msgid "Your project can still receive payments directly through the Juicebox protocol contracts."
 msgstr ""
 
+msgid "Enable payment terminal configurations"
+msgstr ""
+
 msgid "Juicebox native"
 msgstr ""
 
@@ -2319,6 +2319,9 @@ msgid "A project name"
 msgstr ""
 
 msgid "Telegram"
+msgstr ""
+
+msgid "Enable controller migrations"
 msgstr ""
 
 msgid "StudioDAO is a decentralized movie studio flipping the script on how films get funded. By combining the power of collective action with NFTs tied to programmable treasuries, StudioDAO gives audiences a platform to vote on which films they want to fund and watch while giving filmmakers new opportunities to get their projects funded."
@@ -2549,6 +2552,9 @@ msgstr ""
 msgid "Since launching in November 2022 StudioDAO has raised nearly 50 ETH and is gearing up to launch their first film *Ticket to Space*, the first DAO documentary about MoonDAO sending DAO member Yan Kejun to space on a Blue Origin rocket. MoonDAO has recently voted to donate $100,000 to help fund the film's production. To learn more about the Ticket to Space documentary, listen to episode 22 of the Juicebox podcast featuring a roundtable discussion with director Fernando Urdapilleta, producer Susie Conley, MoonDAO co-founder Pablo Moncada-Larrotiz, and StudioDAO co-founders Kenny Miller and Rachel Leventhal: <0>https://podcast.juicebox.money</0>."
 msgstr ""
 
+msgid "Enable payment terminal migrations"
+msgstr ""
+
 msgid "You would receive at least <0/>"
 msgstr ""
 
@@ -2690,6 +2696,9 @@ msgstr ""
 msgid "Your project's current cycle has no duration. Edits you make below will take effect immediately."
 msgstr ""
 
+msgid "Enable controller configurations"
+msgstr ""
+
 msgid "When checked, payments made through this address will mint the project's ERC-20 tokens. Payments will incur slightly higher gas fees. When unchecked, the Juicebox protocol will internally track the beneficiary's tokens, and they can claim their ERC-20 tokens at any time."
 msgstr ""
 
@@ -2709,6 +2718,9 @@ msgid "See the NFTs and rewards offered by this project."
 msgstr ""
 
 msgid "Images will be cropped to a 1:1 square in thumbnail previews on the Juicebox app."
+msgstr ""
+
+msgid "Enable controller config"
 msgstr ""
 
 msgid "Recipients will recieve payouts in ETH"
@@ -3465,9 +3477,6 @@ msgid "Connect"
 msgstr ""
 
 msgid "Contract permissions"
-msgstr ""
-
-msgid "Enable set controller"
 msgstr ""
 
 msgid "Project configurations cannot be changed to the duration of locked cycles."
@@ -4470,6 +4479,9 @@ msgid "Zero"
 msgstr ""
 
 msgid "Latest"
+msgstr ""
+
+msgid "Enable payment terminal config"
 msgstr ""
 
 msgid "Custom metadata resolvers replace the default metadata above. They must conform to the <0>IJBTokenUriResolver</0> interface."


### PR DESCRIPTION
Add "payment migration" and "controller migration" fields to edit cycle form: 
<img width="770" alt="Screenshot 2024-04-09 at 9 46 49 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/7bf7caa9-6bfe-461a-8cc1-9a07e1a2b996">

Add to edit cycle confirm modal:
<img width="568" alt="Screenshot 2024-04-09 at 9 42 43 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/f89f85e1-8468-4264-9e36-5ba6289e6b77">

Successful transaction:
<img width="948" alt="Screenshot 2024-04-09 at 9 46 12 am" src="https://github.com/jbx-protocol/juice-interface/assets/96150256/fcaffa48-6c09-4bbc-b9b9-9cba424fa936">
