### PR TITLE
Fix an nft credit bug where credit is applied irrespective of whether…

### DIFF
--- a/src/packages/v2v3/components/V2V3Project/ProjectDashboard/components/PayRedeemCard/PayProjectModal/PayProjectModal.tsx
+++ b/src/packages/v2v3/components/V2V3Project/ProjectDashboard/components/PayRedeemCard/PayProjectModal/PayProjectModal.tsx
@@ -9,6 +9,7 @@ import { useNftCredits } from 'packages/v2v3/hooks/JB721Delegate/useNftCredits'
 import React, { ReactNode } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { helpPagePath } from 'utils/helpPagePath'
+import { useProjectSelector } from '../../../redux/hooks'
 import { MessageSection } from './components/MessageSection'
 import { ReceiveSection } from './components/ReceiveSection'
 import { usePayAmounts } from './hooks/usePayAmounts'
@@ -167,6 +168,7 @@ export const PayProjectModal: React.FC = () => {
 const AmountSection = () => {
   const { userAddress } = useWallet()
   const { data: nftCredits } = useNftCredits(userAddress)
+  const { chosenNftRewards } = useProjectSelector(state => state.projectCart)
   const { formattedAmount, formattedNftCredits, formattedTotalAmount } =
     usePayAmounts()
 
@@ -192,7 +194,11 @@ const AmountSection = () => {
     </div>
   )
 
-  if (!nftCredits?.gt(0) || !formattedNftCredits)
+  if (
+    !nftCredits?.gt(0) ||
+    !formattedNftCredits ||
+    chosenNftRewards.length === 0
+  )
     return (
       <RowData
         label={t`Total amount`}

--- a/src/packages/v2v3/components/V2V3Project/ProjectDashboard/components/PayRedeemCard/PayProjectModal/hooks/usePayAmounts.ts
+++ b/src/packages/v2v3/components/V2V3Project/ProjectDashboard/components/PayRedeemCard/PayProjectModal/hooks/usePayAmounts.ts
@@ -13,7 +13,9 @@ import { usePayProjectModal } from './usePayProjectModal/usePayProjectModal'
 
 export const usePayAmounts = () => {
   const converter = useCurrencyConverter()
-  const { payAmount } = useProjectSelector(state => state.projectCart)
+  const { payAmount, chosenNftRewards } = useProjectSelector(
+    state => state.projectCart,
+  )
   const { primaryAmount, secondaryAmount } = usePayProjectModal()
   const { userAddress } = useWallet()
   const { data: nftCreditsData } = useNftCredits(userAddress)
@@ -36,7 +38,7 @@ export const usePayAmounts = () => {
   }, [converter, payAmount])
 
   const appliedNFTCreditsRaw = React.useMemo(() => {
-    if (!payAmountRaw || !nftCreditsData) return
+    if (!payAmountRaw || !nftCreditsData || !chosenNftRewards.length) return
 
     const nftCreditsApplied = payAmountRaw.eth.lt(nftCreditsData)
       ? payAmountRaw.eth
@@ -49,7 +51,7 @@ export const usePayAmounts = () => {
       eth,
       usd,
     }
-  }, [converter, nftCreditsData, payAmountRaw])
+  }, [chosenNftRewards.length, converter, nftCreditsData, payAmountRaw])
 
   const formattedNftCredits = React.useMemo(() => {
     if (!appliedNFTCreditsRaw || !payAmount) return

--- a/src/packages/v2v3/components/V2V3Project/ProjectDashboard/components/PayRedeemCard/PayProjectModal/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/packages/v2v3/components/V2V3Project/ProjectDashboard/components/PayRedeemCard/PayProjectModal/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -71,15 +71,17 @@ export const usePayProjectTx = ({
       payAmount.currency === V2V3_CURRENCY_ETH
         ? parseWad(payAmount.amount)
         : converter.usdToWei(payAmount.amount)
-    if (nftCredits) {
-      if (nftCredits.gte(weiAmount)) {
-        weiAmount = parseWad(0)
-      } else {
-        weiAmount = weiAmount.sub(nftCredits)
+    if (chosenNftRewards.length > 0) {
+      if (nftCredits) {
+        if (nftCredits.gte(weiAmount)) {
+          weiAmount = parseWad(0)
+        } else {
+          weiAmount = weiAmount.sub(nftCredits)
+        }
       }
     }
     return weiAmount
-  }, [payAmount, converter, nftCredits])
+  }, [payAmount, converter, chosenNftRewards.length, nftCredits])
 
   const prepareDelegateMetadata = usePrepareDelegatePayMetadata(weiAmount, {
     nftRewards: chosenNftRewards,


### PR DESCRIPTION
This PR fixes a bug where when a user selects to contribute and has NFT credit, they will be shown a payment form that says NFT credit is applied, irrespective of whether they have an NFT or not