### PR TITLE
Aggregate multi-chain projects in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "supabase:login": "supabase login",
     "supabase:pushdb": "supabase db push",
     "supabase:diffdb": "supabase db diff",
-    "supabase:generate:local": "supabase gen types typescript --local > src/types/database.types.ts"
+    "supabase:generate:linked": "supabase gen types typescript --linked > src/types/database.types.ts"
   },
   "browserslist": {
     "production": [

--- a/src/components/AccountDashboard/AccountDashboard.tsx
+++ b/src/components/AccountDashboard/AccountDashboard.tsx
@@ -14,7 +14,7 @@ import { PV_V4 } from 'constants/pv'
 import { BigNumber } from 'ethers'
 import { useWalletContributionsQuery } from 'generated/graphql'
 import { useWalletContributionsQuery as useV4WalletContributionsQuery } from 'generated/v4/graphql'
-import { useDBProjectsQuery } from 'hooks/useDBProjects'
+import { useDBProjectsAggregateQuery } from 'hooks/useDBProjects'
 import useMobile from 'hooks/useMobile'
 import {
   useWalletBookmarkedIds,
@@ -25,7 +25,7 @@ import { useWallet } from 'hooks/Wallet'
 import { bendystrawClient } from 'lib/apollo/bendystrawClient'
 import { client } from 'lib/apollo/client'
 import { Profile } from 'models/database'
-import { SubgraphQueryProject } from 'models/subgraphProjects'
+import { DBProjectsAggregate } from 'models/dbProject'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import SocialLinks from 'packages/v1/components/V1Project/V1ProjectHeader/SocialLinks'
@@ -34,7 +34,7 @@ import { isEqualAddress } from 'utils/address'
 import { ensAvatarUrlForAddress } from 'utils/ens'
 import { etherscanLink } from 'utils/etherscan'
 
-function ProjectsList({ projects }: { projects: SubgraphQueryProject[] }) {
+function ProjectsList({ projects }: { projects: DBProjectsAggregate[] }) {
   const { userAddress } = useWallet()
 
   const { ids: bookmarkedProjectIds } = useWalletBookmarkedIds({
@@ -123,7 +123,7 @@ function ContributedList({ address }: { address: string }) {
 }
 
 function OwnedProjectsList({ address }: { address: string }) {
-  const { data: projects, isLoading } = useDBProjectsQuery({
+  const { data: projects, isLoading } = useDBProjectsAggregateQuery({
     owner: address,
     orderBy: 'created_at',
     orderDirection: 'desc',
@@ -187,7 +187,7 @@ function SavedProjectsList({ address }: { address: string }) {
 }
 
 function CreatedProjectsList({ address }: { address: string }) {
-  const { data: projects, isLoading } = useDBProjectsQuery({
+  const { data: projects, isLoading } = useDBProjectsAggregateQuery({
     creator: address,
   })
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -5,8 +5,7 @@ import { PV_V2, PV_V4 } from 'constants/pv'
 import { useProjectHandleText } from 'hooks/useProjectHandleText'
 import { useProjectMetadata } from 'hooks/useProjectMetadata'
 import { useSubtitle } from 'hooks/useSubtitle'
-import { JBChainId } from 'juice-sdk-react'
-import { SubgraphQueryProject } from 'models/subgraphProjects'
+import { DBProjectsAggregate } from 'models/dbProject'
 import Link from 'next/link'
 import { v2v3ProjectRoute } from 'packages/v2v3/utils/routes'
 import { ChainLogo } from 'packages/v4/components/ChainLogo'
@@ -23,7 +22,7 @@ export default function ProjectCard({
   project,
   bookmarked,
 }: {
-  project?: SubgraphQueryProject & { chainId?: number }
+  project?: DBProjectsAggregate
   bookmarked?: boolean
 }) {
   const { data: metadata } = useProjectMetadata(project?.metadataUri)
@@ -35,7 +34,8 @@ export default function ProjectCard({
 
   if (!project) return null
 
-  const { volume, pv, handle, projectId, createdAt, chainId } = project
+  const { volume, pv, handle, projectId, createdAt, chainIds, chainId } =
+    project
   const tags = metadata?.tags
 
   // If the total paid is greater than 0, but less than 10 ETH, show two decimal places.
@@ -59,7 +59,7 @@ export default function ProjectCard({
       : `/p/${handle}`
 
   const projectCardUrl =
-    pv === PV_V4 && chainId
+    pv === PV_V4
       ? v4ProjectRoute({
           projectId,
           chainId,
@@ -104,26 +104,14 @@ export default function ProjectCard({
             </div>
           ) : null}
 
-          <div className="flex items-center gap-2">
-            {chainId ? (
-              <div>
-                <ChainLogo
-                  chainId={chainId as JBChainId}
-                  width={18}
-                  height={18}
-                />
-              </div>
-            ) : null}
-            <div>
-              <span className="mr-1 font-medium text-black dark:text-slate-100">
-                <ETHAmount amount={volume} precision={precision} />
-              </span>
+          <div>
+            <span className="mr-1 font-medium text-black dark:text-slate-100">
+              <ETHAmount amount={volume} precision={precision} />
+            </span>
 
-              <span className="text-grey-500 dark:text-grey-300">
-                since{' '}
-                {!!createdAt && formatDate(createdAt * 1000, 'yyyy-MM-DD')}
-              </span>
-            </div>
+            <span className="text-grey-500 dark:text-grey-300">
+              since {!!createdAt && formatDate(createdAt * 1000, 'yyyy-MM-DD')}
+            </span>
           </div>
 
           {tags?.length ? (
@@ -135,6 +123,16 @@ export default function ProjectCard({
               {subtitle.text}
             </div>
           ) : null}
+
+          <div className="mt-2 flex items-center gap-2">
+            {chainIds ? (
+              chainIds.map(c => (
+                <ChainLogo key={c} chainId={c} width={18} height={18} />
+              ))
+            ) : (
+              <ChainLogo chainId={1} width={18} height={18} />
+            )}
+          </div>
         </div>
         {bookmarked && (
           <BookmarkIconSolid className="absolute top-4 right-0 h-4 text-black dark:text-slate-100 md:right-4" />

--- a/src/components/Projects/AllProjects.tsx
+++ b/src/components/Projects/AllProjects.tsx
@@ -3,7 +3,7 @@ import Grid from 'components/Grid'
 import Loading from 'components/Loading'
 import ProjectCard from 'components/ProjectCard'
 import { useWallet } from 'hooks/Wallet'
-import { useDBProjectsInfiniteQuery } from 'hooks/useDBProjects'
+import { useDBProjectsAggregateInfiniteQuery } from 'hooks/useDBProjects'
 import { useLoadMoreContent } from 'hooks/useLoadMore'
 import { useWalletBookmarkedIds } from 'hooks/useWalletBookmarkedProjects'
 import { DBProjectQueryOpts } from 'models/dbProject'
@@ -36,7 +36,7 @@ export default function AllProjects({
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useDBProjectsInfiniteQuery({
+  } = useDBProjectsAggregateInfiniteQuery({
     text: searchText,
     tags: searchTags,
     pv,

--- a/src/components/Projects/LatestProjects.tsx
+++ b/src/components/Projects/LatestProjects.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import Grid from 'components/Grid'
 import Loading from 'components/Loading'
 import ProjectCard from 'components/ProjectCard'
-import { useDBProjectsInfiniteQuery } from 'hooks/useDBProjects'
+import { useDBProjectsAggregateInfiniteQuery } from 'hooks/useDBProjects'
 import { useWalletBookmarkedIds } from 'hooks/useWalletBookmarkedProjects'
 import { useWallet } from 'hooks/Wallet'
 import { useEffect, useRef } from 'react'
@@ -18,7 +18,7 @@ export default function LatestProjects() {
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
-  } = useDBProjectsInfiniteQuery({
+  } = useDBProjectsAggregateInfiniteQuery({
     orderBy: 'created_at',
     pageSize,
     orderDirection: 'desc',

--- a/src/components/Projects/TrendingProjectCard.tsx
+++ b/src/components/Projects/TrendingProjectCard.tsx
@@ -7,7 +7,7 @@ import ProjectLogo from 'components/ProjectLogo'
 import { PV_V2, PV_V4 } from 'constants/pv'
 import { useProjectMetadata } from 'hooks/useProjectMetadata'
 import { useProjectTrendingPercentageIncrease } from 'hooks/useProjectTrendingPercentageIncrease'
-import { JBChainId } from 'juice-sdk-react'
+import { JBChainId } from 'juice-sdk-core'
 import { DBProject } from 'models/dbProject'
 import Link from 'next/link'
 import { v2v3ProjectRoute } from 'packages/v2v3/utils/routes'
@@ -32,7 +32,7 @@ export default function TrendingProjectCard({
     | 'handle'
     | 'pv'
     | 'projectId'
-  > & { chainId?: number }
+  > & { chainIds?: JBChainId[] }
   rank: number
   size?: 'sm' | 'lg'
   bookmarked?: boolean
@@ -65,10 +65,10 @@ export default function TrendingProjectCard({
       prefetch={false}
       key={project.handle}
       href={
-        project.pv === PV_V4 && project.chainId
+        project.pv === PV_V4 && project.chainIds?.length
           ? v4ProjectRoute({
               projectId: project.projectId,
-              chainId: project.chainId,
+              chainId: project.chainIds[0],
             })
           : project.pv === PV_V2
           ? v2v3ProjectRoute(project)
@@ -100,20 +100,15 @@ export default function TrendingProjectCard({
             <Skeleton paragraph={false} title={{ width: 120 }} active />
           )}
 
-          <div className="flex w-full flex-wrap text-black dark:text-slate-100">
-            <span className="flex flex-wrap items-center gap-1">
-              {project.chainId ? (
-                <ChainLogo chainId={project.chainId as JBChainId} />
-              ) : null}
-              <span className="font-medium">
-                <ETHAmount amount={project.trendingVolume} />
-              </span>
-              <span className="font-medium text-grey-500 dark:text-grey-300">
-                <Trans>last {TRENDING_WINDOW_DAYS} days</Trans>
-              </span>
-              <span className="font-medium text-juice-400 dark:text-juice-300">
-                {percentGainText && <>{percentGainText}</>}
-              </span>
+          <div className="flex w-full flex-wrap items-center text-black dark:text-slate-100 gap-1">
+            <span className="font-medium">
+              <ETHAmount amount={project.trendingVolume} />
+            </span>
+            <span className="font-medium text-grey-500 dark:text-grey-300">
+              <Trans>last {TRENDING_WINDOW_DAYS} days</Trans>
+            </span>
+            <span className="font-medium text-juice-400 dark:text-juice-300">
+              {percentGainText && <>{percentGainText}</>}
             </span>
           </div>
 
@@ -123,6 +118,16 @@ export default function TrendingProjectCard({
               one="# payment"
               other="# payments"
             />
+          </div>
+
+          <div className="flex gap-2 mt-2">
+            {project.chainIds ? (
+              project.chainIds?.map(c => (
+                <ChainLogo key={c} chainId={c} width={18} height={18} />
+              ))
+            ) : (
+              <ChainLogo chainId={1} width={18} height={18} />
+            )}
           </div>
         </div>
 

--- a/src/components/QuickProjectSearch/QuickProjectSearchModal.tsx
+++ b/src/components/QuickProjectSearch/QuickProjectSearchModal.tsx
@@ -12,11 +12,12 @@ import Loading from 'components/Loading'
 import { ProjectVersionBadge } from 'components/ProjectVersionBadge'
 import ETHAmount from 'components/currency/ETHAmount'
 import { PV_V2 } from 'constants/pv'
-import { useDBProjectsQuery } from 'hooks/useDBProjects'
+import { useDBProjectsAggregateQuery } from 'hooks/useDBProjects'
 import { useRouter } from 'next/router'
 import V1ProjectHandle from 'packages/v1/components/shared/V1ProjectHandle'
 import V2V3ProjectHandleLink from 'packages/v2v3/components/shared/V2V3ProjectHandleLink'
 import { v2v3ProjectRoute } from 'packages/v2v3/utils/routes'
+import { ChainLogo } from 'packages/v4/components/ChainLogo'
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { QuickProjectSearchContext } from './QuickProjectSearchContext'
@@ -34,7 +35,7 @@ export const QuickProjectSearchModal = () => {
 
   const router = useRouter()
 
-  const { data: searchResults, isLoading } = useDBProjectsQuery(
+  const { data: searchResults, isLoading } = useDBProjectsAggregateQuery(
     {
       text: searchText,
       pageSize: MAX_RESULTS,
@@ -202,6 +203,14 @@ export const QuickProjectSearchModal = () => {
                     size="small"
                     versionText={`V${p.pv}`}
                   />
+
+                  <div className="flex gap-2">
+                    {p.chainIds?.map(c => (
+                      <div key={c}>
+                        <ChainLogo width={18} height={18} chainId={c} />
+                      </div>
+                    ))}
+                  </div>
 
                   <div className="flex-1 text-right">
                     {highlightIndex === i && (

--- a/src/hooks/useDBProjects.ts
+++ b/src/hooks/useDBProjects.ts
@@ -5,51 +5,54 @@ import {
   useQuery,
 } from '@tanstack/react-query'
 import axios from 'axios'
-import { DBProject, DBProjectQueryOpts, DBProjectRow } from 'models/dbProject'
-import { Json } from 'models/json'
+import {
+  DBProjectQueryOpts,
+  DBProjectsAggregate,
+  DBProjectsAggregateRow
+} from 'models/dbProject'
 import { formatQueryParams } from 'utils/queryParams'
-import { parseDBProject } from 'utils/sgDbProjects'
+import { parseDBProjectsAggregate } from 'utils/sgDbProjects'
 
 const DEFAULT_STALE_TIME = 60 * 1000 // 60 seconds
 
-export function useDBProjectsQuery(
+export function useDBProjectsAggregateQuery(
   opts: DBProjectQueryOpts | null,
   reactQueryOptions?: Partial<
     UseQueryOptions<
-      DBProject[],
+      DBProjectsAggregate[],
       Error,
-      DBProject[],
+      DBProjectsAggregate[],
       readonly [string, DBProjectQueryOpts | null]
     >
   >,
 ) {
   return useQuery<
-    DBProject[],
+    DBProjectsAggregate[],
     Error,
-    DBProject[],
+    DBProjectsAggregate[],
     readonly [string, DBProjectQueryOpts | null]
   >({
     queryKey: ['dbp-query', opts],
     queryFn: () =>
       opts
         ? axios
-            .get<Json<DBProjectRow>[]>(
+            .get<DBProjectsAggregateRow[]>(
               `/api/projects?${formatQueryParams(opts)}`,
             )
-            .then(res => res.data?.map(parseDBProject))
-        : Promise.resolve([] as DBProject[]),
+            .then(res => res.data?.map(parseDBProjectsAggregate))
+        : Promise.resolve([] as DBProjectsAggregate[]),
     staleTime: DEFAULT_STALE_TIME,
     ...reactQueryOptions,
   })
 }
 
-export function useDBProjectsInfiniteQuery(
+export function useDBProjectsAggregateInfiniteQuery(
   opts: DBProjectQueryOpts,
   reactQueryOptions?: UseInfiniteQueryOptions<
-    DBProject[],
+    DBProjectsAggregate[],
     Error,
-    DBProject[],
-    DBProject[],
+    DBProjectsAggregate[],
+    DBProjectsAggregate[],
     readonly [string, DBProjectQueryOpts]
   >,
 ) {
@@ -58,7 +61,7 @@ export function useDBProjectsInfiniteQuery(
     queryFn: async ({ queryKey, pageParam }) => {
       const { pageSize, ...evaluatedOpts } = queryKey[1]
 
-      const res = await axios.get<DBProjectRow[] | undefined>(
+      const res = await axios.get<DBProjectsAggregateRow[] | undefined>(
         `/api/projects?${formatQueryParams({
           ...evaluatedOpts,
           page: (pageParam as number) ?? 0,
@@ -66,7 +69,7 @@ export function useDBProjectsInfiniteQuery(
         })}`,
       )
 
-      return res?.data?.map(parseDBProject) ?? []
+      return res?.data?.map(parseDBProjectsAggregate) ?? []
     },
     initialPageParam: 0,
     staleTime: DEFAULT_STALE_TIME,

--- a/src/packages/v4/graphql/queries/dbV4Projects.graphql
+++ b/src/packages/v4/graphql/queries/dbV4Projects.graphql
@@ -6,6 +6,7 @@ query DBV4Projects($where: projectFilter, $limit: Int, $after: String) {
     }
     items {
       id
+      suckerGroupId
       projectId
       chainId
       handle

--- a/src/pages/api/projects/health.ts
+++ b/src/pages/api/projects/health.ts
@@ -37,7 +37,10 @@ const handler: NextApiHandler = async (_, res) => {
         client: serverClient,
         document: DbProjectsDocument,
       })) as unknown as Json<
-        Pick<Project & { chainId: number }, SGSBCompareKey>
+        Pick<
+          Project & { chainId: number; suckerGroupId: string },
+          SGSBCompareKey
+        >
       >[]
     ).map(formatSGProjectForDB)
 

--- a/src/pages/api/projects/index.ts
+++ b/src/pages/api/projects/index.ts
@@ -1,5 +1,6 @@
+import { JBChainId } from 'juice-sdk-core'
 import { enableCors } from 'lib/api/nextjs'
-import { queryDBProjects } from 'lib/api/supabase/projects'
+import { queryDBProjectsAggregates } from 'lib/api/supabase/projects'
 import { DBProjectQueryOpts } from 'models/dbProject'
 import { ProjectTagName } from 'models/project-tags'
 import { NextApiHandler } from 'next'
@@ -22,7 +23,7 @@ const handler: NextApiHandler = async (req, res) => {
     orderBy,
     owner,
     creator,
-    projectId,
+    chainIds,
     ids,
   } = req.query
 
@@ -51,8 +52,8 @@ const handler: NextApiHandler = async (req, res) => {
     return
   }
 
-  if (projectId && (Array.isArray(projectId) || isNaN(parseInt(projectId)))) {
-    res.status(400).send('ProjectId is not a number')
+  if (chainIds && typeof chainIds !== 'string') {
+    res.status(400).send('Invalid chainIds')
     return
   }
 
@@ -89,14 +90,14 @@ const handler: NextApiHandler = async (req, res) => {
     return
   }
 
+  const _chainIds = chainIds?.split(',').map(i => parseInt(i) as JBChainId)
+
   const _pageSize = pageSize ? parseInt(pageSize) : undefined
 
   const _page = page ? parseInt(page) : undefined
 
-  const _projectId = projectId ? parseInt(projectId) : undefined
-
   try {
-    const { data: results } = await queryDBProjects(req, res, {
+    const { data: results } = await queryDBProjectsAggregates(req, res, {
       text,
       tags: tags?.split(',') as ProjectTagName[],
       pageSize: _pageSize,
@@ -108,7 +109,7 @@ const handler: NextApiHandler = async (req, res) => {
       orderBy: orderBy as DBProjectQueryOpts['orderBy'],
       owner,
       creator,
-      projectId: _projectId,
+      chainIds: _chainIds,
       ids: ids?.split(','),
     })
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -146,25 +146,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'project_updates_poster_user_id_fkey'
-            columns: ['poster_user_id']
+            foreignKeyName: "project_updates_poster_user_id_fkey"
+            columns: ["poster_user_id"]
             isOneToOne: false
-            referencedRelation: 'user_profiles'
-            referencedColumns: ['id']
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'project_updates_poster_user_id_fkey'
-            columns: ['poster_user_id']
+            foreignKeyName: "project_updates_poster_user_id_fkey"
+            columns: ["poster_user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'project_updates_project_fkey'
-            columns: ['project']
+            foreignKeyName: "project_updates_project_fkey"
+            columns: ["project"]
             isOneToOne: false
-            referencedRelation: 'projects'
-            referencedColumns: ['id']
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -174,6 +174,7 @@ export type Database = {
           _metadata_retries_left: number | null
           _updated_at: number
           archived: boolean | null
+          chain_id: number | null
           contributors_count: number
           created_at: number
           created_within_trending_window: boolean
@@ -191,10 +192,10 @@ export type Database = {
           payments_count: number
           project_id: number
           pv: string
-          chain_id: number
           redeem_count: number
           redeem_volume: string
-          redeem_voume_usd: string
+          redeem_volume_usd: string
+          sucker_group_id: string | null
           tags: string[] | null
           terminal: string | null
           trending_payments_count: number
@@ -208,6 +209,7 @@ export type Database = {
           _metadata_retries_left?: number | null
           _updated_at: number
           archived?: boolean | null
+          chain_id?: number | null
           contributors_count: number
           created_at: number
           created_within_trending_window: boolean
@@ -225,10 +227,10 @@ export type Database = {
           payments_count: number
           project_id: number
           pv: string
-          chain_id: number
           redeem_count: number
           redeem_volume: string
-          redeem_voume_usd: string
+          redeem_volume_usd: string
+          sucker_group_id?: string | null
           tags?: string[] | null
           terminal?: string | null
           trending_payments_count: number
@@ -242,6 +244,7 @@ export type Database = {
           _metadata_retries_left?: number | null
           _updated_at?: number
           archived?: boolean | null
+          chain_id?: number | null
           contributors_count?: number
           created_at?: number
           created_within_trending_window?: boolean
@@ -259,10 +262,10 @@ export type Database = {
           payments_count?: number
           project_id?: number
           pv?: string
-          chain_id?: number
           redeem_count?: number
           redeem_volume?: string
-          redeem_voume_usd?: string
+          redeem_volume_usd?: string
+          sucker_group_id?: string | null
           tags?: string[] | null
           terminal?: string | null
           trending_payments_count?: number
@@ -291,25 +294,25 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'user_bookmarks_project_fkey'
-            columns: ['project']
+            foreignKeyName: "user_bookmarks_project_fkey"
+            columns: ["project"]
             isOneToOne: false
-            referencedRelation: 'projects'
-            referencedColumns: ['id']
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'user_bookmarks_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "user_bookmarks_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'user_profiles'
-            referencedColumns: ['id']
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'user_bookmarks_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "user_bookmarks_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -331,18 +334,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'user_subscriptions_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "user_subscriptions_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'user_profiles'
-            referencedColumns: ['id']
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'user_subscriptions_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "user_subscriptions_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -380,18 +383,46 @@ export type Database = {
           wallet?: string
           website?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: 'users_id_fkey'
-            columns: ['id']
-            isOneToOne: true
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-        ]
+        Relationships: []
       }
     }
     Views: {
+      projects_aggregate: {
+        Row: {
+          archived: boolean | null
+          chain_id: number | null
+          chain_ids: number[] | null
+          contributors_count: number | null
+          created_at: number | null
+          created_within_trending_window: boolean | null
+          creator: string | null
+          current_balance: string | null
+          deployer: string | null
+          description: string | null
+          handle: string | null
+          id: string | null
+          logo_uri: string | null
+          metadata_uri: string | null
+          name: string | null
+          nfts_minted_count: number | null
+          owner: string | null
+          payments_count: number | null
+          project_id: number | null
+          pv: string | null
+          redeem_count: number | null
+          redeem_volume: string | null
+          redeem_volume_usd: string | null
+          sucker_group_id: string | null
+          tags: string[] | null
+          terminal: string | null
+          trending_payments_count: number | null
+          trending_score: string | null
+          trending_volume: string | null
+          volume: string | null
+          volume_usd: string | null
+        }
+        Relationships: []
+      }
       user_profiles: {
         Row: {
           bio: string | null
@@ -417,15 +448,7 @@ export type Database = {
           wallet?: string | null
           website?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: 'users_id_fkey'
-            columns: ['id']
-            isOneToOne: true
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-        ]
+        Relationships: []
       }
     }
     Functions: {
@@ -512,6 +535,7 @@ export type Database = {
           owner_id: string | null
           path_tokens: string[] | null
           updated_at: string | null
+          user_metadata: Json | null
           version: string | null
         }
         Insert: {
@@ -525,6 +549,7 @@ export type Database = {
           owner_id?: string | null
           path_tokens?: string[] | null
           updated_at?: string | null
+          user_metadata?: Json | null
           version?: string | null
         }
         Update: {
@@ -538,15 +563,114 @@ export type Database = {
           owner_id?: string | null
           path_tokens?: string[] | null
           updated_at?: string | null
+          user_metadata?: Json | null
           version?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: 'objects_bucketId_fkey'
-            columns: ['bucket_id']
+            foreignKeyName: "objects_bucketId_fkey"
+            columns: ["bucket_id"]
             isOneToOne: false
-            referencedRelation: 'buckets'
-            referencedColumns: ['id']
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      s3_multipart_uploads: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          id: string
+          in_progress_size: number
+          key: string
+          owner_id: string | null
+          upload_signature: string
+          user_metadata: Json | null
+          version: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          id: string
+          in_progress_size?: number
+          key: string
+          owner_id?: string | null
+          upload_signature: string
+          user_metadata?: Json | null
+          version: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          id?: string
+          in_progress_size?: number
+          key?: string
+          owner_id?: string | null
+          upload_signature?: string
+          user_metadata?: Json | null
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      s3_multipart_uploads_parts: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          etag: string
+          id: string
+          key: string
+          owner_id: string | null
+          part_number: number
+          size: number
+          upload_id: string
+          version: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          etag: string
+          id?: string
+          key: string
+          owner_id?: string | null
+          part_number: number
+          size?: number
+          upload_id: string
+          version: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          etag?: string
+          id?: string
+          key?: string
+          owner_id?: string | null
+          part_number?: number
+          size?: number
+          upload_id?: string
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
+            columns: ["upload_id"]
+            isOneToOne: false
+            referencedRelation: "s3_multipart_uploads"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -556,30 +680,19 @@ export type Database = {
     }
     Functions: {
       can_insert_object: {
-        Args: {
-          bucketid: string
-          name: string
-          owner: string
-          metadata: Json
-        }
+        Args: { bucketid: string; name: string; owner: string; metadata: Json }
         Returns: undefined
       }
       extension: {
-        Args: {
-          name: string
-        }
+        Args: { name: string }
         Returns: string
       }
       filename: {
-        Args: {
-          name: string
-        }
+        Args: { name: string }
         Returns: string
       }
       foldername: {
-        Args: {
-          name: string
-        }
+        Args: { name: string }
         Returns: string[]
       }
       get_size_by_bucket: {
@@ -588,6 +701,41 @@ export type Database = {
           size: number
           bucket_id: string
         }[]
+      }
+      list_multipart_uploads_with_delimiter: {
+        Args: {
+          bucket_id: string
+          prefix_param: string
+          delimiter_param: string
+          max_keys?: number
+          next_key_token?: string
+          next_upload_token?: string
+        }
+        Returns: {
+          key: string
+          id: string
+          created_at: string
+        }[]
+      }
+      list_objects_with_delimiter: {
+        Args: {
+          bucket_id: string
+          prefix_param: string
+          delimiter_param: string
+          max_keys?: number
+          start_after?: string
+          next_token?: string
+        }
+        Returns: {
+          name: string
+          id: string
+          metadata: Json
+          updated_at: string
+        }[]
+      }
+      operation: {
+        Args: Record<PropertyKey, never>
+        Returns: string
       }
       search: {
         Args: {
@@ -619,84 +767,122 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, 'public'>]
+type DefaultSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends
-    | keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-        Database[PublicTableNameOrOptions['schema']]['Views'])
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] &
-      PublicSchema['Views'])
-  ? (PublicSchema['Tables'] &
-      PublicSchema['Views'])[PublicTableNameOrOptions] extends {
-      Row: infer R
-    }
-    ? R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema['Tables']
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-      Insert: infer I
-    }
-    ? I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema['Tables']
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-      Update: infer U
-    }
-    ? U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-    | keyof PublicSchema['Enums']
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
-  ? PublicSchema['Enums'][PublicEnumNameOrOptions]
-  : never
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  juice_auth: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+  storage: {
+    Enums: {},
+  },
+} as const

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -1,6 +1,9 @@
 export function formatQueryParams(
   obj:
-    | Record<string, string | string[] | boolean | number | undefined>
+    | Record<
+        string,
+        string | string[] | number[] | boolean | number | undefined
+      >
     | undefined,
 ) {
   if (!obj) return ''

--- a/supabase/migrations/20250522201752_add_sucker_group_id_aggregate_view.sql
+++ b/supabase/migrations/20250522201752_add_sucker_group_id_aggregate_view.sql
@@ -1,0 +1,103 @@
+ALTER TABLE public.projects
+RENAME COLUMN redeem_voume_usd to redeem_volume_usd;
+ALTER TABLE public.projects
+ADD COLUMN IF NOT EXISTS sucker_group_id text;
+
+drop view if exists projects_aggregate;
+
+create view projects_aggregate as
+(
+  -- One project per suckerGroupId + array of chainIds
+  select distinct on (p.sucker_group_id)
+    p.id,
+    p.handle,
+    p.project_id,
+    p.pv,
+    p.sucker_group_id,
+    p.terminal,
+    p.deployer,
+    p.created_at,
+    p.name,
+    p.description,
+    p.logo_uri,
+    p.metadata_uri,
+    p.tags,
+    p.archived,
+    p.owner,
+    p.creator,
+    p.created_within_trending_window,
+    p.chain_id,
+    sub.chain_ids,
+    sub.contributors_count as contributors_count,
+    sub.current_balance as current_balance,
+    sub.payments_count as payments_count,
+    sub.nfts_minted_count as nfts_minted_count,
+    sub.redeem_count as redeem_count,
+    sub.redeem_volume as redeem_volume,
+    sub.redeem_volume_usd as redeem_volume_usd,
+    sub.trending_payments_count as trending_payments_count,
+    sub.trending_score as trending_score,
+    sub.trending_volume as trending_volume,
+    sub.volume as volume,
+    sub.volume_usd as volume_usd
+  from projects p
+  join (
+    select 
+      sucker_group_id, 
+      coalesce(array_agg(distinct chain_id) filter (where chain_id is not null), '{}') as chain_ids,
+      coalesce(sum(contributors_count), 0) as contributors_count,
+      coalesce(sum((current_balance)::numeric), 0)::bpchar as current_balance,
+      coalesce(sum(payments_count), 0) as payments_count,
+      coalesce(sum(nfts_minted_count), 0) as nfts_minted_count,
+      coalesce(sum(redeem_count), 0) as redeem_count,
+      coalesce(sum(redeem_volume::numeric), 0)::bpchar as redeem_volume,
+      coalesce(sum(redeem_volume_usd::numeric), 0)::bpchar as redeem_volume_usd,
+      coalesce(sum(trending_payments_count), 0) as trending_payments_count,
+      coalesce(sum(trending_score::numeric), 0)::bpchar as trending_score,
+      coalesce(sum(trending_volume::numeric), 0)::bpchar as trending_volume,
+      coalesce(sum(volume::numeric), 0)::bpchar as volume,
+      coalesce(sum(volume_usd::numeric), 0)::bpchar as volume_usd
+    from projects
+    group by sucker_group_id
+  ) sub
+  on p.sucker_group_id = sub.sucker_group_id
+  order by p.sucker_group_id, p.chain_id, p.id
+)
+union
+(
+  -- All other projects (not pv=4), no chainIds array
+  select 
+    id,
+    handle,
+    project_id,
+    pv,
+    sucker_group_id,
+    terminal,
+    deployer,
+    created_at,
+    name,
+    description,
+    logo_uri,
+    metadata_uri,
+    tags,
+    archived,
+    owner,
+    creator,
+    created_within_trending_window,
+    chain_id,
+    coalesce(array[chain_id], '{}')::int[] as chain_ids,
+    contributors_count,
+    current_balance,
+    payments_count,
+    nfts_minted_count,
+    redeem_count,
+    redeem_volume,
+    redeem_volume_usd,
+    trending_payments_count,
+    trending_score,
+    trending_volume,
+    volume,
+    volume_usd
+  from projects
+  where sucker_group_id is null
+);


### PR DESCRIPTION
- Store new `sucker_group_id` column in db projects table
- Create new database view that allows the UI to consume project "aggregates" to display in project lists

The `projects_aggregate` view coalesces projects from the projects table with a shared `suckerGroupId`. Most importantly, the view includes a derived `chain_ids` column that contains the `chainId` of each matching project. For pre-v4 projects this will always be simply `[1]`. Unique columns like `projectId`, `handle` (including `chainId`), metadata properties, etc will be taken from the project with the lowest `chainId` value, ensuring project cards can still link to a valid url generated from `chainId` + `projectId`, preferring the "eth" project if it exists. Importantly, this pattern assumes that the metadata properties of each matching project are identical (in any case, only the properties of the lowest-chainId project will be shown).