### PR TITLE
fix: add v5 project routing to HomepageProjectCard

### DIFF
--- a/src/components/Home/HomepageProjectCard.tsx
+++ b/src/components/Home/HomepageProjectCard.tsx
@@ -3,13 +3,13 @@ import { Skeleton } from 'antd'
 import { HomepageCard } from 'components/Home/HomepageCard'
 import ProjectLogo from 'components/ProjectLogo'
 import ETHAmount from 'components/currency/ETHAmount'
-import { PV_V2, PV_V4 } from 'constants/pv'
+import { PV_V2, PV_V4, PV_V5 } from 'constants/pv'
 import { useProjectMetadata } from 'hooks/useProjectMetadata'
 import { JBChainId } from 'juice-sdk-react'
 import { SubgraphQueryProject } from 'models/subgraphProjects'
 import { v2v3ProjectRoute } from 'packages/v2v3/utils/routes'
 import { ChainLogo } from 'packages/v4v5/components/ChainLogo'
-import { v4ProjectRoute } from 'packages/v4v5/utils/routes'
+import { v4ProjectRoute, v5ProjectRoute } from 'packages/v4v5/utils/routes'
 
 function Statistic({
   name,
@@ -55,7 +55,12 @@ export function HomepageProjectCard({
   return (
     <HomepageCard
       href={
-        project.pv === PV_V4 && project.chainId
+        project.pv === PV_V5 && project.chainId
+          ? v5ProjectRoute({
+              projectId: project.projectId,
+              chainId: project.chainId,
+            })
+          : project.pv === PV_V4 && project.chainId
           ? v4ProjectRoute({
               projectId: project.projectId,
               chainId: project.chainId,


### PR DESCRIPTION
HomepageProjectCard is used in the homepage trending carousel and was showing v5 projects as "p/null" because it didn't have v5 routing logic.

Added PV_V5 constant and v5ProjectRoute function to properly route v5 projects to /v5/{chainSlug}:{projectId} format.

This is the same fix that was applied to TrendingProjectCard for the Projects page trending tab.