### PR TITLE
fix: bendystraw config for whitelisted domains

### DIFF
--- a/src/packages/v4v5/contexts/V4V5SettingsProvider.tsx
+++ b/src/packages/v4v5/contexts/V4V5SettingsProvider.tsx
@@ -35,10 +35,9 @@ export const V4V5SettingsProvider: React.FC<React.PropsWithChildren> = ({
   const bendystrawUrl = urlParts.slice(0, 3).join('/') // https://testnet.bendystraw.xyz or https://bendystraw.xyz
   const bendystrawApiKey = urlParts[3] ?? '' // API key from path
 
-  const bendystrawConfig = {
-    apiKey: isLocalhost ? bendystrawApiKey : '',
-    url: bendystrawUrl,
-  }
+  const bendystrawConfig = isLocalhost && bendystrawApiKey
+    ? { apiKey: bendystrawApiKey, url: bendystrawUrl } // Localhost: pass both API key and URL
+    : { apiKey: '' } // Production (whitelisted domains): just empty API key, no URL
 
   return (
     <AppWrapper hideNav>

--- a/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectProviders.tsx
+++ b/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectProviders.tsx
@@ -31,10 +31,9 @@ const V4V5ProjectProviders: React.FC<
   const bendystrawUrl = urlParts.slice(0, 3).join('/') // https://testnet.bendystraw.xyz or https://bendystraw.xyz
   const bendystrawApiKey = urlParts[3] ?? '' // API key from path
 
-  const bendystrawConfig = {
-    apiKey: isLocalhost ? bendystrawApiKey : '',
-    url: bendystrawUrl,
-  }
+  const bendystrawConfig = isLocalhost && bendystrawApiKey
+    ? { apiKey: bendystrawApiKey, url: bendystrawUrl } // Localhost: pass both API key and URL
+    : { apiKey: '' } // Production (whitelisted domains): just empty API key, no URL
 
   return (
     <AppWrapper txHistoryProvider="wagmi">


### PR DESCRIPTION
## Summary
- Production (whitelisted domains like juicebox.money, sepolia.juicebox.money): only pass `apiKey: ''`, omit `url` property
- Localhost: pass both `apiKey` and `url` since localhost is not whitelisted
- Prevents double-slash in bendystraw GraphQL URL (was creating `https://testnet.bendystraw.xyz//graphql`)

## Why
Bendystraw has CORS whitelist for juicebox.money domains, so they don't need the URL property. The SDK's `BendystrawConfig.url` is optional - when omitted on whitelisted domains, it uses the default endpoint correctly. When we were passing `url` with an empty `apiKey`, the SDK was constructing `${url}/${apiKey}/graphql` which created the double-slash.

## Changes
- `V4V5SettingsProvider.tsx`: Updated bendystraw config logic
- `V4V5ProjectProviders.tsx`: Updated bendystraw config logic

## Test plan
- [ ] Verify localhost still works with API key
- [ ] Verify sepolia.juicebox.money works without double-slash error
- [ ] Verify production juicebox.money works without double-slash error