### PR TITLE
fix: v5 project routing in trending tab and payment success page

### DIFF
--- a/src/components/Projects/TrendingProjectCard.tsx
+++ b/src/components/Projects/TrendingProjectCard.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from 'antd'
 import ETHAmount from 'components/currency/ETHAmount'
 import Loading from 'components/Loading'
 import ProjectLogo from 'components/ProjectLogo'
-import { PV_V2, PV_V4 } from 'constants/pv'
+import { PV_V2, PV_V4, PV_V5 } from 'constants/pv'
 import { useProjectMetadata } from 'hooks/useProjectMetadata'
 import { useProjectTrendingPercentageIncrease } from 'hooks/useProjectTrendingPercentageIncrease'
 import { JBChainId } from 'juice-sdk-core'
@@ -12,7 +12,7 @@ import { DBProject } from 'models/dbProject'
 import Link from 'next/link'
 import { v2v3ProjectRoute } from 'packages/v2v3/utils/routes'
 import { ChainLogo } from 'packages/v4v5/components/ChainLogo'
-import { v4ProjectRoute } from 'packages/v4v5/utils/routes'
+import { v4ProjectRoute, v5ProjectRoute } from 'packages/v4v5/utils/routes'
 import { TRENDING_WINDOW_DAYS } from './RankingExplanation'
 
 export default function TrendingProjectCard({
@@ -65,7 +65,12 @@ export default function TrendingProjectCard({
       prefetch={false}
       key={project.handle}
       href={
-        project.pv === PV_V4 && project.chainIds?.length
+        project.pv === PV_V5 && project.chainIds?.length
+          ? v5ProjectRoute({
+              projectId: project.projectId,
+              chainId: project.chainIds[0],
+            })
+          : project.pv === PV_V4 && project.chainIds?.length
           ? v4ProjectRoute({
               projectId: project.projectId,
               chainId: project.chainIds[0],

--- a/src/packages/v4v5/components/ProjectDashboard/V4V5PayRedeemCard/PayProjectModal/PayProjectModal.tsx
+++ b/src/packages/v4v5/components/ProjectDashboard/V4V5PayRedeemCard/PayProjectModal/PayProjectModal.tsx
@@ -127,7 +127,7 @@ export const PayProjectModal: React.FC = () => {
                 setOpen(false)
                 setTimeout(() => props.resetForm(), 300)
               }}
-              disableOkButton={Boolean(isAddressListedInOFAC)}
+              disableOkButton={Boolean(isAddressListedInOFAC) || !props.values.userAcceptsTerms}
             >
               {isTransactionPending ? (
                 <div className="flex h-full w-full flex-col items-center justify-center">

--- a/src/packages/v4v5/components/ProjectDashboard/V4V5PayRedeemCard/PayProjectModal/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/packages/v4v5/components/ProjectDashboard/V4V5PayRedeemCard/PayProjectModal/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -222,6 +222,7 @@ export const usePayProjectTx = ({
           wagmiConfig,
           {
             hash,
+            chainId,
           },
         )
 

--- a/src/packages/v4v5/components/ProjectDashboard/V4V5PayRedeemCard/PayProjectModal/hooks/usePayProjectModal/usePayProjectTx.ts
+++ b/src/packages/v4v5/components/ProjectDashboard/V4V5PayRedeemCard/PayProjectModal/hooks/usePayProjectModal/usePayProjectTx.ts
@@ -217,7 +217,7 @@ export const usePayProjectTx = ({
         })
 
         onTransactionPendingCallback(formikHelpers)
-        addTransaction?.('Pay', { hash })
+        addTransaction?.('Pay', { hash, chainId })
         const transactionReceipt = await waitForTransactionReceipt(
           wagmiConfig,
           {

--- a/src/packages/v4v5/components/ProjectDashboard/components/SuccessPayView/SuccessPayView.tsx
+++ b/src/packages/v4v5/components/ProjectDashboard/components/SuccessPayView/SuccessPayView.tsx
@@ -4,7 +4,8 @@ import { Button } from 'antd'
 import { useJBChainId } from 'juice-sdk-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { v4ProjectRoute } from 'packages/v4v5/utils/routes'
+import { useV4V5Version } from 'packages/v4v5/contexts/V4V5VersionProvider'
+import { v4v5ProjectRoute } from 'packages/v4v5/utils/routes'
 import { useEffect } from 'react'
 import { SuccessNftItem } from './components/SuccessNftItem'
 import { SuccessPayCard } from './components/SuccessPayCard'
@@ -24,6 +25,7 @@ export const SuccessPayView = () => {
   } = useSuccessPayView()
 
   const chainId = useJBChainId()
+  const { version } = useV4V5Version()
 
   // Scroll to top when component mounts
   useEffect(() => {
@@ -60,7 +62,7 @@ export const SuccessPayView = () => {
               </SubscribeButton>
             )} */}
 
-            <Link href={v4ProjectRoute({ projectId, chainId })}>
+            <Link href={v4v5ProjectRoute({ projectId, chainId, version })}>
               <Button
                 className="flex items-center gap-2 py-2 px-3.5 font-medium"
                 type="link"

--- a/src/packages/v4v5/hooks/useTransferProjectOwnershipTx.ts
+++ b/src/packages/v4v5/hooks/useTransferProjectOwnershipTx.ts
@@ -66,6 +66,7 @@ export function useTransferProjectOwnershipTx() {
         addTransaction?.(`Transfer ownership of ${projectTitle}`, { hash })
         await waitForTransactionReceipt(wagmiConfig, {
           hash,
+          chainId: chainId as JBChainId,
         })
 
         onTransactionConfirmed?.()

--- a/src/packages/v4v5/hooks/useTransferProjectOwnershipTx.ts
+++ b/src/packages/v4v5/hooks/useTransferProjectOwnershipTx.ts
@@ -63,7 +63,7 @@ export function useTransferProjectOwnershipTx() {
         })
 
         onTransactionPending?.(hash)
-        addTransaction?.(`Transfer ownership of ${projectTitle}`, { hash })
+        addTransaction?.(`Transfer ownership of ${projectTitle}`, { hash, chainId: chainId as JBChainId })
         await waitForTransactionReceipt(wagmiConfig, {
           hash,
           chainId: chainId as JBChainId,

--- a/src/packages/v4v5/hooks/useV4V5IssueErc20TokenTx.ts
+++ b/src/packages/v4v5/hooks/useV4V5IssueErc20TokenTx.ts
@@ -53,7 +53,7 @@ export function useV4V5IssueErc20TokenTx() {
         })
 
         onTransactionPendingCallback(hash)
-        addTransaction?.('Launch ERC20 Token', { hash })
+        addTransaction?.('Launch ERC20 Token', { hash, chainId: chainId as JBChainId })
         await waitForTransactionReceipt(
           wagmiConfig,
           {

--- a/src/packages/v4v5/hooks/useV4V5IssueErc20TokenTx.ts
+++ b/src/packages/v4v5/hooks/useV4V5IssueErc20TokenTx.ts
@@ -3,8 +3,8 @@ import { useCallback, useContext } from 'react'
 import { waitForTransactionReceipt } from '@wagmi/core'
 import { TxHistoryContext } from 'contexts/Transaction/TxHistoryContext'
 import { useJBContractContext } from 'juice-sdk-react'
-import { jbControllerAbi } from 'juice-sdk-core'
-import { useWriteContract } from 'wagmi'
+import { jbControllerAbi, JBChainId } from 'juice-sdk-core'
+import { useWriteContract, useChainId } from 'wagmi'
 import { Address, zeroAddress } from 'viem'
 import { BaseTxOpts } from '../models/transactions'
 import { wagmiConfig } from '../wagmiConfig'
@@ -12,6 +12,7 @@ import { wagmiConfig } from '../wagmiConfig'
 export function useV4V5IssueErc20TokenTx() {
   const { addTransaction } = useContext(TxHistoryContext)
   const { projectId, contracts } = useJBContractContext()
+  const chainId = useChainId()
 
   const { writeContractAsync: deployErc20Tx } = useWriteContract()
 
@@ -57,6 +58,7 @@ export function useV4V5IssueErc20TokenTx() {
           wagmiConfig,
           {
             hash,
+            chainId: chainId as JBChainId,
           },
         )
 
@@ -72,6 +74,7 @@ export function useV4V5IssueErc20TokenTx() {
       projectId,
       addTransaction,
       contracts.controller.data,
+      chainId,
     ],
   )
 }

--- a/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5ClaimTokensModal.tsx
+++ b/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5ClaimTokensModal.tsx
@@ -144,6 +144,7 @@ export function V4V5ClaimTokensModal({
       addTransaction?.('Claim tokens as ERC20', { hash })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,
+        chainId: selectedChainId,
       })
 
       setLoading(false)

--- a/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5ClaimTokensModal.tsx
+++ b/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5ClaimTokensModal.tsx
@@ -141,7 +141,7 @@ export function V4V5ClaimTokensModal({
       })
       setTransactionPending(true)
 
-      addTransaction?.('Claim tokens as ERC20', { hash })
+      addTransaction?.('Claim tokens as ERC20', { hash, chainId: selectedChainId })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,
         chainId: selectedChainId,

--- a/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5DistributeReservedTokensModal.tsx
+++ b/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5DistributeReservedTokensModal.tsx
@@ -123,7 +123,7 @@ export default function V4V5DistributeReservedTokensModal({
       })
       setTransactionPending(true)
 
-      addTransaction?.('Send reserved tokens', { hash })
+      addTransaction?.('Send reserved tokens', { hash, chainId: selectedChainId })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,
         chainId: selectedChainId,

--- a/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5DistributeReservedTokensModal.tsx
+++ b/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5DistributeReservedTokensModal.tsx
@@ -126,6 +126,7 @@ export default function V4V5DistributeReservedTokensModal({
       addTransaction?.('Send reserved tokens', { hash })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,
+        chainId: selectedChainId,
       })
 
       setLoading(false)

--- a/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5MintModal.tsx
+++ b/src/packages/v4v5/views/V4V5ProjectDashboard/V4V5ProjectTabs/V4V5TokensPanel/V4V5MintModal.tsx
@@ -130,6 +130,7 @@ export function V4V5MintModal({
 
       addTransaction?.(`Mint tokens on ${NETWORKS[selectedChainId]?.label}`, {
         hash,
+        chainId: selectedChainId,
       })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,

--- a/src/packages/v4v5/views/V4V5ProjectSettings/EditNftsPage/hooks/useUpdateCurrentCollection.ts
+++ b/src/packages/v4v5/views/V4V5ProjectSettings/EditNftsPage/hooks/useUpdateCurrentCollection.ts
@@ -73,7 +73,7 @@ export function useUpdateCurrentCollection({
         address: rulesetMetadata.dataHook,
       })
 
-      addTransaction?.('Update NFT rewards', { hash })
+      addTransaction?.('Update NFT rewards', { hash, chainId })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,
         chainId,

--- a/src/packages/v4v5/views/V4V5ProjectSettings/EditNftsPage/hooks/useUpdateCurrentCollection.ts
+++ b/src/packages/v4v5/views/V4V5ProjectSettings/EditNftsPage/hooks/useUpdateCurrentCollection.ts
@@ -76,6 +76,7 @@ export function useUpdateCurrentCollection({
       addTransaction?.('Update NFT rewards', { hash })
       await waitForTransactionReceipt(wagmiConfig, {
         hash,
+        chainId,
       })
 
       setTxLoading(false)


### PR DESCRIPTION
- Add v5 project support to TrendingProjectCard routing logic
- Fix SuccessPayView to use correct v4/v5 route based on project version
- Import PV_V5 constant and v5ProjectRoute function where needed
- Use useV4V5Version hook to determine project version dynamically
- Use jbChain for addTransaction polling

This fixes the issue where v5 projects showed as "p/null" in the trending
tab and the payment success page routed to v4 URLs for v5 projects. Minor transaction polling fix by adding the chainId for wagmi polling