### PR TITLE
V4 edit cycle: Review and Deploy modal - Payouts diff [2/n]

### DIFF
--- a/src/packages/v4/utils/v4Splits.ts
+++ b/src/packages/v4/utils/v4Splits.ts
@@ -44,7 +44,7 @@ export const totalSplitsPercent = (splits: JBSplit[]): bigint =>
 //  - false if new (exists in new but not old)
 //  - JBSplit if exists in old and new and there is a diff in the splits
 //  - undefined if exists in old and new and there is no diff in the splits
-type OldSplit = JBSplit | boolean | undefined
+type OldSplit = (JBSplit & { totalValue?: bigint } ) | boolean | undefined
 
 export type SplitWithDiff = JBSplit & {
   oldSplit?: OldSplit
@@ -99,7 +99,7 @@ export const sortSplits = (splits: JBSplit[]) => {
 }
 
 /* Determines if two splits AMOUNTS are equal. Extracts amounts for two splits from their respective totalValues **/
-function splitAmountsAreEqual({
+export function splitAmountsAreEqual({
   split1,
   split2,
   split1TotalValue,

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitFields/DiffedJBProjectBeneficiary.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitFields/DiffedJBProjectBeneficiary.tsx
@@ -1,0 +1,34 @@
+import { DiffedItem } from 'components/DiffedItem'
+import EthereumAddress from 'components/EthereumAddress'
+import { JBSplit } from 'juice-sdk-core'
+import { JuiceboxProjectBeneficiary } from 'packages/v4/components/SplitList/SplitItem/JuiceboxProjectBeneficiary'
+
+export function DiffedJBProjectBeneficiary({
+  split,
+  oldSplit,
+}: {
+  split: JBSplit
+  oldSplit?: JBSplit
+}) {
+  const hasDiff = oldSplit && oldSplit.beneficiary !== split.beneficiary
+
+  return (
+    <JuiceboxProjectBeneficiary
+      split={split}
+      value={
+        hasDiff ? (
+          <div className="flex">
+            <DiffedItem
+              value={<EthereumAddress address={oldSplit.beneficiary} />}
+              diffStatus="old"
+            />
+            <DiffedItem
+              value={<EthereumAddress address={split.beneficiary} />}
+              diffStatus="new"
+            />
+          </div>
+        ) : undefined
+      }
+    />
+  )
+}

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitFields/DiffedLockedUntil.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitFields/DiffedLockedUntil.tsx
@@ -1,0 +1,72 @@
+import { DiffedItem } from 'components/DiffedItem'
+import { LockedUntilValue } from 'packages/v4/components/SplitList/SplitItem/LockedUntilValue'
+import { formatDate } from 'utils/format/formatDate'
+
+export function DiffedLockedUntil({
+  lockedUntil,
+  oldLockedUntil,
+}: {
+  lockedUntil: number | undefined
+  oldLockedUntil?: number
+}) {
+  const lockedUntilFormatted = lockedUntil
+    ? formatDate(lockedUntil * 1000, 'yyyy-MM-DD')
+    : undefined
+  const oldLockedUntilFormatted = oldLockedUntil
+    ? formatDate(oldLockedUntil * 1000, 'yyyy-MM-DD')
+    : undefined
+
+  const hasOldLockedUntil =
+    oldLockedUntilFormatted && oldLockedUntil && oldLockedUntil > 0
+  const hasNewLockedUntil = lockedUntil && lockedUntil > 0
+  const hasDiff = lockedUntil !== oldLockedUntil
+
+  if (!hasNewLockedUntil && !hasOldLockedUntil) return null
+
+  if (hasDiff && !hasOldLockedUntil) {
+    // whole lockedUntil section green
+    return (
+      <div className="ml-2">
+        <DiffedItem
+          value={<LockedUntilValue lockedUntil={lockedUntil} />}
+          diffStatus="new"
+        />
+      </div>
+    )
+  }
+
+  if (hasDiff && hasOldLockedUntil) {
+    if (!hasNewLockedUntil) {
+      // whole lockedUntil section red
+      return (
+        <div className="ml-2">
+          <DiffedItem
+            value={<LockedUntilValue lockedUntil={oldLockedUntil} />}
+            diffStatus="old"
+          />
+        </div>
+      )
+    }
+
+    return (
+      <LockedUntilValue
+        value={
+          <div className="flex">
+            {/* Diff within the lockedUntil section */}
+            {hasDiff && lockedUntilFormatted ? (
+              <>
+                <DiffedItem value={oldLockedUntilFormatted} diffStatus="old" />
+                <DiffedItem value={lockedUntilFormatted} diffStatus="new" />
+              </>
+            ) : (
+              // lockedUntil no diff
+              lockedUntilFormatted
+            )}
+          </div>
+        }
+      />
+    )
+  }
+
+  return <LockedUntilValue value={lockedUntilFormatted} />
+}

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitFields/DiffedSplitValue.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitFields/DiffedSplitValue.tsx
@@ -1,0 +1,70 @@
+import { DiffedItem } from 'components/DiffedItem'
+import { JBSplit } from 'juice-sdk-core'
+
+import { SplitProps } from 'packages/v4/components/SplitList/SplitItem'
+import { SplitAmountValue } from 'packages/v4/components/SplitList/SplitItem/SplitAmountValue'
+import { isFinitePayoutLimit, isInfinitePayoutLimit } from 'packages/v4/utils/fundingCycle'
+import { splitAmountsAreEqual } from 'packages/v4/utils/v4Splits'
+
+export function DiffedSplitValue({
+  splitProps,
+  diffSplit,
+}: {
+  splitProps: SplitProps
+  diffSplit?: JBSplit & { totalValue?: bigint }
+}) {
+  const diffSplitProps: SplitProps | undefined = diffSplit
+    ? {
+        split: diffSplit,
+        totalValue: diffSplit.totalValue,
+        projectOwnerAddress: splitProps.projectOwnerAddress,
+        currency: splitProps.currency,
+      }
+    : undefined
+
+  const newValue = isInfinitePayoutLimit(splitProps?.totalValue) ? (
+    <>{splitProps.split.percent.formatPercentage()}%</>
+  ) : (
+    <SplitAmountValue props={splitProps} hideTooltip />
+  )
+
+  if (!diffSplitProps) return newValue
+
+  const oldValue =
+    diffSplit && isInfinitePayoutLimit(diffSplit?.totalValue) ? (
+      <>{diffSplit.percent.formatPercentage()}%</>
+    ) : (
+      <SplitAmountValue
+        props={{
+          ...diffSplitProps,
+          currency: splitProps.oldCurrency,
+        }}
+        hideTooltip
+      />
+    )
+
+  const isFiniteTotalValue =
+    isFinitePayoutLimit(splitProps.totalValue) &&
+    isFinitePayoutLimit(diffSplitProps.totalValue)
+
+  const percentsEqual =
+    splitProps.split.percent === diffSplitProps.split.percent
+
+  const valuesEqual = isFiniteTotalValue
+    ? splitAmountsAreEqual({
+        split1: splitProps.split,
+        split2: diffSplitProps.split,
+        split1TotalValue: splitProps.totalValue ?? 0n,
+        split2TotalValue: diffSplitProps.totalValue ?? 0n,
+      })
+    : percentsEqual
+
+  if (valuesEqual) return <div className="mr-4">{newValue}</div>
+
+  return (
+    <div className="flex">
+      <DiffedItem value={oldValue} diffStatus="old" />
+      <DiffedItem value={newValue} diffStatus="new" />
+    </div>
+  )
+}

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitItem.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitItem.tsx
@@ -1,0 +1,75 @@
+import {
+  DIFF_NEW_BACKGROUND,
+  DIFF_OLD_BACKGROUND,
+  DiffMinus,
+  DiffPlus,
+} from 'components/DiffedItem'
+import { SplitProps } from 'packages/v4/components/SplitList/SplitItem'
+import { ETHAddressBeneficiary } from 'packages/v4/components/SplitList/SplitItem/EthAddressBeneficiary'
+import { ReservedTokensValue } from 'packages/v4/components/SplitList/SplitItem/ReservedTokensValue'
+import { isJuiceboxProjectSplit, SplitWithDiff } from 'packages/v4/utils/v4Splits'
+import { twMerge } from 'tailwind-merge'
+import { DiffedJBProjectBeneficiary } from './DiffedSplitFields/DiffedJBProjectBeneficiary'
+import { DiffedLockedUntil } from './DiffedSplitFields/DiffedLockedUntil'
+import { DiffedSplitValue } from './DiffedSplitFields/DiffedSplitValue'
+
+type DiffedSplitProps = Omit<SplitProps, 'split'> & { split: SplitWithDiff }
+
+export function DiffedSplitItem({ props }: { props: DiffedSplitProps }) {
+  const isJuiceboxProject = isJuiceboxProjectSplit(props.split)
+
+  const oldSplit = props.split.oldSplit
+  const splitIsRemoved = oldSplit === true
+  const splitIsNew = oldSplit === false
+
+  const hasDiff = oldSplit !== undefined && !(splitIsRemoved || splitIsNew)
+
+  const className = twMerge(
+    'flex flex-wrap items-center justify-between py-1 rounded-md',
+    splitIsRemoved ? DIFF_OLD_BACKGROUND : undefined,
+    splitIsNew ? DIFF_NEW_BACKGROUND : undefined,
+    splitIsRemoved || splitIsNew ? 'pl-3 pr-4 my-1' : undefined,
+  )
+
+  return (
+    <div className={className}>
+      <div>
+        <div className="flex items-center">
+          {splitIsRemoved ? <DiffMinus /> : null}
+          {splitIsNew ? <DiffPlus /> : null}
+          {isJuiceboxProject ? (
+            <DiffedJBProjectBeneficiary
+              split={props.split}
+              oldSplit={hasDiff ? oldSplit : undefined}
+            />
+          ) : (
+            <ETHAddressBeneficiary
+              projectOwnerAddress={props.projectOwnerAddress}
+              beneficaryAddress={props.split.beneficiary}
+              hideAvatar
+            />
+          )}
+        </div>
+
+        {(props.split.lockedUntil && props.split.lockedUntil > 0) || hasDiff ? (
+          <DiffedLockedUntil
+            lockedUntil={props.split.lockedUntil}
+            oldLockedUntil={hasDiff ? oldSplit.lockedUntil : undefined}
+          />
+        ) : null}
+      </div>
+      <div className="flex items-center whitespace-nowrap">
+        <DiffedSplitValue
+          diffSplit={hasDiff ? oldSplit : undefined}
+          splitProps={props}
+        />
+        {props.reservedPercent !== undefined ? (
+          <ReservedTokensValue
+            splitPercent={props.split.percent}
+            reservedPercent={props.reservedPercent}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitItem.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitItem.tsx
@@ -6,7 +6,6 @@ import {
 } from 'components/DiffedItem'
 import { SplitProps } from 'packages/v4/components/SplitList/SplitItem'
 import { ETHAddressBeneficiary } from 'packages/v4/components/SplitList/SplitItem/EthAddressBeneficiary'
-import { ReservedTokensValue } from 'packages/v4/components/SplitList/SplitItem/ReservedTokensValue'
 import { isJuiceboxProjectSplit, SplitWithDiff } from 'packages/v4/utils/v4Splits'
 import { twMerge } from 'tailwind-merge'
 import { DiffedJBProjectBeneficiary } from './DiffedSplitFields/DiffedJBProjectBeneficiary'
@@ -63,12 +62,13 @@ export function DiffedSplitItem({ props }: { props: DiffedSplitProps }) {
           diffSplit={hasDiff ? oldSplit : undefined}
           splitProps={props}
         />
-        {props.reservedPercent !== undefined ? (
+        {/* '?' icon that appears next reserved percents */}
+        {/* {props.reservedPercent !== undefined ? (
           <ReservedTokensValue
             splitPercent={props.split.percent}
             reservedPercent={props.reservedPercent}
           />
-        ) : null}
+        ) : null} */}
       </div>
     </div>
   )

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitList.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/DiffedSplits/DiffedSplitList.tsx
@@ -1,0 +1,115 @@
+import { JBSplit as Split } from 'juice-sdk-core'
+import round from 'lodash/round'
+
+import { SplitProps } from 'packages/v4/components/SplitList/SplitItem'
+import useProjectOwnerOf from 'packages/v4/hooks/useV4ProjectOwnerOf'
+import { processUniqueSplits, v4GetProjectOwnerRemainderSplit } from 'packages/v4/utils/v4Splits'
+import { useMemo } from 'react'
+import { DiffedSplitItem } from './DiffedSplitItem'
+
+const JB_PERCENT_PRECISION = 2
+
+type DiffedSplitListProps = {
+  splits: Split[]
+  diffSplits?: Split[]
+  currency?: bigint
+  oldCurrency?: bigint
+  totalValue: bigint | undefined
+  oldTotalValue?: bigint
+  previousTotalValue?: bigint
+  showFees?: boolean
+  valueSuffix?: string | JSX.Element
+  valueFormatProps?: { precision?: number }
+  reservedPercent?: number
+  showDiffs?: boolean
+}
+
+export default function DiffedSplitList({
+  splits,
+  diffSplits,
+  showFees = false,
+  currency,
+  oldCurrency,
+  totalValue,
+  previousTotalValue,
+  valueSuffix,
+  valueFormatProps,
+  reservedPercent,
+  showDiffs,
+}: DiffedSplitListProps) {
+  const { data: projectOwnerAddress } = useProjectOwnerOf()
+  const ownerSplit = useMemo(() => {
+    if (!projectOwnerAddress) return
+    return v4GetProjectOwnerRemainderSplit(projectOwnerAddress, splits)
+  }, [projectOwnerAddress, splits])
+
+  const diffOwnerSplit = useMemo(() => {
+    if (!diffSplits || !projectOwnerAddress || !showDiffs) return
+    return v4GetProjectOwnerRemainderSplit(projectOwnerAddress, diffSplits)
+  }, [projectOwnerAddress, diffSplits, showDiffs])
+
+  const ownerSplitIsRemoved =
+    !ownerSplit?.percent && diffOwnerSplit?.percent.value === 0n
+
+  const roundedDiffOwnerSplitPercent = round((diffOwnerSplit?.percent.formatPercentage() || 0),
+    JB_PERCENT_PRECISION,
+  )
+  const diffOwnerSplitHasPercent =
+    diffOwnerSplit && roundedDiffOwnerSplitPercent !== 0
+
+  const ownerSplitIsNew = ownerSplit?.percent && !diffOwnerSplitHasPercent
+
+  const currencyHasDiff = Boolean(
+    oldCurrency && currency && (oldCurrency !== currency),
+  )
+  const uniqueSplits = processUniqueSplits({
+    oldTotalValue: previousTotalValue,
+    newTotalValue: totalValue,
+    allSplitsChanged: currencyHasDiff,
+    oldSplits: showDiffs ? diffSplits : undefined,
+    newSplits: splits,
+  })
+
+  const splitProps: Omit<SplitProps, 'split'> = {
+    currency,
+    oldCurrency,
+    totalValue,
+    projectOwnerAddress,
+    valueSuffix,
+    valueFormatProps,
+    reservedPercent,
+    showFee: showFees,
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      {uniqueSplits.map(split => {
+        const splitIsRemoved = split.oldSplit === true
+        return (
+          <DiffedSplitItem
+            props={{
+              split,
+              ...splitProps,
+              totalValue: splitIsRemoved ? previousTotalValue : totalValue,
+            }}
+            key={`${split.beneficiary}-${split.projectId}-${split.percent}`}
+          />
+        )
+      })}
+      {ownerSplit?.percent ? (
+        <DiffedSplitItem
+          props={{
+            split: {
+              ...ownerSplit,
+              oldSplit: ownerSplitIsRemoved
+                ? true
+                : ownerSplitIsNew
+                ? false
+                : diffOwnerSplit,
+            },
+            ...splitProps,
+          }}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/PayoutsSectionDiff.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/PayoutsSectionDiff.tsx
@@ -1,6 +1,8 @@
 import { Trans, t } from '@lingui/macro'
 import { FundingCycleListItem } from 'components/FundingCycleListItem'
+import { getV4CurrencyOption } from 'packages/v4/utils/currency'
 import { emptySectionClasses } from './DetailsSectionDiff'
+import DiffedSplitList from './DiffedSplits/DiffedSplitList'
 import { DiffSection } from './DiffSection'
 import { PayoutLimitValue } from './FormattedRulesetValues/DetailsSection/PayoutLimitValue'
 import { usePayoutsSectionValues } from './hooks/usePayoutsSectionValues'
@@ -63,18 +65,18 @@ export function PayoutsSectionDiff() {
               <div className="mb-3 mt-2 text-sm font-semibold">
                 <Trans>Payout recipients:</Trans>
               </div>
-              {/* <DiffedSplitList
+              <DiffedSplitList
                 splits={newPayoutSplits}
                 diffSplits={currentPayoutSplits}
-                currency={BigNumber.from(getV4CurrencyOption(newCurrency))}
-                oldCurrency={BigNumber.from(
+                currency={BigInt(getV4CurrencyOption(newCurrency))}
+                oldCurrency={BigInt(
                   getV4CurrencyOption(currentCurrency),
                 )}
                 totalValue={newDistributionLimit}
                 previousTotalValue={currentDistributionLimit}
                 valueFormatProps={{ precision: roundingPrecision }}
                 showDiffs
-              /> */}
+              />
             </div>
           )}
         </div>

--- a/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
+++ b/src/packages/v4/views/V4ProjectSettings/EditCyclePage/ReviewConfirmModal/TokensSectionDiff.tsx
@@ -2,6 +2,7 @@ import { Trans, t } from '@lingui/macro'
 import { FundingCycleListItem } from 'components/FundingCycleListItem'
 import { useJBUpcomingRuleset } from 'packages/v4/hooks/useJBUpcomingRuleset'
 import { emptySectionClasses } from './DetailsSectionDiff'
+import DiffedSplitList from './DiffedSplits/DiffedSplitList'
 import { DiffSection } from './DiffSection'
 import { AllowedValue } from './FormattedRulesetValues/AllowedValue'
 import { IssuanceRateValue } from './FormattedRulesetValues/Tokens/IssuanceRateValue'
@@ -127,13 +128,13 @@ export function TokensSectionDiff() {
               <div className="mb-3 text-sm font-semibold">
                 <Trans>Reserved recipients:</Trans>
               </div>
-              {/* <DiffedSplitList
+              <DiffedSplitList
                 splits={newReservedSplits}
                 diffSplits={currentReservedSplits}
                 totalValue={undefined}
-                reservedRate={reservedRate}
+                reservedPercent={newReservedRate}
                 showDiffs
-              /> */}
+              />
             </div>
           )}
         </div>


### PR DESCRIPTION
- Copies over `SplitsDiff`, changes everything inside from v2v3 -> v4
- Implements `SplitsDiff` for the payouts diff instance

<img width="569" alt="Screenshot 2024-08-28 at 11 29 12 am" src="https://github.com/user-attachments/assets/c3e7f789-1c41-40c5-85af-0c2075d7e0c4">

Next:
- Implement for the reserved splits diff instance