### PR TITLE
refactor: refine tx history types

### DIFF
--- a/src/components/Navbar/components/TransactionList/TransactionsList.tsx
+++ b/src/components/Navbar/components/TransactionList/TransactionsList.tsx
@@ -5,8 +5,8 @@ import BadgeIcon from 'components/BadgeIcon'
 import ExternalLink from 'components/ExternalLink'
 import Loading from 'components/Loading'
 import {
+  TransactionLog,
   TxHistoryContext,
-  timestampForTxLog,
 } from 'contexts/Transaction/TxHistoryContext'
 import { TxStatus } from 'models/transaction'
 import { useContext, useEffect, useMemo, useState } from 'react'
@@ -14,6 +14,11 @@ import { twMerge } from 'tailwind-merge'
 import { etherscanLink } from 'utils/etherscan'
 import { formatHistoricalDate } from 'utils/format/formatDate'
 import TxStatusIcon from './TxStatusIcon'
+
+// Prefer using tx.timestamp if tx has been mined. Otherwise use createdAt timestamp
+export const timestampForTxLog = (txLog: TransactionLog) => {
+  return txLog.tx?.timestamp ?? txLog.createdAt
+}
 
 export function TransactionsList({
   listClassName,

--- a/src/contexts/Transaction/EthersTxHistoryProvider.tsx
+++ b/src/contexts/Transaction/EthersTxHistoryProvider.tsx
@@ -1,7 +1,7 @@
 import { readProvider } from 'constants/readProvider'
-import { TransactionLog, TxStatus } from 'models/transaction'
+import { TxStatus } from 'models/transaction'
 import { ReactNode, useEffect } from 'react'
-import { TxHistoryContext } from './TxHistoryContext'
+import { TransactionLog, TxHistoryContext } from './TxHistoryContext'
 import { useTransactions } from './useTransactions'
 
 const nowSeconds = () => Math.round(new Date().valueOf() / 1000)

--- a/src/contexts/Transaction/TxHistoryContext.ts
+++ b/src/contexts/Transaction/TxHistoryContext.ts
@@ -1,17 +1,23 @@
-import { providers } from 'ethers'
-import { TransactionCallbacks, TransactionLog } from 'models/transaction'
+import { TransactionCallbacks, TxStatus } from 'models/transaction'
 import { createContext } from 'react'
 
-// Prefer using tx.timestamp if tx has been mined. Otherwise use createdAt timestamp
-export const timestampForTxLog = (txLog: TransactionLog) => {
-  return (
-    (txLog.tx as providers.TransactionResponse)?.timestamp ?? txLog.createdAt
-  )
+export type TransactionType = {
+  hash: string
+  timestamp?: number
+}
+
+export type TransactionLog = {
+  id: number
+  title: string
+  createdAt: number
+  tx: TransactionType | null
+  status: TxStatus.pending | TxStatus.success | TxStatus.failed
+  callbacks?: TransactionCallbacks
 }
 
 export type AddTransactionFunction = (
   title: string,
-  tx: providers.TransactionResponse,
+  tx: TransactionType,
   callbacks?: Omit<TransactionCallbacks, 'onDone' | 'onError'>,
 ) => void
 

--- a/src/contexts/Transaction/useTransactions.ts
+++ b/src/contexts/Transaction/useTransactions.ts
@@ -1,7 +1,7 @@
 import { useWallet } from 'hooks/Wallet'
-import { TransactionLog, TxStatus } from 'models/transaction'
+import { TxStatus } from 'models/transaction'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { AddTransactionFunction } from './TxHistoryContext'
+import { AddTransactionFunction, TransactionLog } from './TxHistoryContext'
 
 // Arbitrary time to give folks a sense of tx history
 const TX_HISTORY_TIME_SECS = 60 * 60 // 1 hr

--- a/src/hooks/useTransactor.ts
+++ b/src/hooks/useTransactor.ts
@@ -134,10 +134,17 @@ export function useTransactor(): Transactor | undefined {
 
         // add transaction to the history UI
         const txTitle = options?.title ?? functionName
-        addTransaction?.(txTitle, result as providers.TransactionResponse, {
-          onConfirmed: options?.onConfirmed,
-          onCancelled: options?.onCancelled,
-        })
+        addTransaction?.(
+          txTitle,
+          {
+            hash: result.hash,
+            timestamp: result.timestamp,
+          },
+          {
+            onConfirmed: options?.onConfirmed,
+            onCancelled: options?.onCancelled,
+          },
+        )
 
         return true
       } catch (e) {

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, Signer, Transaction, providers } from 'ethers'
+import { BigNumberish, Signer, Transaction } from 'ethers'
 
 export enum TxStatus {
   pending = 'PENDING',
@@ -20,20 +20,3 @@ export interface TransactionOptions extends TransactionCallbacks {
   value?: BigNumberish
 }
 
-export type TransactionLog = {
-  id: number
-  title: string
-  createdAt: number
-  callbacks?: TransactionCallbacks
-} & (
-  | {
-      // Only pending txs have not been mined
-      status: TxStatus.pending
-      tx: Transaction | null
-    }
-  | {
-      // Once mined, tx will be a TransactionResponse
-      status: TxStatus.success | TxStatus.failed
-      tx: providers.TransactionResponse | null
-    }
-)


### PR DESCRIPTION
Some more tx history prep. Makes types as minimal as possible, so that we can more easily implement the wagmi tx history provider.