### PR TITLE
fix: sepolia support for single token payment terminal store contracts

### DIFF
--- a/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/useProjectPrimaryEthTerminal.ts
+++ b/src/hooks/v2v3/V2V3ProjectContracts/projectContractLoaders/useProjectPrimaryEthTerminal.ts
@@ -18,7 +18,7 @@ import { useLoadV2V3Contract } from '../../useLoadV2V3Contract'
 export function useProjectPrimaryEthTerminal({
   projectId,
 }: {
-  projectId: number
+  projectId: number | undefined
 }) {
   const { cv, contracts } = useContext(V2V3ContractsContext)
 

--- a/src/models/v2v3/contracts.ts
+++ b/src/models/v2v3/contracts.ts
@@ -8,7 +8,11 @@ export enum V2V3ContractName {
   JBOperatorStore = 'JBOperatorStore',
   JBSplitsStore = 'JBSplitsStore',
   JBTokenStore = 'JBTokenStore',
+
   JBSingleTokenPaymentTerminalStore = 'JBSingleTokenPaymentTerminalStore',
+  JBSingleTokenPaymentTerminalStore3_1 = 'JBSingleTokenPaymentTerminalStore3_1',
+  JBSingleTokenPaymentTerminalStore3_1_1 = 'JBSingleTokenPaymentTerminalStore3_1_1',
+
   JBETHERC20ProjectPayerDeployer = 'JBETHERC20ProjectPayerDeployer',
   JBETHERC20SplitsPayerDeployer = 'JBETHERC20SplitsPayerDeployer',
 
@@ -24,6 +28,23 @@ export enum V2V3ContractName {
   DeprecatedJBDirectory = 'DeprecatedJBDirectory',
 }
 export type V2V3Contracts = Record<V2V3ContractName, Contract>
+
+/**
+ * Single source of truth for supported single token payment terminal store versions.
+ *
+ * DEV NOTE:
+ * To support a new payment single token terminal store:
+ * 1. Add it to V2V3ContractName
+ * 2. Add it to this array
+ * 3. Add support for it in any contract reads or transactions that use it.
+ */
+export const SUPPORTED_SINGLE_TOKEN_PAYMENT_TERMINAL_STORES = [
+  V2V3ContractName.JBSingleTokenPaymentTerminalStore,
+  V2V3ContractName.JBSingleTokenPaymentTerminalStore3_1,
+  V2V3ContractName.JBSingleTokenPaymentTerminalStore3_1_1,
+] as const
+export type SingleTokenPaymentTerminalStoreVersion =
+  (typeof SUPPORTED_SINGLE_TOKEN_PAYMENT_TERMINAL_STORES)[number]
 
 /**
  * Single source of truth for supported terminal versions.

--- a/src/utils/v2v3/contractLoaders/JuiceboxV3.ts
+++ b/src/utils/v2v3/contractLoaders/JuiceboxV3.ts
@@ -93,6 +93,18 @@ export const loadJuiceboxV3Contract = async (
         )) as ContractJson
         break
       }
+      case V2V3ContractName.JBSingleTokenPaymentTerminalStore3_1: {
+        contractJson = (await import(
+          `@jbx-protocol/juice-contracts-v3/deployments/${network}/JBSingleTokenPaymentTerminalStore3_1.json`
+        )) as ContractJson
+        break
+      }
+      case V2V3ContractName.JBSingleTokenPaymentTerminalStore3_1_1: {
+        contractJson = (await import(
+          `@jbx-protocol/juice-contracts-v3/deployments/${network}/JBSingleTokenPaymentTerminalStore3_1_1.json`
+        )) as ContractJson
+        break
+      }
       case V2V3ContractName.JBETHERC20ProjectPayerDeployer: {
         contractJson = (await import(
           `@jbx-protocol/juice-contracts-v3/deployments/${network}/JBETHERC20ProjectPayerDeployer.json`


### PR DESCRIPTION
### TL;DR

**Needed as Sepolia does not have a base `JBSingleTokenPaymentTerminalStore`**


Updated the `useProjectPrimaryEthTerminalStore` function to dynamically support multiple single token payment terminal store versions.

### What changed?

Added logic to determine the correct store contract name based on the address and contracts.

### Why make this change?

To support multiple versions of single token payment terminal stores and ensure compatibility with different contract versions.

---

